### PR TITLE
chore(workspace): remove duplicate migration members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ members = [
     "crates/gents-migration",
     "crates/gents-lenses/fixture_add_label",
     "crates/gents-fs-runner",
-    "crates/gents-migration",
-    "crates/gents-lenses/fixture_add_label",
     "crates/gents-protocol",
     "crates/gents-schemas",
 ]


### PR DESCRIPTION
## Summary

Removes the second occurrence of two workspace members from the root `Cargo.toml`:

- `crates/gents-migration`
- `crates/gents-lenses/fixture_add_label`

No package, dependency, source, test, build script, or regeneration workflow is removed.

## Duplicate evidence

Before this patch, the manifest contained 16 raw member entries but only 14 unique paths. After it, both counts are 14.

The unique member set is identical before and after, and the order of every first occurrence is byte-for-byte unchanged. `default-members`, exclusions, workspace dependencies, and all leaf manifests are untouched.

`Cargo.lock` is byte-identical, so locked dependency resolution is unchanged.

## Regeneration / package evidence

The fixture lens remains a workspace member. `gents-migration/build.rs` still builds it by package name for `wasm32-unknown-unknown`, and CI still builds/tests both migration packages.

## Validation

- `cargo metadata --no-deps --locked --offline` — pass; 14 packages / 14 workspace members
- `cargo check --workspace --all-targets` — pass on current `main`
- `cargo fmt --all -- --check` — pass
- `git diff --check origin/main...HEAD` — pass
- clean worktree

An independent Codex review verified membership-set, order, lockfile, and regeneration parity.