### PR TITLE
test(gents): scope mutex guards before awaits

### DIFF
--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -1988,13 +1988,14 @@ async fn add_replicator_records_filters_at_seam() {
         .await
         .expect("add_replicator empty filters");
 
-    let calls = admin.recorded_filters.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert!(
-        calls[0].1.is_empty(),
-        "empty filters should record as empty"
-    );
-    drop(calls);
+    {
+        let calls = admin.recorded_filters.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(
+            calls[0].1.is_empty(),
+            "empty filters should record as empty"
+        );
+    }
 
     // Non-empty filters are faithfully recorded.
     let mut filters = PairingFilters::default();

--- a/crates/gents/tests/conformance/directory_projection.rs
+++ b/crates/gents/tests/conformance/directory_projection.rs
@@ -220,22 +220,23 @@ async fn tick_preserves_foreign_same_agent_did_and_converges_local_row() {
         first.upserted,
         BTreeSet::from(["did:key:shared-agent".to_string()])
     );
-    let entries = store.entries.lock().unwrap();
-    assert_eq!(
-        entries.get(&(foreign.source_did.clone(), foreign.agent_did.clone())),
-        Some(&foreign),
-        "local projection must not overwrite the foreign same-DID row"
-    );
-    assert_eq!(
-        entries
-            .get(&(
-                "did:key:local-home".to_string(),
-                "did:key:shared-agent".to_string()
-            ))
-            .map(|entry| entry.display_name.as_str()),
-        Some("Local")
-    );
-    drop(entries);
+    {
+        let entries = store.entries.lock().unwrap();
+        assert_eq!(
+            entries.get(&(foreign.source_did.clone(), foreign.agent_did.clone())),
+            Some(&foreign),
+            "local projection must not overwrite the foreign same-DID row"
+        );
+        assert_eq!(
+            entries
+                .get(&(
+                    "did:key:local-home".to_string(),
+                    "did:key:shared-agent".to_string()
+                ))
+                .map(|entry| entry.display_name.as_str()),
+            Some("Local")
+        );
+    }
 
     let second = reconcile_directory_tick(&store, "did:key:local-home")
         .await


### PR DESCRIPTION
## Summary

Replace two explicit mutex-guard `drop` calls in tests with lexical scopes:

- the P2P reconcile filter-recording seam test
- the directory projection same-agent convergence test

This removes the two targeted `await_holding_lock` diagnostics without changing production code or test coverage.

## Semantic-parity evidence

An exact word-level comparison shows that only the scope boundaries replace the explicit `drop(guard)` calls. Every assertion, map lookup, literal, comment, test name/attribute, statement, and order remains unchanged.

In both tests, the closing brace occupies the old explicit-drop position immediately before the same async operation:

- `add_replicator(...).await`
- the second `reconcile_directory_tick(...).await`

The mutex guards are therefore released at the same point and still never cross an await.

Independent semantic review: APPROVE.

## Validation

- exact P2P seam test: 1 passed, 1,149 filtered
- exact directory projection test: 1 passed, 318 filtered
- `cargo clippy -p gents --tests -- -D clippy::await_holding_lock`: pass; zero denied findings
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

The targeted Clippy run still reports unrelated pre-existing warnings (87 in the lib-test target and 8 in conformance), which remain outside this reviewable family.

## Scope

Test-only mechanical lifetime cleanup. No assertion, coverage, public API, runtime behavior, formal invariant, error string, logging, retry behavior, visibility, feature gate, or module path changes.
