### PR TITLE
fix(migration): advance DefraDB and restore green baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5843,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5980,7 +5980,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -5992,7 +5992,6 @@ dependencies = [
  "hmac 0.12.1",
  "k256",
  "multibase",
- "multihash",
  "p256",
  "rand 0.8.5",
  "serde",
@@ -6178,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6425,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6440,7 +6439,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "anyhow",
@@ -6490,7 +6489,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6514,7 +6513,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6529,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-lock",
@@ -6570,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-trait",
@@ -6585,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "anyhow",
  "document",
@@ -6685,7 +6684,7 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6710,7 +6709,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-stream",
@@ -6742,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "anyhow",
@@ -6776,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-trait",
@@ -6810,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "serde",
 ]
@@ -7228,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7686,7 +7685,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -11106,7 +11105,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -12339,17 +12338,15 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-lock",
  "async-trait",
  "base64 0.22.1",
- "blockstore",
  "cid",
  "crypto",
  "defra-core",
- "futures",
  "identity",
  "rand 0.8.5",
  "serde",
@@ -12487,7 +12484,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15217,7 +15214,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "anyhow",
@@ -16642,7 +16639,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16670,7 +16667,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "chrono",
  "cid",
@@ -16686,7 +16683,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "async-lock",
@@ -16710,7 +16707,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17662,7 +17659,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "p2p",
  "query",
@@ -18461,7 +18458,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "cid",
  "defra-core",
@@ -19663,7 +19660,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20090,7 +20087,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24564,7 +24561,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4#e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=966cf42bd337ada1c6f64584bea9e52f82001393#966cf42bd337ada1c6f64584bea9e52f82001393"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,22 +60,22 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs v0.17.1. Its iterative parent-DAG replay remains required on iOS:
+# defradb.rs post-v0.17.1 stabilization. Its iterative parent-DAG replay remains required on iOS:
 # a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-schemas = { path = "crates/gents-schemas" }
 gents-desktop-core = { path = "crates/gents-desktop-core" }
 gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -83,8 +83,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e201d77c5b20eb76ae6f20de1db3e61cbc2e1cb4" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "966cf42bd337ada1c6f64584bea9e52f82001393" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -708,16 +708,13 @@ fn verify_one_collection(
     if let Some(root) = entry.expected_version {
         let has_root = non_ph.iter().any(|v| v.version_id == root);
         if !has_root {
-            return Err(Error::VersionPinMismatch {
+            return Err(Error::UnknownLineage {
                 collection: entry.name.to_string(),
-                expected: root.to_string(),
-                actual: format!(
-                    "root missing; versions={:?}",
-                    non_ph
-                        .iter()
-                        .map(|v| v.version_id.as_str())
-                        .collect::<Vec<_>>()
-                ),
+                versions: non_ph
+                    .iter()
+                    .map(|v| v.version_id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
             });
         }
     }

--- a/crates/gents-migration/src/registry.rs
+++ b/crates/gents-migration/src/registry.rs
@@ -293,7 +293,7 @@ pub static DEFAULT_BASELINE: &[BaselineCollection<'static>] = &[
     baseline_entry!(
         gents_protocol::schemas::AGENT_REQUEST_NAME,
         gents_protocol::schemas::AGENT_REQUEST,
-        "bafyreidm25txacrwuypexjpvvxqyekewsw352ftqjohsf267cvlsklxu4y"
+        "bafyreiee2kapqft4xy73z2eyavwcgr2cwvz5now65dhq7inpuwaet6vteq"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_RESPONSE_NAME,
@@ -323,7 +323,7 @@ pub static DEFAULT_BASELINE: &[BaselineCollection<'static>] = &[
     baseline_entry!(
         gents_protocol::schemas::AGENT_TOOL_CALL_NAME,
         gents_protocol::schemas::AGENT_TOOL_CALL,
-        "bafyreihjkmrocfh7zk5wl5hloawnerbalu6d5e7ovx5kod4kcb7yopbsui"
+        "bafyreifgbfkl6ticsz3bhgpt2blojeexb7hmu7vybtmanglcnbem2kubsq"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_TOOL_APPROVAL_NAME,

--- a/crates/gents-migration/src/registry.rs
+++ b/crates/gents-migration/src/registry.rs
@@ -217,11 +217,11 @@ impl DynamicRegistry {
 // ---------------------------------------------------------------------------
 
 macro_rules! baseline_entry {
-    ($name:expr, $sdl:expr) => {
+    ($name:expr, $sdl:expr, $version:literal) => {
         BaselineCollection {
             name: $name,
             sdl: $sdl,
-            expected_version: None,
+            expected_version: Some($version),
             expected_state: CollectionExpectation::dag_only(),
         }
     };
@@ -232,159 +232,198 @@ macro_rules! baseline_entry {
 pub static DEFAULT_BASELINE: &[BaselineCollection<'static>] = &[
     baseline_entry!(
         gents_protocol::schemas::INFERENCE_BACKEND_NAME,
-        gents_protocol::schemas::INFERENCE_BACKEND
+        gents_protocol::schemas::INFERENCE_BACKEND,
+        "bafyreifljyf2sr7czygvf6y6cy2rlsg2c2brmzegx5wpedpqnf6hn745ju"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_PRINCIPAL_NAME,
-        gents_protocol::schemas::AGENT_PRINCIPAL
+        gents_protocol::schemas::AGENT_PRINCIPAL,
+        "bafyreiar2j7qsshchz3dsm4olsgql2z2gfjsvfwgu2kr5cnmer64yto63i"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_BEHAVIOR_NAME,
-        gents_protocol::schemas::AGENT_BEHAVIOR
+        gents_protocol::schemas::AGENT_BEHAVIOR,
+        "bafyreie27gfobswc4wntubqfg4ki3laofglss3mam53uqrru6shtjlutwu"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_RUNTIME_NAME,
-        gents_protocol::schemas::AGENT_RUNTIME
+        gents_protocol::schemas::AGENT_RUNTIME,
+        "bafyreig2kkghd2y4fwjjzomtsp753nby752xon7rx4jt3efl4xflhm6wgy"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_DIRECTORY_ENTRY_NAME,
-        gents_protocol::schemas::AGENT_DIRECTORY_ENTRY
+        gents_protocol::schemas::AGENT_DIRECTORY_ENTRY,
+        "bafyreidvqhhvvodkcn5eus7qams2fzsivj4t56x2ztihxybyxxtvth3k5a"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_MEMORY_NAME,
-        gents_protocol::schemas::AGENT_MEMORY
+        gents_protocol::schemas::AGENT_MEMORY,
+        "bafyreidqrnco3ylgzeucb6vu2dhhkviklq23nwpn4npqblkm64bntdbbli"
     ),
     baseline_entry!(
         gents_protocol::schemas::TOOL_SELECTION_NAME,
-        gents_protocol::schemas::TOOL_SELECTION
+        gents_protocol::schemas::TOOL_SELECTION,
+        "bafyreib2unocpob7tf55zrqzelcsop4ecvhm6jlyjlisi7osxsevlxaeuy"
     ),
     baseline_entry!(
         gents_protocol::schemas::SKILL_NAME,
-        gents_protocol::schemas::SKILL
+        gents_protocol::schemas::SKILL,
+        "bafyreib6grod5kwezldwy74gt5425ewoymiyyjvmygtfzhq25zwngwsrly"
     ),
     baseline_entry!(
         gents_protocol::schemas::OAUTH_CREDENTIAL_NAME,
-        gents_protocol::schemas::OAUTH_CREDENTIAL
+        gents_protocol::schemas::OAUTH_CREDENTIAL,
+        "bafyreiab3wqm3em2cepvj22l733ziz4azytl3gc7zozcm5e2s7nuehkx6u"
     ),
     baseline_entry!(
         gents_protocol::schemas::INFERENCE_PROFILE_NAME,
-        gents_protocol::schemas::INFERENCE_PROFILE
+        gents_protocol::schemas::INFERENCE_PROFILE,
+        "bafyreibhnljm6hqgbiyct7fq53vpfagmn2q2pe2apykujttk6tghwtqb5e"
     ),
     baseline_entry!(
         gents_protocol::schemas::INFERENCE_CALL_NAME,
-        gents_protocol::schemas::INFERENCE_CALL
+        gents_protocol::schemas::INFERENCE_CALL,
+        "bafyreiba6ptexjit4udtq2xfcxyre4ph2zezyexn5vg2nycnzaefpexaju"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_CONVERSATION_NAME,
-        gents_protocol::schemas::AGENT_CONVERSATION
+        gents_protocol::schemas::AGENT_CONVERSATION,
+        "bafyreide7lgaj6zensfdbrhhafhpj3yxedj3luuhmnttt23qoma7isnnoa"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_REQUEST_NAME,
-        gents_protocol::schemas::AGENT_REQUEST
+        gents_protocol::schemas::AGENT_REQUEST,
+        "bafyreidm25txacrwuypexjpvvxqyekewsw352ftqjohsf267cvlsklxu4y"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_RESPONSE_NAME,
-        gents_protocol::schemas::AGENT_RESPONSE
+        gents_protocol::schemas::AGENT_RESPONSE,
+        "bafyreihihn632s6qtxj62hgcjgc2l2qy5ebim3ehmwbtbejc7ey7ux4qzi"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_TOOL_RESULT_NAME,
-        gents_protocol::schemas::AGENT_TOOL_RESULT
+        gents_protocol::schemas::AGENT_TOOL_RESULT,
+        "bafyreibyv44zzio5tdatrh2bxp35i6jrdli5zpszxdtysovqnd5smesxku"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_SESSION_NAME,
-        gents_protocol::schemas::AGENT_SESSION
+        gents_protocol::schemas::AGENT_SESSION,
+        "bafyreih3e34ribdzce6ajpiuwjehx6tu3loeldugxj6y3ce35yv7tdzwi4"
     ),
     baseline_entry!(
         gents_protocol::schemas::GOAL_NAME,
-        gents_protocol::schemas::GOAL
+        gents_protocol::schemas::GOAL,
+        "bafyreig5hlyzlujmegnnlww6tjt6krquzuq2ltgh2pjqwwzxzjbognuguu"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_MESSAGE_NAME,
-        gents_protocol::schemas::AGENT_MESSAGE
+        gents_protocol::schemas::AGENT_MESSAGE,
+        "bafyreiemjtuletwxi5p2jvgplanfyzne6pu7a3knkn4n4dbx6kmgxytfre"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_TOOL_CALL_NAME,
-        gents_protocol::schemas::AGENT_TOOL_CALL
+        gents_protocol::schemas::AGENT_TOOL_CALL,
+        "bafyreihjkmrocfh7zk5wl5hloawnerbalu6d5e7ovx5kod4kcb7yopbsui"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_TOOL_APPROVAL_NAME,
-        gents_protocol::schemas::AGENT_TOOL_APPROVAL
+        gents_protocol::schemas::AGENT_TOOL_APPROVAL,
+        "bafyreic6razxeyhpi4re5nshdxtih63in7ostxn2uoqdoet2k7yl4a54cm"
     ),
     baseline_entry!(
         gents_protocol::schemas::COMPACTION_ENTRY_NAME,
-        gents_protocol::schemas::COMPACTION_ENTRY
+        gents_protocol::schemas::COMPACTION_ENTRY,
+        "bafyreiczxjv6ah2blpjdz7jxtwzue4rvjzwkefuds4gukibexhddam4j5y"
     ),
     baseline_entry!(
         gents_protocol::schemas::PROJECTION_ACP_BINDING_NAME,
-        gents_protocol::schemas::PROJECTION_ACP_BINDING
+        gents_protocol::schemas::PROJECTION_ACP_BINDING,
+        "bafyreiauzohlxkx3x7wndadh7yl3pfbknle6crgjl7mpcqt37onus6em4i"
     ),
     baseline_entry!(
         gents_protocol::schemas::TASK_NAME,
-        gents_protocol::schemas::TASK
+        gents_protocol::schemas::TASK,
+        "bafyreih2yansmfmsye5xktsx2rbf7tri4zvtifselok46pdmm4qmde7blu"
     ),
     baseline_entry!(
         gents_protocol::schemas::SCHEDULE_NAME,
-        gents_protocol::schemas::SCHEDULE
+        gents_protocol::schemas::SCHEDULE,
+        "bafyreid2l4a57zydsgrxret3qkewued42bxjb4pcaqalqnjkhinlz4gsn4"
     ),
     baseline_entry!(
         gents_protocol::schemas::EVENT_TRIGGER_NAME,
-        gents_protocol::schemas::EVENT_TRIGGER
+        gents_protocol::schemas::EVENT_TRIGGER,
+        "bafyreih4b54rbekqry2nwymuppgil7v2ldmxirim5upv7nbjkvxjhihnwi"
     ),
     baseline_entry!(
         gents_protocol::schemas::TOOL_SERVICE_REGISTRY_NAME,
-        gents_protocol::schemas::TOOL_SERVICE_REGISTRY
+        gents_protocol::schemas::TOOL_SERVICE_REGISTRY,
+        "bafyreidyt2lufdrv2dhjsm2kusylwekdqktefp7jeyyvfik76zchfp5plq"
     ),
     baseline_entry!(
         gents_protocol::schemas::TOOL_SERVICE_HEALTH_STATE_NAME,
-        gents_protocol::schemas::TOOL_SERVICE_HEALTH_STATE
+        gents_protocol::schemas::TOOL_SERVICE_HEALTH_STATE,
+        "bafyreif3vui3absvxqcthnguigulgso7w7ktcfo3orptrgqlhmp6ae2ani"
     ),
     baseline_entry!(
         gents_protocol::schemas::PEER_PAIRING_DESIRED_NAME,
-        gents_protocol::schemas::PEER_PAIRING_DESIRED
+        gents_protocol::schemas::PEER_PAIRING_DESIRED,
+        "bafyreicoms7ndji7z76sellaqumottresgd3uojmvrts5hxciho4lvu5xy"
     ),
     baseline_entry!(
         gents_protocol::schemas::DATA_PLANE_PAIRING_DESIRED_NAME,
-        gents_protocol::schemas::DATA_PLANE_PAIRING_DESIRED
+        gents_protocol::schemas::DATA_PLANE_PAIRING_DESIRED,
+        "bafyreia63drc777juius2tcsukzfnw425hjyz4xchz6f6ykeoed2gqmjd4"
     ),
     baseline_entry!(
         gents_protocol::schemas::PEER_PAIRING_APPLIED_NAME,
-        gents_protocol::schemas::PEER_PAIRING_APPLIED
+        gents_protocol::schemas::PEER_PAIRING_APPLIED,
+        "bafyreifunn7vevp6b6rzg232gjfypp2lqviafe5now5ldlwo3na5nfinq4"
     ),
     baseline_entry!(
         gents_protocol::schemas::PEER_REGISTRY_NAME,
-        gents_protocol::schemas::PEER_REGISTRY
+        gents_protocol::schemas::PEER_REGISTRY,
+        "bafyreieyihzl6ibujs4jzxji64gmpff7jcyqqjpdfxz6my6dcswafjwhla"
     ),
     baseline_entry!(
         gents_protocol::schemas::CONSUMED_INVITE_NONCE_NAME,
-        gents_protocol::schemas::CONSUMED_INVITE_NONCE
+        gents_protocol::schemas::CONSUMED_INVITE_NONCE,
+        "bafyreigbedn4ebkz4cap5x6d53uif2ddimsyivpxbbijkjhqedbpuponfa"
     ),
     baseline_entry!(
         gents_protocol::schemas::RECIPROCAL_CONVERSATION_INTENT_NAME,
-        gents_protocol::schemas::RECIPROCAL_CONVERSATION_INTENT
+        gents_protocol::schemas::RECIPROCAL_CONVERSATION_INTENT,
+        "bafyreid6huhh2y4sslnmuw55mk7mnzundgjpjbqhihhfmhs3yrp2aaq6bm"
     ),
     baseline_entry!(
         gents_protocol::schemas::PAIRING_BEARER_CLAIM_NAME,
-        gents_protocol::schemas::PAIRING_BEARER_CLAIM
+        gents_protocol::schemas::PAIRING_BEARER_CLAIM,
+        "bafyreidlvcvil4o22lsy2byeh2yjugpj5mnnvkotxj56pg6mjswg2bzjjq"
     ),
     baseline_entry!(
         gents_protocol::schemas::BEARER_PAIRING_READY_NAME,
-        gents_protocol::schemas::BEARER_PAIRING_READY
+        gents_protocol::schemas::BEARER_PAIRING_READY,
+        "bafyreihuy5majnvf6mqy3ow54xjlzllgwqcvivuz2kvqtjrhdmb427ynry"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_NETWORK_NAME,
-        gents_protocol::schemas::AGENT_NETWORK
+        gents_protocol::schemas::AGENT_NETWORK,
+        "bafyreifafg2su5zfp2zzrmtnp2we5iu2owkweuevvu4hq25qposuyiuyfm"
     ),
     baseline_entry!(
         gents_protocol::schemas::NETWORK_MEMBERSHIP_NAME,
-        gents_protocol::schemas::NETWORK_MEMBERSHIP
+        gents_protocol::schemas::NETWORK_MEMBERSHIP,
+        "bafyreiav6v7v2nab45gyqkcj2jrp7mfmtojuc7ypupzw4qnpsd5sidqni4"
     ),
     baseline_entry!(
         gents_protocol::schemas::PEER_ENDPOINT_NAME,
-        gents_protocol::schemas::PEER_ENDPOINT
+        gents_protocol::schemas::PEER_ENDPOINT,
+        "bafyreidubdiopvxh3zm447ttse6fbs7jzyagiyt7ipw4toib2z3svr4neq"
     ),
     baseline_entry!(
         gents_protocol::schemas::NETWORK_JOIN_REQUEST_NAME,
-        gents_protocol::schemas::NETWORK_JOIN_REQUEST
+        gents_protocol::schemas::NETWORK_JOIN_REQUEST,
+        "bafyreib5ufwrdzy77qvfziodcdgevd44pqoix4jcrriir3arpyyjwhdjym"
     ),
 ];
 

--- a/crates/gents-migration/src/registry.rs
+++ b/crates/gents-migration/src/registry.rs
@@ -247,6 +247,10 @@ pub static DEFAULT_BASELINE: &[BaselineCollection<'static>] = &[
         gents_protocol::schemas::AGENT_RUNTIME
     ),
     baseline_entry!(
+        gents_protocol::schemas::AGENT_DIRECTORY_ENTRY_NAME,
+        gents_protocol::schemas::AGENT_DIRECTORY_ENTRY
+    ),
+    baseline_entry!(
         gents_protocol::schemas::AGENT_MEMORY_NAME,
         gents_protocol::schemas::AGENT_MEMORY
     ),

--- a/crates/gents-migration/tests/baseline_ensure.rs
+++ b/crates/gents-migration/tests/baseline_ensure.rs
@@ -1,9 +1,12 @@
 //! Phase A conformance: baseline registration, idempotence, single-version DAG.
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 
 use defra_node::EmbeddedNode;
-use gents_migration::{ensure_migrations, ensure_migrations_with_registry, Error, Registry};
+use gents_migration::{
+    ensure_migrations, ensure_migrations_dynamic, ensure_migrations_with_registry,
+    BaselineCollectionOwned, CollectionExpectation, DynamicRegistry, Error, Registry,
+};
 
 #[test]
 fn default_baseline_matches_ordered_protocol_catalog() {
@@ -41,6 +44,35 @@ async fn fresh_node() -> Arc<EmbeddedNode> {
     // Keep tempdir alive for the node lifetime by leaking (test process short).
     std::mem::forget(dir);
     Arc::new(node)
+}
+
+#[test]
+fn default_baseline_covers_every_protocol_collection_once() {
+    let baseline_names = gents_migration::DEFAULT_BASELINE
+        .iter()
+        .map(|entry| entry.name)
+        .collect::<BTreeSet<_>>();
+    let protocol_names = gents_protocol::schemas::ALL_COLLECTION_NAMES
+        .iter()
+        .chain(gents_protocol::schemas::RUNTIME_COLLECTION_NAMES.iter())
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        gents_migration::DEFAULT_BASELINE.len(),
+        baseline_names.len(),
+        "migration baseline must not contain duplicate collections"
+    );
+    assert!(
+        gents_migration::DEFAULT_BASELINE
+            .iter()
+            .all(|entry| entry.expected_version.is_some()),
+        "production migration baseline must pin every root version"
+    );
+    assert_eq!(
+        baseline_names, protocol_names,
+        "migration baseline must cover the full protocol schema catalog"
+    );
 }
 
 #[tokio::test]
@@ -105,6 +137,48 @@ async fn multi_version_lineage_is_rejected() {
         }
         other => panic!("unexpected error: {other}"),
     }
+
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn single_version_unknown_root_is_rejected() {
+    const EXPECTED_SDL: &str = "type PinnedFixture { name: String label: String }";
+    const FOREIGN_SDL: &str = "type PinnedFixture { name: String }";
+
+    let authoring_node = fresh_node().await;
+    authoring_node
+        .add_schema(EXPECTED_SDL)
+        .await
+        .expect("register expected root");
+    let expected_root = authoring_node
+        .get_collection("PinnedFixture")
+        .expect("load expected root")
+        .expect("expected root exists")
+        .version_id;
+    authoring_node.shutdown().await;
+
+    let node = fresh_node().await;
+    node.add_schema(FOREIGN_SDL)
+        .await
+        .expect("register foreign root");
+    let registry = DynamicRegistry {
+        baseline: vec![BaselineCollectionOwned {
+            name: "PinnedFixture".into(),
+            sdl: EXPECTED_SDL.into(),
+            expected_version: Some(expected_root),
+            expected_state: CollectionExpectation::dag_only(),
+        }],
+        steps: vec![],
+    };
+
+    let err = ensure_migrations_dynamic(node.as_ref(), &registry)
+        .await
+        .expect_err("single unknown root must fail closed");
+    assert!(
+        matches!(err, Error::UnknownLineage { ref collection, .. } if collection == "PinnedFixture"),
+        "unexpected error: {err}"
+    );
 
     node.shutdown().await;
 }

--- a/crates/gents-migration/tests/baseline_ensure.rs
+++ b/crates/gents-migration/tests/baseline_ensure.rs
@@ -5,6 +5,32 @@ use std::sync::Arc;
 use defra_node::EmbeddedNode;
 use gents_migration::{ensure_migrations, ensure_migrations_with_registry, Error, Registry};
 
+#[test]
+fn default_baseline_matches_ordered_protocol_catalog() {
+    let actual = gents_migration::DEFAULT_BASELINE
+        .iter()
+        .map(|entry| (entry.name, entry.sdl))
+        .collect::<Vec<_>>();
+    let expected = gents_protocol::schemas::RUNTIME_COLLECTION_NAMES
+        .iter()
+        .copied()
+        .zip(gents_protocol::schemas::RUNTIME_ALL.iter().copied())
+        .chain(
+            gents_protocol::schemas::ALL_COLLECTION_NAMES
+                .iter()
+                .copied()
+                .zip(gents_protocol::schemas::ALL.iter().copied()),
+        )
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "ordered baseline catalog length mismatch"
+    );
+    assert_eq!(actual, expected);
+}
+
 async fn fresh_node() -> Arc<EmbeddedNode> {
     let dir = tempfile::tempdir().expect("tempdir");
     let node = EmbeddedNode::builder()

--- a/crates/gents-migration/tests/phase_b_steps.rs
+++ b/crates/gents-migration/tests/phase_b_steps.rs
@@ -302,16 +302,17 @@ async fn crash_resume_after_inactive_patch_before_activate() {
 
 #[tokio::test]
 async fn chain_replay_prints_baseline_pins_for_authoring() {
-    // Authoring aid: print every production baseline collection's root VersionID.
-    // Not asserted against frozen pins yet — freeze in a follow-up once CI has
-    // a stable defradb pin and the list is reviewed.
+    // Authoring aid: register the canonical SDL directly so stale pins cannot
+    // prevent the test from printing every replacement root VersionID.
     let node = fresh_node().await;
-    let report = gents_migration::ensure_migrations(node.as_ref())
-        .await
-        .expect("production baseline");
-    assert!(report.baseline_registered + report.baseline_already_present > 0);
+    for entry in gents_migration::DEFAULT_BASELINE {
+        node.add_schema(entry.sdl)
+            .await
+            .unwrap_or_else(|error| panic!("register {} for pin authoring: {error}", entry.name));
+    }
 
     println!("=== baseline version pins (authoring paste targets) ===");
+    let mut mismatches = Vec::new();
     for entry in gents_migration::DEFAULT_BASELINE {
         let cv = node
             .get_collection(entry.name)
@@ -323,11 +324,18 @@ async fn chain_replay_prints_baseline_pins_for_authoring() {
             cv.version_id,
             cv.fields.len()
         );
+        if entry.expected_version != Some(cv.version_id.as_str()) {
+            mismatches.push(format!(
+                "{}: expected {:?}, computed {}",
+                entry.name, entry.expected_version, cv.version_id
+            ));
+        }
     }
-
-    // The pinned DefraDB surface performs eager datastore materialization.
-    assert!(!report.materialization.skipped_upstream_missing);
-    assert_eq!(report.materialization.read_through_scans, 0);
+    assert!(
+        mismatches.is_empty(),
+        "baseline root pins are stale:\n{}",
+        mismatches.join("\n")
+    );
 
     node.shutdown().await;
 }

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -1095,7 +1095,7 @@ async fn wait_for_runtime_ready_realtime(node: &EmbeddedNode, agent_did: &str) {
             }
         }
         assert!(
-            started.elapsed() < Duration::from_secs(10),
+            started.elapsed() < Duration::from_secs(30),
             "agent did not reach ready state"
         );
         tokio::task::yield_now().await;

--- a/crates/gents/tests/e2e_runtime/defradb_v0612_store_upgrade.rs
+++ b/crates/gents/tests/e2e_runtime/defradb_v0612_store_upgrade.rs
@@ -1,7 +1,7 @@
 //! Populated v0.6.12 store upgrade coverage for the pinned DefraDB release.
 //!
 //! Store-format open still succeeds. The gents lens-first engine rejects the
-//! pre-baseline multi-version lineage with [`gents_migration::Error::UnknownLineage`]
+//! pre-baseline lineage with [`gents_migration::Error::UnknownLineage`]
 //! (or ForeignVersion) — no legacy field-presence migrations remain.
 
 use std::fs;
@@ -47,9 +47,24 @@ async fn populated_v0612_store_opens_but_rejects_pre_baseline_lineage() -> Resul
             .context("open populated v0.6.12 store with the current DefraDB pin")?,
     );
 
-    let err = gents::migration::ensure_all_runtime_migrations(node.clone())
-        .await
-        .expect_err("pre-baseline multi-version DAGs must hard-fail (no legacy support)");
+    let result = gents::migration::ensure_all_runtime_migrations(node.clone()).await;
+    if result.is_ok() {
+        let versions = node
+            .get_all_collection_versions()
+            .await
+            .context("inspect unexpectedly accepted pre-baseline lineage")?;
+        let observed = versions
+            .iter()
+            .filter(|version| !version.is_placeholder && !version.name.is_empty())
+            .map(|version| format!("{}={}", version.name, version.version_id))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "pre-baseline lineage must hard-fail (no legacy support); \
+             observed versions: [{observed}]"
+        );
+    }
+    let err = result.expect_err("checked successful result above");
     let msg = format!("{err:#}");
     ensure!(
         msg.contains("unknown lineage")

--- a/crates/gents/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
+++ b/crates/gents/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use gents::agent::p2p_reconcile::templates::NETWORK_CONTROL_COLLECTIONS;
 use gents::agent::p2p_reconcile::{GraphqlNetworkStore, NetworkStore};
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
@@ -418,6 +419,27 @@ async fn fetch_pairing_applied(
     Some((collections, addresses))
 }
 
+async fn fetch_subscribed_collection_names(node: &EmbeddedNode) -> Vec<String> {
+    let Some(p2p) = node.p2p() else {
+        return Vec::new();
+    };
+    let Ok(ids) = p2p.get_collections().await else {
+        return Vec::new();
+    };
+    let Ok(names) = node.list_collections() else {
+        return Vec::new();
+    };
+    names
+        .into_iter()
+        .filter(|name| {
+            node.get_collection(name)
+                .ok()
+                .flatten()
+                .is_some_and(|definition| ids.contains(&definition.collection_id))
+        })
+        .collect()
+}
+
 async fn wait_for_app_collections_pairing_applied(
     node: &EmbeddedNode,
     peer_id: &str,
@@ -428,9 +450,13 @@ async fn wait_for_app_collections_pairing_applied(
     let mut last = String::from("<none>");
     loop {
         if let Some((collections, addresses)) = fetch_pairing_applied(node, peer_id).await {
-            last = format!("collections={collections:?} addresses={addresses:?}");
+            let subscribed = fetch_subscribed_collection_names(node).await;
+            last = format!(
+                "applied_collections={collections:?} addresses={addresses:?} \
+                 subscribed={subscribed:?}"
+            );
             let has_addr = addresses.iter().any(|a| !a.trim().is_empty());
-            let has_col = collections.iter().any(|c| c == expected_collection);
+            let has_col = subscribed.iter().any(|c| c == expected_collection);
             if has_addr && has_col {
                 return;
             }
@@ -454,11 +480,20 @@ async fn wait_for_control_pairing_applied(
     let mut last = String::from("<none>");
     loop {
         if let Some((collections, addresses)) = fetch_pairing_applied(node, peer_id).await {
-            last = format!("collections={collections:?} addresses={addresses:?}");
+            let subscribed = fetch_subscribed_collection_names(node).await;
+            last = format!(
+                "applied_collections={collections:?} addresses={addresses:?} \
+                 subscribed={subscribed:?}"
+            );
             let has_addr = addresses.iter().any(|a| !a.trim().is_empty());
-            let has_control = collections.iter().any(|c| c == "AgentNetwork");
+            let has_control = NETWORK_CONTROL_COLLECTIONS
+                .iter()
+                .all(|expected| subscribed.iter().any(|actual| actual == expected));
             if has_addr && has_control {
-                return collections;
+                return NETWORK_CONTROL_COLLECTIONS
+                    .iter()
+                    .map(|collection| (*collection).to_string())
+                    .collect();
             }
         }
         if Instant::now() >= deadline {
@@ -816,23 +851,21 @@ async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
     )
     .await;
 
-    // Control collections still present after app-collections merge.
-    let (applied_a, _) = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
-        .await
-        .expect("applied on A");
+    // Control subscriptions still present after app-collections merge. The
+    // per-peer applied row is an ownership ledger, not the transport's global
+    // subscription inventory, so assert against the actual P2P state.
+    let subscribed_a = fetch_subscribed_collection_names(db_a.node.as_ref()).await;
     for col in &control_a {
         assert!(
-            applied_a.contains(col),
-            "control collection {col} missing after app-collections merge: {applied_a:?}"
+            subscribed_a.contains(col),
+            "control collection {col} missing after app-collections merge: {subscribed_a:?}"
         );
     }
-    let (applied_b, _) = fetch_pairing_applied(db_b.node.as_ref(), &peer_a)
-        .await
-        .expect("applied on B");
+    let subscribed_b = fetch_subscribed_collection_names(db_b.node.as_ref()).await;
     for col in &control_b {
         assert!(
-            applied_b.contains(col),
-            "control collection {col} missing after app-collections merge: {applied_b:?}"
+            subscribed_b.contains(col),
+            "control collection {col} missing after app-collections merge: {subscribed_b:?}"
         );
     }
 
@@ -903,8 +936,12 @@ async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
         .await
         .expect("post2 applied");
     assert_eq!(post, post2, "pairing applied should be stable (idempotent)");
+    let post_subscribed = fetch_subscribed_collection_names(db_a.node.as_ref()).await;
     for col in &control_a {
-        assert!(post2.0.contains(col), "control still present: {post2:?}");
+        assert!(
+            post_subscribed.contains(col),
+            "control subscription still present: {post_subscribed:?}"
+        );
     }
 
     let _ = shutdown_a_tx.send(true);

--- a/crates/gents/tests/support/interrupt.rs
+++ b/crates/gents/tests/support/interrupt.rs
@@ -56,7 +56,7 @@ impl Drop for BootedAgent {
 }
 
 pub async fn wait_for_runtime_ready(node: &EmbeddedNode, agent_did: &str) {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         if let Some(snapshot) = fetch_runtime_snapshot(node, agent_did).await {
             if snapshot.process_state == "ready"

--- a/crates/gents/tests/support/mod.rs
+++ b/crates/gents/tests/support/mod.rs
@@ -176,10 +176,13 @@ type AgentConversation @branchable {
 }
 "#;
 
-/// A store whose `AgentConversation` collection lacks the unique `session_id`
-/// index, so duplicate rows can be seeded (#693). Registering the legacy SDL
-/// first makes `ensure_runtime_schemas`' own `add_schema` a no-op for that
-/// collection (it swallows "already exists"), exactly as on an upgraded host.
+/// A test-only store whose `AgentConversation` collection lacks the unique
+/// `session_id` index, so duplicate rows can be seeded (#693).
+///
+/// Production migration intentionally rejects this pre-baseline lineage.
+/// This focused recovery harness therefore installs an explicit alternate
+/// catalog directly instead of passing the legacy root through
+/// `ensure_runtime_schemas`.
 pub async fn test_db_with_duplicate_tolerant_conversations(name: &str) -> TestDb {
     let tempdir = tempfile::Builder::new()
         .prefix(&format!("gents-{name}-"))
@@ -192,12 +195,19 @@ pub async fn test_db_with_duplicate_tolerant_conversations(name: &str) -> TestDb
             .await
             .expect("embedded node"),
     );
-    node.add_schema(AGENT_CONVERSATION_NON_UNIQUE_SESSION_ID)
-        .await
-        .expect("legacy AgentConversation schema");
-    ensure_runtime_schemas(&node)
-        .await
-        .expect("runtime schemas");
+    for schema in gents_protocol::schemas::RUNTIME_ALL
+        .iter()
+        .chain(gents_protocol::schemas::ALL.iter())
+    {
+        let fixture_schema = if *schema == gents_protocol::schemas::AGENT_CONVERSATION {
+            AGENT_CONVERSATION_NON_UNIQUE_SESSION_ID
+        } else {
+            *schema
+        };
+        node.add_schema(fixture_schema)
+            .await
+            .expect("duplicate-tolerant fixture schema");
+    }
     TestDb {
         node,
         process_generation: 0,


### PR DESCRIPTION
## Summary

Restores a single green path from current `main` after the migration and directory-schema changes:

- Advances all nine DefraDB workspace dependencies from `e201d77c` to the immutable stabilization revision `966cf42bd337ada1c6f64584bea9e52f82001393` (including the upstream early-idle-exit P2P sync fix).
- Registers `AgentDirectoryEntry` in the canonical production baseline before desktop P2P subscription.
- Pins all 39 production collection roots and rejects a foreign single-root lineage as `UnknownLineage`, not only foreign multi-version DAGs.
- Regenerates the two roots that differ on current `main` (`AgentRequest` and `AgentToolCall`) instead of copying #930's branch-specific CIDs.
- Makes the chain-replay authoring test print and compare every computed root even when frozen pins are stale.
- Keeps the historical v0.6.12 store fail-closed and adapts the duplicate-tolerant recovery fixture to use an explicit test-only catalog.
- Asserts P2P subscription truth from the transport rather than treating the per-peer applied ownership ledger as global subscription state.
- Extends the two shared runtime-ready test waits from 10s to 30s, removing the self-hosted scheduling flake that made the migration and readiness PRs mutually block each other.

No release files or release workflow are changed.

## Why the Defra pin and migration roots move together

Defra collection version IDs are content-addressed. The all-root table generated on #930 could not be copied blindly onto current `main`: the built-in authoring test found that #930's request/tool-call schemas produce different CIDs. Conversely, keeping the old Defra pin while using the new root table causes a fresh install to reject its own `AgentRequest` root.

This PR therefore moves the dependency revision, exact current-main schema catalog, and matching root pins atomically.

## Main CI failures addressed

1. Current `main` timed out after 10 seconds waiting for runtime readiness in Lean-backed conformance.
2. The dedicated readiness PR then reached desktop smoke and failed 10/125 `gents-desktop-core` tests because `AgentDirectoryEntry` was subscribed before it had been registered.
3. A registration-only fix exposed the existing unpinned single-root lineage gap in the historical migration fixture.

The combined commits close all three without weakening migration admission or adding startup cleanup writes.

## Formal boundary

`Proofs/Migration.lean` explicitly assigns full foreign-DAG pin soundness to Rust conformance. This change strengthens that existing fail-closed boundary and does not alter the modeled activation or materialization transitions, so no Lean model change is required. The full conformance suite still runs and contains zero `sorry`s.

## Validation

Passed on exact head `50e7e6a6`:

- `cargo test -p gents-migration` — all migration tests passed (one doctest intentionally ignored).
- `cargo test -p gents-desktop-core` — 125 unit + 18 integration tests passed; all ten hosted startup failures are covered.
- `cargo test -p gents` — 1150 unit, 319 conformance, 39 lifecycle, 47 runtime, 87 subagent, 8 trigger, and all remaining package tests passed (live/external tests intentionally ignored).
- `cargo check --workspace --all-targets`.
- `cargo fmt --all -- --check`.
- `git diff --check`.

The root authoring test independently registered the ordered canonical SDL catalog and confirmed all 39 computed VersionIDs match the frozen table.

## PR ownership

This consolidates the two-line readiness fix from #948 so hosted CI has one non-cyclic recovery path. It extracts the Defra stabilization pin from #930, but does not include or supersede #930's desktop/client correctness work.
