### PR TITLE
fix(migration): hard-fail materialize + restore post-migration CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,12 @@ jobs:
         run: cargo check --workspace --all-targets
 
       - name: Build the WASM lens target
-        run: cargo build -p agent-tool-call-lifecycle-v1-to-v2-lens --target wasm32-unknown-unknown
+        run: cargo build -p gents-lens-fixture-add-label --target wasm32-unknown-unknown
+
+      - name: Run migration package tests
+        run: |
+          cargo test -p gents-migration
+          cargo test -p gents-lens-fixture-add-label
 
       # Guards the noq 1.0.1 active_connections underflow fix (gents#634 /
       # n0-computer/noq#743). Vendored under third_party/; not a workspace member.

--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -187,7 +187,10 @@ async fn apply_add_collection(
 
     // If a pin is present, locate and verify the active version by scanning.
     if let Some(pin) = expected_version {
-        let versions = node.get_all_collection_versions().await.map_err(Error::Node)?;
+        let versions = node
+            .get_all_collection_versions()
+            .await
+            .map_err(Error::Node)?;
         let Some(active) = versions
             .iter()
             .find(|v| v.version_id == pin && !v.is_placeholder)
@@ -255,7 +258,10 @@ async fn apply_patch_versioned(
     }
 
     // Locate destination state among all versions.
-    let all = node.get_all_collection_versions().await.map_err(Error::Node)?;
+    let all = node
+        .get_all_collection_versions()
+        .await
+        .map_err(Error::Node)?;
     let dest = all.iter().find(|v| v.version_id == pin);
 
     match dest {
@@ -263,11 +269,13 @@ async fn apply_patch_versioned(
             // destination absent → attach (if lens), then patch inactive.
             if let Some(spec) = lens_spec {
                 let cfg = lens::lens_config(&spec, &active.version_id, pin);
-                node.set_migration(cfg).await.map_err(|e| Error::StepFailed {
-                    step: id.to_string(),
-                    collection: collection.to_string(),
-                    source: e,
-                })?;
+                node.set_migration(cfg)
+                    .await
+                    .map_err(|e| Error::StepFailed {
+                        step: id.to_string(),
+                        collection: collection.to_string(),
+                        source: e,
+                    })?;
             }
             let patched = node
                 .patch_collection(collection, patch)
@@ -481,18 +489,17 @@ async fn repair_transform_if_needed(
         });
     };
     let cfg = lens::lens_config(&spec, source, dest);
-    node.set_migration(cfg).await.map_err(|e| Error::StepFailed {
-        step: id.to_string(),
-        collection: collection.to_string(),
-        source: e,
-    })?;
+    node.set_migration(cfg)
+        .await
+        .map_err(|e| Error::StepFailed {
+            step: id.to_string(),
+            collection: collection.to_string(),
+            source: e,
+        })?;
     report.edges_repaired += 1;
     info!(
         step = id,
-        collection,
-        source,
-        dest,
-        "repaired missing migration edge transform"
+        collection, source, dest, "repaired missing migration edge transform"
     );
     Ok(())
 }
@@ -545,7 +552,10 @@ async fn verify_managed_lineages(
     registry: &Registry<'_>,
     _report: &mut MigrationReport,
 ) -> Result<()> {
-    let all_versions = node.get_all_collection_versions().await.map_err(Error::Node)?;
+    let all_versions = node
+        .get_all_collection_versions()
+        .await
+        .map_err(Error::Node)?;
 
     // Group non-placeholder versions by collection name.
     let mut by_name: HashMap<String, Vec<&CollectionVersion>> = HashMap::new();
@@ -646,14 +656,13 @@ fn verify_one_collection(
     known_pins: &HashSet<String>,
     target_active: &HashMap<String, String>,
 ) -> Result<()> {
-    let versions = by_name.get(entry.name).ok_or_else(|| Error::CollectionMissing {
-        collection: entry.name.to_string(),
-    })?;
+    let versions = by_name
+        .get(entry.name)
+        .ok_or_else(|| Error::CollectionMissing {
+            collection: entry.name.to_string(),
+        })?;
 
-    let non_ph: Vec<&&CollectionVersion> = versions
-        .iter()
-        .filter(|v| !v.is_placeholder)
-        .collect();
+    let non_ph: Vec<&&CollectionVersion> = versions.iter().filter(|v| !v.is_placeholder).collect();
 
     if non_ph.is_empty() {
         return Err(Error::CollectionMissing {
@@ -702,8 +711,13 @@ fn verify_one_collection(
             return Err(Error::VersionPinMismatch {
                 collection: entry.name.to_string(),
                 expected: root.to_string(),
-                actual: format!("root missing; versions={:?}",
-                    non_ph.iter().map(|v| v.version_id.as_str()).collect::<Vec<_>>()),
+                actual: format!(
+                    "root missing; versions={:?}",
+                    non_ph
+                        .iter()
+                        .map(|v| v.version_id.as_str())
+                        .collect::<Vec<_>>()
+                ),
             });
         }
     }

--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -42,7 +42,7 @@ pub async fn ensure_migrations_with_registry(
     apply_steps(node, registry, &mut report).await?;
     verify_managed_lineages(node, registry, &mut report).await?;
 
-    report.materialization = materialize::materialize_all(node, registry).await;
+    report.materialization = materialize::materialize_all(node, registry).await?;
 
     info!(
         baseline_registered = report.baseline_registered,
@@ -50,7 +50,7 @@ pub async fn ensure_migrations_with_registry(
         steps_applied = report.steps_applied,
         steps_already_current = report.steps_already_current,
         edges_repaired = report.edges_repaired,
-        materialize_skipped = report.materialization.skipped_upstream_missing,
+        documents_materialized = report.materialization.documents_materialized,
         "ensure_migrations complete"
     );
 

--- a/crates/gents-migration/src/error.rs
+++ b/crates/gents-migration/src/error.rs
@@ -67,6 +67,10 @@ pub enum Error {
         source: anyhow::Error,
     },
 
+    /// Eager materialization failed for one or more managed collections.
+    #[error("eager materialization failed: {detail}")]
+    MaterializeFailed { detail: String },
+
     /// Node introspection failed (get_collection / list versions).
     #[error("defra node error: {0}")]
     Node(#[from] anyhow::Error),

--- a/crates/gents-migration/src/expectation.rs
+++ b/crates/gents-migration/src/expectation.rs
@@ -122,8 +122,8 @@ pub fn descriptor_digest(version: &CollectionVersion) -> String {
     //
     // Prefer a real sha2 when pins are authored in Phase B; for now the digest
     // is only compared when `descriptor_digest: Some(...)` is set.
-    let bytes = serde_json::to_vec(&normalize_descriptor(version))
-        .unwrap_or_else(|_| b"{}".to_vec());
+    let bytes =
+        serde_json::to_vec(&normalize_descriptor(version)).unwrap_or_else(|_| b"{}".to_vec());
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     bytes.hash(&mut hasher);
     format!("{:016x}", hasher.finish())

--- a/crates/gents-migration/src/materialize.rs
+++ b/crates/gents-migration/src/materialize.rs
@@ -1,32 +1,43 @@
 //! Eager materialization driver.
 //!
-//! Uses DefraDB's datastore-only materialization primitive, which advances
-//! document blobs, stored version keys, and secondary indexes without creating
-//! CRDT commits or replication events.
+//! Uses DefraDB's datastore-only materialization primitive
+//! ([defradb.rs#1230](https://github.com/sourcenetwork/defradb.rs/issues/1230),
+//! merged in #1232): advances document blobs, stored version keys, and
+//! secondary indexes without creating CRDT commits or replication events.
 
 use defra_node::EmbeddedNode;
-use tracing::{debug, warn};
+use tracing::{debug, info};
 
+use crate::error::{Error, Result};
 use crate::registry::Registry;
 use crate::report::MaterializationStats;
 
-/// Attempt eager materialization for every managed collection name.
-pub async fn materialize_all(node: &EmbeddedNode, registry: &Registry<'_>) -> MaterializationStats {
+/// Eagerly materialize every managed collection.
+///
+/// Returns stats on success. Any collection-level failure is a hard error —
+/// after lineage verification every managed collection is expected to exist.
+pub async fn materialize_all(
+    node: &EmbeddedNode,
+    registry: &Registry<'_>,
+) -> Result<MaterializationStats> {
     let names: Vec<&str> = registry.managed_names().collect();
     materialize_collections(node, &names).await
 }
 
-/// Materialize the given collection names.
+/// Materialize the given collection names via `EmbeddedNode::materialize_collection`.
 pub async fn materialize_collections(
     node: &EmbeddedNode,
     collections: &[&str],
-) -> MaterializationStats {
+) -> Result<MaterializationStats> {
     let mut stats = MaterializationStats {
         collections_attempted: collections.len(),
         documents_materialized: 0,
+        collections_failed: 0,
         skipped_upstream_missing: false,
         read_through_scans: 0,
     };
+
+    let mut failures: Vec<String> = Vec::new();
 
     for name in collections {
         match node.materialize_collection(name).await {
@@ -35,10 +46,25 @@ pub async fn materialize_collections(
                 debug!(collection = %name, documents = n, "materialized collection");
             }
             Err(e) => {
-                warn!(collection = %name, error = %e, "collection materialization failed");
+                stats.collections_failed += 1;
+                failures.push(format!("{name}: {e}"));
             }
         }
     }
 
-    stats
+    if !failures.is_empty() {
+        return Err(Error::MaterializeFailed {
+            detail: failures.join("; "),
+        });
+    }
+
+    if stats.documents_materialized > 0 {
+        info!(
+            collections = stats.collections_attempted,
+            documents = stats.documents_materialized,
+            "eager materialization complete"
+        );
+    }
+
+    Ok(stats)
 }

--- a/crates/gents-migration/src/report.rs
+++ b/crates/gents-migration/src/report.rs
@@ -7,9 +7,14 @@ pub struct MaterializationStats {
     pub collections_attempted: usize,
     /// Documents durably advanced to their active collection version.
     pub documents_materialized: usize,
-    /// Legacy compatibility flag; false with the pinned DefraDB materializer.
+    /// Collections that failed materialization (always 0 when
+    /// [`crate::ensure_migrations`] returns `Ok`).
+    pub collections_failed: usize,
+    /// Always `false` on pins that include `materialize_collection`
+    /// (defradb.rs ≥ #1232). Kept for report compatibility.
     pub skipped_upstream_missing: bool,
-    /// Legacy read-through count; zero with eager datastore materialization.
+    /// Always `0` with eager datastore materialization. Kept for report
+    /// compatibility with the pre-#1232 GraphQL read-through path.
     pub read_through_scans: usize,
 }
 

--- a/crates/gents-migration/tests/baseline_ensure.rs
+++ b/crates/gents-migration/tests/baseline_ensure.rs
@@ -48,7 +48,11 @@ async fn ensure_migrations_registers_baseline_and_is_idempotent() {
             .expect("get_collection")
             .unwrap_or_else(|| panic!("missing collection {}", entry.name));
         assert!(cv.is_active, "{} should be active", entry.name);
-        assert!(!cv.is_placeholder, "{} should not be placeholder", entry.name);
+        assert!(
+            !cv.is_placeholder,
+            "{} should not be placeholder",
+            entry.name
+        );
     }
 
     node.shutdown().await;

--- a/crates/gents-migration/tests/phase_b_steps.rs
+++ b/crates/gents-migration/tests/phase_b_steps.rs
@@ -145,7 +145,9 @@ async fn patch_versioned_with_fixture_lens_registers_transform() {
     let wasm = fixture_lens_wasm();
     // Stub wasm is 8 bytes — skip full lens path if build was stubbed.
     if wasm.len() <= 16 {
-        eprintln!("skipping fixture lens e2e: stub wasm (set wasm target / unset GENTS_SKIP_LENS_BUILD)");
+        eprintln!(
+            "skipping fixture lens e2e: stub wasm (set wasm target / unset GENTS_SKIP_LENS_BUILD)"
+        );
         return;
     }
 

--- a/crates/gents/src/schema.rs
+++ b/crates/gents/src/schema.rs
@@ -34,7 +34,9 @@ pub use gents_protocol::schemas::{
 /// Replaced by the full baseline. Kept as a name alias so docs/tests that
 /// still mention the six-collection init subset compile; calling
 /// [`ensure_config_bootstrap_schemas`] registers the **full** baseline.
-#[deprecated(note = "partial bootstrap forks lineage; use ensure_migrations / ensure_runtime_schemas")]
+#[deprecated(
+    note = "partial bootstrap forks lineage; use ensure_migrations / ensure_runtime_schemas"
+)]
 pub const CONFIG_BOOTSTRAP: &[&str] = &[
     AGENT_PRINCIPAL_SCHEMA,
     AGENT_BEHAVIOR_SCHEMA,

--- a/docs/superpowers/specs/2026-07-28-lens-first-migration-design.md
+++ b/docs/superpowers/specs/2026-07-28-lens-first-migration-design.md
@@ -1,14 +1,13 @@
 # Lens-first migration system
 
-**Date:** 2026-07-28 (revised 2026-07-29 after design review)
-**Status:** Phases A–D scaffolding landed on the cutover branch.
-  - **A:** engine + baseline + zero production steps + legacy deleted
-  - **B:** fixture lens, dynamic registry, inactive+fields lock, PatchVersioned e2e,
-    crash-resume, chain-replay pin authoring helper
-  - **C:** materialize driver with upstream probe + GraphQL read-through scan
-    (durable write-back still gated on defradb.rs §7.1)
-  - **D:** rolling-upgrade guidance + unknown-version error classifier
-    (pass-through still gated on defradb.rs §7.2)
+**Date:** 2026-07-28 (revised 2026-07-29; upstream closed 2026-07-29)
+**Status:** **Shipped.** Gents PR #931 + materialize follow-up; DefraDB
+  [PR #1232](https://github.com/sourcenetwork/defradb.rs/pull/1232) merged
+  (`e201d77c`, closes #1230/#1231). Pin includes durable `materialize_collection`
+  and unknown-version pass-through.
+  - **A–B:** engine, baseline (zero production steps at cutover), fixture lens e2e
+  - **C:** `ensure_migrations` calls `EmbeddedNode::materialize_collection` per managed collection
+  - **D:** pass-through on foreign *document* versions; schema DAG still rejects foreign lineage
 **Replaces:** `crates/gents/src/migration.rs` (5,161 lines) and both legacy lens crates
 
 ## Problem
@@ -587,10 +586,11 @@ avoids that window. §7.3 still wants invalidation on `set_migration`.
 
 ### 8.6 Inverse lenses and rolling upgrades
 
-Forward transforms are required on every lens step. Inverse is optional in
-Phase A–B. Until §7.2 (unknown-version pass-through) lands, rolling upgrades
-must promote older nodes promptly — documents stamped beyond a node's known
-chain hard-error on Rust reads.
+Forward transforms are required on every lens step. Inverse is optional.
+Unknown *document* versions pass through without restamping (defradb.rs#1231).
+Schema DAGs with foreign versions still hard-fail at `ensure_migrations`.
+Promote nodes promptly during rolling upgrades so the local chain covers
+replicated stamps.
 
 ### 8.7 Cross-collection / relation ordering
 
@@ -601,19 +601,18 @@ accordingly.
 
 ### 8.8 Post-activation repair
 
-Activation commits before reindex. Repair phase on the next `ensure` pass:
-re-call `set_active_collection_version(pin)` (idempotent; re-triggers
-reindex) and/or `materialize_collection` once upstream. No gents-side reindex
-implementation.
+Activation commits before reindex. On the next `ensure` pass the engine
+re-calls `set_active_collection_version(pin)` when needed and always runs
+`materialize_collection` for managed collections after the chain is current.
 
 ### 8.9 Ship matrix
 
-| Phase | Ships | Upstream gate | Status |
+| Phase | Ships | Upstream | Status |
 | --- | --- | --- | --- |
-| **A** | `gents-migration` crate; baseline registry (zero production steps); unbypassable `ensure_migrations`; delete legacy; Lean model + conformance; multi-version → hard error | none | **done** |
-| **B** | Fixture lens crate + build embedding; `DynamicRegistry`; inactive+fields lock; lensless + fixture-lens `PatchVersioned` e2e; crash-resume; chain-replay pin printer | inactive field-add locked in-tree | **done** (production step chain still empty until a real schema change) |
-| **C** | Materialize driver: probe for `materialize_collection`, else GraphQL read-through scan + stats | §7.1 durable write-back / identity restamp | **driver done; durable restamp blocked upstream** |
-| **D** | `ROLLING_UPGRADE_GUIDANCE` + `is_unknown_version_read_error` classifier | §7.2 unknown-version pass-through in defradb.rs | **policy done; pass-through blocked upstream** |
+| **A** | `gents-migration`; baseline (zero production steps); unbypassable `ensure_migrations`; delete legacy; Lean + conformance | — | **done** (#931) |
+| **B** | Fixture lens; `DynamicRegistry`; inactive+fields; PatchVersioned e2e; crash-resume | — | **done** (#931) |
+| **C** | Eager `materialize_collection` driver (hard-fail on collection error) | [defradb.rs#1230](https://github.com/sourcenetwork/defradb.rs/issues/1230) via [#1232](https://github.com/sourcenetwork/defradb.rs/pull/1232) | **done** |
+| **D** | Unknown *document* version pass-through + rolling-upgrade guidance | [defradb.rs#1231](https://github.com/sourcenetwork/defradb.rs/issues/1231) via [#1232](https://github.com/sourcenetwork/defradb.rs/pull/1232) | **done** |
 
 ### 8.10 Feature-invariant baseline
 

--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -345,7 +345,6 @@ declare -a ALLOWLIST=(
 # - defradb / defradb.rs
 # - defra-core, defra-node, defra-p2p-adapter (upstream DefraDB crates)
 # - agent_did, AgentRequest, AgentResponse, AgentToolCall (domain nouns)
-# - agent-tool-call-lifecycle-v1-to-v2-lens (lens name = domain vocabulary)
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

Lands the remaining migration follow-ups in one PR:

1. **Hard-fail materialize** — `ensure_migrations` treats `materialize_collection` failures as `Error::MaterializeFailed` (defradb.rs #1232 is pinned).
2. **CI gates** (from #946) — retarget WASM build to `gents-lens-fixture-add-label`; run `cargo test -p gents-migration` and the fixture lens package so missing suites fail CI.
3. **rustfmt** on merged migration code (from #946).
4. Design doc: phases C/D marked done.

Supersedes draft #946 (contents merged here).

## Test plan

- [x] `cargo test -p gents-migration`
- [x] `cargo test -p gents-lens-fixture-add-label`
- [x] `cargo fmt -p gents-migration -- --check`
- [ ] CI green