### PR TITLE
style: format merged migration code

### DIFF
--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -187,7 +187,10 @@ async fn apply_add_collection(
 
     // If a pin is present, locate and verify the active version by scanning.
     if let Some(pin) = expected_version {
-        let versions = node.get_all_collection_versions().await.map_err(Error::Node)?;
+        let versions = node
+            .get_all_collection_versions()
+            .await
+            .map_err(Error::Node)?;
         let Some(active) = versions
             .iter()
             .find(|v| v.version_id == pin && !v.is_placeholder)
@@ -255,7 +258,10 @@ async fn apply_patch_versioned(
     }
 
     // Locate destination state among all versions.
-    let all = node.get_all_collection_versions().await.map_err(Error::Node)?;
+    let all = node
+        .get_all_collection_versions()
+        .await
+        .map_err(Error::Node)?;
     let dest = all.iter().find(|v| v.version_id == pin);
 
     match dest {
@@ -263,11 +269,13 @@ async fn apply_patch_versioned(
             // destination absent → attach (if lens), then patch inactive.
             if let Some(spec) = lens_spec {
                 let cfg = lens::lens_config(&spec, &active.version_id, pin);
-                node.set_migration(cfg).await.map_err(|e| Error::StepFailed {
-                    step: id.to_string(),
-                    collection: collection.to_string(),
-                    source: e,
-                })?;
+                node.set_migration(cfg)
+                    .await
+                    .map_err(|e| Error::StepFailed {
+                        step: id.to_string(),
+                        collection: collection.to_string(),
+                        source: e,
+                    })?;
             }
             let patched = node
                 .patch_collection(collection, patch)
@@ -481,18 +489,17 @@ async fn repair_transform_if_needed(
         });
     };
     let cfg = lens::lens_config(&spec, source, dest);
-    node.set_migration(cfg).await.map_err(|e| Error::StepFailed {
-        step: id.to_string(),
-        collection: collection.to_string(),
-        source: e,
-    })?;
+    node.set_migration(cfg)
+        .await
+        .map_err(|e| Error::StepFailed {
+            step: id.to_string(),
+            collection: collection.to_string(),
+            source: e,
+        })?;
     report.edges_repaired += 1;
     info!(
         step = id,
-        collection,
-        source,
-        dest,
-        "repaired missing migration edge transform"
+        collection, source, dest, "repaired missing migration edge transform"
     );
     Ok(())
 }
@@ -545,7 +552,10 @@ async fn verify_managed_lineages(
     registry: &Registry<'_>,
     _report: &mut MigrationReport,
 ) -> Result<()> {
-    let all_versions = node.get_all_collection_versions().await.map_err(Error::Node)?;
+    let all_versions = node
+        .get_all_collection_versions()
+        .await
+        .map_err(Error::Node)?;
 
     // Group non-placeholder versions by collection name.
     let mut by_name: HashMap<String, Vec<&CollectionVersion>> = HashMap::new();
@@ -646,14 +656,13 @@ fn verify_one_collection(
     known_pins: &HashSet<String>,
     target_active: &HashMap<String, String>,
 ) -> Result<()> {
-    let versions = by_name.get(entry.name).ok_or_else(|| Error::CollectionMissing {
-        collection: entry.name.to_string(),
-    })?;
+    let versions = by_name
+        .get(entry.name)
+        .ok_or_else(|| Error::CollectionMissing {
+            collection: entry.name.to_string(),
+        })?;
 
-    let non_ph: Vec<&&CollectionVersion> = versions
-        .iter()
-        .filter(|v| !v.is_placeholder)
-        .collect();
+    let non_ph: Vec<&&CollectionVersion> = versions.iter().filter(|v| !v.is_placeholder).collect();
 
     if non_ph.is_empty() {
         return Err(Error::CollectionMissing {
@@ -702,8 +711,13 @@ fn verify_one_collection(
             return Err(Error::VersionPinMismatch {
                 collection: entry.name.to_string(),
                 expected: root.to_string(),
-                actual: format!("root missing; versions={:?}",
-                    non_ph.iter().map(|v| v.version_id.as_str()).collect::<Vec<_>>()),
+                actual: format!(
+                    "root missing; versions={:?}",
+                    non_ph
+                        .iter()
+                        .map(|v| v.version_id.as_str())
+                        .collect::<Vec<_>>()
+                ),
             });
         }
     }

--- a/crates/gents-migration/src/expectation.rs
+++ b/crates/gents-migration/src/expectation.rs
@@ -122,8 +122,8 @@ pub fn descriptor_digest(version: &CollectionVersion) -> String {
     //
     // Prefer a real sha2 when pins are authored in Phase B; for now the digest
     // is only compared when `descriptor_digest: Some(...)` is set.
-    let bytes = serde_json::to_vec(&normalize_descriptor(version))
-        .unwrap_or_else(|_| b"{}".to_vec());
+    let bytes =
+        serde_json::to_vec(&normalize_descriptor(version)).unwrap_or_else(|_| b"{}".to_vec());
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     bytes.hash(&mut hasher);
     format!("{:016x}", hasher.finish())

--- a/crates/gents-migration/tests/baseline_ensure.rs
+++ b/crates/gents-migration/tests/baseline_ensure.rs
@@ -48,7 +48,11 @@ async fn ensure_migrations_registers_baseline_and_is_idempotent() {
             .expect("get_collection")
             .unwrap_or_else(|| panic!("missing collection {}", entry.name));
         assert!(cv.is_active, "{} should be active", entry.name);
-        assert!(!cv.is_placeholder, "{} should not be placeholder", entry.name);
+        assert!(
+            !cv.is_placeholder,
+            "{} should not be placeholder",
+            entry.name
+        );
     }
 
     node.shutdown().await;

--- a/crates/gents-migration/tests/phase_b_steps.rs
+++ b/crates/gents-migration/tests/phase_b_steps.rs
@@ -145,7 +145,9 @@ async fn patch_versioned_with_fixture_lens_registers_transform() {
     let wasm = fixture_lens_wasm();
     // Stub wasm is 8 bytes — skip full lens path if build was stubbed.
     if wasm.len() <= 16 {
-        eprintln!("skipping fixture lens e2e: stub wasm (set wasm target / unset GENTS_SKIP_LENS_BUILD)");
+        eprintln!(
+            "skipping fixture lens e2e: stub wasm (set wasm target / unset GENTS_SKIP_LENS_BUILD)"
+        );
         return;
     }
 

--- a/crates/gents/src/schema.rs
+++ b/crates/gents/src/schema.rs
@@ -34,7 +34,9 @@ pub use gents_protocol::schemas::{
 /// Replaced by the full baseline. Kept as a name alias so docs/tests that
 /// still mention the six-collection init subset compile; calling
 /// [`ensure_config_bootstrap_schemas`] registers the **full** baseline.
-#[deprecated(note = "partial bootstrap forks lineage; use ensure_migrations / ensure_runtime_schemas")]
+#[deprecated(
+    note = "partial bootstrap forks lineage; use ensure_migrations / ensure_runtime_schemas"
+)]
 pub const CONFIG_BOOTSTRAP: &[&str] = &[
     AGENT_PRINCIPAL_SCHEMA,
     AGENT_BEHAVIOR_SCHEMA,


### PR DESCRIPTION
## Summary

Restore the repository-wide rustfmt gate after migration PR #931 landed unformatted source. This is the exact output of `cargo fmt --all` across the five files reported by the failing gate.

## Evidence

- Current main parent `c873acbe` fails `cargo fmt --all -- --check` in these five files.
- Formatting an archived copy of the original #931 merge parent and comparing the entire tracked tree against this commit produced a byte-for-byte match.
- Token-aware comparison found zero added or removed tokens; identifiers, operators, literals, and comment wording are unchanged.
- Stable patch ID remained `2a2b0061429da07785d2a6e8f4e28bd69001fcb5` through the #942 and #943 rebases.
- No tests, assertions, runtime logic, APIs, errors, logging, or generated outputs are changed.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check HEAD^ HEAD`
- `cargo check --workspace --all-targets` on exact head/base `c873acbe`
- Independent semantic-parity review: APPROVE, no findings

## Diff

Five files, 53 insertions / 31 deletions, formatting only.