### PR TITLE
test(gents): fail missing adapter fixture prerequisite

### DIFF
--- a/crates/gents/tests/e2e_runtime/adapter_projection_external_fixtures.rs
+++ b/crates/gents/tests/e2e_runtime/adapter_projection_external_fixtures.rs
@@ -14,13 +14,12 @@ const FIXTURE_ROOT_ENV: &str = "GENTS_ADAPTER_INTEROP_FIXTURES";
 #[test]
 #[ignore = "external interop: set GENTS_ADAPTER_INTEROP_FIXTURES and pass --ignored"]
 fn external_adapter_projection_fixtures_validate_against_contracts() -> Result<()> {
-    let Some(root) = std::env::var_os(FIXTURE_ROOT_ENV)
+    let root = std::env::var_os(FIXTURE_ROOT_ENV)
         .map(PathBuf::from)
         .map(resolve_fixture_root)
-    else {
-        eprintln!("{FIXTURE_ROOT_ENV} is not set; skipping external adapter fixture validation");
-        return Ok(());
-    };
+        .context(
+            "set GENTS_ADAPTER_INTEROP_FIXTURES to an adapter fixture path and pass --ignored to run external adapter fixture validation",
+        )?;
     let files = collect_json_files(&root)?;
     anyhow::ensure!(
         !files.is_empty(),


### PR DESCRIPTION
## Summary

Makes the ignored external adapter-fixture qualification fail explicitly when `GENTS_ADAPTER_INTEROP_FIXTURES` is missing, instead of printing a skip message and returning `Ok(())`.

The test remains `#[ignore]` with the same reason, so normal package runs are unchanged. When a fixture path is provided, path resolution, file discovery, deserialization, contract validation, JSON-schema assertions, and every existing fixture assertion are untouched.

## False-green evidence

Before this patch, explicitly running the ignored test with `--ignored` but omitting its advertised fixture environment variable produced a green result without validating a fixture.

After the patch:

- normal invocation with the variable unset passes with 1 ignored test and the original ignore reason;
- explicit `--ignored` invocation with the variable unset fails with: `set GENTS_ADAPTER_INTEROP_FIXTURES to an adapter fixture path and pass --ignored to run external adapter fixture validation`.

No fixture-backed coverage is deleted or bypassed.

## Validation

- exact normal adapter invocation — pass, 1 ignored
- exact gates-unset `--ignored` invocation — expected prerequisite failure
- `cargo test -p gents --test e2e_runtime --no-run` — pass
- normal `e2e_runtime` target excluding only the known v0.6.12 migration-lineage baseline defect — 46 passed, 1 ignored, 1 filtered
- `cargo fmt --all -- --check` — pass
- `git diff --check` — pass
- clean worktree

The unfiltered target independently reproduces the existing #931-era `defradb_v0612_store_upgrade` failure; this one-file adapter test diff does not overlap migration code.

Range-diff equality and stable patch ID `eb0a0bd3e976edb05d06af5c4266d3c7495512ab` were preserved across the current-main rebase. Independent Codex review found no behavior change after the prerequisite gate.