### PR TITLE
test(cli): wait for runtime state before config subprocesses

### DIFF
--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -8207,6 +8207,7 @@ async fn codex_shim_binds_when_config_apply_supplies_its_behavior() -> Result<()
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     // The runtime is up and healthy, but the shim has nothing to serve yet.
     assert!(

--- a/crates/gents-cli/tests/cli_config_apply_e2e.rs
+++ b/crates/gents-cli/tests/cli_config_apply_e2e.rs
@@ -124,6 +124,7 @@ async fn config_apply_reconciles_tool_services_tasks_and_schedules_end_to_end() 
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     let planned = run_cli_json(&home_dir, &["config", "diff", "--root", root_str])?;
     assert_eq!(
@@ -672,6 +673,7 @@ async fn config_apply_accepts_explicit_empty_tool_selection_lists_twice() -> Res
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     let applied = run_cli_json(&home_dir, &["config", "apply", "--root", root_str])?;
     assert_eq!(
@@ -869,6 +871,7 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     let planned = run_cli_json(&home_dir, &["config", "diff", "--root", root_str])?;
     assert_eq!(
@@ -1274,6 +1277,7 @@ async fn prepare_live_validation_fixture(suffix: &str) -> Result<LiveValidationF
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     Ok(LiveValidationFixture {
         home_dir,
@@ -1468,6 +1472,7 @@ async fn config_apply_round_trips_write_tools_without_drift() -> Result<()> {
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     let applied = run_cli_json(&home_dir, &["config", "apply", "--root", root_str])?;
     assert_eq!(


### PR DESCRIPTION
## Summary

Fix the intermittent RocksDB home-lock failures tracked in #919 by waiting for the server's `runtime.json` handoff before test subprocesses use home-based runtime discovery.

The server makes `AgentRuntime.process_state = ready` observable before `serve` writes `runtime.json`. These fixtures previously waited only for the ready row, then launched `gents config apply` or `config diff` without `--graphql`. If scheduled in that window, `resolve_config_access` found no runtime state, fell back to opening the same embedded RocksDB home locally, and failed on the server-owned `LOCK`.

## Change

- Add the existing bounded `wait_for_runtime_state_graphql` fixture wait at all five server setup sites in `cli_config_apply_e2e.rs` that subsequently launch home-auto-discovering config commands.
- Add the same wait to `codex_shim_binds_when_config_apply_supplies_its_behavior`, the only affected shim test whose post-start config command omits explicit `--graphql`.
- No production, migration, retry, error-string, logging, or fixture-format changes.

## Scope evidence

- `cli_config_apply_e2e.rs` contains five server setup sites; all five later use home auto-discovery and all five are covered.
- The three live EventTrigger validation tests inherit the wait through `prepare_live_validation_fixture`.
- Other post-start config commands in `cli_codex_shim.rs` pass explicit `--graphql`, which short-circuits runtime-state discovery and cannot fall back to local RocksDB.
- The wait parses `runtime.json` and requires its GraphQL endpoint to match the expected port, so it also tolerates a partial file write and rejects a stale different-port state.

## Reproduction and stress evidence

The original #919 failures were not re-observed locally in a bounded unmodified sample (30/30 full config targets and 20/20 exact shim regressions passed), consistent with the issue's scheduling-dependent behavior. The race is nevertheless structurally demonstrated by the production ordering above.

After the fix:

- 10 paired iterations of both reported config tests passed (20 scenarios).
- 10/10 iterations of `codex_shim_binds_when_config_apply_supplies_its_behavior` passed.
- Nine repeated full config targets passed; the tenth stopped on a distinct HTTP 409 transaction conflict in `apply_accepts_event_trigger_with_valid_filter_and_doc_paths`, not a RocksDB lock. No retry/error behavior was changed for that separate failure.
- Full `cargo test -p gents-cli` passed: 531 unit tests and every non-ignored integration test.

## Validation

On latest `main` at publication time:

- `cargo fmt --all -- --check`
- `cargo test -p gents-cli --test cli_config_apply_e2e` — 7 passed
- `cargo test -p gents-cli --test cli_codex_shim codex_shim_binds_when_config_apply_supplies_its_behavior -- --exact` — passed
- `cargo check --workspace --all-targets`
- `git diff origin/main...HEAD --check`

Strict `cargo clippy -p gents-cli --all-targets -- -D warnings` reached the existing baseline and failed with 51 errors in untouched `crates/gents` code (type complexity, argument counts, large enums, and related warning families). Neither changed test file produced a diagnostic.

## Independent review

- Claude Opus: APPROVED; confirmed the startup ordering, resolver fallback, all six call sites, and no missed same-pattern path in the implicated files.
- Grok: APPROVED; independently confirmed scope, bounded-wait safety, and absence of production behavior changes.

Fixes #919
