### PR TITLE
test(gents): clean assertion hygiene warnings

### DIFF
--- a/crates/gents/src/toolset/session_history.rs
+++ b/crates/gents/src/toolset/session_history.rs
@@ -530,10 +530,12 @@ mod tests {
         // Only the backstop caps it.
         assert_eq!(clamp_limit(Some(MAX_LIMIT + 5_000)), MAX_LIMIT);
         // The scan budget must be able to surface MAX_LIMIT distinct sessions.
-        assert!(
-            REQUEST_SCAN_LIMIT >= MAX_LIMIT,
-            "REQUEST_SCAN_LIMIT must stay >= MAX_LIMIT or the cap is unreachable"
-        );
+        const {
+            assert!(
+                REQUEST_SCAN_LIMIT >= MAX_LIMIT,
+                "REQUEST_SCAN_LIMIT must stay >= MAX_LIMIT or the cap is unreachable"
+            );
+        }
     }
 
     async fn seeded_node() -> Arc<EmbeddedNode> {

--- a/crates/gents/src/trace_export/tests.rs
+++ b/crates/gents/src/trace_export/tests.rs
@@ -364,7 +364,7 @@ fn structured_tool_not_allowed_is_non_retryable() {
     );
     assert_eq!(analysis.validation_errors[0].code, "tool_not_allowed");
     assert_eq!(analysis.validation_errors[0].path, "/service_id");
-    assert_eq!(analysis.validation_errors[0].retryable, false);
+    assert!(!analysis.validation_errors[0].retryable);
     let error = analysis.tool_error.as_ref().expect("tool error");
     assert_eq!(error.failure_class, ToolFailureClass::ServiceUnavailable);
     assert_eq!(error.service_id.as_deref(), Some("observability-mcp"));


### PR DESCRIPTION
## Summary

Clean two test-only assertion-form warnings without deleting either assertion:

- preserve the session scan-budget invariant in an inline `const` block
- express the projected non-retryable boolean with `assert!(!...)`

These are the only two diagnostics in this Clippy assertion-hygiene family on current `main`.

## Coverage and parity evidence

The session-history assertion is unique coverage: it couples the real request scan budget (`REQUEST_SCAN_LIMIT`) to the caller-visible cap (`MAX_LIMIT`). Its exact relation and failure message are preserved verbatim. Moving it into an inline const advances failure from execution of this test to compilation of `cfg(test)` targets; normal production builds and runtime behavior are unchanged.

The trace-export assertion still evaluates the same indexed `TraceValidationError.retryable` boolean exactly once and requires it to be false. A later assertion checks `tool_error.retryable == Some(false)`, which is a different projected field, so neither assertion is duplicate coverage.

The boolean form has a minor diagnostic tradeoff: `assert!` does not render explicit left/right values. The expression still names the exact field, and a boolean has only two states.

Independent semantic review: APPROVE.

## Validation

- exact session-history invariant test: 1 passed, 1,149 filtered
- exact trace-export projection test: 1 passed, 1,149 filtered
- `cargo clippy -p gents --all-targets -- -A warnings -D clippy::assertions_on_constants -D clippy::bool_assert_comparison`: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

## Scope

No test or assertion is removed. No production code, public API, runtime behavior, formal invariant, error string, logging, retry behavior, visibility, feature gate, or module path changes.
