### PR TITLE
test: simplify optional predicate checks

### DIFF
--- a/crates/gents-cli/tests/support/fs.rs
+++ b/crates/gents-cli/tests/support/fs.rs
@@ -543,9 +543,8 @@ pub async fn assert_runtime_init_state(
     // semantically identical. Accept null/absent/[] as "empty".
     let mcp_allowlist = tool_selection.get("allowed_mcp_service_ids");
     assert!(
-        mcp_allowlist.map_or(true, |value| {
-            value.is_null() || value.as_array().is_some_and(Vec::is_empty)
-        }),
+        mcp_allowlist
+            .is_none_or(|value| { value.is_null() || value.as_array().is_some_and(Vec::is_empty) }),
         "expected default tool selection MCP allowlist to be empty (null or []): {tool_selection}"
     );
 

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -525,7 +525,7 @@ async fn drive_streaming_response_interrupt_flow_case(
         assert!(post_response
             .reasoning
             .as_deref()
-            .map_or(true, |reasoning| reasoning.is_empty()));
+            .is_none_or(|reasoning| reasoning.is_empty()));
     }
 
     if case.partial_turn_materialized {


### PR DESCRIPTION
## Summary

Simplify two test-only optional predicates:

- the streaming-compaction assertion that accepts absent or empty reasoning
- the CLI fixture assertion that accepts an absent/null/empty MCP allowlist

No production, proof, R5/backgrounding, or test-body restructuring is included.

## Semantic-parity evidence

Both changes replace:

```rust
option.map_or(true, |value| predicate(value))
```

with:

```rust
option.is_none_or(|value| predicate(value))
```

For `None`, both return true. For `Some(value)`, both invoke the unchanged predicate exactly once and return its result. The old default was the literal `true`, so changing from `map_or` does not remove any observable eager evaluation. Consumption, borrows, assertion text, helper behavior, and all accepted value shapes are unchanged.

The shorter CLI expression receives only rustfmt line reflow.

Independent semantic review: APPROVE.

## Validation

- exact generated streaming interrupt-flow conformance case: 1 passed, 318 filtered; Lean generation/build clean; test body completed in 192.54s
- five exact CLI tests: 5 passed, covering all six calls to the changed fixture helper
- strict `clippy::unnecessary_map_or` on the affected `gents-cli` test targets: pass
- the same strict lint on Gents conformance compiles the edited streaming site clean and exits only on the two pre-existing `coverage.rs` findings owned by the separate R5/backgrounding workstream; there is no diagnostic in `streaming_compaction.rs`
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass

## #949 sequencing

#949 touches the same `streaming_compaction.rs` file at a distinct readiness-wait hunk. `git merge-tree` retains both changes without conflict. This draft may be reviewed now, but it should rebase after #949 lands before merge so the authoritative migration/readiness foundation is validated first.

## Scope

No test or assertion is deleted. No public API, runtime behavior, formal invariant, error string, logging, retry behavior, visibility, feature gate, or module path changes.
