### PR TITLE
ci: restore post-migration gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,12 @@ jobs:
         run: cargo check --workspace --all-targets
 
       - name: Build the WASM lens target
-        run: cargo build -p agent-tool-call-lifecycle-v1-to-v2-lens --target wasm32-unknown-unknown
+        run: cargo build -p gents-lens-fixture-add-label --target wasm32-unknown-unknown
+
+      - name: Run migration package tests
+        run: |
+          cargo test -p gents-migration
+          cargo test -p gents-lens-fixture-add-label
 
       # Guards the noq 1.0.1 active_connections underflow fix (gents#634 /
       # n0-computer/noq#743). Vendored under third_party/; not a workspace member.

--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -187,7 +187,10 @@ async fn apply_add_collection(
 
     // If a pin is present, locate and verify the active version by scanning.
     if let Some(pin) = expected_version {
-        let versions = node.get_all_collection_versions().await.map_err(Error::Node)?;
+        let versions = node
+            .get_all_collection_versions()
+            .await
+            .map_err(Error::Node)?;
         let Some(active) = versions
             .iter()
             .find(|v| v.version_id == pin && !v.is_placeholder)
@@ -255,7 +258,10 @@ async fn apply_patch_versioned(
     }
 
     // Locate destination state among all versions.
-    let all = node.get_all_collection_versions().await.map_err(Error::Node)?;
+    let all = node
+        .get_all_collection_versions()
+        .await
+        .map_err(Error::Node)?;
     let dest = all.iter().find(|v| v.version_id == pin);
 
     match dest {
@@ -263,11 +269,13 @@ async fn apply_patch_versioned(
             // destination absent → attach (if lens), then patch inactive.
             if let Some(spec) = lens_spec {
                 let cfg = lens::lens_config(&spec, &active.version_id, pin);
-                node.set_migration(cfg).await.map_err(|e| Error::StepFailed {
-                    step: id.to_string(),
-                    collection: collection.to_string(),
-                    source: e,
-                })?;
+                node.set_migration(cfg)
+                    .await
+                    .map_err(|e| Error::StepFailed {
+                        step: id.to_string(),
+                        collection: collection.to_string(),
+                        source: e,
+                    })?;
             }
             let patched = node
                 .patch_collection(collection, patch)
@@ -481,18 +489,17 @@ async fn repair_transform_if_needed(
         });
     };
     let cfg = lens::lens_config(&spec, source, dest);
-    node.set_migration(cfg).await.map_err(|e| Error::StepFailed {
-        step: id.to_string(),
-        collection: collection.to_string(),
-        source: e,
-    })?;
+    node.set_migration(cfg)
+        .await
+        .map_err(|e| Error::StepFailed {
+            step: id.to_string(),
+            collection: collection.to_string(),
+            source: e,
+        })?;
     report.edges_repaired += 1;
     info!(
         step = id,
-        collection,
-        source,
-        dest,
-        "repaired missing migration edge transform"
+        collection, source, dest, "repaired missing migration edge transform"
     );
     Ok(())
 }
@@ -545,7 +552,10 @@ async fn verify_managed_lineages(
     registry: &Registry<'_>,
     _report: &mut MigrationReport,
 ) -> Result<()> {
-    let all_versions = node.get_all_collection_versions().await.map_err(Error::Node)?;
+    let all_versions = node
+        .get_all_collection_versions()
+        .await
+        .map_err(Error::Node)?;
 
     // Group non-placeholder versions by collection name.
     let mut by_name: HashMap<String, Vec<&CollectionVersion>> = HashMap::new();
@@ -646,14 +656,13 @@ fn verify_one_collection(
     known_pins: &HashSet<String>,
     target_active: &HashMap<String, String>,
 ) -> Result<()> {
-    let versions = by_name.get(entry.name).ok_or_else(|| Error::CollectionMissing {
-        collection: entry.name.to_string(),
-    })?;
+    let versions = by_name
+        .get(entry.name)
+        .ok_or_else(|| Error::CollectionMissing {
+            collection: entry.name.to_string(),
+        })?;
 
-    let non_ph: Vec<&&CollectionVersion> = versions
-        .iter()
-        .filter(|v| !v.is_placeholder)
-        .collect();
+    let non_ph: Vec<&&CollectionVersion> = versions.iter().filter(|v| !v.is_placeholder).collect();
 
     if non_ph.is_empty() {
         return Err(Error::CollectionMissing {
@@ -702,8 +711,13 @@ fn verify_one_collection(
             return Err(Error::VersionPinMismatch {
                 collection: entry.name.to_string(),
                 expected: root.to_string(),
-                actual: format!("root missing; versions={:?}",
-                    non_ph.iter().map(|v| v.version_id.as_str()).collect::<Vec<_>>()),
+                actual: format!(
+                    "root missing; versions={:?}",
+                    non_ph
+                        .iter()
+                        .map(|v| v.version_id.as_str())
+                        .collect::<Vec<_>>()
+                ),
             });
         }
     }

--- a/crates/gents-migration/src/expectation.rs
+++ b/crates/gents-migration/src/expectation.rs
@@ -122,8 +122,8 @@ pub fn descriptor_digest(version: &CollectionVersion) -> String {
     //
     // Prefer a real sha2 when pins are authored in Phase B; for now the digest
     // is only compared when `descriptor_digest: Some(...)` is set.
-    let bytes = serde_json::to_vec(&normalize_descriptor(version))
-        .unwrap_or_else(|_| b"{}".to_vec());
+    let bytes =
+        serde_json::to_vec(&normalize_descriptor(version)).unwrap_or_else(|_| b"{}".to_vec());
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     bytes.hash(&mut hasher);
     format!("{:016x}", hasher.finish())

--- a/crates/gents-migration/tests/baseline_ensure.rs
+++ b/crates/gents-migration/tests/baseline_ensure.rs
@@ -48,7 +48,11 @@ async fn ensure_migrations_registers_baseline_and_is_idempotent() {
             .expect("get_collection")
             .unwrap_or_else(|| panic!("missing collection {}", entry.name));
         assert!(cv.is_active, "{} should be active", entry.name);
-        assert!(!cv.is_placeholder, "{} should not be placeholder", entry.name);
+        assert!(
+            !cv.is_placeholder,
+            "{} should not be placeholder",
+            entry.name
+        );
     }
 
     node.shutdown().await;

--- a/crates/gents-migration/tests/phase_b_steps.rs
+++ b/crates/gents-migration/tests/phase_b_steps.rs
@@ -145,7 +145,9 @@ async fn patch_versioned_with_fixture_lens_registers_transform() {
     let wasm = fixture_lens_wasm();
     // Stub wasm is 8 bytes — skip full lens path if build was stubbed.
     if wasm.len() <= 16 {
-        eprintln!("skipping fixture lens e2e: stub wasm (set wasm target / unset GENTS_SKIP_LENS_BUILD)");
+        eprintln!(
+            "skipping fixture lens e2e: stub wasm (set wasm target / unset GENTS_SKIP_LENS_BUILD)"
+        );
         return;
     }
 

--- a/crates/gents/src/schema.rs
+++ b/crates/gents/src/schema.rs
@@ -34,7 +34,9 @@ pub use gents_protocol::schemas::{
 /// Replaced by the full baseline. Kept as a name alias so docs/tests that
 /// still mention the six-collection init subset compile; calling
 /// [`ensure_config_bootstrap_schemas`] registers the **full** baseline.
-#[deprecated(note = "partial bootstrap forks lineage; use ensure_migrations / ensure_runtime_schemas")]
+#[deprecated(
+    note = "partial bootstrap forks lineage; use ensure_migrations / ensure_runtime_schemas"
+)]
 pub const CONFIG_BOOTSTRAP: &[&str] = &[
     AGENT_PRINCIPAL_SCHEMA,
     AGENT_BEHAVIOR_SCHEMA,

--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -345,7 +345,6 @@ declare -a ALLOWLIST=(
 # - defradb / defradb.rs
 # - defra-core, defra-node, defra-p2p-adapter (upstream DefraDB crates)
 # - agent_did, AgentRequest, AgentResponse, AgentToolCall (domain nouns)
-# - agent-tool-call-lifecycle-v1-to-v2-lens (lens name = domain vocabulary)
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

This two-commit bootstrap repairs the two mutually blocking CI regressions introduced by #931:

1. retarget the deleted migration-lens WASM package and explicitly run both migration package suites
2. apply only rustfmt output to the merged migration code

These were prepared and reviewed as independent slices, but neither can produce a green PR alone: the CI-wiring slice inherits the formatting failure from main, while the formatting slice reaches the deleted-package command. Keeping the two reviewed commits together is the narrow path that preserves the merge-green rule.

## CI wiring evidence

The previous WASM command deterministically exits 101 because agent-tool-call-lifecycle-v1-to-v2-lens no longer exists. Cargo metadata identifies gents-lens-fixture-add-label as the canonical current lens crate consumed by the migration build.

The new unfiltered package commands close a #898-class false-green gap:

- gents-migration: 13 non-doc tests; one ignored doctest
- gents-lens-fixture-add-label: 3 tests

A missing package, vanished suite, compile failure, or test failure now fails CI.

## Formatting parity evidence

The second commit has stable patch ID 2a2b0061429da07785d2a6e8f4e28bd69001fcb5, identical to the independently reviewed formatting PR. It is exactly cargo fmt output across five Rust files. Whole-tree byte comparison against an archived rustfmt result matched, and token-aware comparison found zero added or deleted Rust tokens.

The two commits touch disjoint file sets and retain their independently reviewed patch IDs.

## Validation

- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo build -p gents-lens-fixture-add-label --target wasm32-unknown-unknown
- cargo test -p gents-migration
- cargo test -p gents-lens-fixture-add-label
- bash -n scripts/rename-to-gents.sh
- scripts/rename-to-gents.sh self-test
- scripts/rename-to-gents.sh guard all
- cargo metadata --no-deps resolves both package IDs
- git diff --check

Independent reviews of both constituent patches: APPROVE with no findings. Final composition review: APPROVE with no findings; patch identities, disjoint file sets, gate failures, and absence of order-dependent interaction were independently verified.