### PR TITLE
test(gents): exercise directory null deserialization

### DIFF
--- a/crates/gents/src/agent/directory_projection.rs
+++ b/crates/gents/src/agent/directory_projection.rs
@@ -698,8 +698,17 @@ mod tests {
         // decodes to `None`, and `unwrap_or_default()` in
         // `list_directory_entries` maps that back to `""` — the same value
         // `derive_directory_entries` defaults to for a runtime-less principal.
-        let decoded: Option<String> = None;
-        assert_eq!(decoded.unwrap_or_default(), "");
+        let row: DirectoryRow = serde_json::from_value(serde_json::json!({
+            "directory_key": "dir-no-runtime",
+            "agent_did": "did:key:no-runtime",
+            "source_did": "did:key:home",
+            "display_name": "No Runtime",
+            "behaviors": [],
+            "runtime_state": "",
+            "last_seen": null,
+        }))
+        .expect("stored directory row with null last_seen should deserialize");
+        assert_eq!(row.last_seen.unwrap_or_default(), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replace a hollow nullable-directory assertion that locally constructed `Option::<String>::None` with a real `serde_json` deserialization of the private `DirectoryRow` shape containing `last_seen: null`.

## Test-integrity evidence

Before this change, the final assertion could only prove the standard-library behavior of `None.unwrap_or_default()`. It never exercised the row decoder used by `list_directory_entries`.

The replacement decodes a representative row through `serde_json`, then evaluates the same `row.last_seen.unwrap_or_default()` expression used by production. Both existing unique assertions that blank and whitespace timestamps render as GraphQL `null` are preserved, as is the final default-to-empty assertion. No test was deleted.

The `behaviors: []` value is serde input only; it is never emitted in a DefraDB mutation.

## Validation

- exact changed test: 1 passed
- full `agent::directory_projection::tests::` filter: 6 pure/unit tests passed; 2 embedded GraphQL cases failed before their assertions because current `main` does not register `AgentDirectoryEntry`
- that deterministic baseline defect is isolated in #949
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- stable patch identity preserved after rebase
- independent semantic review: APPROVE

## Scope and dependency

Test-only, one file, +11/-2. No production/schema/API/logging/error/retry/feature/module behavior changes. Keep draft until #949 repairs the current-main catalog and the embedded cases can be rerun green.