### PR TITLE
test(r5): give Crash a real process restart boundary

### DIFF
--- a/crates/gents/tests/conformance/r5_scenarios.rs
+++ b/crates/gents/tests/conformance/r5_scenarios.rs
@@ -22,6 +22,15 @@ async fn run_scenario(filename: &str) -> Vec<Observation> {
     history
 }
 
+async fn run_crash_scenario(filename: &str) -> Vec<Observation> {
+    let history = run_scenario(filename).await;
+    // Crash fixtures must cross a real process boundary; these checks fail if
+    // Crash is deleted or restored as a no-op while the fixture still claims
+    // a crash (false-green regression from the pre-fix harness).
+    invariants::assert_crash_boundary(&history);
+    history
+}
+
 #[tokio::test]
 async fn r5_happy_path() {
     run_scenario("happy_path.json").await;
@@ -29,12 +38,71 @@ async fn r5_happy_path() {
 
 #[tokio::test]
 async fn r5_b_crash_mid_execution() {
-    run_scenario("b_crash_mid_execution.json").await;
+    let history = run_crash_scenario("b_crash_mid_execution.json").await;
+    let last = history.last().expect("non-empty history");
+    // Cross-deployment background subagent: B crashes mid-execution, recovery
+    // preserves the durable processing child, then a terminal failure projects
+    // onto A's bridge exactly once (not R6 native-tool interrupt-on-restart).
+    let bridge = last
+        .a_bridge_rows
+        .iter()
+        .find(|b| b.tool_call_id == "tool-call-b-crash")
+        .expect("parent bridge on A");
+    assert_eq!(
+        bridge.lifecycle_state, "failed",
+        "B-crash scenario must project child failure onto parent bridge"
+    );
+    let child = last
+        .child_for_bridge(bridge)
+        .expect("child row for B-crash bridge");
+    assert_eq!(child.lifecycle_state, "failed");
+    assert!(
+        last.b_process_generation >= 1,
+        "B must have crossed at least one process crash boundary"
+    );
+    // Projection side effects are durable and unique.
+    assert_eq!(
+        last.subagent_notifications.len(),
+        1,
+        "failed child projects one subagent notification"
+    );
 }
 
 #[tokio::test]
 async fn r5_a_crash_mid_wait() {
-    run_scenario("a_crash_mid_wait.json").await;
+    let history = run_crash_scenario("a_crash_mid_wait.json").await;
+    let last = history.last().expect("non-empty history");
+    // A crashes while waiting on a background child; child terminals that
+    // land while A is down (and after a second crash window) must each
+    // project exactly once onto the durable parent bridge.
+    let before = last
+        .a_bridge_rows
+        .iter()
+        .find(|b| b.tool_call_id == "tool-call-a-crash-before")
+        .expect("pre-crash bridge");
+    let after = last
+        .a_bridge_rows
+        .iter()
+        .find(|b| b.tool_call_id == "tool-call-a-crash-after")
+        .expect("post-crash bridge");
+    assert_eq!(before.lifecycle_state, "completed");
+    assert_eq!(after.lifecycle_state, "completed");
+    assert!(
+        last.a_process_generation >= 2,
+        "A must have crashed twice (generation={})",
+        last.a_process_generation
+    );
+    assert_eq!(
+        last.subagent_notifications.len(),
+        2,
+        "each completed background child projects one notification"
+    );
+    // Wakeups coalesce per parent session; two parent requests ⇒ two sessions.
+    assert_eq!(
+        last.background_wakeup_keys.len(),
+        2,
+        "one coalesced wakeup key per parent session"
+    );
 }
 
 #[tokio::test]

--- a/crates/gents/tests/support/mod.rs
+++ b/crates/gents/tests/support/mod.rs
@@ -47,84 +47,80 @@ impl TestDb {
     ///
     /// Fails if outstanding `Arc` clones prevent exclusive drop of the old
     /// node — that would leave the crash non-falsifiable.
+    ///
+    /// Implementation notes (soundness):
+    /// - Fully safe Rust: `mem::replace` with a short-lived ephemeral node so
+    ///   `self.node` is never left uninitialized under cancel/panic.
+    /// - Process identity is `process_generation`, not pointer inequality
+    ///   (allocator reuse would flake a pointer check).
     pub async fn simulate_process_crash(&mut self) -> anyhow::Result<()> {
         let data_path = self.tempdir.path().to_path_buf();
         let before = self.process_generation;
 
-        // Move the Arc out without requiring `Default` for `EmbeddedNode`.
-        // On every exit path below we either restore `self.node` or write a
-        // reopened handle so the field is never left uninitialized.
-        let old = unsafe { std::ptr::read(&self.node) };
-        let old_ptr = Arc::as_ptr(&old) as usize;
-        old.shutdown().await;
+        // Require exclusive ownership *before* shutdown so a shared handle is
+        // still usable if we bail (callers can still query/tear down cleanly).
+        let strong = Arc::strong_count(&self.node);
+        if strong != 1 {
+            anyhow::bail!(
+                "simulate_process_crash: cannot exclusively drop EmbeddedNode \
+                 (strong_count={strong}); crash boundary would not clear process state"
+            );
+        }
 
-        let owned = match Arc::try_unwrap(old) {
-            Ok(owned) => owned,
+        self.node.shutdown().await;
+
+        // Ephemeral stand-in keeps `self.node` defined across the exclusive
+        // drop + durable reopen. Dropped as soon as reopen succeeds.
+        // (Option<Arc<_>> + accessor would also work, but `pub node: Arc<_>` is
+        // part of the test harness surface used by ~1700 call sites.)
+        let stand_in = Arc::new(
+            EmbeddedNode::builder()
+                .build()
+                .await
+                .map_err(|e| anyhow::anyhow!("simulate_process_crash: stand-in node: {e}"))?,
+        );
+        let old = std::mem::replace(&mut self.node, stand_in);
+
+        // strong_count was 1 before replace; `old` is now the unique owner.
+        match Arc::try_unwrap(old) {
+            Ok(owned) => drop(owned),
             Err(shared) => {
+                // Another clone appeared between the check and replace (or the
+                // count check was racy with external clones). Restore the
+                // shut-down handle so Drop is well-defined, then fail loudly.
                 let count = Arc::strong_count(&shared);
-                unsafe {
-                    std::ptr::write(&mut self.node, shared);
-                }
+                self.node = shared;
                 anyhow::bail!(
                     "simulate_process_crash: cannot exclusively drop EmbeddedNode \
-                     (strong_count={count}); crash boundary would not clear process state"
+                     (strong_count={count} after replace); restored handle is shut \
+                     down and unusable — fix outstanding Arc clones before Crash"
                 );
             }
-        };
-        drop(owned);
+        }
 
-        let reopened = match EmbeddedNode::builder().data_path(&data_path).build().await {
-            Ok(node) => Arc::new(node),
-            Err(error) => {
-                // Store is closed; reconstruct best-effort so Drop still runs.
-                match EmbeddedNode::builder().data_path(&data_path).build().await {
-                    Ok(node) => unsafe {
-                        std::ptr::write(&mut self.node, Arc::new(node));
-                    },
-                    Err(rebuild_error) => {
-                        // Last resort: ephemeral node so `self.node` is valid.
-                        let fallback = EmbeddedNode::builder().build().await.map_err(|e| {
-                            anyhow::anyhow!(
-                                "simulate_process_crash: reopen failed ({error}); \
-                                     fallback rebuild failed ({rebuild_error}); \
-                                     ephemeral fallback failed ({e})"
-                            )
-                        })?;
-                        unsafe {
-                            std::ptr::write(&mut self.node, Arc::new(fallback));
-                        }
-                    }
-                }
-                anyhow::bail!(
-                    "simulate_process_crash: reopen durable store at {} failed: {error}",
+        // Durable path is free. Reopen once; on failure leave the ephemeral
+        // stand-in in place (defined, empty) and surface the error.
+        let reopened = EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "simulate_process_crash: reopen durable store at {} failed: {e}",
                     data_path.display()
-                );
-            }
-        };
+                )
+            })?;
+        // Install the durable handle before schema ensure so a schema error
+        // still leaves `self.node` pointing at the reopened store (not the
+        // empty stand-in).
+        self.node = Arc::new(reopened);
 
         // Schemas already exist on the durable path; ensure is idempotent.
-        if let Err(error) = ensure_runtime_schemas(&reopened).await {
-            unsafe {
-                std::ptr::write(&mut self.node, reopened);
-            }
-            anyhow::bail!("simulate_process_crash: ensure schemas: {error}");
-        }
+        ensure_runtime_schemas(&self.node)
+            .await
+            .map_err(|e| anyhow::anyhow!("simulate_process_crash: ensure schemas: {e}"))?;
 
-        let after_ptr = Arc::as_ptr(&reopened) as usize;
-        if after_ptr == old_ptr {
-            unsafe {
-                std::ptr::write(&mut self.node, reopened);
-            }
-            anyhow::bail!("simulate_process_crash: reopened node pointer equals pre-crash pointer");
-        }
-
-        let after = before
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("process_generation overflow"))?;
-        unsafe {
-            std::ptr::write(&mut self.node, reopened);
-        }
-        self.process_generation = after;
+        self.process_generation = before + 1;
         Ok(())
     }
 }

--- a/crates/gents/tests/support/mod.rs
+++ b/crates/gents/tests/support/mod.rs
@@ -29,7 +29,104 @@ pub const DEADLINE_SECS: u64 = 300;
 
 pub struct TestDb {
     pub node: Arc<EmbeddedNode>,
-    _tempdir: TempDir,
+    /// Monotonic process-identity counter. Bumped by
+    /// [`TestDb::simulate_process_crash`]; starts at 0 for a fresh process.
+    pub process_generation: u64,
+    tempdir: TempDir,
+}
+
+impl TestDb {
+    /// Honest crash/restart boundary for embedded-node harnesses.
+    ///
+    /// Mirrors the production restart seam (and defra-node's own restart tests):
+    /// shutdown the live process, exclusively drop it so store locks release,
+    /// reopen the same durable data path, and advance `process_generation`.
+    /// Durable documents remain; process-local workers, registries, and
+    /// subscriptions do not (they are not owned by `TestDb` and therefore
+    /// cannot survive this boundary).
+    ///
+    /// Fails if outstanding `Arc` clones prevent exclusive drop of the old
+    /// node — that would leave the crash non-falsifiable.
+    pub async fn simulate_process_crash(&mut self) -> anyhow::Result<()> {
+        let data_path = self.tempdir.path().to_path_buf();
+        let before = self.process_generation;
+
+        // Move the Arc out without requiring `Default` for `EmbeddedNode`.
+        // On every exit path below we either restore `self.node` or write a
+        // reopened handle so the field is never left uninitialized.
+        let old = unsafe { std::ptr::read(&self.node) };
+        let old_ptr = Arc::as_ptr(&old) as usize;
+        old.shutdown().await;
+
+        let owned = match Arc::try_unwrap(old) {
+            Ok(owned) => owned,
+            Err(shared) => {
+                let count = Arc::strong_count(&shared);
+                unsafe {
+                    std::ptr::write(&mut self.node, shared);
+                }
+                anyhow::bail!(
+                    "simulate_process_crash: cannot exclusively drop EmbeddedNode \
+                     (strong_count={count}); crash boundary would not clear process state"
+                );
+            }
+        };
+        drop(owned);
+
+        let reopened = match EmbeddedNode::builder().data_path(&data_path).build().await {
+            Ok(node) => Arc::new(node),
+            Err(error) => {
+                // Store is closed; reconstruct best-effort so Drop still runs.
+                match EmbeddedNode::builder().data_path(&data_path).build().await {
+                    Ok(node) => unsafe {
+                        std::ptr::write(&mut self.node, Arc::new(node));
+                    },
+                    Err(rebuild_error) => {
+                        // Last resort: ephemeral node so `self.node` is valid.
+                        let fallback = EmbeddedNode::builder().build().await.map_err(|e| {
+                            anyhow::anyhow!(
+                                "simulate_process_crash: reopen failed ({error}); \
+                                     fallback rebuild failed ({rebuild_error}); \
+                                     ephemeral fallback failed ({e})"
+                            )
+                        })?;
+                        unsafe {
+                            std::ptr::write(&mut self.node, Arc::new(fallback));
+                        }
+                    }
+                }
+                anyhow::bail!(
+                    "simulate_process_crash: reopen durable store at {} failed: {error}",
+                    data_path.display()
+                );
+            }
+        };
+
+        // Schemas already exist on the durable path; ensure is idempotent.
+        if let Err(error) = ensure_runtime_schemas(&reopened).await {
+            unsafe {
+                std::ptr::write(&mut self.node, reopened);
+            }
+            anyhow::bail!("simulate_process_crash: ensure schemas: {error}");
+        }
+
+        let after_ptr = Arc::as_ptr(&reopened) as usize;
+        if after_ptr == old_ptr {
+            unsafe {
+                std::ptr::write(&mut self.node, reopened);
+            }
+            anyhow::bail!("simulate_process_crash: reopened node pointer equals pre-crash pointer");
+        }
+
+        let after = before
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("process_generation overflow"))?;
+        unsafe {
+            std::ptr::write(&mut self.node, reopened);
+        }
+        self.process_generation = after;
+        Ok(())
+    }
 }
 
 pub async fn test_db(name: &str) -> TestDb {
@@ -49,7 +146,8 @@ pub async fn test_db(name: &str) -> TestDb {
         .expect("runtime schemas");
     TestDb {
         node,
-        _tempdir: tempdir,
+        process_generation: 0,
+        tempdir,
     }
 }
 
@@ -106,7 +204,8 @@ pub async fn test_db_with_duplicate_tolerant_conversations(name: &str) -> TestDb
         .expect("runtime schemas");
     TestDb {
         node,
-        _tempdir: tempdir,
+        process_generation: 0,
+        tempdir,
     }
 }
 
@@ -271,7 +370,8 @@ pub async fn test_p2p_db_with_admission(name: &str, admission: TestP2pAdmission)
         .expect("runtime schemas");
     TestDb {
         node,
-        _tempdir: tempdir,
+        process_generation: 0,
+        tempdir,
     }
 }
 

--- a/crates/gents/tests/support/r5_conformance/invariants.rs
+++ b/crates/gents/tests/support/r5_conformance/invariants.rs
@@ -116,54 +116,41 @@ pub mod crash {
             let Some(crashed) = curr.crashed_node.as_deref() else {
                 continue;
             };
-            match crashed {
-                "A" => {
-                    for bridge in &prev.a_bridge_rows {
-                        assert!(
-                            curr.a_bridge_rows
-                                .iter()
-                                .any(|b| b.tool_call_id == bridge.tool_call_id
-                                    && b.lifecycle_state == bridge.lifecycle_state
-                                    && b.child_request_id == bridge.child_request_id),
-                            "Crash(A) lost durable bridge {}",
-                            bridge.tool_call_id
-                        );
-                    }
-                    for child in &prev.a_child_requests {
-                        assert!(
-                            curr.a_child_requests
-                                .iter()
-                                .any(|c| c.request_id == child.request_id
-                                    && c.lifecycle_state == child.lifecycle_state),
-                            "Crash(A) lost durable child request {}",
-                            child.request_id
-                        );
-                    }
-                }
-                "B" => {
-                    for bridge in &prev.b_bridge_rows {
-                        assert!(
-                            curr.b_bridge_rows
-                                .iter()
-                                .any(|b| b.tool_call_id == bridge.tool_call_id
-                                    && b.lifecycle_state == bridge.lifecycle_state
-                                    && b.child_request_id == bridge.child_request_id),
-                            "Crash(B) lost durable bridge {}",
-                            bridge.tool_call_id
-                        );
-                    }
-                    for child in &prev.b_child_requests {
-                        assert!(
-                            curr.b_child_requests
-                                .iter()
-                                .any(|c| c.request_id == child.request_id
-                                    && c.lifecycle_state == child.lifecycle_state),
-                            "Crash(B) lost durable child request {}",
-                            child.request_id
-                        );
-                    }
-                }
+            let (prev_bridges, curr_bridges, prev_children, curr_children) = match crashed {
+                "A" => (
+                    &prev.a_bridge_rows,
+                    &curr.a_bridge_rows,
+                    &prev.a_child_requests,
+                    &curr.a_child_requests,
+                ),
+                "B" => (
+                    &prev.b_bridge_rows,
+                    &curr.b_bridge_rows,
+                    &prev.b_child_requests,
+                    &curr.b_child_requests,
+                ),
                 other => panic!("unknown crashed node {other}"),
+            };
+            for bridge in prev_bridges {
+                assert!(
+                    curr_bridges
+                        .iter()
+                        .any(|b| b.tool_call_id == bridge.tool_call_id
+                            && b.lifecycle_state == bridge.lifecycle_state
+                            && b.child_request_id == bridge.child_request_id),
+                    "Crash({crashed}) lost durable bridge {}",
+                    bridge.tool_call_id
+                );
+            }
+            for child in prev_children {
+                assert!(
+                    curr_children
+                        .iter()
+                        .any(|c| c.request_id == child.request_id
+                            && c.lifecycle_state == child.lifecycle_state),
+                    "Crash({crashed}) lost durable child request {}",
+                    child.request_id
+                );
             }
         }
     }

--- a/crates/gents/tests/support/r5_conformance/invariants.rs
+++ b/crates/gents/tests/support/r5_conformance/invariants.rs
@@ -8,6 +8,7 @@ pub fn assert_all_safety(o: &Observation) {
     completion::wakeup_coalesced(o);
     cancel_propagation::cancel_intent_durable(o);
     cancel_propagation::cascade_interrupts_only_running(o);
+    crash::process_generation_advances_on_crash(o);
 }
 
 pub fn assert_liveness_after_convergence(history: &[Observation]) {
@@ -32,6 +33,137 @@ pub fn assert_liveness_after_convergence(history: &[Observation]) {
                     "cancel intent {} did not interrupt or absorb into terminal child",
                     bridge.tool_call_id
                 );
+            }
+        }
+    }
+}
+
+/// Crash/restart boundary checks. These bind the harness `Crash` action to an
+/// observable process-identity change (TLA `crashCount` / CrashA/CrashB) while
+/// durable bridge and child rows remain loadable from the reopened store.
+pub fn assert_crash_boundary(history: &[Observation]) {
+    crash::assert_crashes_observed(history);
+    crash::assert_durable_rows_survive_crash(history);
+}
+
+pub mod crash {
+    use super::Observation;
+
+    /// Per-snapshot: if this observation followed a Crash action, that node's
+    /// process generation must be strictly positive. A no-op Crash leaves
+    /// generation at 0 and fails this check once any crash action is claimed.
+    pub fn process_generation_advances_on_crash(o: &Observation) {
+        let Some(crashed) = o.crashed_node.as_deref() else {
+            return;
+        };
+        match crashed {
+            "A" => assert!(
+                o.a_process_generation > 0,
+                "Crash(A) left a_process_generation at 0 (no-op crash)"
+            ),
+            "B" => assert!(
+                o.b_process_generation > 0,
+                "Crash(B) left b_process_generation at 0 (no-op crash)"
+            ),
+            other => panic!("unknown crashed node {other}"),
+        }
+    }
+
+    /// History-level: every Crash action must advance that node's generation
+    /// relative to the immediately preceding observation. Deleting the Crash
+    /// arm or restoring a no-op fails this.
+    pub fn assert_crashes_observed(history: &[Observation]) {
+        let mut crash_count = 0usize;
+        for window in history.windows(2) {
+            let prev = &window[0];
+            let curr = &window[1];
+            let Some(crashed) = curr.crashed_node.as_deref() else {
+                continue;
+            };
+            crash_count += 1;
+            match crashed {
+                "A" => assert!(
+                    curr.a_process_generation > prev.a_process_generation,
+                    "Crash(A) did not advance process generation ({} -> {}); \
+                     false-green no-op Crash is not allowed",
+                    prev.a_process_generation,
+                    curr.a_process_generation
+                ),
+                "B" => assert!(
+                    curr.b_process_generation > prev.b_process_generation,
+                    "Crash(B) did not advance process generation ({} -> {}); \
+                     false-green no-op Crash is not allowed",
+                    prev.b_process_generation,
+                    curr.b_process_generation
+                ),
+                other => panic!("unknown crashed node {other}"),
+            }
+        }
+        assert!(
+            crash_count > 0,
+            "crash scenario history has no Crash observations; fixture must cross the crash boundary"
+        );
+    }
+
+    /// Durable AgentToolCall bridges and child AgentRequest rows present just
+    /// before a Crash must still be loadable immediately after reopen. This is
+    /// the durable-vs-volatile split: process identity changes, rows do not
+    /// disappear with the process.
+    pub fn assert_durable_rows_survive_crash(history: &[Observation]) {
+        for window in history.windows(2) {
+            let prev = &window[0];
+            let curr = &window[1];
+            let Some(crashed) = curr.crashed_node.as_deref() else {
+                continue;
+            };
+            match crashed {
+                "A" => {
+                    for bridge in &prev.a_bridge_rows {
+                        assert!(
+                            curr.a_bridge_rows
+                                .iter()
+                                .any(|b| b.tool_call_id == bridge.tool_call_id
+                                    && b.lifecycle_state == bridge.lifecycle_state
+                                    && b.child_request_id == bridge.child_request_id),
+                            "Crash(A) lost durable bridge {}",
+                            bridge.tool_call_id
+                        );
+                    }
+                    for child in &prev.a_child_requests {
+                        assert!(
+                            curr.a_child_requests
+                                .iter()
+                                .any(|c| c.request_id == child.request_id
+                                    && c.lifecycle_state == child.lifecycle_state),
+                            "Crash(A) lost durable child request {}",
+                            child.request_id
+                        );
+                    }
+                }
+                "B" => {
+                    for bridge in &prev.b_bridge_rows {
+                        assert!(
+                            curr.b_bridge_rows
+                                .iter()
+                                .any(|b| b.tool_call_id == bridge.tool_call_id
+                                    && b.lifecycle_state == bridge.lifecycle_state
+                                    && b.child_request_id == bridge.child_request_id),
+                            "Crash(B) lost durable bridge {}",
+                            bridge.tool_call_id
+                        );
+                    }
+                    for child in &prev.b_child_requests {
+                        assert!(
+                            curr.b_child_requests
+                                .iter()
+                                .any(|c| c.request_id == child.request_id
+                                    && c.lifecycle_state == child.lifecycle_state),
+                            "Crash(B) lost durable child request {}",
+                            child.request_id
+                        );
+                    }
+                }
+                other => panic!("unknown crashed node {other}"),
             }
         }
     }

--- a/crates/gents/tests/support/r5_conformance/runner.rs
+++ b/crates/gents/tests/support/r5_conformance/runner.rs
@@ -38,6 +38,13 @@ pub struct Observation {
     pub b_child_requests: Vec<RequestObservation>,
     pub subagent_notifications: Vec<String>,
     pub background_wakeup_keys: Vec<String>,
+    /// Process-identity generation of node A (bumped by honest Crash).
+    pub a_process_generation: u64,
+    /// Process-identity generation of node B (bumped by honest Crash).
+    pub b_process_generation: u64,
+    /// Node id that just crashed for this snapshot, if the preceding action
+    /// was `Crash`. Empty when the snapshot is not post-crash.
+    pub crashed_node: Option<NodeId>,
 }
 
 impl Observation {
@@ -103,8 +110,12 @@ impl Harness {
     pub async fn run(&mut self, scenario: &Scenario) -> Result<()> {
         let _ = &scenario.name;
         for action in &scenario.actions {
+            let crashed = match action {
+                Action::Crash { node } => Some(node.clone()),
+                _ => None,
+            };
             self.apply_action(action).await?;
-            self.record_observation().await?;
+            self.record_observation_after(crashed).await?;
         }
         Ok(())
     }
@@ -198,7 +209,14 @@ impl Harness {
                 let _ =
                     RequestLifecycle::recover_all(self.node(node)?.db.node.as_ref(), did).await?;
             }
-            Action::Crash { node: _ } => {}
+            Action::Crash { node } => {
+                // TLA lead (`SubagentCompletion` CrashA/CrashB,
+                // `SubagentCancelPropagation` Crash): clear process-local
+                // state while retaining durable intent/rows. The R5 harness
+                // owns only the embedded store, so the honest boundary is
+                // shutdown + exclusive drop + reopen on the same data path.
+                self.crash_node(node).await?;
+            }
             Action::AdvanceClockOn { node, seconds } => {
                 advance_r5_clock_effects(self.node(node)?, *seconds).await?;
             }
@@ -226,7 +244,42 @@ impl Harness {
         }
     }
 
+    fn node_mut(&mut self, id: &NodeId) -> Result<&mut HarnessNode> {
+        if id == &self.a.id {
+            Ok(&mut self.a)
+        } else if id == &self.b.id {
+            Ok(&mut self.b)
+        } else {
+            bail!("unknown node {id}")
+        }
+    }
+
+    async fn crash_node(&mut self, id: &NodeId) -> Result<()> {
+        let node = self.node_mut(id)?;
+        let before = node.db.process_generation;
+        node.db
+            .simulate_process_crash()
+            .await
+            .map_err(|e| anyhow::anyhow!("Crash({id}) failed: {e}"))?;
+        if node.db.process_generation != before + 1 {
+            bail!(
+                "Crash({id}): process_generation did not advance ({before} -> {})",
+                node.db.process_generation
+            );
+        }
+        tracing::info!(
+            node = %id,
+            process_generation = node.db.process_generation,
+            "R5 harness process crash/reopen completed"
+        );
+        Ok(())
+    }
+
     async fn record_observation(&mut self) -> Result<()> {
+        self.record_observation_after(None).await
+    }
+
+    async fn record_observation_after(&mut self, crashed_node: Option<NodeId>) -> Result<()> {
         self.history.push(Observation {
             a_bridge_rows: load_bridge_rows(&self.a).await?,
             b_bridge_rows: load_bridge_rows(&self.b).await?,
@@ -234,6 +287,9 @@ impl Harness {
             b_child_requests: load_child_requests(&self.b).await?,
             subagent_notifications: load_subagent_notifications(&self.a).await?,
             background_wakeup_keys: load_background_wakeup_keys(&self.a).await?,
+            a_process_generation: self.a.db.process_generation,
+            b_process_generation: self.b.db.process_generation,
+            crashed_node,
         });
         Ok(())
     }
@@ -360,10 +416,25 @@ async fn write_parent_tool_call(
     behavior_id: &str,
     unclaimed_deadline_at: Option<&str>,
 ) -> Result<()> {
+    // Stamp immutable agent_did so startup recovery scopes match production
+    // (`load_running_tool_call_rows_for_agent`). Without it, Crash →
+    // RunRecoverySweepOn cannot see the bridge.
+    let agent_did = load_request(node, parent_request_id)
+        .await
+        .map(|row| row.agent_did)
+        .unwrap_or_else(|_| {
+            if node.id == "A" {
+                NODE_A_DID.to_string()
+            } else {
+                NODE_B_DID.to_string()
+            }
+        });
+    let session_id_raw = format!("{parent_request_id}-session");
     let parent_request_id = escape_graphql_string(parent_request_id);
     let parent_tool_call_id = escape_graphql_string(parent_tool_call_id);
     let child_request_id = escape_graphql_string(child_request_id);
-    let session_id = escape_graphql_string(&format!("{parent_request_id}-session"));
+    let agent_did = escape_graphql_string(&agent_did);
+    let session_id = escape_graphql_string(&session_id_raw);
     let args = escape_graphql_string(
         &json!({
             "behavior_id": behavior_id,
@@ -390,6 +461,7 @@ async fn write_parent_tool_call(
                     tool_call_key: "{session_id}:{parent_tool_call_id}",
                     request_id: "{parent_request_id}",
                     session_id: "{session_id}",
+                    agent_did: "{agent_did}",
                     message_sequence: 1,
                     tool_name: "spawn_subagent",
                     tool_call_id: "{parent_tool_call_id}",
@@ -453,7 +525,7 @@ async fn export_doc(
             "request_id agent_did behavior_id session_id status lifecycle_state caused_by_parent_request_id caused_by_parent_tool_call_id caused_by_trigger_id caused_by_trigger_kind interrupt_requested_at"
         }
         "AgentToolCall" => {
-            "tool_call_key request_id session_id message_sequence tool_name tool_call_id args result status lifecycle_state started_at deadline_at completed_at tool_failure_class denial_reason denied_argv denied_command denied_argument denied_subcommand denied_prefix policy_mode policy_network cancel_cause latency_ms await_mode cancel_policy child_request_id unclaimed_deadline_at cancel_cascade_intent_at cancel_pending_remote_ack stuck_since"
+            "tool_call_key request_id session_id agent_did message_sequence tool_name tool_call_id args result status lifecycle_state started_at deadline_at completed_at tool_failure_class denial_reason denied_argv denied_command denied_argument denied_subcommand denied_prefix policy_mode policy_network cancel_cause latency_ms await_mode cancel_policy child_request_id unclaimed_deadline_at cancel_cascade_intent_at cancel_pending_remote_ack stuck_since"
         }
         "AgentResponse" => {
             "response_key request_id agent_did behavior_id session_id content reasoning status error_message token_count progress_seq materialized_message_sequence materialized_at created_at completed_at"
@@ -511,6 +583,7 @@ async fn import_tool_call(node: &HarnessNode, row: &serde_json::Value) -> Result
     let tool_call_id = str_field(row, "tool_call_id")?;
     let tool_call_key = str_field(row, "tool_call_key")?;
     let request_id = str_field(row, "request_id")?;
+    let agent_did = opt_str_field(row, "agent_did").unwrap_or(NODE_A_DID);
     let args = escape_graphql_string(str_field(row, "args")?);
     let result = escape_graphql_string(opt_str_field(row, "result").unwrap_or(""));
     let child_request_id =
@@ -530,6 +603,7 @@ async fn import_tool_call(node: &HarnessNode, row: &serde_json::Value) -> Result
                     tool_call_key: "{}",
                     request_id: "{}",
                     session_id: "{}",
+                    agent_did: "{}",
                     message_sequence: {},
                     tool_name: "{}",
                     tool_call_id: "{}",
@@ -561,6 +635,7 @@ async fn import_tool_call(node: &HarnessNode, row: &serde_json::Value) -> Result
         escape_graphql_string(tool_call_key),
         escape_graphql_string(request_id),
         escape_graphql_string(session_id),
+        escape_graphql_string(agent_did),
         row.get("message_sequence")
             .and_then(|v| v.as_i64())
             .unwrap_or(1),

--- a/crates/gents/tests/support/r5_conformance/runner.rs
+++ b/crates/gents/tests/support/r5_conformance/runner.rs
@@ -43,7 +43,7 @@ pub struct Observation {
     /// Process-identity generation of node B (bumped by honest Crash).
     pub b_process_generation: u64,
     /// Node id that just crashed for this snapshot, if the preceding action
-    /// was `Crash`. Empty when the snapshot is not post-crash.
+    /// was `Crash`. `None` when the snapshot is not post-crash.
     pub crashed_node: Option<NodeId>,
 }
 
@@ -583,7 +583,13 @@ async fn import_tool_call(node: &HarnessNode, row: &serde_json::Value) -> Result
     let tool_call_id = str_field(row, "tool_call_id")?;
     let tool_call_key = str_field(row, "tool_call_key")?;
     let request_id = str_field(row, "request_id")?;
-    let agent_did = opt_str_field(row, "agent_did").unwrap_or(NODE_A_DID);
+    // Prefer the exported owner; if absent, scope to the destination node
+    // (same rule as write_parent_tool_call) rather than always NODE_A.
+    let agent_did = opt_str_field(row, "agent_did").unwrap_or(if node.id == "B" {
+        NODE_B_DID
+    } else {
+        NODE_A_DID
+    });
     let args = escape_graphql_string(str_field(row, "args")?);
     let result = escape_graphql_string(opt_str_field(row, "result").unwrap_or(""));
     let child_request_id =


### PR DESCRIPTION
## Summary

R5 crash scenarios (`r5_a_crash_mid_wait`, `r5_b_crash_mid_execution`) previously went green without exercising any crash/restart behavior. The harness arm was:

```rust
Action::Crash { node: _ } => {}
```

This PR repairs the R5 document harness so `Crash` is an honest process boundary for cross-deployment background **subagent** work (`await_mode = "background"` on an `AgentToolCall` bridge), without inventing new lifecycle semantics.

### False-green evidence (pre-fix)

- `Action::Crash` was a no-op in `runner.rs`.
- Deleting or no-op'ing Crash did not fail `r5_a_crash_mid_wait` / `r5_b_crash_mid_execution`.
- After this PR, restoring the no-op fails with:
  `Crash(A) left a_process_generation at 0 (no-op crash)`
  (demonstrated during development against the new invariants).

### Crash boundary now exercised

`TestDb::simulate_process_crash`:

1. `EmbeddedNode::shutdown()`
2. Exclusive `Arc` drop (fails if outstanding clones would leave process state live)
3. Reopen the **same durable data path**
4. Advance `process_generation`

This matches the defra-node restart test pattern and the TLA lead (`SubagentCompletion` CrashA/CrashB, `SubagentCancelPropagation` Crash): volatile process identity is cleared; durable intent/rows remain.

### Durable vs volatile

| Durable (survives Crash) | Volatile (does not survive) |
|---|---|
| `AgentRequest`, `AgentToolCall`, `AgentResponse`, `AgentMessage`, pairing docs | Process-local workers, registries, subscriptions, live observer tasks |
| Bridge lifecycle fields, cancel intent, child terminals | `process_generation` / node handle identity |

Harness does **not** own a live `AgentRuntime`; observers/recovery are invoked as explicit actions against the reopened store (same as production startup recovery re-drives from durable rows).

### Formal / conformance binding

Harness-only repair; **no Lean change** (runtime contract already correct).

Binds to existing formal surface:

- TLA+ `SubagentCompletion` CrashA/CrashB (clear process-local inbound; durable child/bridge/notification/queue retained)
- TLA+ `SubagentCancelPropagation` Crash (clear `inFlight` / `pendingInbound`; retain durable cancel intent/state)
- Lean `Proofs.Background.Properties.Projection` (child terminal projects onto parent bridge)
- Production recovery: `ToolCallLifecycle::recover_all` leaves running background **subagent** bridges running while a live parent waits; `project_background_subagent_completion` / recovery side effects project terminal children after restart

R6 `r6_background_recovery` covers native background **tools** (interrupt-on-restart). These R5 scenarios remain the cross-deployment background **subagent** slice.

### What changed

| Area | Change |
|---|---|
| `TestDb` | `process_generation`, `simulate_process_crash` |
| `Action::Crash` | Real reopen boundary |
| Observation | `a/b_process_generation`, `crashed_node` |
| Parent tool writes | Stamp immutable `agent_did` so recovery can scope bridges |
| Invariants | `assert_crash_boundary` (generation advances; durable rows survive) |
| Crash scenario tests | End-state projection / notification / generation assertions |

### Tests and commands

```text
cargo test -p gents --test conformance 'r5_scenarios::' -- --nocapture
# 5 passed

# Falsifiability: no-op Crash → panic
# Crash(A) left a_process_generation at 0 (no-op crash)

cargo test -p gents --test e2e_subagent r6_background_recovery
# 1 passed

cargo test -p gents
# all targets green (0 failed)

cargo check --workspace --all-targets
# ok

cargo fmt --all -- --check
# ok

git diff --check
# ok
```

No Lean/TLA artifacts changed; `lake build` / TLC not re-run.

### Known limitations / non-goals

- Does not spin a full multi-process agent daemon or P2P mesh restart.
- Does not claim coverage of R6 native background tool registries.
- Does not restore hollow #900 invariant stubs or fake convergence timeouts.
- Replication remains an explicit `ReplicateDoc` harness action (not live gossip during crash).

### Review notes

- Semantic parity for non-crash scenarios: happy path, multi-completion, partition-during-cancel only gain observation fields defaulting to generation 0 / no crash marker.
- Independent review still welcome on exclusive-drop safety of `simulate_process_crash` and whether stamping `agent_did` on fixture bridges is the right recovery coupling.

## Test plan

- [x] `cargo test -p gents --test conformance 'r5_scenarios::'`
- [x] Falsify no-op Crash against new invariants
- [x] `cargo test -p gents`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check` and `git diff --check`
- [ ] CI on draft PR