### PR TITLE
chore(gents): simplify redundant content borrows

### DIFF
--- a/crates/gents/src/agent/loop_stream/tests.rs
+++ b/crates/gents/src/agent/loop_stream/tests.rs
@@ -1061,7 +1061,7 @@ async fn context_message_is_sent_before_prompt() {
     assert!(matches!(
         &histories[0][0],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::Text(text) if text.text.starts_with("<context>"))
+            if matches!(first_content(content), UserContent::Text(text) if text.text.starts_with("<context>"))
     ));
 }
 

--- a/crates/gents/src/agent/stream_processor/tests.rs
+++ b/crates/gents/src/agent/stream_processor/tests.rs
@@ -118,9 +118,9 @@ async fn persist_partial_turn_saves_reasoning_and_text_to_history() {
         Message::Assistant { content, .. }
             if content.len() == 2
                 // Order is text, then reasoning (rig's threading/persist order).
-                && matches!(first_content(&content), AssistantContent::Text(Text { text })
+                && matches!(first_content(content), AssistantContent::Text(Text { text })
                     if text == "I started by checking the repo layout.")
-                && matches!(content.iter().nth(1), Some(AssistantContent::Reasoning(reasoning))
+                && matches!(content.get(1), Some(AssistantContent::Reasoning(reasoning))
                     if reasoning.id.as_deref() == Some("rs_partial"))
     ));
 
@@ -452,7 +452,7 @@ async fn hook_persisted_tool_result_dedupes_matching_stream_result() {
     let tool_results = history
         .iter()
         .filter_map(|message| match message {
-            Message::User { content } => match first_content(&content) {
+            Message::User { content } => match first_content(content) {
                 UserContent::ToolResult(tool_result) => Some(tool_result),
                 _ => None,
             },
@@ -914,7 +914,7 @@ async fn count_tool_result_messages(node: &defra_node::EmbeddedNode, session_id:
         .iter()
         .filter(|message| {
             matches!(message, Message::User { content }
-                if matches!(first_content(&content), UserContent::ToolResult(_)))
+                if matches!(first_content(content), UserContent::ToolResult(_)))
         })
         .count()
 }

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -624,7 +624,7 @@ fn strip_rewrites_tool_results_into_stubs() {
     assert!(files.files_modified.is_empty());
 
     if let Message::User { content } = &stripped[2] {
-        if let UserContent::ToolResult(tr) = first_content(&content) {
+        if let UserContent::ToolResult(tr) = first_content(content) {
             if let ToolResultContent::Text(text) = first_content(&tr.content) {
                 assert_eq!(
                     text.text,
@@ -846,7 +846,7 @@ async fn integration_compaction_persists_entry_and_prompt_builder_uses_it() {
         .unwrap();
 
     if let Message::User { content } = &built.messages[0] {
-        if let UserContent::Text(text) = first_content(&content) {
+        if let UserContent::Text(text) = first_content(content) {
             assert!(text.text.contains("inspected the source files"));
             assert!(text
                 .text

--- a/crates/gents/src/hook/tests.rs
+++ b/crates/gents/src/hook/tests.rs
@@ -704,17 +704,17 @@ async fn completion_call_persists_context_once_before_prompt() {
     assert!(matches!(
         &history[0],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::Text(Text { text }) if text.starts_with("<context>"))
+            if matches!(first_content(content), UserContent::Text(Text { text }) if text.starts_with("<context>"))
     ));
     assert!(matches!(
         &history[1],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::Text(Text { text }) if text == "First request")
+            if matches!(first_content(content), UserContent::Text(Text { text }) if text == "First request")
     ));
     assert!(matches!(
         &history[2],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::Text(Text { text }) if text == "Second turn")
+            if matches!(first_content(content), UserContent::Text(Text { text }) if text == "Second turn")
     ));
 
     let _ = std::fs::remove_dir_all(&data_path);
@@ -1476,27 +1476,27 @@ async fn streaming_turn_persists_full_assistant_history_in_sequence() {
     assert!(matches!(
         &history[0],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::Text(Text { text }) if text == "Inspect /tmp/main.rs")
+            if matches!(first_content(content), UserContent::Text(Text { text }) if text == "Inspect /tmp/main.rs")
     ));
     assert!(matches!(
         &history[1],
         Message::Assistant { content, .. }
             if content.len() == 3
-                && matches!(first_content(&content), AssistantContent::Reasoning(reasoning) if reasoning.id.as_deref() == Some("rs_1"))
-                && matches!(content.iter().nth(1), Some(AssistantContent::ToolCall(tool_call)) if tool_call.call_id.as_deref() == Some("call-1"))
-                && matches!(content.iter().nth(2), Some(AssistantContent::Text(Text { text })) if text == "I'm reading the file now.")
+                && matches!(first_content(content), AssistantContent::Reasoning(reasoning) if reasoning.id.as_deref() == Some("rs_1"))
+                && matches!(content.get(1), Some(AssistantContent::ToolCall(tool_call)) if tool_call.call_id.as_deref() == Some("call-1"))
+                && matches!(content.get(2), Some(AssistantContent::Text(Text { text })) if text == "I'm reading the file now.")
     ));
     assert!(matches!(
         &history[2],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::ToolResult(tool_result)
+            if matches!(first_content(content), UserContent::ToolResult(tool_result)
                 if tool_result.call_id.as_deref() == Some("call-1")
                     && matches!(first_content(&tool_result.content), ToolResultContent::Text(Text { text }) if text == "fn main() {}\n"))
     ));
     assert!(matches!(
         &history[3],
         Message::Assistant { content, .. }
-            if matches!(first_content(&content), AssistantContent::Text(Text { text }) if text == "The file looks healthy.")
+            if matches!(first_content(content), AssistantContent::Text(Text { text }) if text == "The file looks healthy.")
     ));
 
     let resp = node
@@ -1749,7 +1749,7 @@ async fn read_file_result_persists_raw_output_but_models_compact_observation() {
     let Message::User { content } = &history[2] else {
         panic!("expected tool result message");
     };
-    let UserContent::ToolResult(tool_result) = first_content(&content) else {
+    let UserContent::ToolResult(tool_result) = first_content(content) else {
         panic!("expected tool result content");
     };
     assert_eq!(tool_result.call_id.as_deref(), Some("call-read"));
@@ -1873,7 +1873,7 @@ async fn duplicate_tool_result_message_observation_reuses_transcript_row() {
     let tool_results = history
         .iter()
         .filter_map(|message| match message {
-            Message::User { content } => match first_content(&content) {
+            Message::User { content } => match first_content(content) {
                 UserContent::ToolResult(tool_result) => Some(tool_result),
                 _ => None,
             },
@@ -1978,7 +1978,7 @@ async fn tool_result_message_dedupe_preserves_distinct_result_ids() {
     let tool_results = history
         .iter()
         .filter_map(|message| match message {
-            Message::User { content } => match first_content(&content) {
+            Message::User { content } => match first_content(content) {
                 UserContent::ToolResult(tool_result) => Some(tool_result.id.as_str()),
                 _ => None,
             },
@@ -2136,13 +2136,13 @@ async fn tool_call_after_saved_assistant_starts_new_turn_without_orphan_result()
     assert!(matches!(
         &history[2],
         Message::Assistant { content, .. }
-            if matches!(first_content(&content), AssistantContent::ToolCall(tool_call)
+            if matches!(first_content(content), AssistantContent::ToolCall(tool_call)
                 if tool_call.id == "call-2")
     ));
     assert!(matches!(
         &history[3],
         Message::User { content }
-            if matches!(first_content(&content), UserContent::ToolResult(tool_result)
+            if matches!(first_content(content), UserContent::ToolResult(tool_result)
                 if tool_result.id == "call-2"
                     && matches!(first_content(&tool_result.content), ToolResultContent::Text(Text { text }) if text == "second result"))
     ));

--- a/crates/gents/src/identity.rs
+++ b/crates/gents/src/identity.rs
@@ -352,7 +352,7 @@ fn load_or_create_macos_keychain_raw_identity(
             let private_key = crypto::generate_ed25519().map_err(anyhow::Error::from)?;
             let bytes = private_key.raw();
             keychain
-                .set_generic_password(MACOS_KEYCHAIN_SERVICE, label, &bytes)
+                .set_generic_password(MACOS_KEYCHAIN_SERVICE, label, bytes)
                 .with_context(|| format!("storing macOS keychain identity {label}"))?;
             RawIdentity::from_private_key(private_key)
                 .map_err(anyhow::Error::from)

--- a/crates/gents/src/prompt/tests.rs
+++ b/crates/gents/src/prompt/tests.rs
@@ -108,7 +108,7 @@ async fn build_with_summaries_prepends() {
     assert_eq!(prompt.messages.len(), 2);
 
     if let Message::User { content } = &prompt.messages[0] {
-        if let UserContent::Text(t) = first_content(&content) {
+        if let UserContent::Text(t) = first_content(content) {
             assert!(t.text.contains("<system-reminder>"));
             assert!(t.text.contains("project architecture"));
         } else {
@@ -123,7 +123,7 @@ async fn build_with_summaries_prepends() {
 fn system_reminder_format() {
     let msg = LayeredPromptBuilder::system_reminder("The time is 3pm.");
     if let Message::User { content } = &msg {
-        if let UserContent::Text(t) = first_content(&content) {
+        if let UserContent::Text(t) = first_content(content) {
             assert!(t.text.starts_with("<system-reminder>"));
             assert!(t.text.ends_with("</system-reminder>"));
             assert!(t.text.contains("The time is 3pm."));

--- a/crates/gents/src/session/tests.rs
+++ b/crates/gents/src/session/tests.rs
@@ -37,7 +37,7 @@ fn test_load_history_deserializes_legacy_assistant_content() {
         Message::Assistant { content, .. }
             if content.len() == 2
                 && matches!(first_content(&content), AssistantContent::Reasoning(reasoning) if reasoning.id.as_deref() == Some("rs_1"))
-                && matches!(content.iter().nth(1), Some(AssistantContent::Text(Text { text })) if text == "Done")
+                && matches!(content.get(1), Some(AssistantContent::Text(Text { text })) if text == "Done")
     ));
 }
 


### PR DESCRIPTION
## Summary

Apply a narrow clippy cleanup to redundant content access in Gents tests and one equivalent macOS keychain coercion:

- 20 `first_content(&content)` calls become `first_content(content)`
- 4 `content.iter().nth(n)` calls become `content.get(n)`
- 1 macOS keychain `&bytes` argument becomes `bytes`

## Semantic-parity evidence

At every `first_content` site, match ergonomics bind `content` as `&Vec<T>` and the helper accepts `&[T]`; the removed `&` only created an immediately dereferenced extra reference. Each `get(n)` returns the same `Option<&T>` at the same zero-based index as `iter().nth(n)`, with ordering and surrounding assertions unchanged.

`private_key.raw()` returns `&[u8]` in the pinned DefraDB crypto crate and `SecKeychain::set_generic_password` accepts `&[u8]`; the old `&&[u8]` was deref-coerced. No key bytes, keychain service/account, context, or error string changes.

Independent review found exactly these 25 one-line substitutions and no attribute, function, assertion, literal, order, error, or control-flow changes.

## Validation

- `cargo check -p gents --lib` (macOS): pass
- `cargo test -p gents --lib`: 1,146 passed; 4 failed solely because current `main` omits `AgentDirectoryEntry` from the baseline catalog (#949); all affected test modules passed
- focused clippy with `-D clippy::needless_borrow -D clippy::iter_nth`: no `iter_nth` finding; only remaining `needless_borrow` is `tests/conformance/r5_scenarios.rs:19`, intentionally left to the separate user-owned R5 workstream
- `cargo fmt --all -- --check`
- `git diff --check`
- independent semantic review: APPROVE

## Scope

No API, persisted data, runtime behavior, logging, errors, retries, visibility, feature gates, or module paths change. This is a reviewable clippy family slice, not a repository-wide warning sweep.