### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.9.0"
+        default: "0.10.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.9.0"
+        default: "0.10.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.10.0 - 2026-07-29
+
 ### Bridge contract
 
 - 0.5 (additive): merged #871 inference onboarding —
@@ -70,7 +72,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 | Tag        | Bridge crate | npm packages | contract_version | Notes                                         |
 | ---------- | ------------ | ------------ | ---------------- | --------------------------------------------- |
-| unreleased | 0.9.0        | 0.9.0        | 0.5              | Reusable desktop packages implemented in #878 |
+| v0.10.0    | 0.10.0       | 0.10.0       | 0.5              | Reusable desktop packages implemented in #878 |
 
 ## 0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7957,7 +7957,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8558,7 +8558,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -8617,7 +8617,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -8671,7 +8671,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8712,7 +8712,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8741,7 +8741,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -8765,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -8778,7 +8778,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -8790,7 +8790,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -8807,7 +8807,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -8844,7 +8844,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.9.0"
+version = "0.10.0"
 
 [[package]]
 name = "gethostname"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.9.0",
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-fleet": "0.9.0",
-    "@source-inc/gents-desktop-operations": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0",
+    "@source-inc/gents-desktop-chat": "0.10.0",
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-fleet": "0.10.0",
+    "@source-inc/gents-desktop-operations": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -53,12 +53,12 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-chat": "0.9.0",
-    "@source-inc/gents-desktop-fleet": "0.9.0",
-    "@source-inc/gents-desktop-operations": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0"
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-chat": "0.10.0",
+    "@source-inc/gents-desktop-fleet": "0.10.0",
+    "@source-inc/gents-desktop-operations": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0"
   },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.6.0",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.0</string>
+	<string>0.10.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.9.0</string>
+	<string>0.10.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -54,8 +54,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.9.0
-        CFBundleVersion: "0.9.0"
+        CFBundleShortVersionString: 0.10.0
+        CFBundleVersion: "0.10.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -266,7 +266,7 @@
     "desktop://client-updated",
     "desktop://codex-login-url"
   ],
-  "packageVersion": "0.9.0",
+  "packageVersion": "0.10.0",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.9.0
-docker run --rm ghcr.io/source-inc/gents:v0.9.0 version
+docker pull ghcr.io/source-inc/gents:v0.10.0
+docker run --rm ghcr.io/source-inc/gents:v0.10.0 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.9.0 \
+  ghcr.io/source-inc/gents:v0.10.0 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.9.0 \
+  ghcr.io/source-inc/gents:v0.10.0 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -18,14 +18,14 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.9.0",
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-fleet": "0.9.0",
-        "@source-inc/gents-desktop-operations": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-chat": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-fleet": "0.10.0",
+        "@source-inc/gents-desktop-operations": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,17 +43,17 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.9.0",
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-fleet": "0.9.0",
-        "@source-inc/gents-desktop-operations": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-chat": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-fleet": "0.10.0",
+        "@source-inc/gents-desktop-operations": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "fflate": "^0.8.2",
@@ -5088,12 +5088,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5103,9 +5103,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5115,7 +5115,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5127,16 +5127,16 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
         "jsqr": "^1.4.0"
       },
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5145,21 +5145,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5168,24 +5168,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.9.0",
-        "@source-inc/gents-desktop-tokens": "0.9.0",
-        "@source-inc/gents-desktop-ui": "0.9.0",
+        "@source-inc/gents-desktop-client": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-ui": "0.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.9.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5197,7 +5197,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.9.0",
+        "@source-inc/gents-desktop-tokens": "0.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0"
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0",
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,7 +15,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.9.0";
+export const PACKAGE_VERSION = "0.10.0";
 export const MINIMUM_BRIDGE_CONTRACT_VERSION = "0.5";
 
 export function assertCompatibleBridgeContract(

--- a/packages/gents-desktop-client/src/store.test.ts
+++ b/packages/gents-desktop-client/src/store.test.ts
@@ -36,7 +36,7 @@ describe("createDesktopStore", () => {
         },
         desktop_bridge_contract: () => ({
           contractVersion: "0.5",
-          packageVersion: "0.9.0",
+          packageVersion: "0.10.0",
           events: [],
           eventReasons: [],
           errorCodes: [],
@@ -66,7 +66,7 @@ describe("createDesktopStore", () => {
         desktop_client_start: () => ({}),
         desktop_bridge_contract: () => ({
           contractVersion: "0.5",
-          packageVersion: "0.9.0",
+          packageVersion: "0.10.0",
           events: [],
           eventReasons: [],
           errorCodes: [],

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "description": "Reusable peer discovery, pairing, health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -40,14 +40,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0"
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0",
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "description": "Reusable operations rail, liveness, health, lineage, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0"
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.9.0",
-    "@source-inc/gents-desktop-tokens": "0.9.0",
-    "@source-inc/gents-desktop-ui": "0.9.0",
+    "@source-inc/gents-desktop-client": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-ui": "0.10.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.9.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.9.0",
+    "@source-inc/gents-desktop-tokens": "0.10.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary

- bump the Rust workspace and all desktop npm/Tauri/iOS package metadata to `0.10.0`
- regenerate Cargo/npm lockfile workspace entries and the desktop bridge package fingerprint
- update release workflow defaults, container examples, and changelog compatibility metadata

## Why

`v0.10.0` ships the completed durable DefraDB migration/materialization cutover merged in #931. Release workflows require the tag, Cargo workspace, desktop packages, and bridge contract metadata to match exactly.

## Validation

- `npm run check:package-boundaries`
- `cargo metadata --locked --no-deps --format-version 1`
- `npm run test --if-present -w @source-inc/gents-desktop-client` (8 passed)
- `git diff --check`

The `main` CI run for #931 reached 318/319 conformance tests and hit an unrelated existing readiness-timeout flake in `generated_streaming_response_interrupt_flow_cases_drive_daemon_contract`; the previously failing conformance-home check is fixed.