### PR TITLE
docs(gents): reflow config read overview

### DIFF
--- a/crates/gents/src/self_config/read.rs
+++ b/crates/gents/src/self_config/read.rs
@@ -1,8 +1,8 @@
 //! Effective-config read assembly for `get_my_config` (#654).
 //!
-//! Reads the durable documents (behavior + tool selection + profile + backend
-//! + owned skills/automation) inside one identity-scoped transaction, so the
-//! projection is a consistent snapshot and DefraDB ACP governs visibility.
+//! Reads the durable documents for behavior, tool selection, profile, backend,
+//! owned skills, and automation inside one identity-scoped transaction, so
+//! the projection is a consistent snapshot and DefraDB ACP governs visibility.
 //! Documents are the truth being reported; the running slot may still be on
 //! the previous generation (see [`super::core::EFFECT_TIMING_NOTE`]).
 //!


### PR DESCRIPTION
## Summary

Reflow the `self_config::read` module overview so its prose is not parsed as an unindented continuation of a rustdoc list item.

## Evidence

The old parenthesized `behavior + tool selection + ...` sentence triggered `clippy::doc_lazy_continuation`. The replacement is the same list expressed as ordinary prose: behavior, tool selection, profile, backend, owned skills, and automation. The transaction, snapshot-consistency, ACP-visibility, and runtime-generation statements are unchanged.

This is a comment-only 3-line reflow; no items, attributes, links, code, API, visibility, errors, logging, retries, features, or module paths change.

## Validation

- `cargo clippy -p gents --lib -- -D clippy::doc_lazy_continuation`: pass (46 unrelated baseline warning findings remain non-fatal)
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`

## Scope

Single rustdoc warning family, one file, +3/-3. This is intentionally separate from the broader clippy baseline.