### PR TITLE
refactor(desktop): simplify optional agent scoping

### DIFF
--- a/crates/gents-desktop-bridge/src/snapshot/session.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/session.rs
@@ -116,9 +116,7 @@ pub fn build_session_snapshot_from_store_for_agent(
 ) -> Option<DesktopSessionSnapshot> {
     let conversation = store.conversations.iter().find(|row| {
         row.session_id == session_id
-            && agent_did.map_or(true, |agent_did| {
-                row.agent_did.as_deref() == Some(agent_did)
-            })
+            && agent_did.is_none_or(|agent_did| row.agent_did.as_deref() == Some(agent_did))
     });
     let session_row = store
         .sessions
@@ -126,7 +124,7 @@ pub fn build_session_snapshot_from_store_for_agent(
         .enumerate()
         .find(|(index, row)| {
             row.session_id == session_id
-                && agent_did.map_or(true, |agent_did| {
+                && agent_did.is_none_or(|agent_did| {
                     source_matches_agent(&store.session_source_agent_dids, *index, agent_did, false)
                 })
         })
@@ -140,7 +138,7 @@ pub fn build_session_snapshot_from_store_for_agent(
         .iter()
         .filter(|row| {
             row.session_id == session_id
-                && agent_did.map_or(true, |agent_did| row.agent_did == agent_did)
+                && agent_did.is_none_or(|agent_did| row.agent_did == agent_did)
         })
         .min_by(|left, right| {
             left.created_at
@@ -473,9 +471,7 @@ fn logical_turn_index_for_request(
     let request = store.requests.iter().find(|row| {
         row.request_id == request_id
             && row.session_id.as_deref() == Some(session_id)
-            && agent_did.map_or(true, |agent_did| {
-                request_matches_agent(row, agent_did, false)
-            })
+            && agent_did.is_none_or(|agent_did| request_matches_agent(row, agent_did, false))
     })?;
     let root_id = request_turn_root_id(request);
     logical_turn_roots_for_session(store, agent_did, session_id)
@@ -513,9 +509,7 @@ fn build_pending_turn(
     let request = store.requests.iter().find(|row| {
         row.request_id == request_id
             && row.session_id.as_deref() == Some(session_id)
-            && agent_did.map_or(true, |agent_did| {
-                request_matches_agent(row, agent_did, false)
-            })
+            && agent_did.is_none_or(|agent_did| request_matches_agent(row, agent_did, false))
     })?;
 
     let lifecycle_state = normalize_optional(request.lifecycle_state.as_deref());

--- a/crates/gents-desktop-core/src/client/store/mod.rs
+++ b/crates/gents-desktop-core/src/client/store/mod.rs
@@ -777,14 +777,14 @@ impl ClientStore {
 pub type SharedClientStore = Arc<ClientStore>;
 
 fn row_agent_matches(row_agent_did: Option<&str>, agent_did: &str) -> bool {
-    row_agent_did.map_or(true, |row_agent_did| row_agent_did == agent_did)
+    row_agent_did.is_none_or(|row_agent_did| row_agent_did == agent_did)
 }
 
 fn source_agent_matches(sources: &[Option<String>], row_index: usize, agent_did: &str) -> bool {
     sources
         .get(row_index)
         .and_then(|source| source.as_deref())
-        .map_or(true, |source_agent_did| source_agent_did == agent_did)
+        .is_none_or(|source_agent_did| source_agent_did == agent_did)
 }
 
 fn upsert_rows_by_key<T>(target: &mut Vec<T>, incoming: Vec<T>, key_fn: impl Fn(&T) -> String) {


### PR DESCRIPTION
## Summary

Simplify seven optional-agent scope predicates across the desktop bridge snapshot builder and desktop core store.

This is one cohesive Clippy family:

- five snapshot/session selection predicates
- two core store source-agent match predicates

No naming, ownership-model, filtering, or adjacent structural change is included.

## Semantic-parity evidence

Every substitution is:

```rust
option.map_or(true, |value| predicate(value))
```

to:

```rust
option.is_none_or(|value| predicate(value))
```

The complete truth table is identical:

- `None`: true
- `Some(value)`: the same predicate result

Both APIs consume the receiver once and invoke the closure exactly once only for `Some`. Outer `&&` short-circuiting, iterator `find`/`filter`/`min` ordering, source-chain evaluation, borrows, false flags, equality operands, absent-source permissiveness, and all literals remain unchanged. Three closures became short enough for rustfmt to collapse; their formatted bodies are otherwise identical.

Independent semantic review: APPROVE.

## Validation

- strict all-target `clippy::unnecessary_map_or` for `gents-desktop-core` and `gents-desktop-bridge`: pass; unrelated baseline warnings remain
- exact bridge same-session agent-scoping test: 1 passed
- bridge snapshot filter: 38 passed
- core store unit filter: 4 passed
- desktop package-boundary check: pass
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

Broad baseline classification:

- bridge: 97 passed, 18 failed, 2 ignored
- desktop-core lib: 115 passed, 10 failed
- desktop-core `client_store`: 5 passed, 4 failed
- every failure stops at startup with `collection 'AgentDirectoryEntry' not found - add schema before subscribing to P2P`, before any changed predicate executes
- #949 now owns the coherent catalog, root-pin, Defra revision, and readiness foundation

## Scope

No public API, runtime result, ownership or visibility rule, error string, logging, retry behavior, feature gate, or module path changes.
