### PR TITLE
test(pairing): trim dead conformance harness surface

### DIFF
--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -47,7 +47,6 @@ async fn pairing_reconcile_scenarios_satisfy_safety_and_liveness() {
         "read_failure_noop.json",
         "unmanaged_survival.json",
         "delete_after_restart.json",
-        "filter_change_reinstall.json",
     ] {
         let scenario_path = fixture_path(fixture);
         let scenario = Scenario::from_json_file(&scenario_path).expect("scenario parses");

--- a/crates/gents/tests/fixtures/pairing_scenarios/delete_after_restart.json
+++ b/crates/gents/tests/fixtures/pairing_scenarios/delete_after_restart.json
@@ -12,6 +12,6 @@
     { "op": "OperatorDelete", "node": "A", "peer": "B" },
     { "op": "Crash", "node": "A" },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/pairing_scenarios/filter_change_reinstall.json
+++ b/crates/gents/tests/fixtures/pairing_scenarios/filter_change_reinstall.json
@@ -11,7 +11,7 @@
       }
     },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 },
+    { "op": "WaitForConvergence" },
     {
       "op": "OperatorWrite",
       "node": "A",
@@ -22,8 +22,8 @@
       }
     },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 },
+    { "op": "WaitForConvergence" },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/pairing_scenarios/install_teardown_happy_path.json
+++ b/crates/gents/tests/fixtures/pairing_scenarios/install_teardown_happy_path.json
@@ -9,9 +9,9 @@
       "replicator_addresses": ["/ip4/127.0.0.1/tcp/4101/p2p/peer-b"]
     },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 },
+    { "op": "WaitForConvergence" },
     { "op": "OperatorDelete", "node": "A", "peer": "B" },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/pairing_scenarios/read_failure_noop.json
+++ b/crates/gents/tests/fixtures/pairing_scenarios/read_failure_noop.json
@@ -11,6 +11,6 @@
     { "op": "Reconcile", "node": "A" },
     { "op": "Drop", "node": "A" },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/pairing_scenarios/replicator_install_teardown.json
+++ b/crates/gents/tests/fixtures/pairing_scenarios/replicator_install_teardown.json
@@ -8,9 +8,9 @@
       "replicator_addresses": ["/ip4/127.0.0.1/tcp/4102/p2p/peer-b"]
     },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 },
+    { "op": "WaitForConvergence" },
     { "op": "OperatorDelete", "node": "A", "peer": "B" },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/pairing_scenarios/unmanaged_survival.json
+++ b/crates/gents/tests/fixtures/pairing_scenarios/unmanaged_survival.json
@@ -18,6 +18,6 @@
     { "op": "Reconcile", "node": "A" },
     { "op": "OperatorDelete", "node": "A", "peer": "B" },
     { "op": "Reconcile", "node": "A" },
-    { "op": "WaitForConvergence", "timeout_secs": 15 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/support/pairing_conformance/runner.rs
+++ b/crates/gents/tests/support/pairing_conformance/runner.rs
@@ -7,7 +7,6 @@
 //! cycle back to desktop-core.
 
 use std::collections::BTreeSet;
-use std::time::Duration;
 
 use anyhow::{bail, Result};
 use gents::agent::p2p_reconcile::templates::{FilterPredicate, PairingFilters};
@@ -150,12 +149,6 @@ impl Harness {
                 self.record_observation_with_read_failed(read_failed)
                     .await?;
             }
-            Action::ReadFailure { node } => {
-                self.node_mut(node)?.drop_next_reconcile = true;
-                let read_failed = self.reconcile_node(node).await?.read_failed();
-                self.record_observation_with_read_failed(read_failed)
-                    .await?;
-            }
             Action::PreseedActual {
                 node,
                 collections,
@@ -169,10 +162,6 @@ impl Harness {
                 node.actual_connected = *connected;
                 self.record_observation().await?;
             }
-            Action::PeerDisconnected { node } => {
-                self.node_mut(node)?.actual_connected = false;
-                self.record_observation().await?;
-            }
             Action::Drop { node } => {
                 self.node_mut(node)?.drop_next_reconcile = true;
             }
@@ -180,9 +169,8 @@ impl Harness {
                 self.crash_node(node).await?;
                 self.record_observation().await?;
             }
-            Action::WaitForConvergence { timeout_secs } => {
-                self.wait_for_convergence(Duration::from_secs(*timeout_secs))
-                    .await?;
+            Action::WaitForConvergence => {
+                self.wait_for_convergence().await?;
             }
         }
         Ok(())
@@ -213,7 +201,7 @@ impl Harness {
         Ok(ReconcileOutcome::Applied)
     }
 
-    async fn wait_for_convergence(&mut self, _timeout: Duration) -> Result<()> {
+    async fn wait_for_convergence(&mut self) -> Result<()> {
         let snapshot = self.current_snapshot().await?;
         if crate::support::pairing_conformance::invariants::check_liveness(&snapshot) {
             self.history.push(snapshot);

--- a/crates/gents/tests/support/pairing_conformance/scenario.rs
+++ b/crates/gents/tests/support/pairing_conformance/scenario.rs
@@ -1,19 +1,19 @@
 //! Scenario IR for the pairing conformance harness.
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// A single-field equality predicate carried by a scenario's `OperatorWrite`.
 ///
 /// Mirrors the production `FilterPredicate`: the scope filter is part of the
 /// replicator's identity, so changing it forces a teardown+install of the
 /// affected replicator (Lean `PairingReconcile.filter_change_forces_reinstall`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ScenarioFilterPredicate {
     pub field: String,
     pub value: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "op", rename_all = "PascalCase")]
 pub enum Action {
     OperatorWrite {
@@ -37,9 +37,6 @@ pub enum Action {
     Reconcile {
         node: NodeId,
     },
-    ReadFailure {
-        node: NodeId,
-    },
     PreseedActual {
         node: NodeId,
         #[serde(default)]
@@ -49,23 +46,18 @@ pub enum Action {
         #[serde(default)]
         connected: bool,
     },
-    PeerDisconnected {
-        node: NodeId,
-    },
     Drop {
         node: NodeId,
     },
     Crash {
         node: NodeId,
     },
-    WaitForConvergence {
-        timeout_secs: u64,
-    },
+    WaitForConvergence,
 }
 
 pub type NodeId = String;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Scenario {
     pub name: String,
     pub actions: Vec<Action>,
@@ -76,31 +68,5 @@ impl Scenario {
         let bytes = std::fs::read(path)?;
         let scenario = serde_json::from_slice(&bytes)?;
         Ok(scenario)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn round_trip_minimal_scenario() {
-        let scenario = Scenario {
-            name: "smoke".into(),
-            actions: vec![
-                Action::OperatorWrite {
-                    node: "A".into(),
-                    peer: "B".into(),
-                    collections: vec!["c1".into()],
-                    replicator_addresses: vec!["/ip4/127.0.0.1/tcp/4101/p2p/p1".into()],
-                    replicator_filter: Default::default(),
-                },
-                Action::ReadFailure { node: "A".into() },
-                Action::WaitForConvergence { timeout_secs: 10 },
-            ],
-        };
-        let json = serde_json::to_string(&scenario).unwrap();
-        let parsed: Scenario = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.actions.len(), 3);
     }
 }


### PR DESCRIPTION
## Summary

- run the filter-change fixture only in its stronger dedicated test
- remove scenario actions and serialization surface with no reachable fixture consumers
- remove an ignored convergence timeout field without changing runner behavior

## Deletion evidence

- `filter_change_reinstall.json` still runs through `filter_change_reinstalls_replicator`, which retains the aggregate safety/liveness checks and adds teardown/reinstall order, exact install count, and no-trailing-teardown assertions.
- `ReadFailure` and `PeerDisconnected` appeared in no scenario fixture or caller. The surviving `Drop` then `Reconcile` sequence produces the same one `read_failed: true` observation as the removed helper path.
- `timeout_secs` was passed to an underscore-prefixed `_timeout` argument and never read. The runner still performs the same liveness check, one A/B reconcile pass, and exact `convergence timeout: ...` failure.
- The removed `Serialize` derives were consumed only by the deleted round-trip self-test, not by fixture loading.

## Parity review

Grok and Claude Opus independently approved the diff. Both traced the fixture overlap, action reachability, read-failure observation sequence, liveness/safety assertions, and exact runner error behavior. No actionable findings.

## Validation

- all pairing scenario fixtures parse as JSON
- normalized helper/action reachability audit
- `cargo fmt --all -- --check`
- `git diff --check`
- combined authoritative `cargo test -p gents`: 1,169 unit tests, 316 conformance tests, all package integration binaries, and doc tests passed

## Combined workspace and lint gate

- `cargo check --workspace --all-targets` passed in 12m55s on the integrated cleanup batch.
- strict workspace/all-target/all-feature clippy stops on untouched baseline warnings in the lifecycle lens and `gents-protocol`; neither file is in this PR.
- the non-strict full clippy pass completed. No newly added adapter, pairing, or P2P support file emitted a warning; the one warning in the changed builder file blames to pre-existing commit `3d76af9e7`.