### PR TITLE
test(cli): wait for startup quiescence before config writes

### DIFF
--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -4116,6 +4116,7 @@ async fn codex_shim_model_list_enumerates_backend_models() -> Result<()> {
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let create_extra_backend = format!(
         r#"mutation {{
@@ -4268,6 +4269,7 @@ async fn codex_shim_config_read_reflects_doc_mutation() -> Result<()> {
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let switch_behavior = format!(
         r#"mutation {{
@@ -4361,6 +4363,7 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let create_alt_backend = format!(
         r#"mutation {{
@@ -4854,6 +4857,7 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     // Add a principal-scoped skill via the CLI management command.
     let added = run_cli_json(
@@ -5307,6 +5311,7 @@ async fn codex_shim_explicit_selection_respects_effective_set() -> Result<()> {
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     // A BEHAVIOR-scoped skill, enabled, but NOT referenced by the bound behavior
     // (skill_refs is empty by default) -> not in its effective set.
@@ -5641,6 +5646,8 @@ async fn config_skill_cli_disable_enable_and_rm_round_trip() -> Result<()> {
 
     let mut serve = spawn_server_with_env(&home_dir, server_port, &[], &[])?;
     wait_for_port(server_port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     run_cli_json(
         &home_dir,
@@ -5851,6 +5858,7 @@ async fn config_skill_import_export_roundtrip_hermes() -> Result<()> {
     let mut serve = spawn_server_with_env(&home_dir, server_port, &[], &[])?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     // Import the hermes skill tree.
     let imported = run_cli_json(
@@ -6008,6 +6016,7 @@ async fn codex_shim_binds_when_config_apply_supplies_its_behavior() -> Result<()
     wait_for_port(server_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     // The runtime is up and healthy, but the shim has nothing to serve yet.
     assert!(

--- a/crates/gents-cli/tests/cli_config_apply_e2e.rs
+++ b/crates/gents-cli/tests/cli_config_apply_e2e.rs
@@ -125,6 +125,7 @@ async fn config_apply_reconciles_tool_services_tasks_and_schedules_end_to_end() 
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let planned = run_cli_json(&home_dir, &["config", "diff", "--root", root_str])?;
     assert_eq!(
@@ -674,6 +675,7 @@ async fn config_apply_accepts_explicit_empty_tool_selection_lists_twice() -> Res
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let applied = run_cli_json(&home_dir, &["config", "apply", "--root", root_str])?;
     assert_eq!(
@@ -872,6 +874,7 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let planned = run_cli_json(&home_dir, &["config", "diff", "--root", root_str])?;
     assert_eq!(
@@ -1278,6 +1281,7 @@ async fn prepare_live_validation_fixture(suffix: &str) -> Result<LiveValidationF
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     Ok(LiveValidationFixture {
         home_dir,
@@ -1473,6 +1477,7 @@ async fn config_apply_round_trips_write_tools_without_drift() -> Result<()> {
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
+    wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let applied = run_cli_json(&home_dir, &["config", "apply", "--root", root_str])?;
     assert_eq!(


### PR DESCRIPTION
## Summary

- wait for the initial runtime reconcile to become quiescent before immediate config writes in the two suites implicated by #927
- add the missing runtime-ready prerequisite to the skill CRUD fixture, which previously treated an open TCP port as schema readiness
- keep production transaction retries, errors, logging, APIs, and runtime behavior unchanged

This is a test-startup synchronization fix. The existing quiescence helper is bounded by a 45-second deadline and fails the test on timeout; these calls require generation 1 to be idle and stable for two seconds.

## Failure and deletion evidence

No tests or assertions are deleted. Main run `30456645923` / Rust job `90594122911` showed both failure modes:

- `codex_shim_explicit_selection_respects_effective_set` reached an explicit config transaction while startup writers were still active and failed commit with HTTP 409 `transaction conflict`
- `config_skill_cli_disable_enable_and_rm_round_trip` waited only for the TCP port and queried before the Skill schema was available (`Cannot query field "upsert_Skill"`)

The original #927 stress evidence also reproduced the HTTP 409 in `apply_accepts_event_trigger_with_valid_filter_and_doc_paths`. After rebasing onto #873, broad stress independently reproduced the same commit conflict in the late-behavior config-apply fixture before its guard was added. Runtime ready therefore was necessary but not sufficient: it can become observable before startup reconciliation and projection writes settle.

## Coverage map

- `cli_config_apply_e2e`: all 5 server setup paths that immediately apply config now wait for quiescence. Tests using the shared live-validation fixture inherit its guard.
- `cli_codex_shim`: all 8 setup paths in scope that immediately write config documents now wait for quiescence. The file has 9 added lines because the skill CRUD fixture also lacked `wait_for_runtime_ready`.
- the existing live `config_apply_running` concurrency test is unchanged, so deliberate live-write overlap coverage remains intact
- the separate broader Codex `thread/start` transaction conflict observed during stress is not hidden or folded into this patch; it is tracked in #933

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gents-cli --test cli_config_apply_e2e` — 7/7
- `cargo test -p gents-cli --test cli_codex_shim` — 30/30 runnable tests, 10 declared external/live ignores
- 20 complete `cli_config_apply_e2e` runs — 140/140
- 20 Codex skill-filter runs — 100/100 runnable tests plus 20 expected Hermes ignores
- 20 exact late-behavior config-apply runs — 20/20
- 10 exact runs for each of the three direct config-document fixtures identified during review — 30/30
- `cargo test -p gents-cli` — 518/518 unit tests plus every runnable integration test; declared external/live tests ignored
- `cargo check --workspace --all-targets`

## Independent review

- Grok semantic-parity review: PASS
- Claude Opus initial review identified three more direct config-document setup writes; those were added without broadening into session/thread writers
- Claude Opus follow-up on the final 14-line diff: APPROVE; independently verified the 5/5 + 8/8 setup map and fail-closed wait behavior

Closes #927
Related: #933