### PR TITLE
refactor(gents): construct syntax config directly

### DIFF
--- a/crates/gents/src/template/reads.rs
+++ b/crates/gents/src/template/reads.rs
@@ -12,13 +12,8 @@ use super::TemplateError;
 /// Collect the complete set of full variable refs a system template reads,
 /// rejecting constructs that introduce bindings or control flow.
 pub fn collect_system_reads(template: &str) -> Result<BTreeSet<String>, TemplateError> {
-    let ast = parse(
-        template,
-        "system_prompt",
-        SyntaxConfig::default(),
-        Default::default(),
-    )
-    .map_err(|e| TemplateError::Parse(e.to_string()))?;
+    let ast = parse(template, "system_prompt", SyntaxConfig, Default::default())
+        .map_err(|e| TemplateError::Parse(e.to_string()))?;
     let mut reads = BTreeSet::new();
     walk_stmt_system(&ast, &mut reads)?;
     Ok(reads)
@@ -75,7 +70,7 @@ pub fn collect_request_reads(template: &str) -> Result<BTreeSet<String>, Templat
     let ast = parse(
         template,
         "request_context",
-        SyntaxConfig::default(),
+        SyntaxConfig,
         Default::default(),
     )
     .map_err(|e| TemplateError::Parse(e.to_string()))?;


### PR DESCRIPTION
## Summary

Replace the two `SyntaxConfig::default()` constructions in the template read collectors with direct unit-struct construction.

This is one coherent Clippy family slice. A workspace-wide search found exactly these two occurrences, and no warning sweep or adjacent refactor is included.

## Semantic-parity evidence

`Cargo.lock` pins MiniJinja 2.20.0. The workspace enables `builtins`, `serde`, and `unstable_machinery`, but not `custom_syntax`; `cargo tree -p gents -e features -i minijinja` independently confirmed that feature selection.

Under that active configuration, MiniJinja defines:

```rust
#[derive(Clone, Default, Debug)]
pub struct SyntaxConfig;
```

Therefore `SyntaxConfig` and `SyntaxConfig::default()` construct the same zero-field value. The line-count reduction around the first call is only rustfmt compacting an otherwise identical `parse` invocation. No template names, parse inputs, error mapping, walker calls, attributes, visibility, APIs, or module paths change.

Independent semantic review: APPROVE.

## Validation

- `cargo clippy -p gents --all-targets -- -D clippy::default_constructed_unit_structs`: pass
- `cargo test -p gents --lib template::reads::tests`: 3 passed
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

An additional prompt-template conformance filter was started but not claimed: its cold integration-binary link was stopped after the directly affected collector tests passed. No test failure occurred.

## Scope

No public API, runtime behavior, formal invariant, error string, logging, retry behavior, visibility, feature gate, or module path changes.
