### PR TITLE
test(gents): stabilize runtime readiness waits

### DIFF
--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -1095,7 +1095,7 @@ async fn wait_for_runtime_ready_realtime(node: &EmbeddedNode, agent_did: &str) {
             }
         }
         assert!(
-            started.elapsed() < Duration::from_secs(10),
+            started.elapsed() < Duration::from_secs(30),
             "agent did not reach ready state"
         );
         tokio::task::yield_now().await;

--- a/crates/gents/tests/support/interrupt.rs
+++ b/crates/gents/tests/support/interrupt.rs
@@ -56,7 +56,7 @@ impl Drop for BootedAgent {
 }
 
 pub async fn wait_for_runtime_ready(node: &EmbeddedNode, agent_did: &str) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if let Some(snapshot) = fetch_runtime_snapshot(node, agent_did).await {
             if snapshot.process_state == "ready"


### PR DESCRIPTION
## Summary

Raises the runtime-startup readiness budget from 10 to 30 seconds in the two test helpers that implement the same readiness fence:

- the shared ordinary-runtime helper (`tokio::time::Instant` + 50 ms sleep)
- the paused-time streaming helper (`std::time::Instant` + `yield_now`)

Only the timeout literals change. Readiness predicates, polling behavior, timer models, error strings, runtime code, and Lean contracts are unchanged.

## Evidence

Hosted CI reproduced the same startup-readiness timeout family across independent PR heads: five cases together on #946 and two of the same cases on #930. The exact cases passed on a concurrent #945 run, identifying startup headroom rather than a semantic failure.

The existing 10-second helpers were the outliers; 30 seconds is already used by other runtime-startup tests in this repository.

## Validation

- Five exact formerly failing cases: passed.
- Five concurrent repetitions of those five cases: 25/25 passed.
- `cargo test -p gents --test conformance` on current `main`: 319/319 passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.

The broader `cargo test -p gents` gate is currently blocked after its passing library/conformance phases by the separately diagnosed #931 unpinned single-root migration gap exercised by the v0.6.12 fixture; this test-only diff does not touch that path.

## Review

Two independent Codex reviews, Grok, and Claude Opus found no behavioral change beyond the bounded test wait. The maximum downside is 20 seconds of additional diagnosis time when runtime startup genuinely never reaches the unchanged predicate.