### PR TITLE
test(protocol): remove redundant request-options clone

### DIFF
--- a/crates/gents-protocol/src/graphql.rs
+++ b/crates/gents-protocol/src/graphql.rs
@@ -1125,7 +1125,7 @@ mod tx_tests {
             retry_backoff: std::time::Duration::from_millis(50),
         };
 
-        execute_graphql_async_with_tx(&endpoint, "{ __typename }", options.clone(), Some("42"))
+        execute_graphql_async_with_tx(&endpoint, "{ __typename }", options, Some("42"))
             .await
             .unwrap();
         assert_eq!(state.last_tx_header.lock().unwrap().as_deref(), Some("42"));


### PR DESCRIPTION
## Summary

Remove one redundant `.clone()` from the GraphQL transaction-header test. `GraphqlRequestOptions` derives `Copy`, so passing `options` to the first call performs the same field-wise bit copy and leaves the unchanged second call valid.

## Behavior and coverage evidence

The change is confined to one test expression in `crates/gents-protocol/src/graphql.rs`. The endpoint, query, transaction header, retry options, call order, unwraps, and both header assertions are byte-identical. No production path, public API, error string, retry behavior, feature gate, or test case is removed.

An independent review approved the change: the old clone and the implicit Copy pass have identical ownership and value semantics for the three Copy fields (`Duration`, `usize`, `Duration`).

## Current-main rebase / parity evidence

Rebased onto `5d8d862849729ad93d7e7561a0956d87bedf1215` (current `main` after #947). The stable patch ID remains:

`66d433e5819507394afd0067c8310d013895e2d4`

The complete binary diff SHA-256 remains:

`fcc1040cadbcacccda8059c1404be933d19d24ad5684490eeb8cb33ff5253872`

Exact head: `4ecf547c0a5e03c2d2b38649d41c1ff560d9755e`.

## Validation

- `cargo clippy -p gents-protocol --all-targets -- -D clippy::clone_on_copy` — pass
- `cargo check -p gents-protocol --all-targets` — pass
- `cargo test -p gents-protocol` — pass (108/108; doctests pass)
- `cargo check --workspace --all-targets` — passed on the unchanged patch before the current-main rebase
- `cargo fmt --all -- --check` — pass
- `git diff --check origin/main...HEAD` — pass

The full protocol suite now executes meaningfully because #940 repaired its stale schema-catalog cardinality assertion.