### PR TITLE
test(gents): clean trigger harness clippy warnings

### DIFF
--- a/crates/gents/src/trigger_engine/tests/dispatch_contract.rs
+++ b/crates/gents/src/trigger_engine/tests/dispatch_contract.rs
@@ -24,7 +24,7 @@ pub(super) async fn trigger_engine_dispatch_matches_lean_generated_contract_case
             .trigger_id
             .as_ref()
             .map(|trigger_id| (trigger_id.clone(), trigger_kind));
-        let expects_target_supersede = target_key.as_ref().map_or(false, |(trigger_id, kind)| {
+        let expects_target_supersede = target_key.as_ref().is_some_and(|(trigger_id, kind)| {
             case.expected_supersede_call_keys.iter().any(|key| {
                 key.trigger_id == *trigger_id && trigger_kind_from_lean(&key.trigger_kind) == *kind
             })
@@ -35,12 +35,9 @@ pub(super) async fn trigger_engine_dispatch_matches_lean_generated_contract_case
         let mut superseded_prior_ids = case.superseded_prior_ids.iter();
         for key in &case.prior_nonterminal_keys {
             let (prior_trigger_id, prior_trigger_kind) = trigger_key_from_lean(key);
-            if target_key
-                .as_ref()
-                .map_or(false, |(target_id, target_kind)| {
-                    target_id == &prior_trigger_id && *target_kind == prior_trigger_kind
-                })
-            {
+            if target_key.as_ref().is_some_and(|(target_id, target_kind)| {
+                target_id == &prior_trigger_id && *target_kind == prior_trigger_kind
+            }) {
                 if let Some(request_id) = superseded_prior_ids.next() {
                     materializer.mark_nonterminal_request(
                         &prior_trigger_id,

--- a/crates/gents/src/trigger_engine/tests/event_source.rs
+++ b/crates/gents/src/trigger_engine/tests/event_source.rs
@@ -809,8 +809,6 @@ async fn event_source_on_result_writes_runtime_fields_on_skipped_or_errored() {
     cancel.cancel();
 }
 
-/// Build a `ResolvedTask` for unit tests that exercise the manual-fire path.
-
 // ---------------------------------------------------------------------------
 // Regression tests for the duplicate-on-update / fan-out correctness fixes.
 // The DefraDB event bus emits a single `EventName::Update` variant for

--- a/crates/gents/src/trigger_engine/tests/mod.rs
+++ b/crates/gents/src/trigger_engine/tests/mod.rs
@@ -42,6 +42,8 @@ type MaterializeCall = (Option<String>, TriggerKind, String);
 /// Recorded `supersede` invocation: `(trigger_id, trigger_kind)`.
 type SupersedeCall = (String, TriggerKind);
 
+type NonterminalRequests = Arc<Mutex<HashMap<(String, TriggerKind), Vec<String>>>>;
+
 /// Build a minimal `Arc<AgentPrincipal>` for tests that need to satisfy the
 /// principal invariant enforced by `ResolvedRuntimeSnapshot::activate`'s
 /// `debug_assert!`. Does not exercise signing.
@@ -106,7 +108,7 @@ struct MaterializeGate {
 struct SpyMaterializer {
     materialize_calls: Arc<Mutex<Vec<MaterializeCall>>>,
     next_request_id: AtomicUsize,
-    nonterminal_for: Arc<Mutex<HashMap<(String, TriggerKind), Vec<String>>>>,
+    nonterminal_for: NonterminalRequests,
     /// DIDs the engine passed to the concurrency gate / supersede, in call
     /// order. The gate's DID scope is the subject of #605.
     gate_dids: Arc<Mutex<Vec<String>>>,


### PR DESCRIPTION
## Summary

Clean three narrow clippy findings inside the trigger-engine test harness:

- replace two `Option::map_or(false, predicate)` expressions with `is_some_and(predicate)`
- name the repeated private `Arc<Mutex<HashMap<(String, TriggerKind), Vec<String>>>>` test type
- remove an orphan rustdoc comment that no longer documented an item

## Semantic-parity evidence

Both option rewrites operate on the same `Option<&(String, TriggerKind)>`, preserve `None = false`, use the identical predicates/equality comparisons, and retain short-circuit behavior. Prior-key iteration, supersede ordering, and all assertions are unchanged.

The private `NonterminalRequests` alias expands exactly to the previous field type; construction, locking, ownership, key/value types, and visibility are unchanged. The removed comment was unattached and had no code effect.

Independent review found exactly 3 files +7/-10 and no behavioral changes.

## Validation

- `cargo test -p gents trigger_engine::tests:: --lib`: 37 passed, 0 failed/ignored, including the Lean-generated dispatch contract
- targeted clippy warning-mode run: no findings under `trigger_engine/tests`
- strict targeted `-D` is still blocked by unrelated current-main `type_complexity` findings in unchanged production/test files; those remain separate warning slices
- `cargo fmt --all -- --check`
- `git diff --check`
- independent semantic review: APPROVE

## Scope

Test harness only. No Lean model, production transition behavior, APIs, errors, logging, retries, feature gates, visibility, or module paths change.