### PR TITLE
test(gents): fail missing live prerequisites

### DIFF
--- a/crates/gents/tests/e2e_live/interrupt_live.rs
+++ b/crates/gents/tests/e2e_live/interrupt_live.rs
@@ -38,10 +38,10 @@ const LIVE_BEHAVIOR_ID: &str = "live-interrupt";
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored"]
 async fn live_interrupt_mid_stream_on_openai_compatible() -> Result<()> {
-    if std::env::var("GENTS_LIVE_OPENAI").as_deref() != Ok("1") {
-        eprintln!("GENTS_LIVE_OPENAI is not 1; skipping live interrupt smoke");
-        return Ok(());
-    }
+    assert!(
+        std::env::var("GENTS_LIVE_OPENAI").as_deref() == Ok("1"),
+        "set GENTS_LIVE_OPENAI=1 and pass --ignored to run the live interrupt smoke test"
+    );
 
     let endpoint = std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")
         .unwrap_or_else(|_| DEFAULT_LIVE_ENDPOINT.to_string());

--- a/crates/gents/tests/e2e_live/p2p_admission_concurrent_live.rs
+++ b/crates/gents/tests/e2e_live/p2p_admission_concurrent_live.rs
@@ -449,10 +449,10 @@ impl Drop for LiveTopologyGuard {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "live: set GENTS_LIVE_P2P_ADMISSION=1 and pass --ignored"]
 async fn concurrent_multiwave_single_push_worker_converges_with_live_d4f() -> Result<()> {
-    if !live_enabled() {
-        eprintln!("GENTS_LIVE_P2P_ADMISSION is not 1; skipping concurrent multi-wave live e2e");
-        return Ok(());
-    }
+    assert!(
+        live_enabled(),
+        "set GENTS_LIVE_P2P_ADMISSION=1 and pass --ignored to run the concurrent multi-wave live e2e"
+    );
 
     let endpoint = live_endpoint();
     let model = live_model();

--- a/crates/gents/tests/e2e_live/subagent_delegation_live.rs
+++ b/crates/gents/tests/e2e_live/subagent_delegation_live.rs
@@ -4,8 +4,8 @@
 //! delegates work to a subagent behavior via `spawn_subagent`, the subagent
 //! runs (live model), and the result flows back to the orchestrator.
 //!
-//! Normal test runs skip these (they are `#[ignore]`-gated AND early-return
-//! unless `GENTS_LIVE_SUBAGENT=1`). To run locally:
+//! Normal test runs skip these because they are `#[ignore]`-gated. Explicit
+//! runs fail unless `GENTS_LIVE_SUBAGENT=1`. To run locally:
 //!
 //! ```bash
 //! GENTS_LIVE_SUBAGENT=1 \
@@ -74,10 +74,10 @@ fn live_model() -> String {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "live: set GENTS_LIVE_SUBAGENT=1 and pass --ignored"]
 async fn live_local_subagent_delegation() -> Result<()> {
-    if !live_enabled() {
-        eprintln!("GENTS_LIVE_SUBAGENT is not 1; skipping live local subagent delegation");
-        return Ok(());
-    }
+    assert!(
+        live_enabled(),
+        "set GENTS_LIVE_SUBAGENT=1 and pass --ignored to run live local subagent delegation"
+    );
 
     let endpoint = live_endpoint();
     let model = live_model();
@@ -242,10 +242,10 @@ async fn live_local_subagent_delegation() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "live: set GENTS_LIVE_SUBAGENT=1 and pass --ignored"]
 async fn live_cross_node_subagent_delegation() -> Result<()> {
-    if !live_enabled() {
-        eprintln!("GENTS_LIVE_SUBAGENT is not 1; skipping live cross-node subagent delegation");
-        return Ok(());
-    }
+    assert!(
+        live_enabled(),
+        "set GENTS_LIVE_SUBAGENT=1 and pass --ignored to run live cross-node subagent delegation"
+    );
 
     let endpoint = live_endpoint();
     let model = live_model();

--- a/crates/gents/tests/e2e_live/workflow_orchestration_live.rs
+++ b/crates/gents/tests/e2e_live/workflow_orchestration_live.rs
@@ -62,10 +62,10 @@ struct WorkflowToolCallRow {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "live: set GENTS_LIVE_WORKFLOW=1 and pass --ignored"]
 async fn fan_out_and_synthesize_barrier_live() -> Result<()> {
-    if !live_enabled() {
-        eprintln!("GENTS_LIVE_WORKFLOW != 1; skipping workflow orchestration e2e");
-        return Ok(());
-    }
+    assert!(
+        live_enabled(),
+        "set GENTS_LIVE_WORKFLOW=1 and pass --ignored to run the workflow orchestration e2e"
+    );
 
     let endpoint = live_endpoint();
     let model = live_model();


### PR DESCRIPTION
## Summary

Convert the five remaining top-level false-green prerequisite gates in `crates/gents/tests/e2e_live` from log-and-return-success behavior to explicit assertion failures.

Affected live scenarios:

- interrupt/resume
- concurrent P2P admission
- two subagent delegation scenarios
- workflow orchestration

The stale subagent module comment now describes explicit prerequisite failure instead of silent skipping.

## Deletion / behavior evidence

An independent audit found 12 tests in `e2e_live`: 9 ignored live tests and 3 non-live `post_status` tests. Exactly five live tests still returned success when a required gate variable was absent. The other four live prerequisites already fail explicitly (`context(...)?` or assertions). A whole-directory scan found no remaining top-level environment/path skip-and-success return; remaining early returns are polling, cleanup, or successful helper conditions.

All nine `#[ignore]` attributes and reasons are byte-preserved. Endpoint/model/API-key parsing and defaults, fixture paths, setup/teardown, live bodies, unique assertions, and module paths are unchanged. With the gates present, runtime behavior is identical.

## Validation

- `cargo test -p gents --test e2e_live --no-run`
- normal env-unset target: 3 passed, 9 ignored
- each of the five changed tests run via `--ignored --exact` with relevant variables unset: all fail immediately (0.00–0.01s) with their gate-specific prerequisite message and make no live contact
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- independent semantic-parity review: APPROVE

## Scope

Test-integrity only. No production, Lean, conformance, schema, dependency, feature-gate, API, logging, retry, or runtime changes.