### PR TITLE
Fix iOS startup, cross-device sync, and loading flow

### DIFF
--- a/apps/gents-desktop/src-tauri/Cargo.toml
+++ b/apps/gents-desktop/src-tauri/Cargo.toml
@@ -33,10 +33,10 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [features]
-# custom-protocol embeds frontendDist and serves tauri://localhost.
-# Without it Tauri sets cfg(dev) and the mobile shell tries to load devUrl
-# (http://localhost:1420), which fails on device with a Local Network error.
-default = ["custom-protocol"]
+# Production and mobile Tauri builds explicitly enable custom-protocol so the
+# bundled frontend is served from tauri://localhost. Keep it opt-in so ordinary
+# workspace checks do not require a prebuilt frontendDist directory.
+default = []
 custom-protocol = ["tauri/custom-protocol"]
 # Forwards to the bridge; E2E launchers pass --features native-e2e.
 native-e2e = ["gents-desktop-bridge/native-e2e"]

--- a/apps/gents-desktop/src-tauri/Cargo.toml
+++ b/apps/gents-desktop/src-tauri/Cargo.toml
@@ -33,7 +33,11 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [features]
-default = []
+# custom-protocol embeds frontendDist and serves tauri://localhost.
+# Without it Tauri sets cfg(dev) and the mobile shell tries to load devUrl
+# (http://localhost:1420), which fails on device with a Local Network error.
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]
 # Forwards to the bridge; E2E launchers pass --features native-e2e.
 native-e2e = ["gents-desktop-bridge/native-e2e"]
 

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri.xcodeproj/project.pbxproj
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		5DA6544B44A458E0C361C447 /* GentsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C9537E32F3F70D432C59D3 /* GentsUITests.swift */; };
 		71C6080565821E5F55BC7BC4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4AA87E72BB6F6E6A9013ED37 /* Assets.xcassets */; };
 		8143829881E3F0C0DB8A6D6E /* libapp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 29FC53575AC1D708DC7E349B /* libapp.a */; };
-		88EFB05DB5D303BB4A995A0B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4B930D4D1CC1491CC8188CAD /* LaunchScreen.storyboard */; };
 		A49DADAEA00825152FA18A1E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63D599966BF164B2E3721580 /* SystemConfiguration.framework */; };
 		AB4DEA7CDE0EF8AEEEB51066 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9550978DF0AC0816DF1CC6DF /* main.mm */; };
 		ABBC6FAC9160FA4A18515F68 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5DAD3CA911F8C2F902D01BC /* WebKit.framework */; };
@@ -64,7 +63,6 @@
 		4A8E3985F8D178430B2655C8 /* timeline.rs */ = {isa = PBXFileReference; path = timeline.rs; sourceTree = "<group>"; };
 		4A9A0C77855ED19483490C28 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4AA87E72BB6F6E6A9013ED37 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		4B930D4D1CC1491CC8188CAD /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		4FB100F63CC4233DE1144D72 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		5AB282B8BF935EF647AE9F20 /* util.rs */ = {isa = PBXFileReference; path = util.rs; sourceTree = "<group>"; };
 		5B5A7408B9252B2996C02FEB /* support.rs */ = {isa = PBXFileReference; path = support.rs; sourceTree = "<group>"; };
@@ -147,7 +145,6 @@
 			children = (
 				DF999997666534D30CBC7799 /* assets */,
 				4AA87E72BB6F6E6A9013ED37 /* Assets.xcassets */,
-				4B930D4D1CC1491CC8188CAD /* LaunchScreen.storyboard */,
 				E578A9CE50CAD151F94E888C /* gents-desktop-tauri_iOS */,
 				0F8C42C2795F7E73E8279429 /* ios */,
 				E1F731CFA4D72A5157CF32D7 /* Sources */,
@@ -504,7 +501,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				71C6080565821E5F55BC7BC4 /* Assets.xcassets in Resources */,
-				88EFB05DB5D303BB4A995A0B /* LaunchScreen.storyboard in Resources */,
 				3DB3C858BF3C14FFFE4EC35D /* assets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -22,8 +22,8 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Gents uses the camera to scan signed agent pairing invites.</string>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
+	<key>UILaunchScreen</key>
+	<dict/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -37,13 +37,12 @@ targets:
       - path: assets
         buildPhase: resources
         type: folder
-      - path: LaunchScreen.storyboard
     info:
       path: gents-desktop-tauri_iOS/Info.plist
       properties:
         LSRequiresIPhoneOS: true
         NSCameraUsageDescription: Gents uses the camera to scan signed agent pairing invites.
-        UILaunchStoryboardName: LaunchScreen
+        UILaunchScreen: {}
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -12,6 +12,7 @@ import { applyShellPlatform } from "./lib/shellPlatform";
 import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { useAppShortcuts } from "./hooks/useAppShortcuts";
 import { Sidebar } from "./components/Sidebar";
+import { StartupScreen } from "./components/StartupScreen";
 import { useDesktopShell, type DesktopShellBridge } from "./hooks/useDesktopShell";
 import { installExternalLinkGuard } from "./lib/externalLinks";
 import { startNativeSimulatorE2e } from "./lib/nativeSimulatorE2e";
@@ -109,12 +110,18 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
   return (
     <main className={`app-shell app-view-${workspaceView}`}>
       <div aria-hidden="true" className="titlebar-drag-region" data-tauri-drag-region />
-      {shell.error ? (
+      {shell.error && shell.startupPhase === "ready" ? (
         <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
       ) : null}
       <ShortcutsHelp open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
 
-      {workspaceView === "fleet" ? (
+      {shell.startupPhase !== "ready" ? (
+        <StartupScreen
+          error={shell.error}
+          onRetry={shell.onRetryStartup}
+          phase={shell.startupPhase}
+        />
+      ) : workspaceView === "fleet" ? (
         <FleetHostDashboard
           api={bridge.api}
           addingPeer={shell.addingPeer}

--- a/apps/gents-desktop/src/components/StartupScreen.tsx
+++ b/apps/gents-desktop/src/components/StartupScreen.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+
+import type { DesktopStartupPhase } from "../hooks/useDesktopShell";
+import { BrandLockup } from "./fleet/BrandLockup";
+
+const STARTUP_ASIDES = [
+  "Catalyzing dilithium converters.",
+  "Configuring the human-computer interface.",
+  "Waking up the agents.",
+  "Immanentizing the eschaton.",
+  "Teaching the gossip network some manners.",
+  "Aligning the durable timelines.",
+];
+
+type StartupScreenProps = {
+  error: string | null;
+  onRetry: () => Promise<void>;
+  phase: Exclude<DesktopStartupPhase, "ready">;
+};
+
+type StepState = "active" | "complete" | "pending" | "error";
+
+export function StartupScreen({ error, onRetry, phase }: StartupScreenProps) {
+  const [asideIndex, setAsideIndex] = useState(0);
+  const [syncing, setSyncing] = useState(false);
+  const failed = phase === "configuration-error" || phase === "client-error";
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setAsideIndex((current) => (current + 1) % STARTUP_ASIDES.length);
+    }, 2200);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    setSyncing(false);
+    if (phase !== "starting-client") return;
+    const timeout = window.setTimeout(() => setSyncing(true), 900);
+    return () => window.clearTimeout(timeout);
+  }, [phase]);
+
+  let connectionState: StepState = "pending";
+  let clientState: StepState = "pending";
+  let syncState: StepState = "pending";
+
+  if (phase === "loading-configuration") {
+    connectionState = "active";
+  } else if (phase === "starting-client") {
+    connectionState = "complete";
+    clientState = syncing ? "complete" : "active";
+    syncState = syncing ? "active" : "pending";
+  } else if (phase === "configuration-error") {
+    connectionState = "error";
+  } else {
+    connectionState = "complete";
+    clientState = "error";
+  }
+
+  const activeLabel =
+    phase === "loading-configuration"
+      ? "Reading saved connections"
+      : phase === "starting-client" && syncing
+        ? "Synchronizing agent state"
+        : phase === "starting-client"
+          ? "Starting the secure client"
+          : "Startup paused";
+
+  return (
+    <section
+      aria-labelledby="startup-title"
+      className="startup-screen"
+      data-testid="startup-screen"
+    >
+      <div className="startup-card panel">
+        <BrandLockup />
+
+        <div className="startup-heading">
+          <p className="eyebrow">System startup</p>
+          <h2 id="startup-title">
+            {failed ? "Startup paused" : "Bringing Gents online"}
+          </h2>
+          <p aria-live="polite" className="startup-current-status">
+            {activeLabel}
+            {!failed ? <span aria-hidden="true" className="startup-ellipsis" /> : null}
+          </p>
+          {!failed ? (
+            <p aria-hidden="true" className="startup-aside" key={asideIndex}>
+              {STARTUP_ASIDES[asideIndex]}
+            </p>
+          ) : null}
+        </div>
+
+        <ol aria-label="Startup progress" className="startup-steps">
+          <StartupStep label="Read saved connections" state={connectionState} />
+          <StartupStep label="Start secure client" state={clientState} />
+          <StartupStep label="Synchronize agent state" state={syncState} />
+        </ol>
+
+        {failed ? (
+          <div className="startup-recovery">
+            <p className="startup-error">
+              {error ?? "Gents could not finish starting."}
+            </p>
+            <button
+              className="primary-button"
+              data-testid="startup-retry"
+              onClick={() => void onRetry()}
+              type="button"
+            >
+              Try again
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function StartupStep({ label, state }: { label: string; state: StepState }) {
+  return (
+    <li className="startup-step" data-state={state}>
+      <span aria-hidden="true" className="startup-step-marker" />
+      <span>{label}</span>
+      <span className="startup-step-state">
+        {state === "complete"
+          ? "Ready"
+          : state === "active"
+            ? "Working"
+            : state === "error"
+              ? "Needs attention"
+              : "Queued"}
+      </span>
+    </li>
+  );
+}

--- a/apps/gents-desktop/src/hooks/desktopShellPeerActions.ts
+++ b/apps/gents-desktop/src/hooks/desktopShellPeerActions.ts
@@ -11,6 +11,8 @@ import type {
 type PeerActionParams = {
   api: DesktopApiAdapter;
   snapshot: DesktopClientSnapshot | null;
+  /** Shared single-flight start used by autostart and peer actions. */
+  ensureDesktopClientStarted: () => Promise<DesktopClientSnapshot | null>;
   setAddingPeer: Dispatch<SetStateAction<boolean>>;
   setError: Dispatch<SetStateAction<string | null>>;
   setRepairingP2P: Dispatch<SetStateAction<boolean>>;
@@ -22,6 +24,7 @@ type PeerActionParams = {
 export function createDesktopShellPeerActions({
   api,
   snapshot,
+  ensureDesktopClientStarted,
   setAddingPeer,
   setError,
   setRepairingP2P,
@@ -45,9 +48,14 @@ export function createDesktopShellPeerActions({
         addr: summary.p2pListenAddress,
         graphql: summary.graphql,
       };
+      // Init writes the peer directory entry; a fresh start bootstraps it.
+      // A live client needs an explicit addPeer for the new record.
       const next = snapshot?.client
         ? await api.addPeer(peerRequest)
-        : await api.startDesktopClient();
+        : await ensureDesktopClientStarted();
+      if (!next) {
+        throw new Error("desktop client failed to start after local runtime init");
+      }
       setSnapshot(next);
       setSelectedAgentDid(summary.agentDid);
       return summary;
@@ -66,9 +74,10 @@ export function createDesktopShellPeerActions({
     setError(null);
     try {
       if (!snapshot?.client) {
-        setStarting(true);
-        const started = await api.startDesktopClient();
-        setSnapshot(started);
+        const started = await ensureDesktopClientStarted();
+        if (!started) {
+          throw new Error("desktop client failed to start before adding peer");
+        }
       }
       const next = await api.addPeer(request);
       setSnapshot(next);
@@ -89,9 +98,10 @@ export function createDesktopShellPeerActions({
     setError(null);
     try {
       if (!snapshot?.client) {
-        setStarting(true);
-        const started = await api.startDesktopClient();
-        setSnapshot(started);
+        const started = await ensureDesktopClientStarted();
+        if (!started) {
+          throw new Error("desktop client failed to start before pairing");
+        }
       }
       const response = await api.pairBearer(request);
       setSnapshot({

--- a/apps/gents-desktop/src/hooks/useDesktopShell.ts
+++ b/apps/gents-desktop/src/hooks/useDesktopShell.ts
@@ -40,6 +40,13 @@ export type DesktopShellBridge = {
   listenToUpdates: DesktopClientUpdatedListenerFactory;
 };
 
+export type DesktopStartupPhase =
+  | "loading-configuration"
+  | "starting-client"
+  | "configuration-error"
+  | "client-error"
+  | "ready";
+
 export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
   const autostartAttempted = useRef(false);
   const autoRestartInFlight = useRef(false);
@@ -51,8 +58,16 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
   const snapshotRefreshSeq = useRef(0);
   const sessionRefreshSeq = useRef(0);
   const newConversationAgentRef = useRef<string | null>(null);
+  const startupPhaseRef = useRef<DesktopStartupPhase>("loading-configuration");
+  /** Coalesce concurrent shell start paths (autostart + pair + add-peer). */
+  const startClientInFlight = useRef<Promise<DesktopClientSnapshot | null> | null>(
+    null,
+  );
   const [snapshot, setSnapshot] = useState<DesktopClientSnapshot | null>(null);
   const [session, setSession] = useState<DesktopSessionSnapshot | null>(null);
+  const [startupPhase, setStartupPhaseState] = useState<DesktopStartupPhase>(
+    "loading-configuration",
+  );
   const [loading, setLoading] = useState(true);
   const [starting, setStarting] = useState(false);
   const [stopping, setStopping] = useState(false);
@@ -133,6 +148,11 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
   );
   const canSendMessage = shellProjection.sendStatus.kind === "ready";
 
+  function setStartupPhase(next: DesktopStartupPhase) {
+    startupPhaseRef.current = next;
+    setStartupPhaseState(next);
+  }
+
   useEffect(() => {
     setLocalWorkflow((current) =>
       reconcileProjectedWorkflow(current, shellProjection.workflow),
@@ -151,16 +171,27 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
   async function refreshSnapshot() {
     const refreshSeq = snapshotRefreshSeq.current + 1;
     snapshotRefreshSeq.current = refreshSeq;
+    const resolvingConfiguration = startupPhaseRef.current === "loading-configuration";
     setLoading(true);
     try {
       const next = await api.fetchDesktopSnapshot();
       if (snapshotRefreshSeq.current === refreshSeq) {
         setSnapshot(next);
         setError(null);
+        if (resolvingConfiguration) {
+          setStartupPhase(
+            next.client || next.bootstrap.savedPeers.length === 0
+              ? "ready"
+              : "starting-client",
+          );
+        }
       }
     } catch (err) {
       if (snapshotRefreshSeq.current === refreshSeq) {
         setError(String(err));
+        if (resolvingConfiguration) {
+          setStartupPhase("configuration-error");
+        }
       }
     } finally {
       if (snapshotRefreshSeq.current === refreshSeq) {
@@ -200,17 +231,43 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
     }
   }
 
-  async function onStartClient() {
+  async function ensureDesktopClientStarted(): Promise<DesktopClientSnapshot | null> {
+    if (startClientInFlight.current) {
+      return startClientInFlight.current;
+    }
+
     setStarting(true);
     setError(null);
-    try {
-      const next = await api.startDesktopClient();
-      setSnapshot(next);
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setStarting(false);
-    }
+    const pending = (async () => {
+      let started = false;
+      try {
+        const next = await api.startDesktopClient();
+        setSnapshot(next);
+        started = true;
+        return next;
+      } catch (err) {
+        setError(String(err));
+        return null;
+      } finally {
+        if (startupPhaseRef.current === "starting-client") {
+          setStartupPhase(started ? "ready" : "client-error");
+        }
+        startClientInFlight.current = null;
+        setStarting(false);
+      }
+    })();
+    startClientInFlight.current = pending;
+    return pending;
+  }
+
+  async function onStartClient() {
+    await ensureDesktopClientStarted();
+  }
+
+  async function onRetryStartup() {
+    autostartAttempted.current = false;
+    setStartupPhase("loading-configuration");
+    await refreshSnapshot();
   }
 
   async function restartDesktopClient(reason: string) {
@@ -313,6 +370,7 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
   } = createDesktopShellPeerActions({
     api,
     snapshot,
+    ensureDesktopClientStarted,
     setAddingPeer,
     setError,
     setRepairingP2P,
@@ -421,6 +479,7 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
   return {
     snapshot,
     session,
+    startupPhase,
     loading,
     starting,
     stopping,
@@ -432,6 +491,7 @@ export function useDesktopShell({ api, listenToUpdates }: DesktopShellBridge) {
     runningTask,
     error,
     onDismissError,
+    onRetryStartup,
     selectedAgentDid,
     selectedSessionId,
     selectedBehaviorId,

--- a/apps/gents-desktop/src/styles/shell.css
+++ b/apps/gents-desktop/src/styles/shell.css
@@ -103,6 +103,152 @@
     z-index: 1;
   }
 
+  .startup-screen {
+    min-height: 0;
+    display: grid;
+    place-items: center;
+    padding: var(--space-8);
+  }
+
+  .startup-card {
+    width: min(560px, 100%);
+    display: grid;
+    gap: var(--space-8);
+    padding: clamp(var(--space-7), 5vw, var(--space-10));
+    overflow: hidden;
+  }
+
+  .startup-heading {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .startup-heading h2 {
+    font-size: var(--text-3xl);
+  }
+
+  .startup-current-status {
+    color: var(--color-text-soft);
+    font-size: var(--text-md);
+    font-weight: 650;
+  }
+
+  .startup-ellipsis::after {
+    content: "";
+    animation: startup-ellipsis var(--motion-pulse) steps(4, end) infinite;
+  }
+
+  .startup-aside {
+    min-height: 1.5em;
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    animation: startup-aside-in var(--motion-medium) ease both;
+  }
+
+  .startup-steps {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .startup-step {
+    min-height: 42px;
+    display: grid;
+    grid-template-columns: 12px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-4);
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--border-default);
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+  }
+
+  .startup-step[data-state="active"] {
+    border-color: rgb(var(--color-accent-rgb) / 0.38);
+    background: rgb(var(--color-accent-rgb) / 0.07);
+    color: var(--color-text);
+  }
+
+  .startup-step[data-state="complete"] {
+    color: var(--color-text-soft);
+  }
+
+  .startup-step[data-state="error"] {
+    border-color: rgb(var(--color-error-strong-rgb) / 0.28);
+    color: var(--color-error);
+  }
+
+  .startup-step-marker {
+    width: 8px;
+    height: 8px;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+  }
+
+  .startup-step[data-state="active"] .startup-step-marker {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+    box-shadow: 0 0 0 4px rgb(var(--color-accent-rgb) / 0.12);
+    animation: startup-pulse var(--motion-pulse) ease-in-out infinite;
+  }
+
+  .startup-step[data-state="complete"] .startup-step-marker {
+    border-color: var(--color-accent);
+    background: var(--color-accent);
+  }
+
+  .startup-step-state {
+    color: inherit;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .startup-recovery {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-5);
+  }
+
+  .startup-error {
+    color: var(--color-error);
+    font-size: var(--text-sm);
+    overflow-wrap: anywhere;
+  }
+
+  @keyframes startup-pulse {
+    50% {
+      opacity: 0.5;
+      transform: scale(0.82);
+    }
+  }
+
+  @keyframes startup-ellipsis {
+    0% {
+      content: "";
+    }
+    25% {
+      content: ".";
+    }
+    50% {
+      content: "..";
+    }
+    75%,
+    100% {
+      content: "...";
+    }
+  }
+
+  @keyframes startup-aside-in {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+  }
+
   .workspace {
     display: grid;
     grid-template-columns: 300px minmax(0, 1fr);

--- a/apps/gents-desktop/tests/native-command-async-invariant.test.ts
+++ b/apps/gents-desktop/tests/native-command-async-invariant.test.ts
@@ -25,8 +25,13 @@ describe("native command async invariants", () => {
     const occurrences = source.match(/tauri::async_runtime::block_on/g) ?? [];
 
     expect(occurrences).toHaveLength(1);
+    // Large-stack OS thread still runs block_on; the async command awaits a
+    // oneshot instead of thread::join so Tokio workers stay unblocked.
     expect(source).toContain(
-      ".spawn(move || tauri::async_runtime::block_on(ClientCore::start_with_paths(paths)))",
+      "tauri::async_runtime::block_on(ClientCore::start_with_paths(paths))",
     );
+    expect(source).toContain("start_client_core_async");
+    expect(source).toContain("single-flight");
+    expect(source).not.toContain(".join()");
   });
 });

--- a/apps/gents-desktop/tests/playwright/desktop-invariants.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-invariants.spec.ts
@@ -39,7 +39,7 @@ test.describe("desktop UI invariants", () => {
   }) => {
     await gotoHarness(page, "bridge-unavailable");
     await expect(page.locator(".app-shell")).toBeVisible();
-    await expect(page.getByTestId("error-banner")).toContainText(
+    await expect(page.getByTestId("startup-screen")).toContainText(
       "Desktop native bridge is unavailable",
     );
 

--- a/apps/gents-desktop/tests/playwright/desktop-live-backend-contract.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-live-backend-contract.spec.ts
@@ -6,7 +6,7 @@ import { expect, gotoLiveHarness, openChat, PEER_ID, test } from "./desktopTest"
 test.describe("desktop live backend harness contract", () => {
   test("reports missing bridge URL as a handled shell error", async ({ page }) => {
     await gotoLiveHarness(page);
-    await expect(page.getByTestId("error-banner")).toContainText(
+    await expect(page.getByTestId("startup-screen")).toContainText(
       "Live desktop harness backend requires bridgeUrl",
     );
   });

--- a/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
@@ -210,7 +210,7 @@ test.describe("desktop UI harness", () => {
     await captureStableScreenshot(page, testInfo, "empty-fleet");
 
     await gotoHarness(page, "bridge-unavailable");
-    await expect(page.getByTestId("error-banner")).toContainText(
+    await expect(page.getByTestId("startup-screen")).toContainText(
       "Desktop native bridge is unavailable",
     );
 

--- a/apps/gents-desktop/tests/playwright/desktopTest.ts
+++ b/apps/gents-desktop/tests/playwright/desktopTest.ts
@@ -62,6 +62,7 @@ export async function gotoHarness(page: Page, scenario: HarnessScenario = "defau
           '[data-testid="transcript-panel"]',
           ".config-workspace",
           '[data-testid="error-banner"]',
+          '[data-testid="startup-screen"]',
         ].join(", "),
       )
       .first(),
@@ -125,6 +126,7 @@ export async function primarySurfaceCount(page: Page) {
       '[data-testid="fleet-empty"]',
       '[data-testid="transcript-panel"]',
       ".config-workspace",
+      '[data-testid="startup-screen"]',
     ];
     return selectors.filter((selector) => document.querySelector(selector)).length;
   });

--- a/apps/gents-desktop/tests/startup-screen.test.tsx
+++ b/apps/gents-desktop/tests/startup-screen.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  DesktopApiAdapter,
+  DesktopClientSnapshot,
+  DesktopClientUpdatedListenerFactory,
+} from "@source-inc/gents-desktop-client";
+
+import App from "../src/App";
+import { bootstrap, deployment } from "./config-panel-wiring/fixtures";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+const savedPeer = {
+  peerId: deployment.peerId,
+  label: deployment.label,
+  agentDid: deployment.agentDid,
+  addr: deployment.addr,
+  source: deployment.source,
+  graphql: deployment.graphql,
+};
+
+function snapshot(configured: boolean, running: boolean): DesktopClientSnapshot {
+  return {
+    bootstrap: {
+      ...bootstrap,
+      savedPeers: configured ? [savedPeer] : [],
+    },
+    client: running
+      ? {
+          localPeerId: "local-peer",
+          listenAddresses: ["127.0.0.1:9191"],
+          p2pHealth: {
+            status: "healthy",
+            connectedPeerCount: 1,
+            replicatorCount: 1,
+            consecutiveFailures: 0,
+          },
+          bootstrapErrors: [],
+          lastMutationError: null,
+          focusedRequestId: null,
+          configuredPeerCount: 1,
+          dialedPeerCount: 1,
+          peerIssueCount: 0,
+          rowCount: 42,
+          approxSerializedBytes: 2048,
+          deployments: [deployment],
+        }
+      : null,
+  };
+}
+
+function bridge(
+  fetchDesktopSnapshot: DesktopApiAdapter["fetchDesktopSnapshot"],
+  startDesktopClient: DesktopApiAdapter["startDesktopClient"],
+) {
+  const api = {
+    fetchDesktopSnapshot,
+    fetchSessionSnapshot: vi.fn(async () => null),
+    setSelectedAgent: vi.fn(async () => undefined),
+    startDesktopClient,
+  } as unknown as DesktopApiAdapter;
+  const listenToUpdates: DesktopClientUpdatedListenerFactory = async () => () => {};
+  return { api, listenToUpdates };
+}
+
+describe("desktop startup screen", () => {
+  it("never flashes pairing while saved connections load and start", async () => {
+    const initial = deferred<DesktopClientSnapshot>();
+    const started = deferred<DesktopClientSnapshot>();
+    const startDesktopClient = vi.fn(() => started.promise);
+    render(
+      <App
+        bridge={bridge(
+          vi.fn(() => initial.promise),
+          startDesktopClient,
+        )}
+      />,
+    );
+
+    expect(screen.getByTestId("startup-screen")).toHaveTextContent(
+      "Reading saved connections",
+    );
+    expect(screen.getByTestId("startup-screen")).toHaveTextContent(
+      "Catalyzing dilithium converters.",
+    );
+    expect(screen.queryByTestId("fleet-empty")).not.toBeInTheDocument();
+
+    initial.resolve(snapshot(true, false));
+    await waitFor(() => expect(startDesktopClient).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("startup-screen")).toHaveTextContent(
+      "Starting the secure client",
+    );
+    expect(screen.queryByTestId("fleet-empty")).not.toBeInTheDocument();
+
+    started.resolve(snapshot(true, true));
+    await waitFor(() => {
+      expect(screen.getByTestId("fleet-dashboard")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("startup-screen")).not.toBeInTheDocument();
+  });
+
+  it("shows pairing only after configuration is confirmed empty", async () => {
+    const initial = deferred<DesktopClientSnapshot>();
+    const startDesktopClient = vi.fn(async () => snapshot(false, true));
+    render(
+      <App
+        bridge={bridge(
+          vi.fn(() => initial.promise),
+          startDesktopClient,
+        )}
+      />,
+    );
+
+    expect(screen.getByTestId("startup-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("fleet-empty")).not.toBeInTheDocument();
+
+    initial.resolve(snapshot(false, false));
+    await waitFor(() => {
+      expect(screen.getByTestId("fleet-empty")).toBeInTheDocument();
+    });
+    expect(startDesktopClient).not.toHaveBeenCalled();
+  });
+
+  it("offers a retry when reading saved configuration fails", async () => {
+    const fetchDesktopSnapshot = vi
+      .fn<DesktopApiAdapter["fetchDesktopSnapshot"]>()
+      .mockRejectedValueOnce(new Error("configuration unavailable"))
+      .mockResolvedValueOnce(snapshot(false, false));
+    render(
+      <App
+        bridge={bridge(
+          fetchDesktopSnapshot,
+          vi.fn(async () => snapshot(false, true)),
+        )}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("startup-retry")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("startup-screen")).toHaveTextContent(
+      "configuration unavailable",
+    );
+
+    await userEvent.click(screen.getByTestId("startup-retry"));
+    await waitFor(() => {
+      expect(screen.getByTestId("fleet-empty")).toBeInTheDocument();
+    });
+    expect(fetchDesktopSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/crates/gents-desktop-bridge/src/state.rs
+++ b/crates/gents-desktop-bridge/src/state.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use gents_desktop_core::client::{ClientCore, DesktopPaths};
 use tauri::async_runtime::{spawn, JoinHandle};
 use tauri::{AppHandle, Emitter, Runtime, State};
+use tokio::sync::watch;
 
 use crate::config::{AgentHomePolicy, AppMeta, BootstrapPolicy, BridgeConfig, HomePolicy};
 use crate::snapshot::projection::SnapshotGrants;
@@ -19,8 +20,23 @@ pub struct ResolvedBridgePolicy {
     pub snapshot_grants: SnapshotGrants,
 }
 
+/// Outcome of a single-flight `desktop_client_start`.
+///
+/// Concurrent start callers share one in-flight open of the embedded node so a
+/// second `NodeBuilder` cannot race the first for the RocksDB LOCK file.
+#[derive(Debug, Clone)]
+pub enum ClientStartProgress {
+    Pending,
+    Ready,
+    Failed(String),
+}
+
 pub struct DesktopAppState {
     pub bridge: Mutex<DesktopBridge>,
+    /// Serializes start *install* / shutdown mutations against bridge state.
+    /// Long-running node open does **not** hold this lock (see single-flight
+    /// `start_inflight` instead) so a cancelled Tauri command cannot drop the
+    /// lock while RocksDB is still opening on a background thread.
     pub client_lifecycle: tokio::sync::Mutex<()>,
     pub policy: ResolvedBridgePolicy,
 }
@@ -31,6 +47,10 @@ pub struct DesktopBridge {
     /// Cancel handle for an in-flight ChatGPT/Codex login server, so a closed
     /// browser can be aborted instead of hanging the callback wait.
     pub codex_login_cancel: Option<codex_login::ShutdownHandle>,
+    /// Shared progress for an in-flight client start. The sender is owned by
+    /// the detached starter task; waiters hold receivers and do not open a
+    /// second node.
+    pub start_inflight: Option<watch::Sender<ClientStartProgress>>,
 }
 
 impl DesktopAppState {
@@ -40,6 +60,7 @@ impl DesktopAppState {
                 core: None,
                 updates_task: None,
                 codex_login_cancel: None,
+                start_inflight: None,
             }),
             client_lifecycle: tokio::sync::Mutex::new(()),
             policy,

--- a/crates/gents-desktop-bridge/src/tauri_commands/lifecycle.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/lifecycle.rs
@@ -5,13 +5,16 @@ use gents_desktop_core::local_runtime::{
     dangerously_overwrite_desktop_home, init_standard_local_runtime, reset_desktop_runtime_state,
     DesktopInitOptions, DesktopInitSummary,
 };
-use tauri::{AppHandle, Emitter, Runtime, State};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State};
+use tokio::sync::watch;
 
 use crate::config::BootstrapPolicy;
 use crate::contract::{current_contract, BridgeContract};
 use crate::error::{BridgeError, BridgeErrorCode};
 use crate::snapshot::{build_bootstrap_summary_for_policy, build_client_snapshot_with_grants};
-use crate::state::{current_core, snapshot_grants, spawn_client_update_task, DesktopAppState};
+use crate::state::{
+    current_core, snapshot_grants, spawn_client_update_task, ClientStartProgress, DesktopAppState,
+};
 use crate::types::{
     ClientUpdateEvent, DesktopBootstrapSummary, DesktopClientSnapshot, DesktopInitRequest,
 };
@@ -47,7 +50,18 @@ pub async fn desktop_init_local_standard(
         BootstrapPolicy::LocalRuntimeAllowed { .. } => {}
     }
 
+    // Drain in-flight start before locking lifecycle so the starter can finish
+    // installing (it needs the lifecycle mutex).
+    wait_for_start_inflight(&state).await?;
+
     let _lifecycle_guard = state.client_lifecycle.lock().await;
+    // Re-check under the lock: a new start must not begin mid-init.
+    if start_inflight_is_pending(&state) {
+        return Err(BridgeError::new(
+            BridgeErrorCode::InvalidArgument,
+            "desktop client is starting; retry local runtime init after start completes",
+        ));
+    }
     ensure_client_stopped_for_init(current_core(&state).is_some())?;
 
     let agent_home = state.policy.agent_home.clone().ok_or_else(|| {
@@ -93,34 +107,190 @@ pub async fn desktop_client_start<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, DesktopAppState>,
 ) -> Result<DesktopClientSnapshot, BridgeError> {
-    let _lifecycle_guard = state.client_lifecycle.lock().await;
     let grants = snapshot_grants(&state);
+
+    // Single-flight: return the live core, wait on an in-flight start, or become
+    // the starter. NodeBuilder runs on a detached task so cancelling this
+    // command cannot leave RocksDB open while a second start races the LOCK.
+    // Never hold the std::sync::Mutex across an await (future must be Send).
     if let Some(core) = current_core(&state) {
         return build_client_snapshot_with_grants(Some(&core), Some(&state.policy), grants)
             .await
             .map_err(BridgeError::from_legacy_message);
     }
 
-    let paths = state.policy.desktop_paths.clone();
-    let core = Arc::new(start_client_core_with_large_stack(paths)?);
-    let updates_task = spawn_client_update_task(app.clone(), Arc::clone(&core));
+    let progress_rx = claim_or_join_client_start(&app, &state);
 
-    {
-        let mut bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
-        bridge.core = Some(Arc::clone(&core));
-        bridge.updates_task = Some(updates_task);
-    }
+    wait_for_client_start_progress(progress_rx).await?;
 
-    let _ = app.emit(
-        "desktop://client-updated",
-        ClientUpdateEvent {
-            reason: "lifecycle",
-        },
-    );
+    let core = current_core(&state).ok_or_else(|| {
+        BridgeError::new(
+            BridgeErrorCode::ClientStartFailed,
+            "desktop client start completed without installing a live client",
+        )
+    })?;
 
     build_client_snapshot_with_grants(Some(&core), Some(&state.policy), grants)
         .await
         .map_err(BridgeError::from_legacy_message)
+}
+
+/// Register as the single-flight starter or subscribe to the in-flight one.
+/// Synchronous so the bridge mutex is never held across an await.
+fn claim_or_join_client_start<R: Runtime>(
+    app: &AppHandle<R>,
+    state: &State<'_, DesktopAppState>,
+) -> watch::Receiver<ClientStartProgress> {
+    let mut bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
+
+    // Another caller may have installed the core between our check and this lock.
+    // Waiters still use the progress channel; Ready is sent after install.
+    if let Some(sender) = bridge.start_inflight.as_ref() {
+        tracing::debug!("desktop client start: joining in-flight single-flight start");
+        return sender.subscribe();
+    }
+
+    let (tx, rx) = watch::channel(ClientStartProgress::Pending);
+    // If a core is already live, mark ready immediately so waiters short-circuit.
+    if bridge.core.is_some() {
+        let _ = tx.send(ClientStartProgress::Ready);
+        return rx;
+    }
+
+    bridge.start_inflight = Some(tx.clone());
+    let paths = state.policy.desktop_paths.clone();
+    let app_for_start = app.clone();
+    drop(bridge);
+
+    tracing::info!("desktop client start: single-flight starter claimed");
+    tauri::async_runtime::spawn(async move {
+        run_detached_client_start(app_for_start, paths, tx).await;
+    });
+    rx
+}
+
+async fn run_detached_client_start<R: Runtime>(
+    app: AppHandle<R>,
+    paths: gents_desktop_core::client::DesktopPaths,
+    progress_tx: watch::Sender<ClientStartProgress>,
+) {
+    let start_result = start_client_core_async(paths).await;
+
+    let state = app.state::<DesktopAppState>();
+    // Serialize install against shutdown so we never leave an untracked open DB
+    // or install over a concurrent tear-down without coordination.
+    let _lifecycle_guard = state.client_lifecycle.lock().await;
+
+    match start_result {
+        Ok(core) => {
+            let core = Arc::new(core);
+            let orphan = {
+                let mut bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
+                let orphan = if bridge.core.is_none() {
+                    let updates_task = spawn_client_update_task(app.clone(), Arc::clone(&core));
+                    bridge.core = Some(Arc::clone(&core));
+                    bridge.updates_task = Some(updates_task);
+                    None
+                } else {
+                    // Shutdown or another install won the slot. Drop our open
+                    // node so RocksDB is not held by an untracked Arc.
+                    Some(core)
+                };
+                bridge.start_inflight = None;
+                orphan
+            };
+
+            if let Some(orphan_core) = orphan {
+                tracing::warn!(
+                    "desktop client start: core already installed after open; shutting down orphan"
+                );
+                if let Err(error) = orphan_core.shutdown().await {
+                    tracing::warn!(
+                        error = %error,
+                        "desktop client start: failed to shut down orphan core"
+                    );
+                }
+            } else {
+                let _ = app.emit(
+                    "desktop://client-updated",
+                    ClientUpdateEvent {
+                        reason: "lifecycle",
+                    },
+                );
+                tracing::info!("desktop client start: single-flight ready");
+            }
+
+            let _ = progress_tx.send(ClientStartProgress::Ready);
+        }
+        Err(error) => {
+            {
+                let mut bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
+                bridge.start_inflight = None;
+            }
+            let message = error.message.clone();
+            let _ = progress_tx.send(ClientStartProgress::Failed(message));
+            tracing::error!(
+                error = %error.message,
+                "desktop client start: single-flight failed"
+            );
+        }
+    }
+}
+
+async fn wait_for_client_start_progress(
+    mut progress_rx: watch::Receiver<ClientStartProgress>,
+) -> Result<(), BridgeError> {
+    loop {
+        let current = progress_rx.borrow().clone();
+        match current {
+            ClientStartProgress::Pending => {
+                if progress_rx.changed().await.is_err() {
+                    return Err(BridgeError::new(
+                        BridgeErrorCode::ClientStartFailed,
+                        "desktop client start was abandoned",
+                    ));
+                }
+            }
+            ClientStartProgress::Ready => return Ok(()),
+            ClientStartProgress::Failed(message) => {
+                return Err(BridgeError::from_legacy_message(message));
+            }
+        }
+    }
+}
+
+fn start_inflight_is_pending(state: &State<'_, DesktopAppState>) -> bool {
+    state
+        .bridge
+        .lock()
+        .expect("desktop bridge lock poisoned")
+        .start_inflight
+        .is_some()
+}
+
+/// Wait until any in-flight start finishes (ready or failed). Does **not** hold
+/// `client_lifecycle` so the detached starter can acquire it to install.
+async fn wait_for_start_inflight(state: &State<'_, DesktopAppState>) -> Result<(), BridgeError> {
+    loop {
+        let progress_rx = {
+            let bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
+            bridge
+                .start_inflight
+                .as_ref()
+                .map(|sender| sender.subscribe())
+        };
+        let Some(progress_rx) = progress_rx else {
+            return Ok(());
+        };
+        // Failed starts still clear inflight and wake waiters; treat failure as
+        // "not running" for shutdown/init drain purposes.
+        match wait_for_client_start_progress(progress_rx).await {
+            Ok(()) => {}
+            Err(_) => {
+                // Starter failed; inflight should be cleared. Loop to confirm.
+            }
+        }
+    }
 }
 
 #[tauri::command]
@@ -128,10 +298,22 @@ pub async fn desktop_client_shutdown<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, DesktopAppState>,
 ) -> Result<DesktopClientSnapshot, BridgeError> {
-    let _lifecycle_guard = state.client_lifecycle.lock().await;
-    let (core, updates_task) = {
-        let mut bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
-        (bridge.core.take(), bridge.updates_task.take())
+    // Drain in-flight start first (without lifecycle) so the starter can install
+    // and we can then take the core cleanly. Retry if a start sneaks in between
+    // drain and the lifecycle lock.
+    let (core, updates_task) = loop {
+        wait_for_start_inflight(&state).await?;
+        let lifecycle_guard = state.client_lifecycle.lock().await;
+        if start_inflight_is_pending(&state) {
+            drop(lifecycle_guard);
+            continue;
+        }
+        let taken = {
+            let mut bridge = state.bridge.lock().expect("desktop bridge lock poisoned");
+            (bridge.core.take(), bridge.updates_task.take())
+        };
+        drop(lifecycle_guard);
+        break taken;
     };
 
     if let Some(task) = updates_task {
@@ -168,27 +350,34 @@ pub async fn desktop_client_snapshot(
         .map_err(BridgeError::from_legacy_message)
 }
 
-fn start_client_core_with_large_stack(
+/// Open the embedded node on a large-stack OS thread without blocking a Tokio
+/// worker: the worker awaits a oneshot instead of `thread::join`.
+async fn start_client_core_async(
     paths: gents_desktop_core::client::DesktopPaths,
 ) -> Result<ClientCore, BridgeError> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
     std::thread::Builder::new()
         .name("desktop-client-start".to_string())
         .stack_size(CLIENT_START_STACK_SIZE)
-        .spawn(move || tauri::async_runtime::block_on(ClientCore::start_with_paths(paths)))
+        .spawn(move || {
+            let result = tauri::async_runtime::block_on(ClientCore::start_with_paths(paths));
+            let _ = tx.send(result);
+        })
         .map_err(|error| {
             BridgeError::new(
                 BridgeErrorCode::ClientStartFailed,
                 format!("spawning desktop client startup thread: {error}"),
             )
-        })?
-        .join()
-        .map_err(|_| {
-            BridgeError::new(
-                BridgeErrorCode::ClientStartFailed,
-                "desktop client startup thread panicked",
-            )
-        })?
-        .map_err(|error| BridgeError::from_legacy_message(error.to_string()))
+        })?;
+
+    match rx.await {
+        Ok(Ok(core)) => Ok(core),
+        Ok(Err(error)) => Err(BridgeError::from_legacy_message(error.to_string())),
+        Err(_) => Err(BridgeError::new(
+            BridgeErrorCode::ClientStartFailed,
+            "desktop client startup thread panicked or dropped its result",
+        )),
+    }
 }
 
 #[tauri::command]
@@ -283,5 +472,22 @@ mod tests {
         assert_eq!(error.code, BridgeErrorCode::InvalidArgument);
         assert!(error.message.contains("shut down"));
         assert!(ensure_client_stopped_for_init(false).is_ok());
+    }
+
+    #[test]
+    fn start_progress_ready_is_distinct_from_pending() {
+        assert!(matches!(
+            ClientStartProgress::Pending,
+            ClientStartProgress::Pending
+        ));
+        assert!(matches!(
+            ClientStartProgress::Ready,
+            ClientStartProgress::Ready
+        ));
+        let failed = ClientStartProgress::Failed("boom".into());
+        match failed {
+            ClientStartProgress::Failed(message) => assert_eq!(message, "boom"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 }

--- a/crates/gents-desktop-core/src/client/core.rs
+++ b/crates/gents-desktop-core/src/client/core.rs
@@ -503,9 +503,7 @@ impl ClientCore {
             .filter(|value| !value.is_empty())
             .ok_or_else(|| anyhow::anyhow!("peer {} has no GraphQL endpoint", record.label))?;
 
-        let mut snapshot =
-            load_full_snapshot_from_graphql(graphql, &record.agent_did, self.principal.did())
-                .await?;
+        let mut snapshot = load_full_snapshot_from_graphql(graphql, &record.agent_did).await?;
         snapshot.stamp_source_agent_did(&record.agent_did);
         let rows = snapshot.row_count();
         let version = self

--- a/crates/gents-desktop-core/src/client/query.rs
+++ b/crates/gents-desktop-core/src/client/query.rs
@@ -96,10 +96,8 @@ pub async fn load_full_snapshot_with_peer_records(
 
         let peer = peer.clone();
         let graphql = graphql.to_string();
-        let requester_did = requester_did.to_string();
         remote_loads.push(tokio::spawn(async move {
-            let result =
-                load_full_snapshot_from_graphql(&graphql, &peer.agent_did, &requester_did).await;
+            let result = load_full_snapshot_from_graphql(&graphql, &peer.agent_did).await;
             (peer, graphql, result)
         }));
     }
@@ -477,16 +475,21 @@ pub async fn load_tool_service_registries(
     .await
 }
 
+/// Load the connected agent's host view.
+///
+/// Requester identity remains attached to rows for audit and future policy
+/// projection, but it does not partition conversation visibility here. This
+/// lets a user start a session through one client and continue observing it
+/// from another client connected to the same agent runtime.
 pub async fn load_full_snapshot_from_graphql(
     graphql: &str,
     agent_did: &str,
-    requester_did: &str,
 ) -> Result<ClientStore> {
     let client = reqwest::Client::builder()
         .timeout(REMOTE_SNAPSHOT_HTTP_TIMEOUT)
         .build()
         .context("building remote GraphQL snapshot HTTP client")?;
-    let data = execute_remote_snapshot_query(&client, graphql, agent_did, requester_did).await?;
+    let data = execute_remote_snapshot_query(&client, graphql, agent_did).await?;
 
     Ok(ClientStore::from_rows(ClientStoreRows {
         agent_principals: parse_remote_rows(&data, "AgentPrincipal")?,
@@ -682,9 +685,8 @@ async fn execute_remote_snapshot_query(
     client: &reqwest::Client,
     graphql: &str,
     agent_did: &str,
-    requester_did: &str,
 ) -> Result<Value> {
-    let query = remote_snapshot_query(agent_did, requester_did);
+    let query = remote_snapshot_query(agent_did);
     execute_remote_graphql_query(client, graphql, &query, "snapshot").await
 }
 
@@ -871,24 +873,23 @@ query DesktopRemoteChatPatch {{
     )
 }
 
-fn remote_snapshot_query(agent_did: &str, requester_did: &str) -> String {
+fn remote_snapshot_query(agent_did: &str) -> String {
     let agent_did = escape_graphql_string(agent_did);
-    let requester_did = escape_graphql_string(requester_did);
     format!(
         r#"
 query DesktopRemoteSnapshot {{
   AgentPrincipal(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_PRINCIPAL_FIELDS} }}
   AgentBehavior(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_BEHAVIOR_FIELDS} }}
   AgentRuntime(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_RUNTIME_FIELDS} }}
-  AgentConversation(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_CONVERSATION_FIELDS} }}
-  AgentRequest(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_REQUEST_FIELDS} }}
-  AgentResponse(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_RESPONSE_FIELDS} }}
-  AgentMessage(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_MESSAGE_FIELDS} }}
-  AgentSession(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_SESSION_FIELDS} }}
+  AgentConversation(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_CONVERSATION_FIELDS} }}
+  AgentRequest(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_REQUEST_FIELDS} }}
+  AgentResponse(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_RESPONSE_FIELDS} }}
+  AgentMessage(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_MESSAGE_FIELDS} }}
+  AgentSession(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_SESSION_FIELDS} }}
   Goal(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {GOAL_FIELDS} }}
-  AgentToolCall(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_TOOL_CALL_FIELDS} }}
-  AgentToolResult(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {AGENT_TOOL_RESULT_FIELDS} }}
-  CompactionEntry(filter: {{ agent_did: {{ _eq: "{agent_did}" }}, requester_did: {{ _eq: "{requester_did}" }} }}) {{ {COMPACTION_ENTRY_FIELDS} }}
+  AgentToolCall(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_TOOL_CALL_FIELDS} }}
+  AgentToolResult(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {AGENT_TOOL_RESULT_FIELDS} }}
+  CompactionEntry(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ {COMPACTION_ENTRY_FIELDS} }}
   Task {{ task_id name description behavior_id prompt_template enabled output_schema_ref created_at updated_at }}
   Schedule {{ schedule_id task_id interval_secs cron timezone missed_run_policy enabled concurrency next_run_at last_attempt_at last_status last_error fire_count created_at updated_at }}
   EventTrigger {{ trigger_id task_id source_collection event_kind filter enabled concurrency created_at updated_at last_attempt_at last_fired_source_doc_id last_status last_error fire_count }}
@@ -1448,13 +1449,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remote_snapshot_hydrates_from_requester_scoped_query() {
+    async fn remote_snapshot_hydrates_from_agent_scoped_query() {
         let server = MockServer::start().await;
         let data = json!({
             "AgentPrincipal": [],
             "AgentBehavior": [],
             "AgentRuntime": [],
-            "AgentConversation": [],
+            "AgentConversation": [
+                {
+                    "session_id": "host-session",
+                    "agent_did": "did:test:agent",
+                    "requester_did": null
+                },
+                {
+                    "session_id": "phone-session",
+                    "agent_did": "did:test:agent",
+                    "requester_did": "did:test:requester"
+                }
+            ],
             "AgentRequest": [],
             "AgentResponse": [],
             "AgentMessage": [],
@@ -1474,19 +1486,25 @@ mod tests {
         });
         Mock::given(method("POST"))
             .and(body_string_contains("did:test:agent"))
-            .and(body_string_contains("did:test:requester"))
             .and(body_string_contains("requester_did"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": data })))
             .expect(1)
             .mount(&server)
             .await;
 
-        let snapshot =
-            load_full_snapshot_from_graphql(&server.uri(), "did:test:agent", "did:test:requester")
-                .await
-                .expect("requester-scoped remote snapshot");
+        let snapshot = load_full_snapshot_from_graphql(&server.uri(), "did:test:agent")
+            .await
+            .expect("agent-scoped remote snapshot");
 
-        assert_eq!(snapshot.row_count(), 0);
+        assert_eq!(snapshot.conversations.len(), 2);
+        assert!(snapshot
+            .conversations
+            .iter()
+            .any(|row| row.session_id == "host-session" && row.requester_did.is_none()));
+        assert!(snapshot.conversations.iter().any(|row| {
+            row.session_id == "phone-session"
+                && row.requester_did.as_deref() == Some("did:test:requester")
+        }));
     }
 
     #[tokio::test]
@@ -1675,7 +1693,7 @@ mod tests {
     #[test]
     fn remote_tool_call_queries_include_local_field_set() {
         let chat_patch = remote_chat_patch_query("sess-1");
-        let remote_snapshot = remote_snapshot_query("did:test:agent", "did:test:requester");
+        let remote_snapshot = remote_snapshot_query("did:test:agent");
         for field in AGENT_TOOL_CALL_FIELDS.split_whitespace() {
             assert!(
                 chat_patch.contains(field),
@@ -1691,7 +1709,7 @@ mod tests {
     #[test]
     fn remote_goal_queries_include_local_field_set() {
         let chat_patch = remote_chat_patch_query("sess-1");
-        let remote_snapshot = remote_snapshot_query("did:test:agent", "did:test:requester");
+        let remote_snapshot = remote_snapshot_query("did:test:agent");
         for field in GOAL_FIELDS.split_whitespace() {
             assert!(
                 chat_patch.contains(field),
@@ -1706,7 +1724,7 @@ mod tests {
 
     #[test]
     fn remote_runtime_query_includes_local_field_set() {
-        let remote_snapshot = remote_snapshot_query("did:test:agent", "did:test:requester");
+        let remote_snapshot = remote_snapshot_query("did:test:agent");
         for field in AGENT_RUNTIME_FIELDS.split_whitespace() {
             assert!(
                 remote_snapshot.contains(field),
@@ -1716,18 +1734,16 @@ mod tests {
     }
 
     #[test]
-    fn remote_snapshot_scopes_conversation_rows_to_agent_and_requester() {
-        let query = remote_snapshot_query(
-            r#"did:test:agent"with-quote"#,
-            r#"did:test:requester"with-quote"#,
-        );
+    fn remote_snapshot_scopes_conversation_rows_to_agent() {
+        let query = remote_snapshot_query(r#"did:test:agent"with-quote"#);
 
         assert!(query.contains(
-            r#"agent_did: { _eq: "did:test:agent\"with-quote" }, requester_did: { _eq: "did:test:requester\"with-quote" }"#
+            r#"AgentConversation(filter: { agent_did: { _eq: "did:test:agent\"with-quote" } })"#
         ));
         assert!(query.contains(
-            r#"AgentMessage(filter: { agent_did: { _eq: "did:test:agent\"with-quote" }, requester_did: { _eq: "did:test:requester\"with-quote" } })"#
+            r#"AgentMessage(filter: { agent_did: { _eq: "did:test:agent\"with-quote" } })"#
         ));
+        assert!(!query.contains("requester_did: { _eq:"));
         assert!(!query.contains("AgentConversation {"));
         assert!(!query.contains("AgentRequest {"));
     }


### PR DESCRIPTION
## What changed

- embed the production frontend in iOS builds through Tauri's custom protocol
- make desktop client startup single-flight and cancellation-safe so concurrent startup paths cannot race for RocksDB
- load remote conversation history by agent rather than requester, preserving requester DIDs for audit while allowing a conversation to move between computer and phone
- use the modern iOS launch-screen declaration and preserve the compiled app-icon catalog
- add an explicit startup hydration screen with concrete progress states, rotating playful status copy, failure recovery, and retry
- defer pairing onboarding until the saved-peer configuration has loaded and is confirmed empty

## Why

The iPhone build could attempt to load the development server, concurrent startup calls could race the embedded database, and remote snapshots hid host-originated conversations behind the phone requester's DID. The UI also interpreted an unhydrated empty deployment list as an unconfigured app, briefly showing pairing even when servers were already saved.

## Impact

The signed iOS app now starts from embedded assets, keeps one client startup in flight, restores the existing icon, shows useful startup progress, and exposes all conversations for the selected agent across computer and phone. New requests still retain the originating requester DID.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p gents-desktop-core`
- `cargo test -p gents-desktop-bridge`
- `npm run test -- --run` — 333 passed, 15 skipped
- `npm run build`
- `npm run tauri -- ios build --ci --export-method debugging`
- signed app installed and launched successfully on a connected iPhone without replacing its data container
