### PR TITLE
feat(directory): behavior ids alongside display names for client behavior selection (#714)

### DIFF
--- a/crates/gents-migration/src/registry.rs
+++ b/crates/gents-migration/src/registry.rs
@@ -253,7 +253,7 @@ pub static DEFAULT_BASELINE: &[BaselineCollection<'static>] = &[
     baseline_entry!(
         gents_protocol::schemas::AGENT_DIRECTORY_ENTRY_NAME,
         gents_protocol::schemas::AGENT_DIRECTORY_ENTRY,
-        "bafyreidvqhhvvodkcn5eus7qams2fzsivj4t56x2ztihxybyxxtvth3k5a"
+        "bafyreigmknbknyus2brheq75c6evk3wbpto7e6eg65ldnb5cqqoxpz5zam"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_MEMORY_NAME,

--- a/crates/gents-migration/src/registry.rs
+++ b/crates/gents-migration/src/registry.rs
@@ -253,7 +253,7 @@ pub static DEFAULT_BASELINE: &[BaselineCollection<'static>] = &[
     baseline_entry!(
         gents_protocol::schemas::AGENT_DIRECTORY_ENTRY_NAME,
         gents_protocol::schemas::AGENT_DIRECTORY_ENTRY,
-        "bafyreigmknbknyus2brheq75c6evk3wbpto7e6eg65ldnb5cqqoxpz5zam"
+        "bafyreib3nckkjgeabgwk7uy2h4xc7ztmivf7qkrfzghrjpln6ze4i6e52m"
     ),
     baseline_entry!(
         gents_protocol::schemas::AGENT_MEMORY_NAME,

--- a/crates/gents-schemas/schemas/agent/agent_directory_entry.graphql
+++ b/crates/gents-schemas/schemas/agent/agent_directory_entry.graphql
@@ -28,6 +28,11 @@ type AgentDirectoryEntry @branchable {
     # the principal has no behaviors - empty list literals corrupt nillable
     # array columns.
     behaviors: [String]
+    # Behavior ids, index-aligned with `behaviors` (ids[i] names[i]) so
+    # clients can stamp AgentRequest.behavior_id from a picked display name.
+    # Emitted as null (never []) when empty - empty list literals corrupt
+    # nillable array columns.
+    behavior_ids: [String]
     runtime_state: String @index
     last_seen: DateTime
     updated_at: DateTime @index(direction: DESC)

--- a/crates/gents-schemas/schemas/agent/agent_directory_entry.graphql
+++ b/crates/gents-schemas/schemas/agent/agent_directory_entry.graphql
@@ -33,6 +33,10 @@ type AgentDirectoryEntry @branchable {
     # Emitted as null (never []) when empty - empty list literals corrupt
     # nillable array columns.
     behavior_ids: [String]
+    # The agent's resolved default (from AgentPrincipal.default_behavior_id),
+    # so clients can badge threads bound to a NON-default behavior; empty
+    # when the principal has none.
+    default_behavior_id: String
     runtime_state: String @index
     last_seen: DateTime
     updated_at: DateTime @index(direction: DESC)

--- a/crates/gents/src/agent/directory_projection.rs
+++ b/crates/gents/src/agent/directory_projection.rs
@@ -29,6 +29,10 @@ pub struct DirectoryEntry {
     pub source_did: String,
     pub display_name: String,
     pub behaviors: Vec<String>,
+    /// Index-aligned with `behaviors` (`behavior_ids[i]` names `behaviors[i]`)
+    /// so clients can stamp `AgentRequest.behavior_id` from a picked display
+    /// name.
+    pub behavior_ids: Vec<String>,
     pub runtime_state: String,
     pub last_seen: String,
 }
@@ -43,7 +47,9 @@ pub struct DirectoryTickOutcome {
 #[async_trait]
 pub trait DirectoryStore: Send + Sync {
     async fn load_principals(&self) -> Result<Vec<(String, String)>>;
-    async fn load_behavior_names(&self) -> Result<BTreeMap<String, Vec<String>>>;
+    /// Per principal, the enabled behaviors as `(behavior_id, display_name)`
+    /// pairs (display name falls back to the id when blank).
+    async fn load_behaviors(&self) -> Result<BTreeMap<String, Vec<(String, String)>>>;
     async fn load_runtime_states(&self) -> Result<BTreeMap<String, (String, String)>>;
     async fn list_directory_entries(
         &self,
@@ -108,16 +114,21 @@ fn canonicalize_last_seen(updated_at: &str) -> String {
 pub fn derive_directory_entries(
     source_did: &str,
     principals: &[(String, String)],
-    behaviors: &BTreeMap<String, Vec<String>>,
+    behaviors: &BTreeMap<String, Vec<(String, String)>>,
     runtimes: &BTreeMap<String, (String, String)>,
 ) -> BTreeMap<String, DirectoryEntry> {
     principals
         .iter()
         .filter(|(did, _)| !did.trim().is_empty())
         .map(|(did, display_name)| {
-            let mut names = behaviors.get(did).cloned().unwrap_or_default();
-            names.sort();
-            names.dedup();
+            // Sort by (name, id) for a stable picker order, then dedup by id
+            // (a behavior's id determines its identity; same id implies same
+            // name, so duplicates land adjacent after the sort).
+            let mut pairs = behaviors.get(did).cloned().unwrap_or_default();
+            pairs.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+            pairs.dedup_by(|a, b| a.0 == b.0);
+            let names = pairs.iter().map(|(_, name)| name.clone()).collect();
+            let ids = pairs.into_iter().map(|(id, _)| id).collect();
             let (runtime_state, updated_at) = runtimes.get(did).cloned().unwrap_or_default();
             (
                 did.clone(),
@@ -127,6 +138,7 @@ pub fn derive_directory_entries(
                     source_did: source_did.to_string(),
                     display_name: display_name.clone(),
                     behaviors: names,
+                    behavior_ids: ids,
                     runtime_state,
                     last_seen: canonicalize_last_seen(&updated_at),
                 },
@@ -149,10 +161,7 @@ pub async fn reconcile_directory_tick(
         .load_principals()
         .await
         .context("load agent principals")?;
-    let behaviors = store
-        .load_behavior_names()
-        .await
-        .context("load behavior names")?;
+    let behaviors = store.load_behaviors().await.context("load behaviors")?;
     let runtimes = store
         .load_runtime_states()
         .await
@@ -317,7 +326,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
             .collect())
     }
 
-    async fn load_behavior_names(&self) -> Result<BTreeMap<String, Vec<String>>> {
+    async fn load_behaviors(&self) -> Result<BTreeMap<String, Vec<(String, String)>>> {
         let query = r#"{
             AgentBehavior {
                 agent_did
@@ -328,7 +337,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
         }"#;
         let response = self.node.execute(query).await;
         ensure_no_errors(&response, "query AgentBehavior")?;
-        let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut grouped: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
         for row in rows::<BehaviorRow>(&response, "AgentBehavior")? {
             if !row.enabled.unwrap_or(true) {
                 continue;
@@ -339,22 +348,23 @@ impl DirectoryStore for GraphqlDirectoryStore {
             if did.is_empty() {
                 continue;
             }
+            let Some(behavior_id) = row
+                .behavior_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+            else {
+                continue;
+            };
             let name = row
                 .display_name
                 .as_deref()
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(ToOwned::to_owned)
-                .or_else(|| {
-                    row.behavior_id
-                        .as_deref()
-                        .map(str::trim)
-                        .filter(|value| !value.is_empty())
-                        .map(ToOwned::to_owned)
-                });
-            if let Some(name) = name {
-                grouped.entry(did).or_default().push(name);
-            }
+                .unwrap_or_else(|| behavior_id.clone());
+            grouped.entry(did).or_default().push((behavior_id, name));
         }
         Ok(grouped)
     }
@@ -406,6 +416,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
                 source_did
                 display_name
                 behaviors
+                behavior_ids
                 runtime_state
                 last_seen
             }}
@@ -430,6 +441,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
                     source_did: row.source_did.unwrap_or_default(),
                     display_name: row.display_name.unwrap_or_default(),
                     behaviors: row.behaviors.unwrap_or_default(),
+                    behavior_ids: row.behavior_ids.unwrap_or_default(),
                     runtime_state: row.runtime_state.unwrap_or_default(),
                     last_seen: row.last_seen.unwrap_or_default(),
                 };
@@ -459,6 +471,10 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
     let source_did = escape_graphql_string(&entry.source_did);
     let display_name = escape_graphql_string(&entry.display_name);
     let behaviors = graphql_string_list_literal(entry.behaviors.iter().map(String::as_str));
+    // Index-aligned with `behaviors`; rendered as null (never []) when empty
+    // — an empty list literal types as JsonArray and corrupts nillable array
+    // columns.
+    let behavior_ids = graphql_string_list_literal(entry.behavior_ids.iter().map(String::as_str));
     let runtime_state = escape_graphql_string(&entry.runtime_state);
     let last_seen = graphql_nullable_datetime_literal(&entry.last_seen);
     let now = escape_graphql_string(now);
@@ -472,6 +488,7 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
                     source_did: "{source_did}",
                     display_name: "{display_name}",
                     behaviors: {behaviors},
+                    behavior_ids: {behavior_ids},
                     runtime_state: "{runtime_state}",
                     last_seen: {last_seen},
                     updated_at: "{now}"
@@ -479,6 +496,7 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
                 update: {{
                     display_name: "{display_name}",
                     behaviors: {behaviors},
+                    behavior_ids: {behavior_ids},
                     runtime_state: "{runtime_state}",
                     last_seen: {last_seen},
                     updated_at: "{now}"
@@ -581,6 +599,8 @@ struct DirectoryRow {
     #[serde(default)]
     behaviors: Option<Vec<String>>,
     #[serde(default)]
+    behavior_ids: Option<Vec<String>>,
+    #[serde(default)]
     runtime_state: Option<String>,
     #[serde(default)]
     last_seen: Option<String>,
@@ -597,6 +617,7 @@ mod tests {
             source_did: "did:key:home".to_string(),
             display_name: "Display".to_string(),
             behaviors: Vec::new(),
+            behavior_ids: Vec::new(),
             runtime_state: "running".to_string(),
             last_seen: last_seen.to_string(),
         }
@@ -653,6 +674,30 @@ mod tests {
             "2026-07-23T00:00:00Z",
         );
         assert!(mutation.contains(r#"last_seen: "2026-07-20T00:00:00Z""#));
+    }
+
+    /// `behavior_ids` follows the same null-never-[] discipline as
+    /// `behaviors`, and stays index-aligned when both are populated.
+    #[test]
+    fn upsert_mutation_renders_null_behavior_ids_when_empty_and_aligned_list_when_present() {
+        let empty = upsert_directory_entry_mutation(
+            &entry("did:key:no-behaviors", "2026-07-20T00:00:00Z"),
+            "2026-07-23T00:00:00Z",
+        );
+        assert!(
+            empty.contains("behavior_ids: null"),
+            "empty behavior_ids must render as null, never []: {empty}"
+        );
+
+        let mut with_behaviors = entry("did:key:with-behaviors", "2026-07-20T00:00:00Z");
+        with_behaviors.behaviors = vec!["Artist".to_string(), "Coder".to_string()];
+        with_behaviors.behavior_ids = vec![
+            "did:key:a:artist".to_string(),
+            "did:key:a:coder".to_string(),
+        ];
+        let mutation = upsert_directory_entry_mutation(&with_behaviors, "2026-07-23T00:00:00Z");
+        assert!(mutation.contains(r#"behaviors: ["Artist", "Coder"]"#));
+        assert!(mutation.contains(r#"behavior_ids: ["did:key:a:artist", "did:key:a:coder"]"#));
     }
 
     /// Round-trip consistency: a stored `null` `last_seen` must decode back
@@ -810,6 +855,12 @@ mod tests {
                 enabled: true
             }) { _docID }
             create_AgentBehavior(input: {
+                behavior_id: "artist-behavior",
+                agent_did: "did:key:with-runtime",
+                display_name: "Artist Behavior",
+                enabled: true
+            }) { _docID }
+            create_AgentBehavior(input: {
                 behavior_id: "disabled-behavior",
                 agent_did: "did:key:with-runtime",
                 display_name: "Disabled Behavior",
@@ -840,7 +891,21 @@ mod tests {
             .get("did:key:with-runtime")
             .expect("with-runtime directory row");
         assert_eq!(with_runtime.runtime_state, "running");
-        assert_eq!(with_runtime.behaviors, vec!["Enabled Behavior".to_string()]);
+        assert_eq!(
+            with_runtime.behaviors,
+            vec![
+                "Artist Behavior".to_string(),
+                "Enabled Behavior".to_string()
+            ]
+        );
+        assert_eq!(
+            with_runtime.behavior_ids,
+            vec![
+                "artist-behavior".to_string(),
+                "enabled-behavior".to_string()
+            ],
+            "behavior_ids must round-trip index-aligned with behaviors through a real node"
+        );
         assert!(
             !entries.contains_key("did:key:disabled"),
             "disabled principals must not be advertised"

--- a/crates/gents/src/agent/directory_projection.rs
+++ b/crates/gents/src/agent/directory_projection.rs
@@ -33,6 +33,10 @@ pub struct DirectoryEntry {
     /// so clients can stamp `AgentRequest.behavior_id` from a picked display
     /// name.
     pub behavior_ids: Vec<String>,
+    /// The agent's resolved default (from `AgentPrincipal.default_behavior_id`),
+    /// so clients can badge threads bound to a NON-default behavior; empty
+    /// when the principal has none.
+    pub default_behavior_id: String,
     pub runtime_state: String,
     pub last_seen: String,
 }
@@ -46,7 +50,10 @@ pub struct DirectoryTickOutcome {
 
 #[async_trait]
 pub trait DirectoryStore: Send + Sync {
-    async fn load_principals(&self) -> Result<Vec<(String, String)>>;
+    /// One row per enabled principal: `(agent_did, display_name,
+    /// default_behavior_id)`. `default_behavior_id` is empty when the
+    /// principal has none.
+    async fn load_principals(&self) -> Result<Vec<(String, String, String)>>;
     /// Per principal, the enabled behaviors as `(behavior_id, display_name)`
     /// pairs (display name falls back to the id when blank).
     async fn load_behaviors(&self) -> Result<BTreeMap<String, Vec<(String, String)>>>;
@@ -113,14 +120,14 @@ fn canonicalize_last_seen(updated_at: &str) -> String {
 /// Mirrors Lean `project`.
 pub fn derive_directory_entries(
     source_did: &str,
-    principals: &[(String, String)],
+    principals: &[(String, String, String)],
     behaviors: &BTreeMap<String, Vec<(String, String)>>,
     runtimes: &BTreeMap<String, (String, String)>,
 ) -> BTreeMap<String, DirectoryEntry> {
     principals
         .iter()
-        .filter(|(did, _)| !did.trim().is_empty())
-        .map(|(did, display_name)| {
+        .filter(|(did, _, _)| !did.trim().is_empty())
+        .map(|(did, display_name, default_behavior_id)| {
             // Sort by (name, id) for a stable picker order, then dedup by id
             // (a behavior's id determines its identity; same id implies same
             // name, so duplicates land adjacent after the sort).
@@ -139,6 +146,7 @@ pub fn derive_directory_entries(
                     display_name: display_name.clone(),
                     behaviors: names,
                     behavior_ids: ids,
+                    default_behavior_id: default_behavior_id.clone(),
                     runtime_state,
                     last_seen: canonicalize_last_seen(&updated_at),
                 },
@@ -295,11 +303,12 @@ impl GraphqlDirectoryStore {
 
 #[async_trait]
 impl DirectoryStore for GraphqlDirectoryStore {
-    async fn load_principals(&self) -> Result<Vec<(String, String)>> {
+    async fn load_principals(&self) -> Result<Vec<(String, String, String)>> {
         let query = r#"{
             AgentPrincipal {
                 agent_did
                 display_name
+                default_behavior_id
                 enabled
             }
         }"#;
@@ -321,7 +330,13 @@ impl DirectoryStore for GraphqlDirectoryStore {
                     .map(str::trim)
                     .unwrap_or_default()
                     .to_string();
-                Some((did, display_name))
+                let default_behavior_id = row
+                    .default_behavior_id
+                    .as_deref()
+                    .map(str::trim)
+                    .unwrap_or_default()
+                    .to_string();
+                Some((did, display_name, default_behavior_id))
             })
             .collect())
     }
@@ -417,6 +432,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
                 display_name
                 behaviors
                 behavior_ids
+                default_behavior_id
                 runtime_state
                 last_seen
             }}
@@ -442,6 +458,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
                     display_name: row.display_name.unwrap_or_default(),
                     behaviors: row.behaviors.unwrap_or_default(),
                     behavior_ids: row.behavior_ids.unwrap_or_default(),
+                    default_behavior_id: row.default_behavior_id.unwrap_or_default(),
                     runtime_state: row.runtime_state.unwrap_or_default(),
                     last_seen: row.last_seen.unwrap_or_default(),
                 };
@@ -475,6 +492,7 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
     // — an empty list literal types as JsonArray and corrupts nillable array
     // columns.
     let behavior_ids = graphql_string_list_literal(entry.behavior_ids.iter().map(String::as_str));
+    let default_behavior_id = escape_graphql_string(&entry.default_behavior_id);
     let runtime_state = escape_graphql_string(&entry.runtime_state);
     let last_seen = graphql_nullable_datetime_literal(&entry.last_seen);
     let now = escape_graphql_string(now);
@@ -489,6 +507,7 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
                     display_name: "{display_name}",
                     behaviors: {behaviors},
                     behavior_ids: {behavior_ids},
+                    default_behavior_id: "{default_behavior_id}",
                     runtime_state: "{runtime_state}",
                     last_seen: {last_seen},
                     updated_at: "{now}"
@@ -497,6 +516,7 @@ fn upsert_directory_entry_mutation(entry: &DirectoryEntry, now: &str) -> String 
                     display_name: "{display_name}",
                     behaviors: {behaviors},
                     behavior_ids: {behavior_ids},
+                    default_behavior_id: "{default_behavior_id}",
                     runtime_state: "{runtime_state}",
                     last_seen: {last_seen},
                     updated_at: "{now}"
@@ -564,6 +584,8 @@ struct PrincipalRow {
     #[serde(default)]
     display_name: Option<String>,
     #[serde(default)]
+    default_behavior_id: Option<String>,
+    #[serde(default)]
     enabled: Option<bool>,
 }
 
@@ -601,6 +623,8 @@ struct DirectoryRow {
     #[serde(default)]
     behavior_ids: Option<Vec<String>>,
     #[serde(default)]
+    default_behavior_id: Option<String>,
+    #[serde(default)]
     runtime_state: Option<String>,
     #[serde(default)]
     last_seen: Option<String>,
@@ -618,6 +642,7 @@ mod tests {
             display_name: "Display".to_string(),
             behaviors: Vec::new(),
             behavior_ids: Vec::new(),
+            default_behavior_id: String::new(),
             runtime_state: "running".to_string(),
             last_seen: last_seen.to_string(),
         }
@@ -698,6 +723,26 @@ mod tests {
         let mutation = upsert_directory_entry_mutation(&with_behaviors, "2026-07-23T00:00:00Z");
         assert!(mutation.contains(r#"behaviors: ["Artist", "Coder"]"#));
         assert!(mutation.contains(r#"behavior_ids: ["did:key:a:artist", "did:key:a:coder"]"#));
+    }
+
+    /// `default_behavior_id` is a plain string field (unlike the nullable
+    /// list/DateTime fields above): empty stays `""`, never `null`, so the
+    /// client can compare it against a picked `behavior_id` unconditionally.
+    #[test]
+    fn upsert_mutation_renders_default_behavior_id_as_plain_string() {
+        let empty = upsert_directory_entry_mutation(
+            &entry("did:key:no-default", "2026-07-20T00:00:00Z"),
+            "2026-07-23T00:00:00Z",
+        );
+        assert!(
+            empty.contains(r#"default_behavior_id: """#),
+            "empty default_behavior_id must render as an empty string, never null: {empty}"
+        );
+
+        let mut with_default = entry("did:key:with-default", "2026-07-20T00:00:00Z");
+        with_default.default_behavior_id = "did:key:a:coder".to_string();
+        let mutation = upsert_directory_entry_mutation(&with_default, "2026-07-23T00:00:00Z");
+        assert!(mutation.contains(r#"default_behavior_id: "did:key:a:coder""#));
     }
 
     /// Round-trip consistency: a stored `null` `last_seen` must decode back
@@ -833,6 +878,7 @@ mod tests {
             create_AgentPrincipal(input: {
                 agent_did: "did:key:with-runtime",
                 display_name: "With Runtime",
+                default_behavior_id: "enabled-behavior",
                 enabled: true,
                 created_at: "2026-07-23T00:00:00Z"
             }) { _docID }
@@ -906,6 +952,10 @@ mod tests {
             ],
             "behavior_ids must round-trip index-aligned with behaviors through a real node"
         );
+        assert_eq!(
+            with_runtime.default_behavior_id, "enabled-behavior",
+            "default_behavior_id must round-trip from AgentPrincipal through a real node"
+        );
         assert!(
             !entries.contains_key("did:key:disabled"),
             "disabled principals must not be advertised"
@@ -921,6 +971,10 @@ mod tests {
         assert_eq!(
             no_runtime.last_seen, "",
             "runtime-less principal's stored null last_seen must round-trip to \"\""
+        );
+        assert_eq!(
+            no_runtime.default_behavior_id, "",
+            "a principal with no default_behavior_id must stay empty, not null-coerced garbage"
         );
 
         // Settled state is a write-free fixpoint: the runtime-less principal

--- a/crates/gents/tests/conformance/directory_projection.rs
+++ b/crates/gents/tests/conformance/directory_projection.rs
@@ -11,7 +11,7 @@ use gents::agent::directory_projection::{
 #[derive(Default)]
 struct DirectoryFixtureStore {
     principals: Vec<(String, String)>,
-    behaviors: BTreeMap<String, Vec<String>>,
+    behaviors: BTreeMap<String, Vec<(String, String)>>,
     runtimes: BTreeMap<String, (String, String)>,
     entries: Mutex<BTreeMap<(String, String), DirectoryEntry>>,
     upserts: Mutex<Vec<String>>,
@@ -23,7 +23,7 @@ impl DirectoryStore for DirectoryFixtureStore {
     async fn load_principals(&self) -> Result<Vec<(String, String)>> {
         Ok(self.principals.clone())
     }
-    async fn load_behavior_names(&self) -> Result<BTreeMap<String, Vec<String>>> {
+    async fn load_behaviors(&self) -> Result<BTreeMap<String, Vec<(String, String)>>> {
         Ok(self.behaviors.clone())
     }
     async fn load_runtime_states(&self) -> Result<BTreeMap<String, (String, String)>> {
@@ -69,7 +69,13 @@ fn derivation_projects_exactly_the_principals() {
     let derived = derive_directory_entries(
         "did:key:home",
         &[principal("did:key:a", "Amy"), principal("did:key:b", "Bob")],
-        &BTreeMap::from([("did:key:a".to_string(), vec!["coder".to_string()])]),
+        &BTreeMap::from([(
+            "did:key:a".to_string(),
+            vec![
+                ("did:key:a:coder".to_string(), "Coder".to_string()),
+                ("did:key:a:artist".to_string(), "Artist".to_string()),
+            ],
+        )]),
         &BTreeMap::from([(
             "did:key:a".to_string(),
             ("running".to_string(), "2026-07-23T00:00:00Z".to_string()),
@@ -82,10 +88,18 @@ fn derivation_projects_exactly_the_principals() {
     let a = &derived["did:key:a"];
     assert_eq!(a.source_did, "did:key:home");
     assert_eq!(a.display_name, "Amy");
-    assert_eq!(a.behaviors, vec!["coder".to_string()]);
+    assert_eq!(a.behaviors, vec!["Artist".to_string(), "Coder".to_string()]);
+    assert_eq!(
+        a.behavior_ids,
+        vec![
+            "did:key:a:artist".to_string(),
+            "did:key:a:coder".to_string()
+        ],
+        "ids must stay index-aligned with display names"
+    );
     assert_eq!(a.runtime_state, "running");
     let b = &derived["did:key:b"];
-    assert!(b.behaviors.is_empty());
+    assert!(b.behaviors.is_empty() && b.behavior_ids.is_empty());
     assert_eq!(b.runtime_state, "");
 }
 
@@ -105,6 +119,7 @@ async fn tick_converges_then_quiesces() {
                 source_did: "did:key:home".to_string(),
                 display_name: "Amy".to_string(),
                 behaviors: Vec::new(),
+                behavior_ids: Vec::new(),
                 runtime_state: "starting".to_string(),
                 last_seen: String::new(),
             },
@@ -145,6 +160,7 @@ async fn tick_retracts_only_removed_principals() {
                     source_did: "did:key:home".to_string(),
                     display_name: "Amy".to_string(),
                     behaviors: Vec::new(),
+                    behavior_ids: Vec::new(),
                     runtime_state: String::new(),
                     last_seen: String::new(),
                 },
@@ -157,6 +173,7 @@ async fn tick_retracts_only_removed_principals() {
                     source_did: "did:key:home".to_string(),
                     display_name: "Bob".to_string(),
                     behaviors: Vec::new(),
+                    behavior_ids: Vec::new(),
                     runtime_state: String::new(),
                     last_seen: String::new(),
                 },
@@ -184,6 +201,7 @@ async fn tick_preserves_foreign_same_agent_did_and_converges_local_row() {
         source_did: "did:key:foreign-home".to_string(),
         display_name: "Foreign".to_string(),
         behaviors: Vec::new(),
+        behavior_ids: Vec::new(),
         runtime_state: String::new(),
         last_seen: String::new(),
     };

--- a/crates/gents/tests/conformance/directory_projection.rs
+++ b/crates/gents/tests/conformance/directory_projection.rs
@@ -10,7 +10,7 @@ use gents::agent::directory_projection::{
 
 #[derive(Default)]
 struct DirectoryFixtureStore {
-    principals: Vec<(String, String)>,
+    principals: Vec<(String, String, String)>,
     behaviors: BTreeMap<String, Vec<(String, String)>>,
     runtimes: BTreeMap<String, (String, String)>,
     entries: Mutex<BTreeMap<(String, String), DirectoryEntry>>,
@@ -20,7 +20,7 @@ struct DirectoryFixtureStore {
 
 #[async_trait]
 impl DirectoryStore for DirectoryFixtureStore {
-    async fn load_principals(&self) -> Result<Vec<(String, String)>> {
+    async fn load_principals(&self) -> Result<Vec<(String, String, String)>> {
         Ok(self.principals.clone())
     }
     async fn load_behaviors(&self) -> Result<BTreeMap<String, Vec<(String, String)>>> {
@@ -60,15 +60,30 @@ impl DirectoryStore for DirectoryFixtureStore {
     }
 }
 
-fn principal(did: &str, name: &str) -> (String, String) {
-    (did.to_string(), name.to_string())
+fn principal(did: &str, name: &str) -> (String, String, String) {
+    (did.to_string(), name.to_string(), String::new())
+}
+
+fn principal_with_default(
+    did: &str,
+    name: &str,
+    default_behavior_id: &str,
+) -> (String, String, String) {
+    (
+        did.to_string(),
+        name.to_string(),
+        default_behavior_id.to_string(),
+    )
 }
 
 #[test]
 fn derivation_projects_exactly_the_principals() {
     let derived = derive_directory_entries(
         "did:key:home",
-        &[principal("did:key:a", "Amy"), principal("did:key:b", "Bob")],
+        &[
+            principal_with_default("did:key:a", "Amy", "did:key:a:coder"),
+            principal("did:key:b", "Bob"),
+        ],
         &BTreeMap::from([(
             "did:key:a".to_string(),
             vec![
@@ -97,9 +112,17 @@ fn derivation_projects_exactly_the_principals() {
         ],
         "ids must stay index-aligned with display names"
     );
+    assert_eq!(
+        a.default_behavior_id, "did:key:a:coder",
+        "default_behavior_id must copy through from the principal"
+    );
     assert_eq!(a.runtime_state, "running");
     let b = &derived["did:key:b"];
     assert!(b.behaviors.is_empty() && b.behavior_ids.is_empty());
+    assert_eq!(
+        b.default_behavior_id, "",
+        "a principal with no default behavior must derive an empty default_behavior_id"
+    );
     assert_eq!(b.runtime_state, "");
 }
 
@@ -120,6 +143,7 @@ async fn tick_converges_then_quiesces() {
                 display_name: "Amy".to_string(),
                 behaviors: Vec::new(),
                 behavior_ids: Vec::new(),
+                default_behavior_id: String::new(),
                 runtime_state: "starting".to_string(),
                 last_seen: String::new(),
             },
@@ -161,6 +185,7 @@ async fn tick_retracts_only_removed_principals() {
                     display_name: "Amy".to_string(),
                     behaviors: Vec::new(),
                     behavior_ids: Vec::new(),
+                    default_behavior_id: String::new(),
                     runtime_state: String::new(),
                     last_seen: String::new(),
                 },
@@ -174,6 +199,7 @@ async fn tick_retracts_only_removed_principals() {
                     display_name: "Bob".to_string(),
                     behaviors: Vec::new(),
                     behavior_ids: Vec::new(),
+                    default_behavior_id: String::new(),
                     runtime_state: String::new(),
                     last_seen: String::new(),
                 },
@@ -202,6 +228,7 @@ async fn tick_preserves_foreign_same_agent_did_and_converges_local_row() {
         display_name: "Foreign".to_string(),
         behaviors: Vec::new(),
         behavior_ids: Vec::new(),
+        default_behavior_id: String::new(),
         runtime_state: String::new(),
         last_seen: String::new(),
     };


### PR DESCRIPTION
## Summary

Adds `behavior_ids: [String]` to `AgentDirectoryEntry`, index-aligned with the existing `behaviors` display-name array, so machine-paired clients can offer per-thread behavior selection and stamp `AgentRequest.behavior_id` from a picked name — without replicating the mutable config collections to chat clients (their deliberate exclusion stands).

- Projection loader returns `(behavior_id, display_name)` pairs (name falls back to id; rows with blank ids are skipped — unstampable behaviors would be picker footguns); derivation sorts by (name, id), dedups by id, splits into aligned arrays.
- Alignment is contractual: documented in the schema comment and pinned by conformance + embedded-node round-trip assertions on both arrays.
- Mutation renders `null` (never `[]`) for empty; settled full-row equality includes the new field (write-free fixpoint preserved — the DirectoryProjection.lean payload abstraction is untouched).
- `gents-migration` baseline pin for AgentDirectoryEntry re-authored via `chain_replay_prints_baseline_pins_for_authoring` (same lever as 3f777a0d).

## Note for the merge-gate owner

Re-pinning the baseline root means homes created in the 2026-07-29 → now window (post-cutover, pre-this-merge) hit `UnknownLineage` on boot and need a rebuild — a known property of the Phase A/B baseline (live-constant SDL entries, zero production steps), not introduced here, but this PR advances the pin so the window closes behind it.

## Client half

gents-mobile branch `feat/behavior-threads` (PR to follow): behavior picker on New-thread, per-thread `behavior_id` stamping, badges from conversation rows.

Gates: conformance 5/5, lib 10/10, full package (lake-environmental failures only), `cargo check --workspace --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Arv3YzUJH1oSvYL21kekca