### PR TITLE
fix(release): install Lean for desktop package tests

### DIFF
--- a/.github/workflows/release-desktop-packages.yml
+++ b/.github/workflows/release-desktop-packages.yml
@@ -33,6 +33,12 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" --version
+
       - name: Install workspace dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Install `elan` in the desktop package release workflow before running package tests.

## Root cause

The `@source-inc/gents-desktop-chat` suite invokes `lake build Proofs.Conformance.Contracts`, but `release-desktop-packages.yml` only installed Node. The initial `v0.10.0` run therefore failed with `spawnSync lake ENOENT` after package builds and the other suites passed.

## Validation

- workflow setup matches the established `Install elan` step in CI and desktop UI QA
- `git diff --check`
- targeted chat test found `/opt/homebrew/bin/lake` and advanced past the missing-tool failure; its redundant local Lean compilation was stopped to prioritize the release rerun