### PR TITLE
test(cli): update local diagnose schema expectation

### DIFF
--- a/crates/gents-cli/src/commands/background.rs
+++ b/crates/gents-cli/src/commands/background.rs
@@ -25,7 +25,7 @@ async fn background_list(args: BackgroundListArgs) -> Result<()> {
     let now = Utc::now();
     let age_cutoff = age_cutoff(args.age_gt.as_deref(), now)?;
     let (access, _home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let tool_calls = load_background_tool_calls(&access, &args, age_cutoff).await?;
     let liveness = match &access {
         ConfigAccess::Graphql(graphql) => {

--- a/crates/gents-cli/src/commands/codex_auth_probe.rs
+++ b/crates/gents-cli/src/commands/codex_auth_probe.rs
@@ -27,7 +27,7 @@ struct OpenAiModelSummary {
 
 pub(crate) async fn codex_auth_probe(args: CodexAuthProbeArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let agent_did = resolve_agent_did(Some(&home_dir), args.agent_did.as_deref())?;
     let provider = gents::chatgpt_codex::normalize_provider(&args.provider);
     let credential = load_oauth_credential(&access, &agent_did, &provider)

--- a/crates/gents-cli/src/commands/codex_login.rs
+++ b/crates/gents-cli/src/commands/codex_login.rs
@@ -28,7 +28,7 @@ pub(crate) struct CodexLoginOutcome {
 
 pub(crate) async fn codex_login(args: CodexLoginArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let agent_did = resolve_agent_did(Some(&home_dir), args.agent_did.as_deref())?;
     let outcome = run_codex_login(
         &access,

--- a/crates/gents-cli/src/commands/config/apply.rs
+++ b/crates/gents-cli/src/commands/config/apply.rs
@@ -13,8 +13,7 @@ use crate::{
 };
 
 pub(super) async fn config_apply(args: ConfigApplyArgs) -> Result<()> {
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let bound = super::binding::load_bound_manifest(super::binding::ManifestBindingOptions {
         root: &args.root,
         home: args.home.as_deref(),

--- a/crates/gents-cli/src/commands/config/binding.rs
+++ b/crates/gents-cli/src/commands/config/binding.rs
@@ -227,7 +227,7 @@ async fn resolve_bound_agent_did(
             if let Some(access) = access {
                 return resolve_live_agent_did(access).await;
             }
-            let (access, _) = crate::resolve_config_access(home, graphql, false).await?;
+            let (access, _) = crate::resolve_config_access(home, graphql).await?;
             resolve_live_agent_did(&access).await
         }
     }

--- a/crates/gents-cli/src/commands/config/crud.rs
+++ b/crates/gents-cli/src/commands/config/crud.rs
@@ -67,7 +67,7 @@ pub(super) const MCP_SPEC: ConfigDocumentSpec = ConfigDocumentSpec {
 };
 
 pub(super) async fn config_list(spec: ConfigDocumentSpec, args: ConfigListArgs) -> Result<()> {
-    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false)
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref())
         .await
         .with_context(|| format!("resolving access for config {} list", spec.noun))?;
     let mut rows = query_collection(&access, spec, None, None).await?;
@@ -92,7 +92,7 @@ pub(super) async fn config_list(spec: ConfigDocumentSpec, args: ConfigListArgs) 
 
 pub(super) async fn config_show(spec: ConfigDocumentSpec, args: ConfigShowArgs) -> Result<()> {
     let id = resolve_config_id(spec, &args)?;
-    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false)
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref())
         .await
         .with_context(|| format!("resolving access for config {} show", spec.noun))?;
     let row = load_one(&access, spec, &id).await?;
@@ -111,7 +111,7 @@ pub(super) async fn config_rm(spec: ConfigDocumentSpec, args: ConfigShowArgs) ->
     let output = args
         .output
         .ensure_supported(&format!("config {} rm", spec.noun), &[OutputFormat::Json])?;
-    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true)
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref())
         .await
         .with_context(|| format!("resolving access for config {} rm", spec.noun))?;
     let live = live_manifest_for_delete(

--- a/crates/gents-cli/src/commands/config/diff.rs
+++ b/crates/gents-cli/src/commands/config/diff.rs
@@ -8,8 +8,7 @@ use crate::print_json;
 use crate::{build_desired_state_live_bundle, live_manifest_from_bundle, resolve_config_access};
 
 pub(super) async fn config_diff(args: ConfigDiffArgs) -> Result<()> {
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let bound = super::binding::load_bound_manifest(super::binding::ManifestBindingOptions {
         root: &args.root,
         home: args.home.as_deref(),

--- a/crates/gents-cli/src/commands/config/export.rs
+++ b/crates/gents-cli/src/commands/config/export.rs
@@ -5,8 +5,7 @@ use crate::desired_state;
 use crate::{build_config_export_bundle, resolve_config_access};
 
 pub(super) async fn config_export(args: ConfigExportArgs) -> Result<()> {
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let agent_did = super::binding::resolve_target_agent_did(
         args.agent_did.as_deref(),
         args.bind_agent_did,

--- a/crates/gents-cli/src/commands/config/import.rs
+++ b/crates/gents-cli/src/commands/config/import.rs
@@ -11,8 +11,7 @@ use crate::{
 pub(super) async fn config_import(args: ConfigImportArgs) -> Result<()> {
     let bundle = read_config_import_bundle(args.path.as_deref())?;
     validate_config_import_bundle(&bundle)?;
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let txn = access.begin_apply_txn().await?;
 
     let result = async {

--- a/crates/gents-cli/src/commands/config/task_run.rs
+++ b/crates/gents-cli/src/commands/config/task_run.rs
@@ -86,12 +86,7 @@ pub(crate) async fn enqueue_task_run(args: &ConfigTaskRunArgs) -> Result<TaskRun
     // 2. Resolve GraphQL / local access the same way every other config
     //    subcommand does. Ensures local schemas if we fell back to an
     //    embedded node.
-    let (access, _) = resolve_config_access(
-        args.home.as_deref(),
-        args.graphql.as_deref(),
-        /* ensure_local_schemas */ true,
-    )
-    .await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     // 3. Fetch the Task doc.
     let task_query = format!(

--- a/crates/gents-cli/src/commands/diagnose/mod.rs
+++ b/crates/gents-cli/src/commands/diagnose/mod.rs
@@ -30,8 +30,7 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
         None => false,
     };
     let agent_did = resolve_agent_did(args.home.as_deref(), args.agent_did.as_deref())?;
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     let schema_checks = diagnose_schema_presence(&access).await;
     let bundle_result = build_config_export_bundle(&access, &agent_did).await;

--- a/crates/gents-cli/src/commands/goal.rs
+++ b/crates/gents-cli/src/commands/goal.rs
@@ -23,7 +23,7 @@ pub(crate) async fn dispatch(command: GoalCommand) -> Result<()> {
 async fn goal_show(args: GoalShowArgs) -> Result<()> {
     args.output
         .ensure_supported("goal show", &[OutputFormat::Json])?;
-    let (access, agent_did) = access_and_did(&args.scope, false).await?;
+    let (access, agent_did) = access_and_did(&args.scope).await?;
     let goal = load_goal(&access, &agent_did, &args.scope.session)
         .await?
         .with_context(|| format!("no durable goal for session {}", args.scope.session))?;
@@ -36,7 +36,7 @@ async fn goal_show(args: GoalShowArgs) -> Result<()> {
 async fn goal_set(args: GoalSetArgs) -> Result<()> {
     args.output
         .ensure_supported("goal set", &[OutputFormat::Json])?;
-    let (access, agent_did) = access_and_did(&args.scope, true).await?;
+    let (access, agent_did) = access_and_did(&args.scope).await?;
     let status = args.status.map(GoalStatus::from);
     let budget = if args.clear_token_budget {
         Some(None)
@@ -76,7 +76,7 @@ async fn goal_set(args: GoalSetArgs) -> Result<()> {
 async fn goal_clear(args: GoalShowArgs) -> Result<()> {
     args.output
         .ensure_supported("goal clear", &[OutputFormat::Json])?;
-    let (access, agent_did) = access_and_did(&args.scope, true).await?;
+    let (access, agent_did) = access_and_did(&args.scope).await?;
     let goal = load_goal(&access, &agent_did, &args.scope.session)
         .await?
         .with_context(|| format!("no durable goal for session {}", args.scope.session))?;
@@ -111,10 +111,10 @@ async fn goal_clear(args: GoalShowArgs) -> Result<()> {
     }))
 }
 
-async fn access_and_did(scope: &GoalScopeArgs, write: bool) -> Result<(ConfigAccess, String)> {
+async fn access_and_did(scope: &GoalScopeArgs) -> Result<(ConfigAccess, String)> {
     let agent_did = resolve_agent_did(scope.home.as_deref(), scope.agent_did.as_deref())
         .context("resolving goal owner agent_did")?;
-    let (access, _) = resolve_config_access(scope.home.as_deref(), scope.graphql.as_deref(), write)
+    let (access, _) = resolve_config_access(scope.home.as_deref(), scope.graphql.as_deref())
         .await
         .context("resolving durable-goal access")?;
     Ok((access, agent_did))

--- a/crates/gents-cli/src/commands/mcp.rs
+++ b/crates/gents-cli/src/commands/mcp.rs
@@ -30,8 +30,7 @@ async fn mcp_probe(args: McpProbeArgs) -> Result<()> {
         anyhow::bail!("--timeout must be greater than zero");
     }
 
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let services = load_mcp_services(&access, target.service_id()).await?;
     if matches!(target, ProbeTarget::Single(_)) && services.is_empty() {
         anyhow::bail!(

--- a/crates/gents-cli/src/commands/p2p/claim.rs
+++ b/crates/gents-cli/src/commands/p2p/claim.rs
@@ -93,7 +93,7 @@ pub(super) async fn p2p_claim(args: P2pClaimArgs) -> Result<()> {
     let addresses = vec![token.ticket.clone()];
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     // Same local-network match gate as v5 join: a node already bound to a
     // different network (or a different admin for the same id) must refuse the

--- a/crates/gents-cli/src/commands/p2p/invite.rs
+++ b/crates/gents-cli/src/commands/p2p/invite.rs
@@ -46,8 +46,7 @@ pub(super) async fn p2p_invite(args: P2pInviteArgs) -> Result<()> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .context("p2p pairings invite requires --member-did for v5 membership-gated invites")?;
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let network = load_single_network_record(&access)
         .await
         .context("loading local AgentNetwork for v5 invite")?;
@@ -104,8 +103,7 @@ async fn p2p_invite_bearer(args: P2pInviteArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let home_dir = resolve_home_dir(args.home.as_deref());
     let template = resolve_pairing_template(&args.template)?;
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let network = load_single_network_record(&access)
         .await
         .context("loading local AgentNetwork for bearer invite")?;

--- a/crates/gents-cli/src/commands/p2p/join.rs
+++ b/crates/gents-cli/src/commands/p2p/join.rs
@@ -72,7 +72,7 @@ pub(super) async fn p2p_join(args: P2pJoinArgs) -> Result<()> {
     let addresses = vec![remote.ticket.clone()];
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     // v5 admission is membership-gated by two admin-signed records carried in
     // the token: the AgentNetwork root and an active NetworkMembership grant for

--- a/crates/gents-cli/src/commands/p2p/network.rs
+++ b/crates/gents-cli/src/commands/p2p/network.rs
@@ -52,7 +52,7 @@ struct PeerRegistryRow {
 pub(super) async fn p2p_network_register(args: P2pNetworkRegisterArgs) -> Result<()> {
     let graphql = crate::resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     // Resolve peer_id + addresses from the live runtime.
     let p2p_status = load_live_http_p2p_status(args.home.as_deref(), &graphql).await;
@@ -144,7 +144,7 @@ pub(super) async fn p2p_network_register(args: P2pNetworkRegisterArgs) -> Result
 
 pub(super) async fn p2p_network_list(args: P2pNetworkListArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     // Load PeerRegistry rows.
     let registry_rows = graphql_rows(&access, "PeerRegistry", registry_list_query())
@@ -196,7 +196,7 @@ pub(super) async fn p2p_network_list(args: P2pNetworkListArgs) -> Result<()> {
 pub(super) async fn p2p_network_rm(args: P2pAccessArgs) -> Result<()> {
     let graphql = crate::resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     // Resolve peer_id for this node.
     let p2p_status = load_live_http_p2p_status(args.home.as_deref(), &graphql).await;

--- a/crates/gents-cli/src/commands/p2p/network_admin.rs
+++ b/crates/gents-cli/src/commands/p2p/network_admin.rs
@@ -23,7 +23,7 @@ use super::output::load_live_http_p2p_status;
 pub(super) async fn p2p_network_create(args: P2pNetworkCreateArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let identity = resolve_home_identity(args.home.as_deref())
         .context("resolving local agent identity for network creation")?;
     let admin_did = identity.did().to_string();
@@ -99,7 +99,7 @@ pub(super) async fn p2p_network_create(args: P2pNetworkCreateArgs) -> Result<()>
 
 pub(super) async fn p2p_network_grant(args: P2pNetworkGrantArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let identity = resolve_home_identity(args.home.as_deref())
         .context("resolving local agent identity for network grant")?;
     let network = load_single_network_record(&access).await?;
@@ -135,7 +135,7 @@ pub(super) async fn p2p_network_grant(args: P2pNetworkGrantArgs) -> Result<()> {
 
 pub(super) async fn p2p_network_revoke(args: P2pNetworkRevokeArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let identity = resolve_home_identity(args.home.as_deref())
         .context("resolving local agent identity for network revoke")?;
     let network = load_single_network_record(&access).await?;

--- a/crates/gents-cli/src/commands/p2p/pairings.rs
+++ b/crates/gents-cli/src/commands/p2p/pairings.rs
@@ -46,7 +46,7 @@ struct PeerPairingAppliedRow {
 
 pub(super) async fn p2p_pairings_list(args: P2pPairingsListArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let rows = graphql_rows(&access, "PeerPairingDesired", pairings_list_query())
         .await
         .context("loading PeerPairingDesired rows")?;
@@ -89,7 +89,7 @@ pub(super) async fn p2p_pairings_set(args: P2pPairingSetArgs) -> Result<()> {
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
     let graphql = crate::resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let doc_id = write_pairing_desired(
         &access,
         &peer_id,
@@ -148,7 +148,7 @@ pub(super) async fn p2p_pairings_remove(args: P2pPairingRefArgs) -> Result<()> {
     let peer_id = required_trimmed(&args.peer_id, "--peer")?;
     let mutation = delete_pairing_mutation(&peer_id);
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let response = access
         .execute(&mutation)
         .await

--- a/crates/gents-cli/src/commands/provision.rs
+++ b/crates/gents-cli/src/commands/provision.rs
@@ -29,7 +29,7 @@ pub(crate) async fn provision(args: ProvisionArgs) -> Result<()> {
     )
     .await?;
 
-    let (access, _) = resolve_config_access(Some(&home_dir), None, true).await?;
+    let (access, _) = resolve_config_access(Some(&home_dir), None).await?;
     let bound = binding::load_bound_manifest(binding::ManifestBindingOptions {
         root: &args.root,
         home: Some(&home_dir),

--- a/crates/gents-cli/src/commands/schema.rs
+++ b/crates/gents-cli/src/commands/schema.rs
@@ -68,7 +68,7 @@ pub(crate) async fn schema_apply(args: SchemaApplyArgs) -> Result<()> {
     }
 
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let graphql = match &access {
         ConfigAccess::Graphql(endpoint) => Some(endpoint.clone()),
         ConfigAccess::Local(_) => None,

--- a/crates/gents-cli/src/commands/session.rs
+++ b/crates/gents-cli/src/commands/session.rs
@@ -28,7 +28,7 @@ async fn session_list(args: ConfigListArgs) -> Result<()> {
     let output = args
         .output
         .ensure_supported("session list", &[OutputFormat::Table, OutputFormat::Json])?;
-    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false)
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref())
         .await
         .context("resolving access for session list")?;
     let mut rows = query_sessions(&access, None).await?;
@@ -59,7 +59,7 @@ async fn session_show(args: ConfigShowArgs) -> Result<()> {
     let output = args
         .output
         .ensure_supported("session show", &[OutputFormat::Json])?;
-    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false)
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref())
         .await
         .context("resolving access for session show")?;
     let mut rows = query_sessions(&access, Some(&id)).await?;

--- a/crates/gents-cli/src/commands/subagent.rs
+++ b/crates/gents-cli/src/commands/subagent.rs
@@ -43,12 +43,7 @@ async fn subagent_cancel(args: SubagentCancelArgs) -> Result<()> {
     let cause = parse_cancel_cause(&args.cause)?;
     let wait_timeout = resolve_wait_timeout(args.wait, args.timeout.as_deref())?;
 
-    let (access, _) = resolve_config_access(
-        args.home.as_deref(),
-        args.graphql.as_deref(),
-        /* ensure_local_schemas */ true,
-    )
-    .await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
 
     let snapshots = match access {
         ConfigAccess::Graphql(graphql) => {
@@ -672,8 +667,7 @@ struct SubagentCancelRender {
 }
 
 async fn subagent_list(args: SubagentListArgs) -> Result<()> {
-    let (access, _) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let rows = match args.root.as_deref().and_then(non_empty_str) {
         Some(root) => load_rooted_lineage(&access, root, args.depth).await?,
         None => load_lineage_forest(&access, args.depth).await?,

--- a/crates/gents-cli/src/commands/task.rs
+++ b/crates/gents-cli/src/commands/task.rs
@@ -24,12 +24,7 @@ pub(crate) async fn dispatch(command: TaskCommand) -> Result<()> {
 }
 
 pub(crate) async fn task_list(args: TaskListArgs) -> Result<()> {
-    let (access, _) = resolve_config_access(
-        args.home.as_deref(),
-        args.graphql.as_deref(),
-        /* ensure_local_schemas */ false,
-    )
-    .await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let inventory = load_task_inventory(&access, None).await?;
     let tasks = inventory.task_summaries();
     print_json(&json!({
@@ -45,12 +40,7 @@ pub(crate) async fn task_show(args: TaskShowArgs) -> Result<()> {
         args.task_id.as_deref(),
         args.task_id_flag.as_deref(),
     )?;
-    let (access, _) = resolve_config_access(
-        args.home.as_deref(),
-        args.graphql.as_deref(),
-        /* ensure_local_schemas */ false,
-    )
-    .await?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let inventory = load_task_inventory(&access, Some(&task_id)).await?;
     let Some(task) = inventory.tasks.first() else {
         anyhow::bail!("no Task with task_id = {task_id}");

--- a/crates/gents-cli/src/commands/tools.rs
+++ b/crates/gents-cli/src/commands/tools.rs
@@ -27,7 +27,7 @@ pub(crate) async fn dispatch(command: ToolsCommand) -> Result<()> {
 
 async fn holds(args: ToolsHoldsArgs) -> Result<()> {
     let (access, _home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let agent_did = if args.all {
         None
     } else {
@@ -49,7 +49,7 @@ async fn holds(args: ToolsHoldsArgs) -> Result<()> {
 
 async fn approve(args: ToolsApproveArgs) -> Result<()> {
     let (access, _home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let scope_did = match args.agent_did.as_deref() {
         Some(did) => Some(did.to_string()),
         None => resolve_agent_did(args.home.as_deref(), None).ok(),
@@ -103,7 +103,7 @@ async fn approve(args: ToolsApproveArgs) -> Result<()> {
 
 async fn explain(args: ToolExplainArgs) -> Result<()> {
     let (access, home_dir) =
-        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let agent_did = resolve_agent_did(args.home.as_deref(), args.agent_did.as_deref())?;
     let init_config = read_init_config(&home_dir)?;
     let (ceiling_arg, ceiling_source, tool_root, tool_ceiling) =

--- a/crates/gents-cli/src/commands/trace.rs
+++ b/crates/gents-cli/src/commands/trace.rs
@@ -50,7 +50,7 @@ pub(crate) async fn dispatch(command: TraceCommand) -> Result<()> {
 
 async fn trace_timeline(args: TraceTimelineArgs) -> Result<()> {
     let (access, _home_dir) =
-        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let timeline = load_run_timeline(&access, &args.request_id).await?;
     let value = serde_json::to_value(&timeline)?;
     if let Some(path) = args.output_file.as_deref() {
@@ -63,7 +63,7 @@ async fn trace_timeline(args: TraceTimelineArgs) -> Result<()> {
 
 async fn trace_project(args: TraceProjectArgs) -> Result<()> {
     let (access, _home_dir) =
-        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let actor_did = args.actor_did;
     let projection_kind = adapter_projection_kind(args.projection);
     let scope = ProjectionDocumentScope {
@@ -831,7 +831,7 @@ fn projection_redaction_mode(arg: TraceProjectionRedactionArg) -> ProjectionReda
 
 async fn trace_export(args: TraceExportArgs) -> Result<()> {
     let (access, _home_dir) =
-        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
     let requested_request = match args.request_id.as_deref() {
         Some(request_id) => Some(load_request_by_id(&access, request_id).await?),
         None => None,

--- a/crates/gents-cli/src/main.rs
+++ b/crates/gents-cli/src/main.rs
@@ -557,7 +557,6 @@ pub(crate) async fn http_delete_json<B: Serialize>(
 pub(crate) async fn resolve_config_access(
     home: Option<&Path>,
     explicit_graphql: Option<&str>,
-    ensure_local_schemas: bool,
 ) -> Result<(ConfigAccess, PathBuf)> {
     let home_dir = resolve_home_dir(home);
     if let Some(graphql) = explicit_graphql
@@ -586,11 +585,8 @@ pub(crate) async fn resolve_config_access(
                 })?,
         );
         // Single schema entry point (baseline + chain + lineage verify). Always
-        // runs — including when ensure_local_schemas is false — so absent
-        // collections are bootstrapped rather than rejected as UnknownLineage.
-        // `ensure_local_schemas` is retained as a call-site flag for documentation
-        // only; both paths share one lineage.
-        let _ = ensure_local_schemas;
+        // runs so absent collections are bootstrapped rather than rejected as
+        // UnknownLineage.
         gents::migration::ensure_all_runtime_migrations(node_arc.clone()).await?;
         // Unwrap the Arc: at this point the only live Arc is node_arc itself, so
         // try_unwrap always succeeds. The unwrap_or_else fallback is unreachable

--- a/crates/gents-cli/tests/cli_diagnose.rs
+++ b/crates/gents-cli/tests/cli_diagnose.rs
@@ -49,7 +49,7 @@ async fn diagnose_works_from_local_home_without_server() -> Result<()> {
     );
     assert_eq!(
         runtime_schema.get("ok").and_then(Value::as_bool),
-        Some(false)
+        Some(true)
     );
     assert_eq!(
         output.get("access_mode").and_then(Value::as_str),

--- a/docs/superpowers/specs/2026-07-28-lens-first-migration-design.md
+++ b/docs/superpowers/specs/2026-07-28-lens-first-migration-design.md
@@ -327,8 +327,8 @@ that any bypass creates a divergent lineage:
   out-of-band `ensure_agent_behavior_migrations` inside
   `Gents::from_default_behavior_documents` (`agent.rs:163`).
 - The entry point tolerates databases where target collections don't yet
-  exist (the CLI runs migrations even when `ensure_local_schemas` is false) —
-  absent collections are bootstrapped, never `UnknownLineage`.
+  exist (the CLI runs migrations on every embedded-node access path) — absent
+  collections are bootstrapped, never `UnknownLineage`.
 - Test helpers (~246 `ensure_*schemas` call sites, mostly `#[cfg(test)]`)
   route through the same entry point via one shared test-support function.
 - `gents init`'s six-collection `CONFIG_BOOTSTRAP` subset is replaced by the


### PR DESCRIPTION
## Summary

Update the `diagnose_reports_schema_checks_without_mutating_home` fixture to expect the `AgentRuntime` schema probe to succeed.

## Evidence

The previous `ok: false` expectation predates #931. Local `resolve_config_access` now runs `ensure_all_runtime_migrations` before diagnose performs its schema probes, so a fresh-home local diagnose has `AgentRuntime` available. The test still verifies diagnose behavior without adding user configuration or otherwise mutating the home fixture.

The diff is one assertion (`Some(false)` → `Some(true)`). Every other diagnose assertion, error string, serialized field, and production path is unchanged. Stable patch identity was preserved across the rebase to current `main`.

## Validation

- `cargo test -p gents-cli --test cli_diagnose --no-run`
- exact changed test: 1 passed
- full `cli_diagnose` integration target: 2 passed
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- independent intent/parity review: APPROVE

## Scope

Test expectation only. No CLI runtime, schema bootstrap, filesystem, API, logging, error, retry, feature-gate, or module-path changes.