### PR TITLE
test(schemas): update catalog cardinality assertions

### DIFF
--- a/crates/gents-protocol/src/schemas.rs
+++ b/crates/gents-protocol/src/schemas.rs
@@ -146,7 +146,7 @@ mod tests {
     fn all_contains_every_schema() {
         assert_eq!(
             ALL.len(),
-            37,
+            38,
             "ALL should enumerate every non-runtime schema"
         );
     }

--- a/crates/gents-schemas/src/lib.rs
+++ b/crates/gents-schemas/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn all_contains_every_agent_schema() {
-        assert_eq!(ALL.len(), 32);
+        assert_eq!(ALL.len(), 33);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Update the two schema-catalog cardinality assertions left stale when #873 added `AgentDirectoryEntry` to the canonical inventories.

- `gents-protocol`: 37 → 38 total protocol schemas (33 agent + 5 local)
- `gents-schemas`: 32 → 33 agent schema files

## Deletion / behavior evidence

This changes only two test constants. It does not change a schema, generated output, runtime path, feature gate, API, or regeneration workflow. The canonical inventories were enumerated directly before changing the expected counts.

Before the repair, the package gates failed with the catalog reporting 38/33 against stale expectations of 37/32. After the repair, both complete package suites pass.

## Parity evidence

The branch was rebased onto `528d4a891114ea6d371da9d5d19030508da59a0c` (`main` after #934). Its stable patch ID remained:

`b68bb90017c128df9237ae3e4784cf75a0044e1d`

The complete diff SHA-256 remained:

`5fdc236ad124fd542a35d1b9acf60ce2bd7cd536275a106ad2cb3907c3cf0b46`

An independent test-integrity review approved the change: both counts match the canonical inventories, and no runtime/generated arrays are touched.

## Validation

- `cargo test -p gents-schemas -p gents-protocol` — pass (4/4 schemas, 108/108 protocol, doc tests pass)
- `cargo check --workspace --all-targets` — pass
- `cargo fmt --all -- --check` — pass
- `git diff --check origin/main..HEAD` — pass

This PR intentionally lands before the isolated protocol clippy repair so that its full package suite is a meaningful green gate.