### PR TITLE
chore(gents): simplify managed tool dispatch

### DIFF
--- a/crates/gents/src/toolset/bash_tools.rs
+++ b/crates/gents/src/toolset/bash_tools.rs
@@ -135,7 +135,6 @@ impl Tool for ReadOnlyBashTool {
             args.raw_json,
         )
         .await
-        .map_err(Into::into)
     }
 }
 
@@ -216,6 +215,5 @@ impl Tool for UnrestrictedBashTool {
             args.raw_json,
         )
         .await
-        .map_err(Into::into)
     }
 }

--- a/crates/gents/src/toolset/native_runner.rs
+++ b/crates/gents/src/toolset/native_runner.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context as _};
 use gents_fs_runner::protocol::{NativeFsRunnerRequest, NativeFsRunnerResponse};
-use tokio_util::sync::CancellationToken;
 
 use super::shared::{ToolContext, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
@@ -68,7 +67,7 @@ impl NativeFsRunner {
         let cancellation_token = runtime
             .as_ref()
             .map(|runtime| runtime.cancellation_token.clone())
-            .unwrap_or_else(CancellationToken::new);
+            .unwrap_or_default();
         let live_output = runtime
             .as_ref()
             .and_then(|runtime| runtime.live_output.clone());

--- a/crates/gents/src/toolset/shared/command.rs
+++ b/crates/gents/src/toolset/shared/command.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Serialize;
-use tokio_util::sync::CancellationToken;
 
 use super::context::{ToolContext, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
@@ -200,7 +199,7 @@ pub(crate) async fn run_command(
     let cancellation_token = runtime
         .as_ref()
         .map(|runtime| runtime.cancellation_token.clone())
-        .unwrap_or_else(CancellationToken::new);
+        .unwrap_or_default();
     let live_output = runtime.and_then(|runtime| runtime.live_output);
     let started = Instant::now();
     let outcome = run_managed_exec(ManagedExecRequest {


### PR DESCRIPTION
## Summary

Apply one narrow Clippy cleanup to managed tool dispatch:

- use the default cancellation-token fallback at two private dispatch seams
- remove two identity `ToolError` conversions from Bash tool wrappers
- remove the two imports made unused by those substitutions

The diff is three files, `+2/-6`, with no adjacent refactor.

## Semantic-parity evidence

`Cargo.lock` pins tokio-util 0.7.18. Its `Default for CancellationToken` implementation directly returns `CancellationToken::new()`, which creates a fresh non-cancelled token.

`Option::unwrap_or_default()` retains the old laziness:

- `Some(token)`: preserves the same cloned Arc-backed runtime token
- `None`: allocates the same fresh, unattached, non-cancelled token as `unwrap_or_else(CancellationToken::new)`

Both removed `.map_err(Into::into)` calls operated on `Result<String, ToolError>` where the containing method declares the same `ToolError`. The blanket `From<T> for T` was therefore an identity move. Removing it preserves exact variants, anyhow chains, display strings, policy payloads, validation order, await timing, and cancellation/timeout outcomes.

Independent semantic review: APPROVE.

## Validation

Six focused tests passed individually:

- unrestricted shell command wrapper
- read-only raw-JSON escape hatch
- Bash timeout metadata
- request-deadline lifecycle marker
- native filesystem deadline and queue advancement
- managed-exec cancellation and process-group kill

Additional gates:

- `cargo clippy -p gents --all-targets -- -D clippy::unwrap_or_default -D clippy::useless_conversion`: pass; unrelated baseline warning families remain
- `cargo check --workspace --all-targets`: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

Required full-package gate:

- Lean contract build: 872/872
- `cargo test -p gents`: 1,146 passed, 4 failed
- all four failures are the known current-`main` `AgentDirectoryEntry` catalog defect (three directory projection GraphQL failures and one embedded collection-not-found failure)
- no edited-path test failed; #949 isolates the catalog registration issue

## Scope

No public API, runtime behavior, formal invariant, error string, logging, retry or cancellation behavior, visibility, feature gate, or module path changes.
