### PR TITLE
fix(p2p): retry transient initial pairing sweeps

### DIFF
--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
@@ -310,6 +310,28 @@ def pairingReconcileShutdownBoundaryCases :
     }
   ]
 
+/-- The single-peer `PairingReconcile` machine models read failure as a
+    phase-preserving transition, but the runtime also owns the daemon boundary
+    around whole-sweep enumeration. This witness fences that refinement: an
+    initial top-level enumeration failure must not terminate the reconciler,
+    the already-ready first interval tick retries convergence, and shutdown
+    remains the prioritized supervisor outcome. Rust exercises this witness in
+    `pairing_reconciler_retries_initial_enumeration_failure_then_cancels_cleanly`.
+    -/
+def pairingReconcileSweepRetryBoundaryCases :
+    List PairingReconcileSweepRetryBoundaryCase :=
+  [ { name := "initial_top_level_sweep_failure_retries_without_terminating_reconciler"
+    , supervisor := "pairingReconciler"
+    , workClass := "p2pReconcileSweep"
+    , boundary := "pairingReconcileSupervisorBoundary"
+    , failureScope := "topLevelSweepEnumeration"
+    , failureTerminal := false
+    , retryTrigger := "immediateFirstIntervalTick"
+    , cancellationPrioritized := true
+    , convergenceRetried := true
+    }
+  ]
+
 /-- The single-peer `PairingReconcile` machine does not model how a runtime
     sweep schedules several independent peers. This witness fences that
     refinement: slow discovery/dial preparation is bounded and concurrent, so

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -191,6 +191,18 @@ structure PairingReconcileShutdownBoundaryCase where
   shutdownJoinBounded : Bool
   deriving Repr
 
+structure PairingReconcileSweepRetryBoundaryCase where
+  name : String
+  supervisor : String
+  workClass : String
+  boundary : String
+  failureScope : String
+  failureTerminal : Bool
+  retryTrigger : String
+  cancellationPrioritized : Bool
+  convergenceRetried : Bool
+  deriving Repr
+
 structure PairingReconcileSweepSchedulingCase where
   name : String
   supervisor : String

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Runtime.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Runtime.lean
@@ -56,6 +56,23 @@ def pairingReconcileShutdownBoundaryCaseJson
       ++ boolString witness.shutdownJoinBounded
     ++ "}"
 
+def pairingReconcileSweepRetryBoundaryCaseJson
+    (witness : PairingReconcileSweepRetryBoundaryCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"supervisor\":" ++ jsonString witness.supervisor ++ ","
+    ++ "\"work_class\":" ++ jsonString witness.workClass ++ ","
+    ++ "\"boundary\":" ++ jsonString witness.boundary ++ ","
+    ++ "\"failure_scope\":" ++ jsonString witness.failureScope ++ ","
+    ++ "\"failure_terminal\":"
+      ++ boolString witness.failureTerminal ++ ","
+    ++ "\"retry_trigger\":" ++ jsonString witness.retryTrigger ++ ","
+    ++ "\"cancellation_prioritized\":"
+      ++ boolString witness.cancellationPrioritized ++ ","
+    ++ "\"convergence_retried\":"
+      ++ boolString witness.convergenceRetried
+    ++ "}"
+
 def pairingReconcileSweepSchedulingCaseJson
     (witness : PairingReconcileSweepSchedulingCase) : String :=
   "{"

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -96,6 +96,10 @@ def snapshotJson : String :=
       ++ jsonArray
         (pairingReconcileShutdownBoundaryCases.map
           pairingReconcileShutdownBoundaryCaseJson) ++ ","
+    ++ "\"pairing_reconcile_sweep_retry_boundary_cases\":"
+      ++ jsonArray
+        (pairingReconcileSweepRetryBoundaryCases.map
+          pairingReconcileSweepRetryBoundaryCaseJson) ++ ","
     ++ "\"pairing_reconcile_sweep_scheduling_cases\":"
       ++ jsonArray
         (pairingReconcileSweepSchedulingCases.map

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -612,6 +612,11 @@ def caseCoverage : List CoverageEntry :=
       "pairing-reconcile" [Surface.runtimeInternal]
   , tagged (consumerCoverage
       "pairing_reconcile_cases"
+      "PairingReconcileSweepRetryBoundaryCases"
+      "conformance::pairing_reconcile_top_level_sweep_failure_is_nonterminal_and_retried")
+      "pairing-reconcile" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "pairing_reconcile_cases"
       "PairingReconcileSweepSchedulingCases"
       "conformance::pairing_reconcile_sweep_does_not_head_of_line_block_ready_peer")
       "pairing-reconcile" [Surface.runtimeInternal]

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -335,37 +335,54 @@ pub async fn run_pairing_reconciler(
 
     let admin = EmbeddedRemoteP2pAdmin::new(node.clone());
     let store = GraphqlPairingStateStore::new(node.clone(), identity);
-    let mut subscription = node.subscribe(&[EventName::Update]);
+    let subscription = node.subscribe(&[EventName::Update]);
+
+    run_pairing_reconciler_loop(&admin, &store, subscription, &cancel).await;
+    Ok(())
+}
+
+async fn run_pairing_reconciler_loop(
+    admin: &dyn RemoteP2pAdmin,
+    store: &dyn PairingStateStore,
+    mut subscription: events::Subscription,
+    cancel: &CancellationToken,
+) {
     let mut interval = tokio::time::interval(super::intervals::sweep_interval());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut replay_connections = BTreeMap::new();
     let mut failing_peers = BTreeSet::<String>::new();
 
-    if !sweep_pairings_until_cancelled(
-        &admin,
-        &store,
+    // A transient top-level read failure during the first sweep is no more
+    // terminal than one during a recurring sweep. The interval's first tick is
+    // immediately ready, so logging here preserves the prompt startup retry
+    // without introducing a separate backoff path. Unlike the registry and
+    // endpoint heartbeat daemons, do not consume that first tick before this
+    // sweep: it is the retry fence if startup hits a transient store error.
+    if !sweep_pairings_logged_until_cancelled(
+        admin,
+        store,
         &mut replay_connections,
         &mut failing_peers,
-        &cancel,
+        cancel,
     )
-    .await?
+    .await
     {
-        return Ok(());
+        return;
     }
 
     loop {
         tokio::select! {
             biased;
-            _ = cancel.cancelled() => return Ok(()),
+            _ = cancel.cancelled() => return,
             _ = interval.tick() => {
                 if !sweep_pairings_logged_until_cancelled(
-                    &admin,
-                    &store,
+                    admin,
+                    store,
                     &mut replay_connections,
                     &mut failing_peers,
-                    &cancel,
+                    cancel,
                 ).await {
-                    return Ok(());
+                    return;
                 }
             }
             message = subscription.recv() => {
@@ -378,13 +395,13 @@ pub async fn run_pairing_reconciler(
                     tracing::warn!(dropped, "pairing reconciler update subscription dropped messages");
                 }
                 if !sweep_pairings_logged_until_cancelled(
-                    &admin,
-                    &store,
+                    admin,
+                    store,
                     &mut replay_connections,
                     &mut failing_peers,
-                    &cancel,
+                    cancel,
                 ).await {
-                    return Ok(());
+                    return;
                 }
             }
         }
@@ -397,24 +414,8 @@ pub async fn run_pairing_reconciler(
 /// peers. Awaiting the sweep directly therefore multiplies shutdown latency by
 /// the number of peers. Dropping the sweep future on cancellation preempts the
 /// current admin wait and skips the remaining peer loop; the outer runtime can
-/// then join this task promptly.
-async fn sweep_pairings_until_cancelled(
-    admin: &dyn RemoteP2pAdmin,
-    store: &dyn PairingStateStore,
-    replay_connections: &mut BTreeMap<String, bool>,
-    failing_peers: &mut BTreeSet<String>,
-    cancel: &CancellationToken,
-) -> Result<bool> {
-    tokio::select! {
-        biased;
-        _ = cancel.cancelled() => Ok(false),
-        result = sweep_pairings(admin, store, replay_connections, failing_peers) => {
-            result?;
-            Ok(true)
-        }
-    }
-}
-
+/// then join this task promptly. Sweep errors are logged and remain nonterminal;
+/// `false` means only that cancellation won the biased boundary.
 async fn sweep_pairings_logged_until_cancelled(
     admin: &dyn RemoteP2pAdmin,
     store: &dyn PairingStateStore,

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 
 use anyhow::anyhow;
+use events::Bus;
 
 use super::*;
 use crate::agent::p2p_reconcile::{RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator};
@@ -354,6 +355,11 @@ struct MockStore {
     applied: Mutex<PairingApplied>,
     saved: Mutex<Vec<PairingApplied>>,
     deleted: Mutex<usize>,
+    list_peer_ids_failures: Mutex<usize>,
+    list_peer_ids_calls: Mutex<usize>,
+    list_peer_ids_retry_started: Option<Arc<tokio::sync::Notify>>,
+    list_peer_ids_retry_release: Option<Arc<tokio::sync::Notify>>,
+    save_applied_completed: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl Default for MockStore {
@@ -363,6 +369,11 @@ impl Default for MockStore {
             applied: Mutex::new(PairingApplied::default()),
             saved: Mutex::new(Vec::new()),
             deleted: Mutex::new(0),
+            list_peer_ids_failures: Mutex::new(0),
+            list_peer_ids_calls: Mutex::new(0),
+            list_peer_ids_retry_started: None,
+            list_peer_ids_retry_release: None,
+            save_applied_completed: None,
         }
     }
 }
@@ -393,6 +404,9 @@ impl PairingStateStore for MockStore {
     async fn save_applied(&self, _peer_id: &str, applied: &PairingApplied) -> Result<()> {
         *self.applied.lock().unwrap() = applied.clone();
         self.saved.lock().unwrap().push(applied.clone());
+        if let Some(completed) = &self.save_applied_completed {
+            completed.notify_one();
+        }
         Ok(())
     }
 
@@ -403,6 +417,25 @@ impl PairingStateStore for MockStore {
     }
 
     async fn list_peer_ids(&self) -> Result<BTreeSet<String>> {
+        *self.list_peer_ids_calls.lock().unwrap() += 1;
+        let should_fail = {
+            let mut failures = self.list_peer_ids_failures.lock().unwrap();
+            if *failures == 0 {
+                false
+            } else {
+                *failures -= 1;
+                true
+            }
+        };
+        if should_fail {
+            anyhow::bail!("transient list_peer_ids failure");
+        }
+        if let Some(started) = &self.list_peer_ids_retry_started {
+            started.notify_one();
+        }
+        if let Some(release) = &self.list_peer_ids_retry_release {
+            release.notified().await;
+        }
         Ok(set(&["peer-a"]))
     }
 }
@@ -686,7 +719,7 @@ async fn cancellation_preempts_in_flight_pairing_sweep_admin_wait() {
     let cancel = CancellationToken::new();
     let mut replay_connections = BTreeMap::new();
     let mut failing_peers = BTreeSet::new();
-    let sweep = sweep_pairings_until_cancelled(
+    let sweep = sweep_pairings_logged_until_cancelled(
         &admin,
         &store,
         &mut replay_connections,
@@ -703,9 +736,82 @@ async fn cancellation_preempts_in_flight_pairing_sweep_admin_wait() {
     cancel.cancel();
     let completed = tokio::time::timeout(Duration::from_millis(100), &mut sweep)
         .await
-        .expect("cancellation must preempt the in-flight admin wait")
-        .expect("cancelled sweep result");
+        .expect("cancellation must preempt the in-flight admin wait");
     assert!(!completed, "cancelled sweep must skip its remaining peers");
+}
+
+#[tokio::test(start_paused = true)]
+async fn pairing_reconciler_retries_initial_enumeration_failure_then_cancels_cleanly() {
+    let retry_started = Arc::new(tokio::sync::Notify::new());
+    let retry_release = Arc::new(tokio::sync::Notify::new());
+    let convergence_completed = Arc::new(tokio::sync::Notify::new());
+    let store = MockStore {
+        desired: Mutex::new(Ok(Some(PairingDesired {
+            collections: set(&["AgentRequest"]),
+            ..Default::default()
+        }))),
+        list_peer_ids_failures: Mutex::new(1),
+        list_peer_ids_retry_started: Some(retry_started.clone()),
+        list_peer_ids_retry_release: Some(retry_release.clone()),
+        save_applied_completed: Some(convergence_completed.clone()),
+        ..Default::default()
+    };
+    let admin = MockAdmin::default();
+    let event_bus = events::ChannelBus::new();
+    let subscription = event_bus.subscribe(&[EventName::Update]);
+    let cancel = CancellationToken::new();
+    let reconciler = run_pairing_reconciler_loop(&admin, &store, subscription, &cancel);
+    tokio::pin!(reconciler);
+    let retry_fence_time = tokio::time::Instant::now();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        tokio::select! {
+            _ = retry_started.notified() => {}
+            result = &mut reconciler => {
+                panic!("initial enumeration failure terminated reconciler before retry: {result:?}")
+            }
+        }
+    })
+    .await
+    .expect("immediate first interval tick must start the retry");
+    assert_eq!(
+        tokio::time::Instant::now(),
+        retry_fence_time,
+        "startup retry must consume the already-ready first tick without advancing time"
+    );
+    assert_eq!(
+        *store.list_peer_ids_calls.lock().unwrap(),
+        2,
+        "the interval's immediately-ready first tick must start the retry"
+    );
+    assert!(
+        admin.emitted.lock().unwrap().is_empty(),
+        "the failed initial sweep and gated retry must emit no operation"
+    );
+
+    let converged = convergence_completed.notified();
+    tokio::pin!(converged);
+    retry_release.notify_one();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        tokio::select! {
+            _ = &mut converged => {}
+            result = &mut reconciler => {
+                panic!("reconciler terminated before retry convergence: {result:?}")
+            }
+        }
+    })
+    .await
+    .expect("healthy immediate-tick retry must converge");
+    assert_eq!(*store.list_peer_ids_calls.lock().unwrap(), 2);
+    assert_eq!(
+        *admin.emitted.lock().unwrap(),
+        vec![DiffOp::InstallCollection("AgentRequest".to_string())]
+    );
+
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_millis(100), &mut reconciler)
+        .await
+        .expect("cancellation must stop the reconciler");
 }
 
 #[tokio::test]

--- a/crates/gents/src/lean_vocab_test/slot_persistence_health.rs
+++ b/crates/gents/src/lean_vocab_test/slot_persistence_health.rs
@@ -122,6 +122,19 @@ pub(crate) struct LeanPairingReconcileShutdownBoundaryCase {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct LeanPairingReconcileSweepRetryBoundaryCase {
+    pub(crate) name: String,
+    pub(crate) supervisor: String,
+    pub(crate) work_class: String,
+    pub(crate) boundary: String,
+    pub(crate) failure_scope: String,
+    pub(crate) failure_terminal: bool,
+    pub(crate) retry_trigger: String,
+    pub(crate) cancellation_prioritized: bool,
+    pub(crate) convergence_retried: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct LeanPairingReconcileSweepSchedulingCase {
     pub(crate) name: String,
     pub(crate) supervisor: String,

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -61,6 +61,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) managed_exec_tool_boundary_cases: Vec<LeanManagedExecToolBoundaryCase>,
     pub(crate) pairing_reconcile_shutdown_boundary_cases:
         Vec<LeanPairingReconcileShutdownBoundaryCase>,
+    pub(crate) pairing_reconcile_sweep_retry_boundary_cases:
+        Vec<LeanPairingReconcileSweepRetryBoundaryCase>,
     pub(crate) pairing_reconcile_sweep_scheduling_cases:
         Vec<LeanPairingReconcileSweepSchedulingCase>,
     pub(crate) managed_exec_liveness_cases: Vec<LeanManagedExecLivenessCase>,
@@ -544,6 +546,11 @@ pub(crate) fn lean_managed_exec_tool_boundary_cases() -> &'static [LeanManagedEx
 pub(crate) fn lean_pairing_reconcile_shutdown_boundary_cases(
 ) -> &'static [LeanPairingReconcileShutdownBoundaryCase] {
     &lean_contract_snapshot().pairing_reconcile_shutdown_boundary_cases
+}
+
+pub(crate) fn lean_pairing_reconcile_sweep_retry_boundary_cases(
+) -> &'static [LeanPairingReconcileSweepRetryBoundaryCase] {
+    &lean_contract_snapshot().pairing_reconcile_sweep_retry_boundary_cases
 }
 
 pub(crate) fn lean_pairing_reconcile_sweep_scheduling_cases(

--- a/crates/gents/tests/conformance.rs
+++ b/crates/gents/tests/conformance.rs
@@ -338,6 +338,11 @@ fn pairing_reconcile_shutdown_boundary_preempts_in_flight_sweep() {
 }
 
 #[test]
+fn pairing_reconcile_top_level_sweep_failure_is_nonterminal_and_retried() {
+    pairing_reconcile::pairing_reconcile_top_level_sweep_failure_is_nonterminal_and_retried();
+}
+
+#[test]
 fn pairing_reconcile_sweep_does_not_head_of_line_block_ready_peer() {
     pairing_reconcile::pairing_reconcile_sweep_does_not_head_of_line_block_ready_peer();
 }

--- a/crates/gents/tests/conformance/cancel_propagation.rs
+++ b/crates/gents/tests/conformance/cancel_propagation.rs
@@ -107,18 +107,19 @@ async fn drive_declarative_cancel_propagation() {
     let host = boot_agent(host_db, host_identity, "cancel-propagation-host").await;
     let coord = boot_agent(coord_db, coord_identity, "cancel-propagation-coord").await;
 
-    // 180s, not 60s: the wait returns as soon as the row lands, but under a
-    // loaded CI runner (rust-and-cli runs this beside full builds) reconcile
-    // has blown a 60s budget while the same suite passes in the quieter
-    // lean-proofs job. Flaky-by-load is still a defect; pay it in budget once.
+    // Retain the loaded-runner budget while #929's startup retry fix soaks.
+    // If it fires again, the bounded runtime/P2P snapshots below provide
+    // additional state for classifying the failure without extending the wait.
     wait_for_replicator_installed(
         coord.db.node.as_ref(),
+        &coord_did,
         "cancel-host",
         Duration::from_secs(180),
     )
     .await;
     wait_for_replicator_installed(
         host.db.node.as_ref(),
+        &host_did,
         "cancel-coord",
         Duration::from_secs(180),
     )
@@ -486,7 +487,12 @@ async fn wait_for_connected_peer(node: &EmbeddedNode, timeout: Duration) {
     }
 }
 
-async fn wait_for_replicator_installed(node: &EmbeddedNode, peer_id: &str, timeout: Duration) {
+async fn wait_for_replicator_installed(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    peer_id: &str,
+    timeout: Duration,
+) {
     let deadline = Instant::now() + timeout;
     let escaped_peer_id = escape_graphql_string(peer_id);
     let mut last = String::from("<none>");
@@ -518,12 +524,53 @@ async fn wait_for_replicator_installed(node: &EmbeddedNode, peer_id: &str, timeo
             }
         }
         if Instant::now() >= deadline {
+            let runtime = runtime_diagnostic(node, agent_did).await;
+            let p2p = p2p_diagnostic(node).await;
             panic!(
-                "timed out waiting for PeerPairingApplied({peer_id}) to install a replicator; last row={last}"
+                "timed out waiting for PeerPairingApplied({peer_id}) to install a replicator; \
+                 last row={last}; runtime={runtime}; p2p={p2p}"
             );
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
+}
+
+async fn runtime_diagnostic(node: &EmbeddedNode, agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    let query = format!(
+        r#"{{
+            AgentRuntime(
+                filter: {{ agent_did: {{ _eq: "{agent_did}" }} }},
+                limit: 1
+            ) {{
+                process_state
+                reconcile_phase
+                active_generation
+                router_generation
+                last_reconcile_result
+                last_reconcile_error
+            }}
+        }}"#
+    );
+    let response = match tokio::time::timeout(Duration::from_secs(2), node.execute(&query)).await {
+        Ok(response) => response,
+        Err(_) => return "<timed out after 2s>".to_string(),
+    };
+    let data = response
+        .data
+        .as_ref()
+        .map(serde_json::Value::to_string)
+        .unwrap_or_else(|| "<none>".to_string());
+    format!("data={data}, errors={:?}", response.errors)
+}
+
+async fn p2p_diagnostic(node: &EmbeddedNode) -> String {
+    let Some(p2p) = node.p2p() else {
+        return "<disabled>".to_string();
+    };
+    let peers = tokio::time::timeout(Duration::from_secs(2), p2p.connected_peers()).await;
+    let replicators = tokio::time::timeout(Duration::from_secs(2), p2p.get_replicators()).await;
+    format!("connected_peers={peers:?}, replicators={replicators:?}")
 }
 
 async fn wait_for_interrupt_requested_at(

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -600,6 +600,15 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "PairingReconcileShutdownBoundaryCases".to_string(),
         ));
     }
+    if !snapshot
+        .pairing_reconcile_sweep_retry_boundary_cases
+        .is_empty()
+    {
+        emitted.insert((
+            "pairing_reconcile_cases".to_string(),
+            "PairingReconcileSweepRetryBoundaryCases".to_string(),
+        ));
+    }
     if !snapshot.pairing_reconcile_sweep_scheduling_cases.is_empty() {
         emitted.insert((
             "pairing_reconcile_cases".to_string(),

--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -9,7 +9,9 @@ use gents::agent::p2p_reconcile::{
 };
 
 use crate::lean_vocab_test::{
-    lean_pairing_reconcile_shutdown_boundary_cases, lean_pairing_reconcile_sweep_scheduling_cases,
+    lean_pairing_reconcile_shutdown_boundary_cases,
+    lean_pairing_reconcile_sweep_retry_boundary_cases,
+    lean_pairing_reconcile_sweep_scheduling_cases,
 };
 use crate::support::pairing_conformance::invariants::{
     check_liveness, check_safety, ObservedSnapshot,
@@ -291,6 +293,27 @@ pub(super) fn pairing_reconcile_shutdown_boundary_preempts_in_flight_sweep() {
     assert!(case.current_admin_future_dropped);
     assert!(case.remaining_peers_skipped);
     assert!(case.shutdown_join_bounded);
+}
+
+pub(super) fn pairing_reconcile_top_level_sweep_failure_is_nonterminal_and_retried() {
+    // The generated row pins the Lean-owned boundary vocabulary. The production
+    // loop behavior is exercised by
+    // `agent::p2p_reconcile::engine::tests::pairing_reconciler_retries_initial_enumeration_failure_then_cancels_cleanly`.
+    let cases = lean_pairing_reconcile_sweep_retry_boundary_cases();
+    assert_eq!(cases.len(), 1);
+    let case = &cases[0];
+    assert_eq!(
+        case.name,
+        "initial_top_level_sweep_failure_retries_without_terminating_reconciler"
+    );
+    assert_eq!(case.supervisor, "pairingReconciler");
+    assert_eq!(case.work_class, "p2pReconcileSweep");
+    assert_eq!(case.boundary, "pairingReconcileSupervisorBoundary");
+    assert_eq!(case.failure_scope, "topLevelSweepEnumeration");
+    assert!(!case.failure_terminal);
+    assert_eq!(case.retry_trigger, "immediateFirstIntervalTick");
+    assert!(case.cancellation_prioritized);
+    assert!(case.convergence_retried);
 }
 
 pub(super) fn pairing_reconcile_sweep_does_not_head_of_line_block_ready_peer() {

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -631,6 +631,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "pairing_reconcile_shutdown_boundary_preempts_in_flight_sweep",
         },
         ConformanceConsumer::RustTest {
+            id: "conformance::pairing_reconcile_top_level_sweep_failure_is_nonterminal_and_retried",
+            package: "gents",
+            source_path: "crates/gents/tests/conformance.rs",
+            module_path: "conformance",
+            function: "pairing_reconcile_top_level_sweep_failure_is_nonterminal_and_retried",
+        },
+        ConformanceConsumer::RustTest {
             id: "conformance::pairing_reconcile_sweep_does_not_head_of_line_block_ready_peer",
             package: "gents",
             source_path: "crates/gents/tests/conformance.rs",


### PR DESCRIPTION
Fixes #929.

## Failure evidence

CI run `30431815757` / job `90510526691` completed 309 conformance tests before `cancel_propagation_cases_drive_production_interrupt` timed out after 187.59s:

> timed out waiting for PeerPairingApplied(cancel-host) to install a replicator; last row=<none>

An exact rerun of the same head passed in 7.08s. The earlier mitigation (`c240cb62`) had already increased the two loaded-runner pairing waits from 60s to 180s, yet this attempt still failed.

## Root cause and fix

The observed state is consistent with a concrete startup error-boundary gap:

- the pairing reconciler's initial sweep used `sweep_pairings_until_cancelled(...).await?`;
- a transient top-level store read such as `list_peer_ids` therefore returned from the background task;
- the agent supervisor treats any completed background task as terminal;
- every recurring sweep already used `sweep_pairings_logged_until_cancelled`, which logs the same error and retries.

This PR routes the initial sweep through that existing logged/cancellation-aware boundary. A private `run_pairing_reconciler_loop` now owns the exact production interval, initial sweep, subscription/select loop, and biased cancellation boundary; the unchanged public wrapper constructs the concrete dependencies and returns `Ok(())` after the infallible loop exits on cancellation.

The Tokio interval is still created before the startup sweep and its first tick is immediately ready, so a failed startup sweep receives a prompt retry without a new cadence or backoff path. No public API, persisted schema, production error string, warning text, log message, retry interval, cancellation priority, feature gate, visibility, or module path changes. The existing warning remains `pairing reconciler sweep failed; retrying on next tick`.

## Lean and generated conformance contract

The previously unmodeled supervisor boundary is now Lean-first and machine-readable:

- `PairingReconcileSweepRetryBoundaryCases` adds one `BoundaryRuntime` witness for a top-level sweep-enumeration failure;
- the generated row pins `failureTerminal = false`, `retryTrigger = immediateFirstIntervalTick`, `cancellationPrioritized = true`, and `convergenceRetried = true`;
- the row is serialized into the contract snapshot, decoded by Rust, registered in the emitted-domain/consumer coverage ledger, and asserted field-for-field by conformance;
- the witness cross-references the production-loop regression below.

This formalizes the supervisor boundary rather than changing legal `PairingReconcile` transitions or invariants. The proof tree remains free of `sorry`.

## Coverage and diagnostics

- `pairing_reconciler_retries_initial_enumeration_failure_then_cancels_cleanly` runs the actual production loop under paused Tokio time. It injects exactly one `list_peer_ids` failure, proves the task survives, proves the first retry begins without virtual-time advancement, gates that retry to exclude premature work, observes exactly two enumeration calls and exactly one `InstallCollection("AgentRequest")`, then cancels and requires a clean exit within 100ms.
- The prior helper-only regression was replaced; it could not prove that the daemon loop retained the logged helper or stayed alive.
- The in-flight cancellation test still targets the retained production helper and preserves its 100ms preemption assertion.
- All existing cancellation, bridge, request, acknowledgement, and third-party assertions remain intact.
- Both 180s loaded-runner waits remain while the startup fix soaks.
- Timeout failures retain bounded `AgentRuntime` and P2P snapshots as additional failure-classification evidence. GraphQL, peer, and replicator diagnostic calls are each bounded to two seconds; these diagnostics do not claim to prove reconciler task state.

## Rebase and parity evidence

Final head `b2819a01` is based on `a8f48f88` after merged R5 backgrounding PR #936.

#936 changed exactly four R5 conformance/support files:

- `crates/gents/tests/conformance/r5_scenarios.rs`
- `crates/gents/tests/support/mod.rs`
- `crates/gents/tests/support/r5_conformance/invariants.rs`
- `crates/gents/tests/support/r5_conformance/runner.rs`

None overlaps this PR's 14 files. The rebase was conflict-free. The stable patch ID remains `eeed27009aa3ef5ff73016b86ae3dbd1f0ddf197`, and the complete diff SHA-256 remains `aa798014575bbeea6a61d282eef66627afc28fc1c73cffbc32ed9e51ba72967e` before and after the base advance.

The prior base advance from `40d2d1c7` to `435c0cdb` was exactly #935's two CLI integration-test files, also with no overlap and the same stable patch ID.

## Validation

Combined R5 + #934 tree at `b2819a01` / `a8f48f88`:

- `cargo test -p gents` — pass: 1,186/1,186 unit tests, 319/319 conformance tests, and every runnable package integration suite; only declared live/external tests ignored
- all five merged #936 R5 scenario/conformance tests passed in that package run
- `cargo check --workspace --all-targets` — pass
- `cargo fmt --all -- --check` — pass
- `git diff --check origin/main..HEAD` — pass
- clean worktree and expected 14-file diff (`+322/-44`)

The first saturated local package attempt compiled successfully and ran 1,185/1,186 unit tests before `run_agent_shutdown_is_prompt_while_request_waits_for_backend_capacity` timed out waiting for its mock chat request. That unrelated test then passed once in isolation, 10/10 consecutive repetitions under continued load, and the complete warm package rerun above. No timeout or assertion was weakened.

Earlier exact proportional gates on the identical #934 patch also passed:

- `lake build Proofs.Conformance.Contracts:olean`
- exact production-loop retry/cancellation regression — 1/1
- exact generated sweep-retry witness — 1/1
- `cargo test -p gents --lib agent::p2p_reconcile::engine::tests::` — 46/46
- `cargo test -p gents --test conformance` — 319/319

Fresh exact-head CI is run `30487289093`.

## Independent review

- Grok 4.5 follow-up: **APPROVE**, no actionable findings.
- Claude Opus follow-up: **APPROVE**, no actionable findings after the daemon-level wiring test, infallible private-loop contract, paused-time immediate-tick proof, precise helper documentation, and corrected diagnostic claims were incorporated.
- Post-#932 repository review: **APPROVE**; it confirmed the generated-contract build changes do not overlap or regress this boundary witness.
- The final #936 rebase retained the independently reviewed patch byte-for-byte by complete diff hash and had no path overlap.
