### PR TITLE
chore(release): prepare v0.10.1

### DIFF
--- a/.github/scripts/setup-rust-build-cache.sh
+++ b/.github/scripts/setup-rust-build-cache.sh
@@ -27,7 +27,19 @@ echo "Using SCCACHE_DIR=${SCCACHE_DIR}"
 echo "Using SCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE:-sccache default}"
 
 sccache --version
-if ! sccache --start-server; then
-  echo "::notice::sccache server was already starting or running; verifying connectivity."
-  sccache --show-stats >/dev/null
+# Studio runners share a long-lived sccache daemon across jobs. A prior job that
+# cleaned its workdir can leave the daemon with a dead cwd, which surfaces as
+# "Couldn't determine current working directory" / missing dep-info files mid
+# compile. Always recycle the server so each job starts from a live process.
+if sccache --stop-server >/dev/null 2>&1; then
+  echo "Stopped existing sccache server."
+else
+  echo "No sccache server was running (or stop failed); starting fresh."
 fi
+# Brief settle so the old process releases the port / lock before we restart.
+sleep 1
+if ! sccache --start-server; then
+  echo "::error::Failed to start sccache server after recycle."
+  exit 1
+fi
+sccache --show-stats >/dev/null

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.10.0"
+        default: "0.10.1"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.10.0"
+        default: "0.10.1"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.10.1 - 2026-07-30
+
+### Dependencies
+
+- Advance DefraDB to v0.17.4 (`f9e21c68`), following the v0.17.3 pin from #972.
+
+### Runtime and reliability
+
+- Stabilize mobile chat and stop synthetic agent turns (#930).
+- Complete native backgrounding for subagents and tools with real GLM E2E (#937, #945).
+- Fix machine pairing replicator install: `source_did` must be `@immutable` (#939).
+- Hard-fail materialize + restore post-migration CI gates; complete and pin the
+  runtime migration baseline catalog (#947, #949).
+
+### Cleanup
+
+- Integration cleanup pass for runtime, desktop, CLI, and tests (#970, #971).
+- Clippy and harness hygiene for trigger tests (#961).
+
 ## 0.10.0 - 2026-07-29
 
 ### Bridge contract
@@ -72,6 +91,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 | Tag        | Bridge crate | npm packages | contract_version | Notes                                         |
 | ---------- | ------------ | ------------ | ---------------- | --------------------------------------------- |
+| v0.10.1    | 0.10.1       | 0.10.1       | 0.5              | DefraDB v0.17.4; mobile/subagent/migration fixes |
 | v0.10.0    | 0.10.0       | 0.10.0       | 0.5              | Reusable desktop packages implemented in #878 |
 
 ## 0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -872,7 +872,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -883,7 +883,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1890,14 +1890,14 @@ dependencies = [
  "h2 0.4.13",
  "http 1.4.0",
  "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -2072,7 +2072,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1 0.10.6",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tower",
@@ -2094,7 +2094,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2221,7 +2221,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2308,15 +2308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -2438,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3481,8 +3472,8 @@ dependencies = [
  "opentelemetry",
  "rand 0.9.2",
  "reqwest 0.12.28",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4873,7 +4864,7 @@ name = "codex-utils-rustls-provider"
 version = "0.0.0"
 source = "git+https://github.com/openai/codex?rev=c4e53d103c102f8d5201247adbc60bbddd47c88d#c4e53d103c102f8d5201247adbc60bbddd47c88d"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
 ]
 
 [[package]]
@@ -5584,7 +5575,6 @@ dependencies = [
  "signature 2.2.0",
  "subtle-encoding",
  "tendermint",
- "tendermint-rpc",
  "thiserror 1.0.69",
 ]
 
@@ -5609,15 +5599,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.54.0",
-]
-
-[[package]]
-name = "cpp_demangle"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -5817,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5954,7 +5935,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6151,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6392,13 +6373,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6412,7 +6393,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "anyhow",
@@ -6462,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6486,7 +6467,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6501,7 +6482,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-lock",
@@ -6542,7 +6523,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-trait",
@@ -6557,7 +6538,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "anyhow",
  "document",
@@ -6657,7 +6638,7 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6682,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-stream",
@@ -6714,7 +6695,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "anyhow",
@@ -6748,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-trait",
@@ -6782,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "serde",
 ]
@@ -7057,16 +7038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7115,7 +7086,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7200,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7604,7 +7575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7654,7 +7625,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -7925,7 +7896,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7951,7 +7922,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
- "eyre",
  "paste",
 ]
 
@@ -8289,7 +8259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -8352,20 +8322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "fxprof-processed-profile"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
-dependencies = [
- "bitflags 2.11.0",
- "debugid",
- "rustc-hash 2.1.2",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -8478,7 +8434,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -8495,7 +8451,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "acp",
  "anyhow",
@@ -8554,7 +8510,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "acp",
  "anyhow",
@@ -8608,7 +8564,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -8622,7 +8578,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -8649,7 +8605,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8679,7 +8635,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -8703,7 +8659,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -8716,7 +8672,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "globset",
@@ -8728,7 +8684,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -8745,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -8763,7 +8719,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -8782,7 +8738,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.10.0"
+version = "0.10.1"
 
 [[package]]
 name = "gethostname"
@@ -8937,7 +8893,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10308,11 +10264,11 @@ dependencies = [
  "ipnet",
  "jni 0.22.4",
  "rand 0.10.1",
- "rustls 0.23.37",
+ "rustls",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tracing",
  "url",
 ]
@@ -10448,12 +10404,12 @@ dependencies = [
  "parking_lot 0.12.5",
  "rand 0.10.1",
  "resolv-conf",
- "rustls 0.23.37",
+ "rustls",
  "smallvec",
- "system-configuration 0.7.0",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -10656,20 +10612,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
@@ -10677,11 +10619,11 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
 ]
@@ -10732,8 +10674,8 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
- "system-configuration 0.7.0",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -10818,7 +10760,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -11044,7 +10986,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -11112,7 +11054,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.7.0",
+ "system-configuration",
  "tokio",
  "windows 0.62.2",
 ]
@@ -11170,20 +11112,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im-rc"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -11512,7 +11440,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.2",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "smallvec",
@@ -11598,7 +11526,7 @@ dependencies = [
  "ndk-context",
  "portable-atomic",
  "rand 0.10.1",
- "rustls 0.23.37",
+ "rustls",
  "simple-dns",
  "strum 0.28.0",
  "tokio",
@@ -11690,13 +11618,13 @@ dependencies = [
  "postcard",
  "rand 0.10.1",
  "reqwest 0.13.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tokio-websockets",
  "tracing",
@@ -11764,7 +11692,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11830,26 +11758,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "ittapi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
-dependencies = [
- "anyhow",
- "ittapi-sys",
- "log",
-]
-
-[[package]]
-name = "ittapi-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "ixdtf"
@@ -12194,7 +12102,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-lock",
@@ -12340,7 +12248,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -12759,7 +12667,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.14",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
@@ -12891,7 +12799,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen 0.11.3",
  "ring 0.17.14",
- "rustls 0.23.37",
+ "rustls",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
  "x509-parser 0.16.0",
@@ -13783,7 +13691,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
  "security-framework 3.7.0",
@@ -14086,8 +13994,8 @@ dependencies = [
  "noq-udp",
  "pin-project-lite",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
- "socket2 0.5.10",
+ "rustls",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -14113,7 +14021,7 @@ dependencies = [
  "rand_pcg 0.10.2",
  "ring 0.17.14",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.7.0",
  "slab",
@@ -14132,7 +14040,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -14179,7 +14087,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14387,7 +14295,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14846,12 +14754,6 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -15025,7 +14927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15059,7 +14961,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "anyhow",
@@ -15313,33 +15215,6 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
 ]
-
-[[package]]
-name = "peg"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
-dependencies = [
- "peg-macros",
- "peg-runtime",
-]
-
-[[package]]
-name = "peg-macros"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
-dependencies = [
- "peg-runtime",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "peg-runtime"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "pem"
@@ -16267,7 +16142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.11.0",
  "log",
  "multimap 0.10.1",
@@ -16314,7 +16189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16327,7 +16202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16448,7 +16323,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16476,7 +16351,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "chrono",
  "cid",
@@ -16492,7 +16367,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "async-lock",
@@ -16516,7 +16391,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16595,8 +16470,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
- "socket2 0.5.10",
+ "rustls",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -16616,7 +16491,7 @@ dependencies = [
  "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -16634,7 +16509,7 @@ dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -16858,7 +16733,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
 ]
 
@@ -16945,11 +16820,11 @@ dependencies = [
  "rama-net",
  "rama-utils",
  "rcgen 0.14.7",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "webpki-roots 1.0.6",
  "x509-parser 0.18.1",
 ]
@@ -17152,15 +17027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -17433,53 +17299,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "p2p",
  "query",
  "schema",
  "serde_json",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.50.0",
 ]
 
 [[package]]
@@ -17501,7 +17326,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -17511,16 +17336,16 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -17549,7 +17374,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -17558,14 +17383,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -18001,19 +17826,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.14",
- "rustls-webpki 0.101.7",
- "sct",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18034,35 +17847,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -18086,14 +17878,14 @@ dependencies = [
  "jni 0.21.1",
  "log",
  "once_cell",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18107,14 +17899,14 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "once_cell",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18232,7 +18024,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "cid",
  "defra-core",
@@ -18382,16 +18174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18525,7 +18307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19279,16 +19061,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19359,7 +19131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19434,7 +19206,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -19563,7 +19335,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -19861,7 +19633,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-trait",
  "bm25",
@@ -20131,12 +19903,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -20228,34 +19994,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -20641,7 +20386,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20709,20 +20454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-config"
-version = "0.40.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069d1791f9b02a596abcd26eb72003b2e9906c6169a60fa82ffc080dd3a43fda"
-dependencies = [
- "flex-error",
- "serde",
- "serde_json",
- "tendermint",
- "toml 0.8.2",
- "url",
-]
-
-[[package]]
 name = "tendermint-proto"
 version = "0.40.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20735,39 +20466,6 @@ dependencies = [
  "serde_bytes",
  "subtle-encoding",
  "time",
-]
-
-[[package]]
-name = "tendermint-rpc"
-version = "0.40.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e0569a4b4cc42ff00df5a665be2858a39ff79df4790b176f1cd0e169bc0fc2"
-dependencies = [
- "async-trait",
- "bytes",
- "flex-error",
- "futures",
- "getrandom 0.2.17",
- "peg",
- "pin-project",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "semver 1.0.28",
- "serde",
- "serde_bytes",
- "serde_json",
- "subtle",
- "subtle-encoding",
- "tendermint",
- "tendermint-config",
- "tendermint-proto",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
 ]
 
 [[package]]
@@ -20818,7 +20516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -21078,21 +20776,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -21127,10 +20815,10 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite 0.23.0",
  "webpki-roots 0.26.11",
 ]
@@ -21154,11 +20842,11 @@ source = "git+https://github.com/openai-oss-forks/tokio-tungstenite?rev=132f5b39
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tungstenite 0.27.0",
 ]
 
@@ -21209,7 +20897,7 @@ dependencies = [
  "sha1_smol",
  "simdutf8",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
 ]
 
@@ -21361,10 +21049,10 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls-native-certs 0.8.3",
- "sync_wrapper 1.0.2",
+ "rustls-native-certs",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -21394,7 +21082,7 @@ dependencies = [
  "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -21689,7 +21377,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 1.0.69",
@@ -21726,7 +21414,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
@@ -21801,7 +21489,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -22364,27 +22052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-compose"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd23d12cc95c451c1306db5bc63075fbebb612bb70c53b4237b1ce5bc178343"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "im-rc",
- "indexmap 2.13.1",
- "log",
- "petgraph 0.6.5",
- "serde",
- "serde_derive",
- "serde_yaml",
- "smallvec",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wat",
-]
-
-[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22402,16 +22069,6 @@ checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.246.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -22493,17 +22150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.246.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
-dependencies = [
- "bitflags 2.11.0",
- "indexmap 2.13.1",
- "semver 1.0.28",
-]
-
-[[package]]
 name = "wasmprinter"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22526,11 +22172,6 @@ dependencies = [
  "bumpalo",
  "cc",
  "cfg-if",
- "encoding_rs",
- "futures",
- "fxprof-processed-profile",
- "gimli 0.33.0",
- "ittapi",
  "libc",
  "log",
  "mach2",
@@ -22539,22 +22180,13 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
- "rayon",
  "rustix 1.1.4",
- "semver 1.0.28",
  "serde",
  "serde_derive",
- "serde_json",
  "smallvec",
  "target-lexicon 0.13.5",
- "tempfile",
- "wasm-compose",
- "wasm-encoder 0.245.1",
  "wasmparser 0.245.1",
  "wasmtime-environ",
- "wasmtime-internal-cache",
- "wasmtime-internal-component-macro",
- "wasmtime-internal-component-util",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
@@ -22562,8 +22194,6 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "wat",
  "windows-sys 0.61.2",
 ]
 
@@ -22574,7 +22204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
- "cpp_demangle",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
@@ -22584,8 +22213,6 @@ dependencies = [
  "log",
  "object 0.38.1",
  "postcard",
- "rustc-demangle",
- "semver 1.0.28",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
@@ -22594,50 +22221,8 @@ dependencies = [
  "wasm-encoder 0.245.1",
  "wasmparser 0.245.1",
  "wasmprinter",
- "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
-
-[[package]]
-name = "wasmtime-internal-cache"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fd4103ba413c0da2e636f73490c6c8e446d708cbde7573703941bc3d6a448"
-dependencies = [
- "base64 0.22.1",
- "directories-next",
- "log",
- "postcard",
- "rustix 1.1.4",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ",
- "windows-sys 0.61.2",
- "zstd 0.13.3",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d6914f34be2f9d78d8ee9f422e834dfc204e71ccce697205fae95fed87892"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wasmtime-internal-component-util",
- "wasmtime-internal-wit-bindgen",
- "wit-parser 0.245.1",
-]
-
-[[package]]
-name = "wasmtime-internal-component-util"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3751b0616b914fdd87fe1bf804694a078f321b000338e6476bc48a4d6e454f21"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -22645,7 +22230,6 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22632b187e1b0716f1b9ac57ad29013bed33175fcb19e10bb6896126f82fac67"
 dependencies = [
- "anyhow",
  "hashbrown 0.16.1",
  "libm",
  "serde",
@@ -22700,8 +22284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d950310d07391d34369f62c48336ebb14eacbd4d6f772bb5f349c24e838e0664"
 dependencies = [
  "cc",
- "object 0.38.1",
- "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
@@ -22739,58 +22321,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8007342bd12ff400293a817973f7ecd6f1d9a8549a53369a9c1af357166f1f1e"
-dependencies = [
- "cranelift-codegen",
- "gimli 0.33.0",
- "log",
- "object 0.38.1",
- "target-lexicon 0.13.5",
- "wasmparser 0.245.1",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7900c3e3c1d6e475bc225d73b02d6d5484815f260022e6964dca9558e50dd01a"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "heck 0.5.0",
- "indexmap 2.13.1",
- "wit-parser 0.245.1",
-]
-
-[[package]]
-name = "wast"
-version = "246.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width 0.2.1",
- "wasm-encoder 0.246.2",
-]
-
-[[package]]
-name = "wat"
-version = "1.246.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
-dependencies = [
- "wast",
 ]
 
 [[package]]
@@ -23145,7 +22675,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -23153,25 +22683,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "43.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f45f7172a2628c8317766e427babc0a400f9d10b1c0f0b0617c5ed5b79de6"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli 0.33.0",
- "regalloc2",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.18",
- "wasmparser 0.245.1",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "window-vibrancy"
@@ -23835,16 +23346,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -23905,7 +23406,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.244.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -23955,7 +23456,7 @@ dependencies = [
  "wasm-encoder 0.244.0",
  "wasm-metadata",
  "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -23974,25 +23475,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
-dependencies = [
- "anyhow",
- "hashbrown 0.16.1",
- "id-arena",
- "indexmap 2.13.1",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.245.1",
 ]
 
 [[package]]
@@ -24323,7 +23805,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=0aa9446fed186b596aecdc86e222abae736211a9#0aa9446fed186b596aecdc86e222abae736211a9"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f9e21c682c93fd64e85434b7804b7a4112c51216#f9e21c682c93fd64e85434b7804b7a4112c51216"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"
@@ -57,22 +57,22 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs v0.17.3. Its iterative parent-DAG replay remains required on iOS:
+# defradb.rs v0.17.4. Its iterative parent-DAG replay remains required on iOS:
 # a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-schemas = { path = "crates/gents-schemas" }
 gents-desktop-core = { path = "crates/gents-desktop-core" }
 gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -80,8 +80,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "0aa9446fed186b596aecdc86e222abae736211a9" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f9e21c682c93fd64e85434b7804b7a4112c51216" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.10.0",
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-fleet": "0.10.0",
-    "@source-inc/gents-desktop-operations": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0",
+    "@source-inc/gents-desktop-chat": "0.10.1",
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-fleet": "0.10.1",
+    "@source-inc/gents-desktop-operations": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -52,12 +52,12 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-chat": "0.10.0",
-    "@source-inc/gents-desktop-fleet": "0.10.0",
-    "@source-inc/gents-desktop-operations": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0"
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-chat": "0.10.1",
+    "@source-inc/gents-desktop-fleet": "0.10.1",
+    "@source-inc/gents-desktop-operations": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1"
   },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.6.0",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.0</string>
+	<string>0.10.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.10.0</string>
+	<string>0.10.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -54,8 +54,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.10.0
-        CFBundleVersion: "0.10.0"
+        CFBundleShortVersionString: 0.10.1
+        CFBundleVersion: "0.10.1"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -270,7 +270,7 @@
     "desktop://client-updated",
     "desktop://codex-login-url"
   ],
-  "packageVersion": "0.10.0",
+  "packageVersion": "0.10.1",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.10.0
-docker run --rm ghcr.io/source-inc/gents:v0.10.0 version
+docker pull ghcr.io/source-inc/gents:v0.10.1
+docker run --rm ghcr.io/source-inc/gents:v0.10.1 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.10.0 \
+  ghcr.io/source-inc/gents:v0.10.1 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.10.0 \
+  ghcr.io/source-inc/gents:v0.10.1 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -18,14 +18,14 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.10.0",
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-fleet": "0.10.0",
-        "@source-inc/gents-desktop-operations": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-chat": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-fleet": "0.10.1",
+        "@source-inc/gents-desktop-operations": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,17 +43,17 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.10.0",
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-fleet": "0.10.0",
-        "@source-inc/gents-desktop-operations": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-chat": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-fleet": "0.10.1",
+        "@source-inc/gents-desktop-operations": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -2787,7 +2787,7 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.10.1"
       }
     },
     "node_modules/indent-string": {
@@ -4100,7 +4100,7 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.10.1"
       }
     },
     "node_modules/react-dom": {
@@ -4157,7 +4157,7 @@
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.10.1"
       }
     },
     "node_modules/redent": {
@@ -4359,7 +4359,7 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.10.1"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -5088,12 +5088,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5103,9 +5103,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5115,7 +5115,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5127,16 +5127,16 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
         "jsqr": "^1.4.0"
       },
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5145,21 +5145,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5168,24 +5168,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.0",
-        "@source-inc/gents-desktop-tokens": "0.10.0",
-        "@source-inc/gents-desktop-ui": "0.10.0",
+        "@source-inc/gents-desktop-client": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-ui": "0.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5197,7 +5197,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.10.0",
+        "@source-inc/gents-desktop-tokens": "0.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0"
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0",
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,7 +15,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.10.0";
+export const PACKAGE_VERSION = "0.10.1";
 export const MINIMUM_BRIDGE_CONTRACT_VERSION = "0.7";
 
 export function assertCompatibleBridgeContract(

--- a/packages/gents-desktop-client/src/store.test.ts
+++ b/packages/gents-desktop-client/src/store.test.ts
@@ -36,7 +36,7 @@ describe("createDesktopStore", () => {
         },
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.10.0",
+          packageVersion: "0.10.1",
           events: [],
           eventReasons: [],
           errorCodes: [],
@@ -66,7 +66,7 @@ describe("createDesktopStore", () => {
         desktop_client_start: () => ({}),
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.10.0",
+          packageVersion: "0.10.1",
           events: [],
           eventReasons: [],
           errorCodes: [],

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "description": "Reusable peer discovery, pairing, health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -40,14 +40,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0"
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0",
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "description": "Reusable operations rail, liveness, health, lineage, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0"
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.10.0",
-    "@source-inc/gents-desktop-tokens": "0.10.0",
-    "@source-inc/gents-desktop-ui": "0.10.0",
+    "@source-inc/gents-desktop-client": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-ui": "0.10.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.10.0",
+    "@source-inc/gents-desktop-tokens": "0.10.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary

- Lockstep workspace / npm / desktop package train: **0.10.0 → 0.10.1**
- Advance DefraDB pin from **v0.17.3** to **v0.17.4** (`f9e21c682c93fd64e85434b7804b7a4112c51216`)
- Changelog + compatibility matrix for post-v0.10.0 fixes (mobile chat, native backgrounding, pairing, migration baseline)

## Pre-flight (local)

- `cargo check --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test -p gents` ✅

## Release plan

After merge to `main`: tag `v0.10.1` and push the tag to trigger release workflows (linux/macos/desktop packages/container).