### PR TITLE
chore: remove unused leaf dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,6 @@ name = "agent-subagent-v2-to-v3-lens"
 version = "0.1.0"
 dependencies = [
  "lens_sdk",
- "serde",
  "serde_json",
 ]
 
@@ -322,7 +321,6 @@ name = "agent-tool-call-lifecycle-v1-to-v2-lens"
 version = "0.1.0"
 dependencies = [
  "lens_sdk",
- "serde",
  "serde_json",
 ]
 
@@ -7982,8 +7980,6 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -8651,7 +8647,6 @@ dependencies = [
  "codex-arg0",
  "codex-config",
  "codex-login",
- "codex-model-provider-info",
  "codex-protocol",
  "codex-tui",
  "codex-utils-absolute-path",
@@ -8675,7 +8670,6 @@ dependencies = [
  "query",
  "regex",
  "reqwest 0.12.28",
- "rig-core",
  "rmcp 1.3.0",
  "schemars 1.2.1",
  "serde",
@@ -8754,7 +8748,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -8767,17 +8760,13 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
- "blake3",
  "chrono",
  "clap",
  "gents",
  "gents-desktop-bridge",
  "gents-desktop-core",
- "gents-lean-contract",
  "gents-protocol",
- "hostname",
  "reqwest 0.12.28",
- "rig-core",
  "serde",
  "serde_json",
  "tauri",
@@ -8787,7 +8776,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -8797,13 +8785,10 @@ dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
  "gents-desktop-bridge",
- "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
- "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/apps/fixture-host/src-tauri/Cargo.toml
+++ b/apps/fixture-host/src-tauri/Cargo.toml
@@ -18,9 +18,6 @@ tauri-build = { version = "2", features = [] }
 dirs.workspace = true
 fixture-domain-plugin = { path = "../../../crates/fixture-domain-plugin" }
 gents-desktop-bridge.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
-tokio.workspace = true
-tracing.workspace = true

--- a/apps/gents-desktop/src-tauri/Cargo.toml
+++ b/apps/gents-desktop/src-tauri/Cargo.toml
@@ -18,12 +18,10 @@ tauri-build = { version = "2", features = [] }
 anyhow.workspace = true
 clap.workspace = true
 chrono.workspace = true
-blake3 = "1"
 gents = { path = "../../../crates/gents" }
 gents-desktop-bridge = { workspace = true }
 gents-desktop-core.workspace = true
 gents-protocol = { path = "../../../crates/gents-protocol" }
-hostname.workspace = true
 reqwest.workspace = true
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
@@ -33,7 +31,6 @@ tempfile = "3"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-uuid.workspace = true
 
 [features]
 default = []
@@ -42,5 +39,3 @@ native-e2e = ["gents-desktop-bridge/native-e2e"]
 
 [dev-dependencies]
 axum = "0.8"
-gents-lean-contract.workspace = true
-rig-core.workspace = true

--- a/crates/fixture-domain-plugin/Cargo.toml
+++ b/crates/fixture-domain-plugin/Cargo.toml
@@ -12,8 +12,6 @@ build = "build.rs"
 serde.workspace = true
 serde_json.workspace = true
 tauri = { version = "2", features = [] }
-tokio.workspace = true
-tracing.workspace = true
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/crates/gents-cli/Cargo.toml
+++ b/crates/gents-cli/Cargo.toml
@@ -27,7 +27,6 @@ codex-app-server-protocol.workspace = true
 codex-arg0 = { workspace = true, optional = true }
 codex-config = { workspace = true, optional = true }
 codex-login.workspace = true
-codex-model-provider-info.workspace = true
 codex-protocol.workspace = true
 codex-tui = { workspace = true, optional = true }
 codex-utils-absolute-path.workspace = true
@@ -46,7 +45,6 @@ opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 p2p.workspace = true
 reqwest.workspace = true
-rig-core.workspace = true
 rmcp = { version = "1.2.0", features = [
     "server",
     "transport-streamable-http-server",

--- a/crates/gents-desktop-core/Cargo.toml
+++ b/crates/gents-desktop-core/Cargo.toml
@@ -23,7 +23,6 @@ p2p.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true

--- a/crates/gents-lenses/agent_subagent_v2_to_v3/Cargo.toml
+++ b/crates/gents-lenses/agent_subagent_v2_to_v3/Cargo.toml
@@ -9,6 +9,5 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lens_sdk = "^0.8"

--- a/crates/gents-lenses/agent_tool_call_lifecycle_v1_to_v2/Cargo.toml
+++ b/crates/gents-lenses/agent_tool_call_lifecycle_v1_to_v2/Cargo.toml
@@ -17,6 +17,5 @@ default = ["lens-entry"]
 lens-entry = []
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lens_sdk = "^0.8"


### PR DESCRIPTION
## Summary

Remove 15 unused direct dependency declarations from seven leaf/peripheral manifests and normalize the corresponding `Cargo.lock` package dependency arrays.

No Rust source, tests, runtime logic, features, public APIs, module paths, logging, retry behavior, error strings, or formal models changed.

## Deletion evidence

Static source/test/build-script/example/feature inspection found no reachable consumer for these direct declarations:

- `gents-cli`: `codex-model-provider-info`, `rig-core`
- `gents-desktop-tauri`: `blake3`, `hostname`, `uuid`; dev-only `gents-lean-contract`, `rig-core`
- `gents-fixture-host`: `serde`, `tokio`, `tracing`
- `fixture-domain-plugin`: `tokio`, `tracing`
- `agent-tool-call-lifecycle-v1-to-v2-lens`: `serde`
- `agent-subagent-v2-to-v3-lens`: `serde`
- `gents-desktop-core`: `thiserror`

The lockfile diff removes exactly those same 15 direct dependency edges. It removes no package records because those crates remain transitively reachable elsewhere in the workspace.

Diff: 8 files changed, 30 deletions (15 manifest lines + 15 lockfile dependency-array lines).

## Validation

Passed on top of `origin/main` `22d9839d`:

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p gents-cli --all-targets`
- `cargo check -p gents-cli --all-targets --no-default-features`
- `cargo check -p fixture-domain-plugin -p gents-fixture-host -p gents-desktop-core -p gents-desktop-tauri --all-targets --features gents-desktop-tauri/native-e2e`
- `cargo build -p agent-tool-call-lifecycle-v1-to-v2-lens --target wasm32-unknown-unknown --release`
- `cargo build -p agent-subagent-v2-to-v3-lens --target wasm32-unknown-unknown --release`

Focused test disclosure:

- `cargo test -p fixture-domain-plugin -p gents-desktop-core` compiled successfully.
- `fixture-domain-plugin`: 1/1 passed.
- `gents-desktop-core`: 129/130 tests visibly passed. The existing `client::mutations::chat::request::tests::generated_session_recovery_cases_drive_desktop_retry_request` remained silent for more than 10 minutes after Cargo's 60-second slow-test notice and was terminated. This dependency-only PR does not alter that test or its code path; the all-targets compile above is green.
