### PR TITLE
Stabilize wait_subagent synchronization

### DIFF
--- a/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
+++ b/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
@@ -52,9 +52,13 @@ async fn wait_subagent_waits_on_existing_bridge_without_lifecycle_row() {
             .await
     });
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let foregrounded_bridge =
-        fetch_tool_call(db.node.as_ref(), &session_id, "internal-wait-spawn").await;
+    let foregrounded_bridge = wait_for_tool_call_await_mode(
+        db.node.as_ref(),
+        &session_id,
+        "internal-wait-spawn",
+        "foreground",
+    )
+    .await;
     assert_eq!(
         foregrounded_bridge.await_mode.as_deref(),
         Some("foreground")
@@ -507,9 +511,13 @@ async fn wait_subagent_from_resumed_hook_cascades_parent_interrupt() {
             .await
     });
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    let foregrounded_bridge =
-        fetch_tool_call(db.node.as_ref(), &session_id, "internal-wait-resume-spawn").await;
+    let foregrounded_bridge = wait_for_tool_call_await_mode(
+        db.node.as_ref(),
+        &session_id,
+        "internal-wait-resume-spawn",
+        "foreground",
+    )
+    .await;
     assert_eq!(
         foregrounded_bridge.await_mode.as_deref(),
         Some("foreground")
@@ -595,7 +603,13 @@ async fn wait_subagent_returns_background_receipt_when_bridge_is_backgrounded() 
             .await
     });
 
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    wait_for_tool_call_await_mode(
+        db.node.as_ref(),
+        &session_id,
+        "internal-wait-bg-spawn",
+        "foreground",
+    )
+    .await;
     let mut lifecycle =
         ToolCallLifecycle::load(db.node.clone(), &session_id, "internal-wait-bg-spawn")
             .await


### PR DESCRIPTION
Fixes #918.

## Root cause

Three `wait_subagent` E2E cases spawned an asynchronous wait task, slept for 100 ms, and then assumed its persisted bridge had already changed from `background` to `foreground`.

That duration is not a runtime contract. Before foregrounding, production loads the assistant turn, parent context, authorized child edge, and tool-call lifecycle, then awaits a compare-and-swap DefraDB mutation. Under a parallel E2E run, the test can read the original `background` row before those awaited operations finish.

Latest-main reproduction with the full target at high concurrency failed on the first stress iteration:

```text
r4_subagent_tools::wait_subagent::wait_subagent_from_resumed_hook_cascades_parent_interrupt
left:  Some("background")
right: Some("foreground")
95 passed; 1 failed
```

## Change

Replace all three fixed 100 ms synchronization sleeps in `wait_subagent.rs` with the existing `wait_for_tool_call_await_mode` helper.

The helper polls the persisted bridge for at most five seconds. This preserves the foreground assertions and strengthens the backgrounding case's precondition. It cannot hide a real foreground regression: if production never persists `foreground`, the helper times out and the test still fails with a state-specific message.

This is test-only. Runtime behavior, formal models, migrations, fixtures, public APIs, errors, logging, retries, and timing remain unchanged.

## Validation

- pre-fix reproduction: full 96-test E2E target failed on stress iteration 1 with the #918 mismatch
- post-fix stress: 10 full target runs at 96 test threads — 960 passed, 0 failed
- post-fix exact regression test: 20 serialized runs — 20 passed, 0 failed
- serialized `wait_subagent` module: 7 passed, 0 failed
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- Claude Opus independent read-only review: **APPROVED**, no findings
