### PR TITLE
refactor(gents): deduplicate request doc ID resolution

### DIFF
--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -34,6 +34,26 @@ fn graphql_retry_root_request(retry_root_request: Option<&str>, request_id: &str
     escape_graphql_string(retry_root_request.unwrap_or(request_id))
 }
 
+fn extract_single_doc_id(response: &defra_node::QueryResponse, key: &str) -> Option<String> {
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get(key))
+        .and_then(|value| {
+            value
+                .get("_docID")
+                .and_then(|doc_id| doc_id.as_str())
+                .or_else(|| {
+                    value
+                        .as_array()
+                        .and_then(|rows| rows.first())
+                        .and_then(|row| row.get("_docID"))
+                        .and_then(|doc_id| doc_id.as_str())
+                })
+                .map(ToOwned::to_owned)
+        })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LocalLifecycleState {
     Pending,

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -37,6 +37,38 @@ fn trigger_lineage_graphql_fields(trigger_lineage: &TriggerLineage) -> String {
     format!("{caused_by_trigger_id_field}{caused_by_trigger_kind_field}")
 }
 
+async fn resolve_created_agent_request_doc_id(
+    node: &EmbeddedNode,
+    mutation_response: &defra_node::QueryResponse,
+    mutation_field: &str,
+    escaped_request_id: &str,
+    lookup_error: &str,
+    missing_doc_id_error: &str,
+) -> Result<String> {
+    if let Some(doc_id) = extract_single_doc_id(mutation_response, mutation_field) {
+        return Ok(doc_id);
+    }
+
+    let query = format!(
+        r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }}) {{ _docID }} }}"#
+    );
+    let query_resp = node.execute(&query).await;
+    if query_resp.has_errors() {
+        anyhow::bail!("{lookup_error}: {:?}", query_resp.errors);
+    }
+
+    query_resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|value| value.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("_docID"))
+        .and_then(|doc_id| doc_id.as_str())
+        .ok_or_else(|| anyhow::anyhow!("{missing_doc_id_error}"))
+        .map(str::to_string)
+}
+
 pub(crate) async fn write_pending_agent_request_with_lineage_and_conversation_title(
     node: &EmbeddedNode,
     agent_did: &str,
@@ -116,48 +148,15 @@ pub(crate) async fn write_pending_agent_request_with_lineage_and_conversation_ti
         );
     }
 
-    let inline_doc_id = response
-        .data
-        .as_ref()
-        .and_then(|d| d.get("create_AgentRequest"))
-        .and_then(|value| {
-            value
-                .get("_docID")
-                .and_then(|doc_id| doc_id.as_str())
-                .or_else(|| {
-                    value
-                        .as_array()
-                        .and_then(|rows| rows.first())
-                        .and_then(|row| row.get("_docID"))
-                        .and_then(|doc_id| doc_id.as_str())
-                })
-                .map(|s| s.to_string())
-        });
-
-    let doc_id = if let Some(doc_id) = inline_doc_id {
-        doc_id
-    } else {
-        let query = format!(
-            r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }}) {{ _docID }} }}"#
-        );
-        let query_resp = node.execute(&query).await;
-        if query_resp.has_errors() {
-            anyhow::bail!(
-                "querying created pending AgentRequest doc id failed: {:?}",
-                query_resp.errors
-            );
-        }
-        query_resp
-            .data
-            .as_ref()
-            .and_then(|d| d.get("AgentRequest"))
-            .and_then(|v| v.as_array())
-            .and_then(|rows| rows.first())
-            .and_then(|row| row.get("_docID"))
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("pending AgentRequest create returned no _docID"))?
-            .to_string()
-    };
+    let doc_id = resolve_created_agent_request_doc_id(
+        node,
+        &response,
+        "create_AgentRequest",
+        &escaped_request_id,
+        "querying created pending AgentRequest doc id failed",
+        "pending AgentRequest create returned no _docID",
+    )
+    .await?;
 
     if let Some(title) = conversation_title {
         let seed_result = async {
@@ -325,46 +324,15 @@ impl RequestLifecycle {
             anyhow::bail!("creating claimed AgentRequest failed: {:?}", resp.errors);
         }
 
-        let doc_id = if let Some(doc_id) = resp
-            .data
-            .as_ref()
-            .and_then(|data| data.get("add_AgentRequest"))
-            .and_then(|value| {
-                value
-                    .get("_docID")
-                    .and_then(|doc_id| doc_id.as_str())
-                    .or_else(|| {
-                        value
-                            .as_array()
-                            .and_then(|rows| rows.first())
-                            .and_then(|row| row.get("_docID"))
-                            .and_then(|doc_id| doc_id.as_str())
-                    })
-            }) {
-            doc_id.to_string()
-        } else {
-            let query = format!(
-                r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }}) {{ _docID }} }}"#
-            );
-            let query_resp = node.execute(&query).await;
-            if query_resp.has_errors() {
-                anyhow::bail!(
-                    "querying created AgentRequest doc id failed: {:?}",
-                    query_resp.errors
-                );
-            }
-
-            query_resp
-                .data
-                .as_ref()
-                .and_then(|d| d.get("AgentRequest"))
-                .and_then(|v| v.as_array())
-                .and_then(|rows| rows.first())
-                .and_then(|row| row.get("_docID"))
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| anyhow::anyhow!("add_AgentRequest returned no _docID"))?
-                .to_string()
-        };
+        let doc_id = resolve_created_agent_request_doc_id(
+            node.as_ref(),
+            &resp,
+            "add_AgentRequest",
+            &escaped_request_id,
+            "querying created AgentRequest doc id failed",
+            "add_AgentRequest returned no _docID",
+        )
+        .await?;
 
         let lineage_mutation = format!(
             r#"mutation {{

--- a/crates/gents/src/lifecycle/queue.rs
+++ b/crates/gents/src/lifecycle/queue.rs
@@ -9,7 +9,7 @@ use crate::session;
 use crate::watcher::AgentRequest;
 
 use super::materialize::EnqueuedAgentRequest;
-use super::{ExecutionOrigin, DEFAULT_REQUEST_MAX_RETRIES};
+use super::{extract_single_doc_id, ExecutionOrigin, DEFAULT_REQUEST_MAX_RETRIES};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct RequestQueueMetadata {
@@ -547,26 +547,6 @@ fn parent_linkage_graphql_fields(parent: &AgentRequest) -> String {
         }
         _ => String::new(),
     }
-}
-
-fn extract_single_doc_id(response: &defra_node::QueryResponse, key: &str) -> Option<String> {
-    response
-        .data
-        .as_ref()
-        .and_then(|data| data.get(key))
-        .and_then(|value| {
-            value
-                .get("_docID")
-                .and_then(|doc_id| doc_id.as_str())
-                .or_else(|| {
-                    value
-                        .as_array()
-                        .and_then(|rows| rows.first())
-                        .and_then(|row| row.get("_docID"))
-                        .and_then(|doc_id| doc_id.as_str())
-                })
-                .map(ToOwned::to_owned)
-        })
 }
 
 async fn lookup_request_doc_id(node: &EmbeddedNode, request_id: &str) -> Result<String> {


### PR DESCRIPTION
## Summary

Consolidates AgentRequest `_docID` response parsing across the lifecycle module without changing request creation behavior.

- Moves the existing private object-or-first-array extractor from `queue.rs` to the private lifecycle parent.
- Leaves all four queue call sites unchanged except for the import.
- Reuses that extractor for the duplicated mutation-response handling in the pending and claimed materialization paths.
- Centralizes their identical fallback query flow while retaining each paths exact errors.

Final diff: 3 files, +71/−103 (32 net lines removed).

## Parity evidence

The old queue helper body and new parent helper body compare byte-for-byte identical. Queue arguments, retry wrappers, contexts, and call ordering are unchanged.

For both materialization paths:

- inline response parsing still accepts `_docID` from an object first, then the first array row;
- the fallback GraphQL query is character-identical and interpolates the same canonical pre-escaped request ID;
- selection remains `AgentRequest { _docID }` with first-row handling;
- fallback parsing deliberately remains array-only, avoiding a behavior broadening;
- mutation field names and all lookup/missing-ID error strings are verbatim;
- mutation error checks still precede lookup, and conversation-title/lineage work remains after it.

No public API, visibility, module path, lifecycle transition, logging, retry, feature gate, or Lean invariant changes.

## Validation

- queue unit tests — 10/10 pass
- manual-request unit tests — 5/5 pass
- exact lifecycle-policy conformance case — 1/1 pass
- `cargo fmt --all -- --check` — pass
- `git diff --check origin/main..HEAD` — pass
- helper-body identity comparison — empty diff
- clean worktree

The broad `cargo test -p gents` gate is independently blocked by the known v0.6.12 unpinned-lineage baseline defect; this structural lifecycle diff does not touch migration code.

## Review

- Independent Codex review: APPROVE on the final three-file diff.
- Claude Opus: APPROVE after identifying and verifying incorporation of the pre-existing queue helper.
- Grok: APPROVE on exact materialize query, escaping, response-shape, error, and ordering parity.

Final stable patch ID: `b697a4ca05cecdefc2f8e9a3ecb2992033572b51`.