### PR TITLE
fix(p2p): machine pairing fails to install its replicator — source_did must be @immutable

### DIFF
--- a/crates/gents-schemas/schemas/agent/agent_directory_entry.graphql
+++ b/crates/gents-schemas/schemas/agent/agent_directory_entry.graphql
@@ -18,7 +18,11 @@ type AgentDirectoryEntry @branchable {
     agent_did: String @index
     # DID of the runtime that derived this row. Machine replication filters
     # on this field, and each projector reconciles only its own partition.
-    source_did: String @index
+    # @immutable is REQUIRED: defradb rejects any replication-filter field
+    # that is not immutable at add_replicator time (see migration.rs's
+    # requester_did precedent) - and it is semantically immutable anyway,
+    # being half of the directory_key identity hash.
+    source_did: String @index @immutable
     display_name: String
     # Behavior display names for the picker. Emitted as null (never []) when
     # the principal has no behaviors - empty list literals corrupt nillable

--- a/crates/gents-schemas/src/lib.rs
+++ b/crates/gents-schemas/src/lib.rs
@@ -182,8 +182,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn all_contains_every_agent_schema() {
-        assert_eq!(ALL.len(), 33);
+    fn all_contains_every_agent_schema_file() {
+        let schema_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("schemas/agent");
+        let schema_file_count = std::fs::read_dir(schema_dir)
+            .expect("read agent schema directory")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry.path().extension().and_then(|ext| ext.to_str()) == Some("graphql")
+            })
+            .count();
+
+        assert_eq!(ALL.len(), schema_file_count);
     }
 
     #[test]

--- a/crates/gents/src/agent/directory_projection.rs
+++ b/crates/gents/src/agent/directory_projection.rs
@@ -497,7 +497,6 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
                     updated_at: "{now}"
                 }},
                 update: {{
-                    source_did: "{source_did}",
                     display_name: "{display_name}",
                     behaviors: {behaviors},
                     runtime_state: "{runtime_state}",
@@ -643,6 +642,23 @@ mod tests {
         assert_ne!(
             directory_entry_key("did:key:local-home", "did:key:shared-agent"),
             directory_entry_key("did:key:foreign-home", "did:key:shared-agent"),
+        );
+    }
+
+    #[test]
+    fn upsert_mutation_sets_immutable_source_did_only_when_adding() {
+        let mutation = upsert_directory_entry_mutation(
+            &entry("did:key:running", "2026-07-20T00:00:00Z"),
+            "2026-07-23T00:00:00Z",
+        );
+        let (add, update) = mutation
+            .split_once("update: {")
+            .expect("upsert mutation has update payload");
+
+        assert!(add.contains(r#"source_did: "did:key:home""#));
+        assert!(
+            !update.contains("source_did:"),
+            "immutable source_did must not be resent in update payload: {update}"
         );
     }
 

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -302,7 +302,7 @@ mod tests {
     use p2p::iroh::{IrohDiscoveryConfig, IrohRelayModeConfig};
 
     use super::*;
-    use crate::agent::p2p_reconcile::templates::SUBAGENT_HOST_TEMPLATE;
+    use crate::agent::p2p_reconcile::templates::{Scope, SUBAGENT_HOST_TEMPLATE};
     use crate::agent::p2p_reconcile::{resolve_template, scope_filter, FilterPredicate};
     use crate::defra_node::P2PConfig;
     use crate::ensure_runtime_schemas;
@@ -609,6 +609,8 @@ mod tests {
             .connect(&remote_addresses)
             .await
             .expect("connect remote");
+        wait_for_active_peer(&local_admin).await;
+        wait_for_active_peer(&remote_admin).await;
 
         for template in super::super::templates::builtin_templates() {
             if template.collections.is_empty() {
@@ -620,6 +622,28 @@ mod tests {
                 "did:key:z6MkPeerForFilterValidation",
                 "did:key:z6MkSelfForFilterValidation",
             );
+            match &template.scope {
+                Scope::Unscoped => assert!(
+                    filters.is_empty(),
+                    "unscoped template '{}' unexpectedly has filters",
+                    template.id
+                ),
+                Scope::PerCollection(_) => {
+                    let filter_collections =
+                        filters.keys().map(String::as_str).collect::<BTreeSet<_>>();
+                    let template_collections = template
+                        .collections
+                        .iter()
+                        .copied()
+                        .collect::<BTreeSet<_>>();
+                    assert_eq!(
+                        filter_collections, template_collections,
+                        "per-collection template '{}' must filter every collection",
+                        template.id
+                    );
+                }
+                Scope::PeerDid { .. } => {}
+            }
             local_admin
                 .add_replicator(
                     &remote_addresses,

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -588,6 +588,61 @@ mod tests {
         node.shutdown().await;
     }
 
+    /// Catalog-wide fence for defradb's replication-filter validation: every
+    /// builtin template's filter fields must be `@immutable` in the target
+    /// collection's schema, or `add_replicator` rejects the install at
+    /// pairing time (the exact failure that shipped in #873's merge: the
+    /// machine template filters `AgentDirectoryEntry.source_did`, which the
+    /// amended schema left mutable). Runs against real runtime schemas so a
+    /// new template or filter rule cannot pass review while violating the
+    /// constraint defradb only enforces at install time.
+    #[tokio::test]
+    async fn embedded_all_builtin_template_filters_pass_replicator_validation() {
+        let local_test = runtime_test_node().await;
+        let remote_test = runtime_test_node().await;
+        let local = Arc::clone(&local_test.node);
+        let remote = Arc::clone(&remote_test.node);
+        let local_admin = EmbeddedRemoteP2pAdmin::new(Arc::clone(&local));
+        let remote_admin = EmbeddedRemoteP2pAdmin::new(Arc::clone(&remote));
+        let remote_addresses = wait_for_peer_info(&remote_admin).await;
+        local_admin
+            .connect(&remote_addresses)
+            .await
+            .expect("connect remote");
+
+        for template in super::super::templates::builtin_templates() {
+            if template.collections.is_empty() {
+                continue; // app-collections: bring-your-own collection set.
+            }
+            let filters = super::super::templates::scope_filter(
+                &template.scope,
+                template.collections,
+                "did:key:z6MkPeerForFilterValidation",
+                "did:key:z6MkSelfForFilterValidation",
+            );
+            local_admin
+                .add_replicator(
+                    &remote_addresses,
+                    &template
+                        .collections
+                        .iter()
+                        .map(|c| (*c).to_string())
+                        .collect::<Vec<_>>(),
+                    &filters,
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "template '{}' filter set rejected by add_replicator: {error:#}",
+                        template.id
+                    )
+                });
+        }
+
+        local.shutdown().await;
+        remote.shutdown().await;
+    }
+
     #[tokio::test]
     async fn embedded_replicators_round_trip() {
         let local_test = test_node().await;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -258,6 +258,12 @@ Clients render an agent picker from it and address
 `AgentRequest`s to the picked `agent_did`. Existing `conversation` pairings
 are unchanged; re-pair with a machine QR to opt in.
 
+> **Upgrade note:** A home initialized with the pre-fix `AgentDirectoryEntry`
+> schema retains mutable `source_did`; DefraDB cannot safely change an existing
+> field to immutable. Upgrading the binary alone does not repair that home.
+> Recreate the home (or manually recreate this derived collection) before using
+> a `machine` pairing. Fresh homes are unaffected.
+
 ## Admin filtered replication
 
 The low-level `p2p admin replicators add` command accepts `--filter` to express


### PR DESCRIPTION
## Summary

Every `machine`-template pairing on current main fails to install its data-plane replicator:

```
add_replicator: replication filter field 'source_did' in collection '<AgentDirectoryEntry cid>' must be marked @immutable
```

defradb validates that replication-filter fields are `@immutable` at install time (the same rule migration.rs already documents for `requester_did`). The #873 merge amendments added the `source_did` partition filter to the machine template but left the field mutable in the SDL. Net effect observed live: bearer claim succeeds, phone pushes fine, but the server's reverse push never installs — chat clients hang on "thinking…" while the server visibly processes and streams.

## Fix

- `agent_directory_entry.graphql`: `source_did` gains `@immutable` (semantically correct regardless — it is half of the `directory_key` identity hash, which is already immutable), with a comment pointing at the defradb rule.
- **New catalog-wide fence** (`embedded_all_builtin_template_filters_pass_replicator_validation`): every builtin template's filter set is installed through real `add_replicator` against embedded nodes with the full runtime schemas. This is the validation defradb only performs at install time, now enforced at test time — a future template/filter/schema mismatch cannot ship again. RED reproduced the exact live error before the fix.
- Drive-by: `gents-schemas` `ALL.len()` count literal was stale (32 → 33 after BearerPairingReady landed) — `cargo test -p gents-schemas` fails on clean main; suggests CI does not run that crate's suite.

## Upgrade note

Homes bootstrapped between #873's merge and this fix carry the mutable-field collection and will keep failing after upgrading the binary; a fresh home (or manual collection recreation) is needed. Pre-#873 homes are unaffected (collection is created from the fixed SDL).

## Related

- #938 (bearer QR density — the other live-demo finding from the same session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Arv3YzUJH1oSvYL21kekca