### PR TITLE
refactor(gents): simplify response normalization predicates

### DIFF
--- a/crates/gents/src/llm/responses_normalize.rs
+++ b/crates/gents/src/llm/responses_normalize.rs
@@ -24,13 +24,13 @@ fn normalize_assistant_item(item: &mut Value, index: usize) {
     object
         .entry("type".to_string())
         .or_insert_with(|| Value::String("message".to_string()));
-    if !object.get("id").is_some_and(|value| !value.is_null()) {
+    if object.get("id").is_none_or(|value| value.is_null()) {
         object.insert(
             "id".to_string(),
             Value::String(format!("msg_gents_{index}")),
         );
     }
-    if !object.get("status").is_some_and(|value| !value.is_null()) {
+    if object.get("status").is_none_or(|value| value.is_null()) {
         object.insert("status".to_string(), Value::String("completed".to_string()));
     }
 


### PR DESCRIPTION
## Summary

Simplify the two equivalent missing-or-null predicates used to normalize assistant response `id` and `status` fields.

This is one isolated production Clippy family: two substitutions in one private normalizer, with no adjacent restructuring.

## Semantic-parity evidence

For both fields, the old predicate:

```rust
!object.get(key).is_some_and(|value| !value.is_null())
```

and the new predicate:

```rust
object.get(key).is_none_or(|value| value.is_null())
```

have the same complete truth table:

- missing: insert the generated default
- present and null: insert the generated default
- present and non-null: preserve the existing value

Both forms perform one `object.get`, call `is_null` exactly once only for a present value, and leave the mutation order (`type` → `id` → `status` → `content`), generated literals, index formatting, and insertion calls unchanged. Existing focused tests cover missing, null, and non-null pairs.

Independent semantic review: APPROVE.

## Validation

- pre-change strict Clippy: exactly two `clippy::nonminimal_bool` errors at these predicates
- `cargo clippy -p gents --lib -- -D clippy::nonminimal-bool`: pass after the change; 47 unrelated baseline warnings remain
- `cargo test -p gents llm::responses_normalize::tests -- --nocapture`: 4 passed; all package test targets compile
- `cargo check -p gents --lib`: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

Required full-package gate:

- Lean contract build: 872/872
- `cargo test -p gents`: 1,146 passed, 4 failed
- all four failures are the known current-`main` migration catalog defect: `AgentDirectoryEntry` is absent from the baseline registration, producing three directory projection GraphQL errors and one embedded collection-not-found error
- no response-normalizer test failed; #949 isolates the shared catalog fix

## Scope

No public API, runtime behavior, formal invariant, error string, logging, retry behavior, visibility, feature gate, or module path changes.
