### PR TITLE
Fix silent tool-failure persistence and reconcile the Request contract with production writers

### DIFF
--- a/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
@@ -17,6 +17,9 @@ def boundaryRequestInputRequiredReservedId : String :=
 def boundaryRequestDeadPreclaimOnlyId : String :=
   "boundary.request.dead-preclaim-only"
 
+def boundaryRequestRecoverySweepReachableId : String :=
+  "boundary.request.recovery-sweep-reachable"
+
 def boundaryToolCallPermanentWithoutRetryEvidenceId : String :=
   "boundary.tool-call.permanent-without-retry-evidence"
 
@@ -87,7 +90,15 @@ def boundaries : List Boundary :=
     , domain := "RequestLifecycle"
     , subject := "dead terminal state"
     , statement :=
-        "dead is terminal only for stale pre-claim work; post-claim provider, retry, tool, and deadline failures remain failed."
+        "In the request machine dead is terminal only for stale pre-claim work; post-claim provider, retry, tool, and deadline failures remain failed. The subagent-liveness recovery sweep is the one exception: it terminalizes an expired claimed or processing child as dead, published as recoveryReachable under boundary.request.recovery-sweep-reachable."
+    }
+  , { id := boundaryRequestRecoverySweepReachableId
+    , domain := "RequestLifecycle"
+    , subject := "recovery-sweep reachable request edges"
+    , statement :=
+        "claimed->completed, claimed->dead, and processing->dead are taken by no single RequestContext.Action, but registered recovery sweeps perform them on persisted rows: terminal repair completes a claimed request whose response already landed, and the subagent-liveness sweep terminalizes an expired claimed or processing child as dead. They are published as recoveryReachable rather than illegal so the emitted contract does not assert Rust has no writer for an edge the product performs."
+    , acceptedFollowUp :=
+        some "Compose the Request machine with Proofs/Recovery so these edges are proven in one model instead of cited across two."
     }
   , { id := boundaryToolCallPermanentWithoutRetryEvidenceId
     , domain := "ToolExecution"

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/LifecycleTransitions.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/LifecycleTransitions.lean
@@ -9,6 +9,7 @@ inductive LifecycleTransitionClassification where
   | legal
   | illegal
   | productUnreachable
+  | recoveryReachable
   deriving DecidableEq, Repr
 
 namespace LifecycleTransitionClassification
@@ -17,6 +18,7 @@ def toContract : LifecycleTransitionClassification → String
   | .legal => "legal"
   | .illegal => "illegal"
   | .productUnreachable => "productUnreachable"
+  | .recoveryReachable => "recoveryReachable"
 
 end LifecycleTransitionClassification
 
@@ -109,6 +111,21 @@ def requestTransitionAction? (source target : String) : Option String :=
     source
     target
 
+/-- Request edges that no single `RequestContext.Action` takes, but that
+registered recovery sweeps legitimately perform on persisted rows.
+
+`claimed -> completed` is terminal repair finishing a claimed request whose
+response document already landed; `claimed -> dead` and `processing -> dead` are
+the subagent-liveness sweep terminalizing an expired child. The licensing models
+live in `Proofs/Recovery/` — the request machine alone does not model them, so
+publishing these as `illegal` made the emitted contract assert that Rust has no
+writer for edges the product actually performs. -/
+def requestRecoverySweepReachable : RequestState → RequestState → Bool
+  | .claimed, .completed => true
+  | .claimed, .dead => true
+  | .processing, .dead => true
+  | _, _ => false
+
 def requestTransitionClassification
     (source target : RequestState)
     (action : Option String) : LifecycleTransitionClassification :=
@@ -117,6 +134,8 @@ def requestTransitionClassification
   | none =>
       if source = .inputRequired ∨ target = .inputRequired then
         .productUnreachable
+      else if requestRecoverySweepReachable source target then
+        .recoveryReachable
       else
         .illegal
 
@@ -135,6 +154,8 @@ def requestTransitionCase (source target : RequestState) : LifecycleTransitionCa
       match classification with
       | .productUnreachable =>
           some Conformance.Contracts.boundaryRequestInputRequiredReservedId
+      | .recoveryReachable =>
+          some Conformance.Contracts.boundaryRequestRecoverySweepReachableId
       | _ => none
   }
 

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -339,9 +339,12 @@ Operational meaning:
 - `inputRequired` is reserved for a blocked external-input cycle; current Rust
   runtime code does not emit it because autonomous tool calls run inline, and
   active runtime filters exclude it until that loop is modeled
-- `dead` is persisted only for stale pre-claim TTL expiry; post-claim provider
-  failure, retry exhaustion, tool failure, and deadline expiry are terminal
-  `failed`
+- `dead` is persisted by the request machine only for stale pre-claim TTL
+  expiry; post-claim provider failure, retry exhaustion, tool failure, and
+  deadline expiry are terminal `failed`. The subagent-liveness recovery sweep
+  is the one exception: it terminalizes an expired `claimed`/`processing` child
+  as `dead` (`Proofs/Recovery/`), published in the contract as
+  `recoveryReachable` under `boundary.request.recovery-sweep-reachable`
 - `interrupted` models operator cancellation and releases admission
 - terminal states are `completed`, `failed`, `superseded`, `dead`, and `interrupted`
 

--- a/crates/gents/src/agent/loop_stream.rs
+++ b/crates/gents/src/agent/loop_stream.rs
@@ -887,14 +887,24 @@ fn value_to_json_string(value: &serde_json::Value) -> String {
     }
 }
 
-async fn dispatch_tool(
+pub(crate) async fn dispatch_tool(
     tools: &[Box<dyn ToolDyn>],
     name: &str,
     args: String,
     live_output: Option<crate::background_tools::LiveToolOutputWriter>,
 ) -> String {
     let Some(tool) = tools.iter().find(|tool| tool.name() == name) else {
-        return format!("error: unknown tool '{name}'");
+        // Marked, not a bare string: an unresolved tool name is a dispatch
+        // FAILURE, and an unmarked result classifies as `None` and terminalizes
+        // the call `completed`. Models hallucinate tool names and stale surfaces
+        // outlive their tools, so this is a routine path, not an exotic one — it
+        // would otherwise reproduce exactly the durability bug this marker exists
+        // to close. The detail text is unchanged so the model sees what it always
+        // saw.
+        return tool_dispatch_failure_result(
+            ToolDispatchFailure::ToolCallError,
+            &format!("error: unknown tool '{name}'"),
+        );
     };
 
     let Some(scope) = current_tool_runtime_context() else {

--- a/crates/gents/src/agent/loop_stream.rs
+++ b/crates/gents/src/agent/loop_stream.rs
@@ -44,7 +44,9 @@ use rig::completion::{
     CompletionError, CompletionModel, CompletionRequest, GetTokenUsage, PromptError, Usage,
 };
 
-use crate::llm::tool::{ToolDyn, ToolError, UnparseableArgsKind};
+use crate::llm::tool::{
+    ToolDyn, ToolError, UnparseableArgsKind, JSON_ERROR_PREFIX, TOOL_CALL_ERROR_PREFIX,
+};
 use crate::llm::ToolChoice;
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
 
@@ -931,7 +933,7 @@ async fn dispatch_tool(
     }
 }
 
-fn tool_outcome_to_result(name: &str, outcome: Result<String, ToolError>) -> String {
+pub(crate) fn tool_outcome_to_result(name: &str, outcome: Result<String, ToolError>) -> String {
     match outcome {
         Ok(result) => result,
         Err(ToolError::UnparseableArgs { kind, reason }) => {
@@ -955,7 +957,18 @@ fn tool_outcome_to_result(name: &str, outcome: Result<String, ToolError>) -> Str
                 "tool '{name}' arguments could not be parsed: {guidance}."
             ))
         }
-        Err(error) => error.to_string(),
+        // Stamp the prefixes `classify_runtime_failure` matches on. Without
+        // them the persistence path cannot tell a failed call from a successful
+        // one and terminalizes it `completed` (#400/D6 regression).
+        //
+        // The INNER error is rendered, not the `ToolError` wrapper: a command
+        // policy denial arrives as a `ToolCallError` whose payload is the denial
+        // JSON, and `parse_command_policy_denial` strips this prefix and parses
+        // the remainder. Rendering the wrapper's own "tool call error: " text
+        // here would leave non-JSON in front of the payload and silently
+        // downgrade every denial to an unstructured failure.
+        Err(ToolError::JsonError(error)) => format!("{JSON_ERROR_PREFIX} {error}"),
+        Err(ToolError::ToolCallError(error)) => format!("{TOOL_CALL_ERROR_PREFIX} {error}"),
     }
 }
 

--- a/crates/gents/src/agent/loop_stream.rs
+++ b/crates/gents/src/agent/loop_stream.rs
@@ -44,18 +44,16 @@ use rig::completion::{
     CompletionError, CompletionModel, CompletionRequest, GetTokenUsage, PromptError, Usage,
 };
 
-use crate::llm::tool::{
-    ToolDyn, ToolError, UnparseableArgsKind, JSON_ERROR_PREFIX, TOOL_CALL_ERROR_PREFIX,
-};
+use crate::llm::tool::{ToolDyn, ToolError, UnparseableArgsKind};
 use crate::llm::ToolChoice;
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
 
 use super::stream_processor::AssistantTurnAccumulator;
 use crate::hook::DefraSessionHook;
 use crate::tool_call_lifecycle::runtime::{
-    cancelled_result, current_tool_runtime_context, deadline_remaining,
+    cancelled_result, current_tool_runtime_context, deadline_remaining, model_facing_tool_result,
     scope_request_tool_execution_with_workspace_and_live_output, timeout_result,
-    unparseable_args_notice, unparseable_args_result,
+    tool_dispatch_failure_result, unparseable_args_result, ToolDispatchFailure,
 };
 use crate::truncation::{tool_result_truncation_mode, truncate_text, TruncationLimits};
 
@@ -584,11 +582,8 @@ where
                                         )))?;
                                     }
                                 }
-                                // The internal marker must never reach the model.
-                                match unparseable_args_notice(&bounded) {
-                                    Some(notice) => notice.to_string(),
-                                    None => bounded,
-                                }
+                                // Internal lifecycle markers must never reach the model.
+                                model_facing_tool_result(&bounded).to_string()
                             }
                         };
 
@@ -957,18 +952,25 @@ pub(crate) fn tool_outcome_to_result(name: &str, outcome: Result<String, ToolErr
                 "tool '{name}' arguments could not be parsed: {guidance}."
             ))
         }
-        // Stamp the prefixes `classify_runtime_failure` matches on. Without
-        // them the persistence path cannot tell a failed call from a successful
-        // one and terminalizes it `completed` (#400/D6 regression).
+        // Stamp the collision-free marker `classify_runtime_failure` matches on.
+        // Without it the persistence path cannot tell a failed call from a
+        // successful one and terminalizes it `completed` (#400/D6 regression).
+        // A human-readable prefix will not do: tool output is untrusted text, so
+        // a tool that merely printed the token could forge a failure — and a
+        // structured policy denial with it.
         //
-        // The INNER error is rendered, not the `ToolError` wrapper: a command
+        // The INNER error is carried, not the `ToolError` wrapper: a command
         // policy denial arrives as a `ToolCallError` whose payload is the denial
-        // JSON, and `parse_command_policy_denial` strips this prefix and parses
-        // the remainder. Rendering the wrapper's own "tool call error: " text
-        // here would leave non-JSON in front of the payload and silently
-        // downgrade every denial to an unstructured failure.
-        Err(ToolError::JsonError(error)) => format!("{JSON_ERROR_PREFIX} {error}"),
-        Err(ToolError::ToolCallError(error)) => format!("{TOOL_CALL_ERROR_PREFIX} {error}"),
+        // JSON, and `parse_command_policy_denial` parses the detail after the
+        // marker. The wrapper's own "tool call error: " text in front of the
+        // payload would silently downgrade every denial to an unstructured
+        // failure.
+        Err(ToolError::JsonError(error)) => {
+            tool_dispatch_failure_result(ToolDispatchFailure::JsonError, &error.to_string())
+        }
+        Err(ToolError::ToolCallError(error)) => {
+            tool_dispatch_failure_result(ToolDispatchFailure::ToolCallError, &error.to_string())
+        }
     }
 }
 

--- a/crates/gents/src/agent/loop_stream/tests.rs
+++ b/crates/gents/src/agent/loop_stream/tests.rs
@@ -1945,9 +1945,20 @@ async fn dispatch_tool_calls_known_tool_and_reports_unknown() {
         super::dispatch_tool(&tools, "echo", "{}".to_string(), None).await,
         "ECHOED".to_string()
     );
+    // An unresolved tool name is a dispatch FAILURE, so it carries the
+    // collision-free marker the persistence classifier keys on. Without it the
+    // call terminalizes `completed` and a hallucinated tool name is durably
+    // recorded as a successful call (fenced end-to-end by
+    // `hook::tests::hook_maps_unknown_tool_dispatch_to_failed_lifecycle`).
+    let unknown = super::dispatch_tool(&tools, "missing", "{}".to_string(), None).await;
+    let (kind, detail) = crate::tool_call_lifecycle::runtime::tool_dispatch_failure(&unknown)
+        .expect("unknown tool must be marked as a dispatch failure");
+    assert_eq!(kind, ToolDispatchFailure::ToolCallError);
+    assert_eq!(detail, "error: unknown tool 'missing'");
+    // The model still sees exactly the text it always saw.
     assert_eq!(
-        super::dispatch_tool(&tools, "missing", "{}".to_string(), None).await,
-        "error: unknown tool 'missing'".to_string()
+        crate::tool_call_lifecycle::runtime::model_facing_tool_result(&unknown),
+        "error: unknown tool 'missing'"
     );
 }
 

--- a/crates/gents/src/hook/persistence/helpers.rs
+++ b/crates/gents/src/hook/persistence/helpers.rs
@@ -606,13 +606,13 @@ pub(super) struct RuntimeFailure {
 }
 
 pub(super) fn classify_runtime_failure(result: &str) -> Option<RuntimeFailure> {
-    if result.starts_with("JsonError:") {
+    if result.starts_with(crate::llm::tool::JSON_ERROR_PREFIX) {
         return Some(RuntimeFailure {
             failure_class: crate::tool_call_lifecycle::FailureClass::ArgumentInvalid,
             command_denial: None,
         });
     }
-    if result.starts_with("ToolCallError:") {
+    if result.starts_with(crate::llm::tool::TOOL_CALL_ERROR_PREFIX) {
         if let Some(denial) = parse_command_policy_denial(result) {
             return Some(RuntimeFailure {
                 failure_class: crate::tool_call_lifecycle::FailureClass::PolicyDenied,
@@ -643,7 +643,7 @@ fn parse_command_policy_denial(result: &str) -> Option<CommandPolicyDenial> {
 fn strip_error_prefixes(mut value: &str) -> &str {
     loop {
         let stripped = value
-            .strip_prefix("ToolCallError:")
+            .strip_prefix(crate::llm::tool::TOOL_CALL_ERROR_PREFIX)
             .or_else(|| value.strip_prefix("error:"))
             .or_else(|| value.strip_prefix("Error:"))
             .or_else(|| value.strip_prefix("ERROR:"));
@@ -657,6 +657,51 @@ fn strip_error_prefixes(mut value: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::tool::ToolError;
+    use crate::tool_call_lifecycle::FailureClass;
+
+    /// The dispatcher's rendering of a failed tool call must be classifiable by
+    /// the persistence path. This drives both production functions end-to-end
+    /// rather than hand-writing the string between them: when the owned loop
+    /// replaced rig's toolset dispatcher (#400/D6) the rendered prefix changed
+    /// and every `Err` tool outcome began persisting as a completed call.
+    #[test]
+    fn dispatcher_rendered_tool_call_error_classifies_as_runtime_failure() {
+        let rendered = crate::agent::loop_stream::tool_outcome_to_result(
+            "bash",
+            Err(ToolError::ToolCallError("boom".into())),
+        );
+
+        let failure = classify_runtime_failure(&rendered).unwrap_or_else(|| {
+            panic!("dispatcher-rendered tool failure must classify as a runtime failure: {rendered:?}")
+        });
+        assert_eq!(
+            failure.failure_class,
+            FailureClass::ToolReturnedError,
+            "rendered: {rendered:?}"
+        );
+    }
+
+    /// Same contract for the JSON-serialization arm, whose `JsonError:`-prefixed
+    /// rendering is specified in [`ToolError`]'s docs.
+    #[test]
+    fn dispatcher_rendered_json_error_classifies_as_argument_invalid() {
+        let json_error = serde_json::from_str::<serde_json::Value>("{oops")
+            .expect_err("malformed JSON must fail to parse");
+        let rendered = crate::agent::loop_stream::tool_outcome_to_result(
+            "bash",
+            Err(ToolError::JsonError(json_error)),
+        );
+
+        let failure = classify_runtime_failure(&rendered).unwrap_or_else(|| {
+            panic!("dispatcher-rendered JSON failure must classify as a runtime failure: {rendered:?}")
+        });
+        assert_eq!(
+            failure.failure_class,
+            FailureClass::ArgumentInvalid,
+            "rendered: {rendered:?}"
+        );
+    }
 
     #[test]
     fn json_envelope_bounds_oversized_result_and_stays_valid_json() {
@@ -773,6 +818,29 @@ mod tests {
         assert!(bounded.contains("line 1\nline 2"));
         assert!(!bounded.contains("line 3"));
         assert!(bounded.contains("[Showing lines 1-2 of 4"));
+    }
+
+    /// A command-policy denial arrives as a `ToolCallError` carrying the denial
+    /// JSON. It must survive the dispatcher's rendering intact enough for
+    /// `parse_command_policy_denial` to recover the structured payload — the
+    /// prefix has to be the only thing in front of the JSON.
+    #[test]
+    fn dispatcher_rendered_policy_denial_survives_as_structured_denial() {
+        let payload = r#"{"ok":false,"failure_class":"policyDenied","denial_reason":"readOnlySubcommandNotAllowlisted","denied_argv":null,"denied_command":"git","denied_argument":null,"denied_subcommand":"commit","denied_prefix":null,"policy_mode":"read_only","policy_network":"inherit","message":"git subcommand is not allowed by the read-only bash tool: commit"}"#;
+        let rendered = crate::agent::loop_stream::tool_outcome_to_result(
+            "bash",
+            Err(ToolError::ToolCallError(payload.into())),
+        );
+
+        let failure = classify_runtime_failure(&rendered).unwrap_or_else(|| {
+            panic!("dispatcher-rendered policy denial must classify: {rendered:?}")
+        });
+        assert_eq!(failure.failure_class, FailureClass::PolicyDenied);
+        let denial = failure
+            .command_denial
+            .unwrap_or_else(|| panic!("structured denial must survive rendering: {rendered:?}"));
+        assert_eq!(denial.to_contract(), "readOnlySubcommandNotAllowlisted");
+        assert_eq!(denial.reason.denied_subcommand(), Some("commit"));
     }
 
     #[test]

--- a/crates/gents/src/hook/persistence/helpers.rs
+++ b/crates/gents/src/hook/persistence/helpers.rs
@@ -605,26 +605,33 @@ pub(super) struct RuntimeFailure {
     pub(super) command_denial: Option<CommandPolicyDenial>,
 }
 
+/// Classify a tool result that carries an internal dispatch-failure marker.
+///
+/// Keyed on the collision-free marker, never on human-readable text: tool output
+/// is untrusted, so a successful call whose output merely began with a token like
+/// `ToolCallError:` would otherwise be persisted as failed — and its text parsed
+/// as a structured policy denial.
 pub(super) fn classify_runtime_failure(result: &str) -> Option<RuntimeFailure> {
-    if result.starts_with(crate::llm::tool::JSON_ERROR_PREFIX) {
-        return Some(RuntimeFailure {
+    use crate::tool_call_lifecycle::runtime::{tool_dispatch_failure, ToolDispatchFailure};
+    let (kind, detail) = tool_dispatch_failure(result)?;
+    match kind {
+        ToolDispatchFailure::JsonError => Some(RuntimeFailure {
             failure_class: crate::tool_call_lifecycle::FailureClass::ArgumentInvalid,
             command_denial: None,
-        });
-    }
-    if result.starts_with(crate::llm::tool::TOOL_CALL_ERROR_PREFIX) {
-        if let Some(denial) = parse_command_policy_denial(result) {
-            return Some(RuntimeFailure {
-                failure_class: crate::tool_call_lifecycle::FailureClass::PolicyDenied,
-                command_denial: Some(denial),
-            });
+        }),
+        ToolDispatchFailure::ToolCallError => {
+            if let Some(denial) = parse_command_policy_denial(detail) {
+                return Some(RuntimeFailure {
+                    failure_class: crate::tool_call_lifecycle::FailureClass::PolicyDenied,
+                    command_denial: Some(denial),
+                });
+            }
+            Some(RuntimeFailure {
+                failure_class: classify_runtime_error(detail),
+                command_denial: None,
+            })
         }
-        return Some(RuntimeFailure {
-            failure_class: classify_runtime_error(result),
-            command_denial: None,
-        });
     }
-    None
 }
 
 fn parse_command_policy_denial(result: &str) -> Option<CommandPolicyDenial> {
@@ -643,8 +650,7 @@ fn parse_command_policy_denial(result: &str) -> Option<CommandPolicyDenial> {
 fn strip_error_prefixes(mut value: &str) -> &str {
     loop {
         let stripped = value
-            .strip_prefix(crate::llm::tool::TOOL_CALL_ERROR_PREFIX)
-            .or_else(|| value.strip_prefix("error:"))
+            .strip_prefix("error:")
             .or_else(|| value.strip_prefix("Error:"))
             .or_else(|| value.strip_prefix("ERROR:"));
         let Some(stripped) = stripped else {
@@ -673,7 +679,9 @@ mod tests {
         );
 
         let failure = classify_runtime_failure(&rendered).unwrap_or_else(|| {
-            panic!("dispatcher-rendered tool failure must classify as a runtime failure: {rendered:?}")
+            panic!(
+                "dispatcher-rendered tool failure must classify as a runtime failure: {rendered:?}"
+            )
         });
         assert_eq!(
             failure.failure_class,
@@ -682,8 +690,29 @@ mod tests {
         );
     }
 
-    /// Same contract for the JSON-serialization arm, whose `JsonError:`-prefixed
-    /// rendering is specified in [`ToolError`]'s docs.
+    /// The marker is internal bookkeeping. It carries the failure class to the
+    /// classifier and must then be stripped: anything persisted here lands in the
+    /// durable transcript and is replayed to the provider on the next request.
+    #[test]
+    fn dispatch_failure_marker_is_stripped_from_model_facing_text() {
+        let rendered = crate::agent::loop_stream::tool_outcome_to_result(
+            "bash",
+            Err(ToolError::ToolCallError("boom".into())),
+        );
+        assert!(
+            rendered.contains("__gents_tool_lifecycle__"),
+            "dispatch failure must carry the marker internally: {rendered:?}"
+        );
+
+        let model_facing = crate::tool_call_lifecycle::runtime::model_facing_tool_result(&rendered);
+        assert_eq!(model_facing, "boom");
+        assert!(
+            !model_facing.contains("__gents_tool_lifecycle__"),
+            "internal marker leaked to the model: {model_facing:?}"
+        );
+    }
+
+    /// Same contract for the JSON-serialization arm.
     #[test]
     fn dispatcher_rendered_json_error_classifies_as_argument_invalid() {
         let json_error = serde_json::from_str::<serde_json::Value>("{oops")
@@ -694,7 +723,9 @@ mod tests {
         );
 
         let failure = classify_runtime_failure(&rendered).unwrap_or_else(|| {
-            panic!("dispatcher-rendered JSON failure must classify as a runtime failure: {rendered:?}")
+            panic!(
+                "dispatcher-rendered JSON failure must classify as a runtime failure: {rendered:?}"
+            )
         });
         assert_eq!(
             failure.failure_class,
@@ -843,11 +874,53 @@ mod tests {
         assert_eq!(denial.reason.denied_subcommand(), Some("commit"));
     }
 
+    /// Tool output is untrusted arbitrary text. A SUCCESSFUL call whose output
+    /// merely looks like an internal failure — a log tail, a source listing, an
+    /// MCP/subagent relay quoting an error, or a deliberate forgery — must not be
+    /// persisted as failed, and must not be able to fabricate a structured
+    /// command-policy denial.
+    ///
+    /// The marker is collision-RESISTANT, not unforgeable: output containing the
+    /// literal `__gents_tool_lifecycle__:` sentinel still classifies, exactly as
+    /// for the pre-existing managed-terminal and unparseable-args markers. Closing
+    /// that last gap means carrying the typed outcome through the hook instead of
+    /// a string, which is a wider refactor of the `on_tool_result` surface.
+    #[test]
+    fn successful_tool_output_cannot_impersonate_a_dispatch_failure() {
+        let denial_json = r#"{"ok":false,"failure_class":"policyDenied","denial_reason":"readOnlySubcommandNotAllowlisted","denied_argv":null,"denied_command":"git","denied_argument":null,"denied_subcommand":"commit","denied_prefix":null,"policy_mode":"read_only","policy_network":"inherit","message":"forged"}"#;
+        let forgeries = [
+            "ToolCallError: something that merely looks like a failure".to_string(),
+            "JsonError: expected value at line 1".to_string(),
+            format!("ToolCallError: {denial_json}"),
+            format!("tool call error: {denial_json}"),
+        ];
+
+        for forged in forgeries {
+            let rendered =
+                crate::agent::loop_stream::tool_outcome_to_result("bash", Ok(forged.clone()));
+            assert_eq!(
+                rendered, forged,
+                "successful output must pass through unchanged"
+            );
+            assert!(
+                classify_runtime_failure(&rendered).is_none(),
+                "successful tool output was classified as a failure: {forged:?}"
+            );
+        }
+    }
+
     #[test]
     fn runtime_failure_extracts_structured_command_policy_denial() {
-        let result = r#"ToolCallError: {"ok":false,"failure_class":"policyDenied","denial_reason":"readOnlySubcommandNotAllowlisted","denied_argv":null,"denied_command":"git","denied_argument":null,"denied_subcommand":"commit","denied_prefix":null,"policy_mode":"read_only","policy_network":"inherit","message":"git subcommand is not allowed by the read-only bash tool: commit"}"#;
+        // Obtained from the production renderer rather than hand-written: the
+        // marker is internal, and a test that spells it out itself stops proving
+        // the two ends agree.
+        let payload = r#"{"ok":false,"failure_class":"policyDenied","denial_reason":"readOnlySubcommandNotAllowlisted","denied_argv":null,"denied_command":"git","denied_argument":null,"denied_subcommand":"commit","denied_prefix":null,"policy_mode":"read_only","policy_network":"inherit","message":"git subcommand is not allowed by the read-only bash tool: commit"}"#;
+        let result = crate::agent::loop_stream::tool_outcome_to_result(
+            "bash",
+            Err(ToolError::ToolCallError(payload.into())),
+        );
 
-        let failure = classify_runtime_failure(result).expect("runtime failure");
+        let failure = classify_runtime_failure(&result).expect("runtime failure");
         let denial = failure.command_denial.expect("command denial");
 
         assert_eq!(failure.failure_class, FailureClass::PolicyDenied);

--- a/crates/gents/src/hook/persistence/mod.rs
+++ b/crates/gents/src/hook/persistence/mod.rs
@@ -27,7 +27,8 @@ use crate::document_config::{load_agent_behavior, SubagentTarget};
 use crate::session;
 use crate::tool_call_lifecycle::query::load_tool_call_result;
 use crate::tool_call_lifecycle::runtime::{
-    classify_managed_tool_result, unparseable_args_notice, ManagedToolTerminal,
+    classify_managed_tool_result, model_facing_tool_result, unparseable_args_notice,
+    ManagedToolTerminal,
 };
 use crate::tool_call_lifecycle::{
     AwaitMode, CancelCause, CancelPolicy, CascadeDispatch, ChildTerminal, FailureClass,

--- a/crates/gents/src/hook/persistence/prompt_hook.rs
+++ b/crates/gents/src/hook/persistence/prompt_hook.rs
@@ -416,6 +416,14 @@ impl DefraSessionHook {
                 None => (result, false),
             };
 
+            // A dispatch-failure marker carries the failure class out-of-band,
+            // exactly like the unparseable-args notice above: classify while the
+            // marker is still attached, then strip it. Persisting the marked text
+            // would put internal bookkeeping into the durable transcript, and it
+            // would be replayed to the provider on the next request.
+            let runtime_failure = classify_runtime_failure(result);
+            let result = model_facing_tool_result(result);
+
             let (session_id, should_persist_message, persisted_result_id, persisted_call_id) = {
                 let mut state = self.state.lock().await;
                 let session_id = state
@@ -466,7 +474,7 @@ impl DefraSessionHook {
             if force_argument_invalid {
                 lc.fail(&truncated.text, FailureClass::ArgumentInvalid)
                     .await?;
-            } else if let Some(failure) = classify_runtime_failure(result_for_persistence) {
+            } else if let Some(failure) = runtime_failure {
                 if let Some(denial) = failure.command_denial.as_ref() {
                     lc.fail_with_command_denial(&truncated.text, denial).await?;
                 } else {

--- a/crates/gents/src/hook/tests.rs
+++ b/crates/gents/src/hook/tests.rs
@@ -866,6 +866,80 @@ async fn hook_maps_managed_timeout_result_to_timed_out_lifecycle() {
     let _ = std::fs::remove_dir_all(&data_path);
 }
 
+/// An unresolved tool name must persist as a FAILED call, end to end.
+///
+/// The result string is produced by the real dispatcher against an empty tool
+/// surface — not hand-written here — and fed through the real hook, so this fails
+/// if `dispatch_tool` ever stops marking the unknown-tool branch. Before the
+/// marker, that branch returned a bare `error: unknown tool` string, which
+/// classified as `None` and terminalized the call `completed`: a hallucinated or
+/// stale tool name was durably recorded as a SUCCESSFUL call.
+#[tokio::test]
+async fn hook_maps_unknown_tool_dispatch_to_failed_lifecycle() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-unknown-tool-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:test:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        hook.on_completion_call(&user_text_message("Run"), &[])
+            .await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+    hook.set_active_request_id(Some("req-unknown-tool".to_string()))
+        .await;
+
+    assert!(matches!(
+        hook.on_tool_call("ghost_tool", None, "internal-unknown", "{}")
+            .await,
+        ToolCallHookAction::Continue
+    ));
+
+    // The production dispatcher's own unknown-tool result, against an empty
+    // tool surface.
+    let dispatched =
+        crate::agent::loop_stream::dispatch_tool(&[], "ghost_tool", "{}".to_string(), None).await;
+
+    let _ = hook
+        .on_tool_result("ghost_tool", None, "internal-unknown", "{}", &dispatched)
+        .await;
+
+    let row = fetch_tool_call_row(&node, &session_id, "internal-unknown").await;
+    assert_eq!(
+        row.get("lifecycle_state").and_then(|value| value.as_str()),
+        Some("failed"),
+        "unknown tool must terminalize as failed, got row {row:?}"
+    );
+    let persisted_result = row
+        .get("result")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        persisted_result.contains("unknown tool"),
+        "persisted result should explain the failure: {persisted_result:?}"
+    );
+    assert!(
+        !persisted_result.contains("__gents_tool_lifecycle__"),
+        "internal marker leaked into the persisted result: {persisted_result:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
 #[tokio::test]
 async fn hook_spills_full_tool_output_and_persists_bounded_observation() {
     let data_path =

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -1098,7 +1098,7 @@ pub(crate) fn assert_lifecycle_transition_cases_partition(
         }
         if !matches!(
             case.classification.as_str(),
-            "legal" | "illegal" | "productUnreachable"
+            "legal" | "illegal" | "productUnreachable" | "recoveryReachable"
         ) {
             invalid_cases.push(format!(
                 "{} has invalid classification {:?}",
@@ -1111,13 +1111,21 @@ pub(crate) fn assert_lifecycle_transition_cases_partition(
         if case.classification != "legal" && case.action.is_some() {
             invalid_cases.push(format!("{} non-legal case has action", case.name));
         }
-        if case.classification == "productUnreachable" && case.boundary.is_none() {
+        // `productUnreachable` and `recoveryReachable` are the two classifications
+        // that stand outside the machine's own transition relation, so each must
+        // name the boundary that licenses it. `legal` and `illegal` are decided by
+        // the relation itself and must not carry one.
+        let requires_boundary = matches!(
+            case.classification.as_str(),
+            "productUnreachable" | "recoveryReachable"
+        );
+        if requires_boundary && case.boundary.is_none() {
             invalid_cases.push(format!(
-                "{} product-unreachable case missing boundary",
-                case.name
+                "{} {} case missing boundary",
+                case.name, case.classification
             ));
         }
-        if case.classification != "productUnreachable" && case.boundary.is_some() {
+        if !requires_boundary && case.boundary.is_some() {
             invalid_cases.push(format!("{} reachable case has boundary", case.name));
         }
         if !expected_pairs.contains(&(case.from.clone(), case.to.clone())) {

--- a/crates/gents/src/llm/tool.rs
+++ b/crates/gents/src/llm/tool.rs
@@ -5,6 +5,19 @@ use serde::{Deserialize, Serialize};
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// Prefixes the tool dispatcher stamps onto a failed tool call's rendered
+/// result string, and the persistence classifier matches on to terminalize the
+/// call as `failed(class)` rather than `completed`.
+///
+/// The rendered result is the only channel between dispatch
+/// (`agent::loop_stream::tool_outcome_to_result`) and classification
+/// (`hook::persistence::helpers::classify_runtime_failure`), so these live here
+/// next to [`ToolError`] and are shared by both sides: when the owned loop
+/// (#400/D6) took over dispatch from rig's toolset the two ends silently
+/// disagreed about the prefix and every `Err` outcome persisted as a success.
+pub(crate) const TOOL_CALL_ERROR_PREFIX: &str = "ToolCallError:";
+pub(crate) const JSON_ERROR_PREFIX: &str = "JsonError:";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolDefinition {
     pub name: String,

--- a/crates/gents/src/llm/tool.rs
+++ b/crates/gents/src/llm/tool.rs
@@ -5,19 +5,6 @@ use serde::{Deserialize, Serialize};
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Prefixes the tool dispatcher stamps onto a failed tool call's rendered
-/// result string, and the persistence classifier matches on to terminalize the
-/// call as `failed(class)` rather than `completed`.
-///
-/// The rendered result is the only channel between dispatch
-/// (`agent::loop_stream::tool_outcome_to_result`) and classification
-/// (`hook::persistence::helpers::classify_runtime_failure`), so these live here
-/// next to [`ToolError`] and are shared by both sides: when the owned loop
-/// (#400/D6) took over dispatch from rig's toolset the two ends silently
-/// disagreed about the prefix and every `Err` outcome persisted as a success.
-pub(crate) const TOOL_CALL_ERROR_PREFIX: &str = "ToolCallError:";
-pub(crate) const JSON_ERROR_PREFIX: &str = "JsonError:";
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolDefinition {
     pub name: String,

--- a/crates/gents/src/tool_call_lifecycle/runtime.rs
+++ b/crates/gents/src/tool_call_lifecycle/runtime.rs
@@ -28,6 +28,16 @@ const CANCELLED_MARKER: &str = "__gents_tool_lifecycle__:cancelled";
 /// follows after a `:` separator; the hook strips the marker before persisting or
 /// threading, so the model only ever sees the clean notice.
 const UNPARSEABLE_ARGS_MARKER: &str = "__gents_tool_lifecycle__:unparseableArgs";
+/// Internal sentinels for a tool dispatch that returned `Err`. Same reasoning as
+/// [`UNPARSEABLE_ARGS_MARKER`]: the rendered result string is the only channel
+/// between dispatch and the persistence classifier, and tool output is untrusted
+/// arbitrary text, so the failure signal must be something successful output
+/// cannot forge. A human-readable prefix like `ToolCallError:` is forgeable — a
+/// tool that merely *prints* that token (a log tail, a source listing, an
+/// MCP/subagent relay) would be persisted as a failed call, and its text parsed
+/// as a structured command-policy denial.
+const TOOL_CALL_ERROR_MARKER: &str = "__gents_tool_lifecycle__:toolCallError";
+const JSON_ERROR_MARKER: &str = "__gents_tool_lifecycle__:jsonError";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ManagedToolTerminal {
@@ -171,6 +181,50 @@ pub(crate) fn unparseable_args_notice(result: &str) -> Option<&str> {
     result
         .strip_prefix(UNPARSEABLE_ARGS_MARKER)
         .map(|rest| rest.strip_prefix(':').unwrap_or(rest))
+}
+
+/// Which `ToolError` arm a dispatch-failure marker records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolDispatchFailure {
+    ToolCallError,
+    JsonError,
+}
+
+/// Build the tool result for a failed dispatch: a collision-free marker the hook
+/// maps to `failed(class)`, carrying the detail text after a `:` separator.
+pub(crate) fn tool_dispatch_failure_result(kind: ToolDispatchFailure, detail: &str) -> String {
+    let marker = match kind {
+        ToolDispatchFailure::ToolCallError => TOOL_CALL_ERROR_MARKER,
+        ToolDispatchFailure::JsonError => JSON_ERROR_MARKER,
+    };
+    format!("{marker}:{detail}")
+}
+
+/// If `result` carries a dispatch-failure marker, return its kind and the detail
+/// after the marker. Callers strip the marker before threading the result back to
+/// the model.
+pub(crate) fn tool_dispatch_failure(result: &str) -> Option<(ToolDispatchFailure, &str)> {
+    for (marker, kind) in [
+        (TOOL_CALL_ERROR_MARKER, ToolDispatchFailure::ToolCallError),
+        (JSON_ERROR_MARKER, ToolDispatchFailure::JsonError),
+    ] {
+        if let Some(rest) = result.strip_prefix(marker) {
+            return Some((kind, rest.strip_prefix(':').unwrap_or(rest)));
+        }
+    }
+    None
+}
+
+/// Strip any internal lifecycle marker, yielding the model-facing text. The
+/// markers are runtime bookkeeping and must never reach the provider.
+pub(crate) fn model_facing_tool_result(result: &str) -> &str {
+    if let Some(notice) = unparseable_args_notice(result) {
+        return notice;
+    }
+    if let Some((_, detail)) = tool_dispatch_failure(result) {
+        return detail;
+    }
+    result
 }
 
 struct RuntimeManagedTool {

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -266,6 +266,7 @@ fn lean_boundary_metadata_is_typed_and_reviewable() {
     let expected_boundary_ids = [
         "boundary.request.input-required-reserved",
         "boundary.request.dead-preclaim-only",
+        "boundary.request.recovery-sweep-reachable",
         "boundary.tool-call.permanent-without-retry-evidence",
         "boundary.mcp.call-tool-dispatch-retry-evidence",
         "boundary.inference-slots.running-row-derived",

--- a/crates/gents/tests/conformance/request_lifecycle.rs
+++ b/crates/gents/tests/conformance/request_lifecycle.rs
@@ -323,11 +323,12 @@ pub(super) async fn generated_request_transition_cases_cover_lifecycle_policy() 
             }
             "illegal" => {
                 illegal_count += 1;
-                // NOTE: this consults the writer inventory above, not production
-                // behaviour — an unlisted writer is invisible here. Inverting the
-                // fence (drive every production writer from every state and assert
-                // the observed edge set is a subset of legal + recoveryReachable)
-                // is tracked in #994.
+                // This consults the writer inventory above, which catches drift
+                // between the inventory and the Lean contract. The claim that
+                // production cannot REACH these edges is carried by
+                // `production_request_writers_only_reach_contracted_edges`, which
+                // drives the real writers and asserts the observed edge set falls
+                // inside legal + recoveryReachable.
                 assert!(
                     rust_request_transition_action(&case.from, &case.to).is_none()
                         && rust_request_recovery_sweep_writer(&case.from, &case.to).is_none(),
@@ -396,22 +397,52 @@ pub(super) async fn generated_request_transition_cases_cover_lifecycle_policy() 
     assert_eq!(recovery_reachable_count, 3);
 }
 
-/// Persisted `(status, lifecycle_state)` pair for a terminal request, mirroring
-/// the bridge documented in `proofs/README.md`: terminal work carries a terminal
+/// Persisted `(status, lifecycle_state)` pair for a request, mirroring the bridge
+/// documented in `proofs/README.md`: in-flight work is `status="processing"` with
+/// the finer `lifecycle_state`, terminal work carries a terminal
 /// `lifecycle_state`, and `failed` is persisted with `status="error"`.
-fn terminal_persisted_pair(lifecycle_state: &str) -> (&'static str, &'static str) {
+fn persisted_status_pair(lifecycle_state: &str) -> (&'static str, &'static str) {
     match lifecycle_state {
+        "pending" => ("pending", "pending"),
+        "claimed" => ("processing", "claimed"),
+        "processing" => ("processing", "processing"),
+        "inputRequired" => ("processing", "inputRequired"),
         "completed" => ("completed", "completed"),
         "failed" => ("error", "failed"),
         "superseded" => ("superseded", "superseded"),
         "dead" => ("dead", "dead"),
         "interrupted" => ("interrupted", "interrupted"),
-        other => panic!("not a terminal lifecycle_state: {other}"),
+        other => panic!("unknown lifecycle_state: {other}"),
     }
+}
+
+fn terminal_persisted_pair(lifecycle_state: &str) -> (&'static str, &'static str) {
+    assert!(
+        matches!(
+            lifecycle_state,
+            "completed" | "failed" | "superseded" | "dead" | "interrupted"
+        ),
+        "not a terminal lifecycle_state: {lifecycle_state}"
+    );
+    persisted_status_pair(lifecycle_state)
+}
+
+async fn force_persisted_state(node: &EmbeddedNode, doc_id: &str, lifecycle_state: &str) {
+    let (status, lifecycle_state) = persisted_status_pair(lifecycle_state);
+    force_persisted_pair(node, doc_id, status, lifecycle_state).await;
 }
 
 async fn force_terminal_persisted_state(node: &EmbeddedNode, doc_id: &str, lifecycle_state: &str) {
     let (status, lifecycle_state) = terminal_persisted_pair(lifecycle_state);
+    force_persisted_pair(node, doc_id, status, lifecycle_state).await;
+}
+
+async fn force_persisted_pair(
+    node: &EmbeddedNode,
+    doc_id: &str,
+    status: &str,
+    lifecycle_state: &str,
+) {
     let escaped_doc_id = escape_graphql_string(doc_id);
     let mutation = format!(
         r#"mutation {{
@@ -427,6 +458,170 @@ async fn force_terminal_persisted_state(node: &EmbeddedNode, doc_id: &str, lifec
         "forcing terminal persisted state failed: {:?}",
         resp.errors
     );
+}
+
+/// Every `RequestLifecycle` writer that mutates `AgentRequest`, driven from every
+/// persisted start state, with the observed edge recorded from the document.
+///
+/// This is the INVERSION of the `illegal` branch in the generated-case test
+/// (#994). That branch asks "does my hand-written inventory list a writer for this
+/// pair?", which is a statement about the table, not the code — a writer the table
+/// omits is invisible to it, which is how three edges with real writers stayed
+/// classified `illegal`. This asks the opposite and stronger question: drive the
+/// real writers, see which edges they actually produce, and require that set to
+/// fall inside what the contract permits.
+///
+/// NOT driven, and so still outside this fence:
+/// - `advance`, which issues `update_AgentResponse` only.
+/// - `queue::reconcile_coalesced_pending_request` (pending -> superseded), whose
+///   CAS requires a second coalescing duplicate to act on.
+/// - `ToolCallLifecycle::reconcile_subagent_liveness` (-> dead), which needs a
+///   running-bridge plus expired-child fixture.
+///   Both remain tracked in #994.
+#[tokio::test]
+async fn production_request_writers_only_reach_contracted_edges() {
+    const START_STATES: [&str; 9] = [
+        "pending",
+        "claimed",
+        "processing",
+        "inputRequired",
+        "completed",
+        "failed",
+        "superseded",
+        "dead",
+        "interrupted",
+    ];
+    const WRITERS: [&str; 7] = [
+        "claim",
+        "claim_after_ttl_lapse",
+        "begin_execution",
+        "complete",
+        "fail",
+        "interrupt",
+        "repair_terminal_requests",
+    ];
+
+    let mut observed: std::collections::BTreeSet<(String, String)> = Default::default();
+
+    for start in START_STATES {
+        let db = test_db(&format!("production-edges-{}", start.to_lowercase())).await;
+
+        for writer in WRITERS {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let session_id = uuid::Uuid::new_v4().to_string();
+            let created_at = chrono::Utc::now().to_rfc3339();
+            let doc_id =
+                create_request(&db.node, &request_id, &session_id, "pending", &created_at).await;
+            let mut lifecycle = request_lifecycle_for_case(
+                &db,
+                doc_id.clone(),
+                request_id.clone(),
+                session_id.clone(),
+                created_at.clone(),
+            );
+
+            // Take ownership through the real path where the start state allows
+            // it, so the LOCAL state machine permits the call and the persisted
+            // CAS filter is what decides. Then pin the persisted row to the start
+            // state under test, as a concurrent actor would.
+            if start != "pending" {
+                assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+                lifecycle.prepare_session_with_identity().await.unwrap();
+                if start == "processing" {
+                    lifecycle.begin_execution().await.unwrap();
+                }
+                if !matches!(start, "claimed" | "processing") {
+                    force_persisted_state(&db.node, &doc_id, start).await;
+                }
+            }
+
+            if writer == "repair_terminal_requests" {
+                create_response_with_status(
+                    &db.node,
+                    &format!("resp-{request_id}"),
+                    &request_id,
+                    &session_id,
+                    "complete",
+                )
+                .await;
+            }
+
+            let before = fetch_request_snapshot(&db.node, &doc_id)
+                .await
+                .lifecycle_state;
+            assert_eq!(
+                before, start,
+                "fixture for {start}/{writer} did not reach the intended start state"
+            );
+
+            match writer {
+                "claim" => {
+                    let _ = lifecycle.claim().await;
+                }
+                "claim_after_ttl_lapse" => {
+                    // The expiry writer is reached THROUGH claim(): a pre-claim
+                    // request whose TTL has lapsed terminalizes to `dead`.
+                    let past = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+                    set_valid_until(&db.node, &doc_id, &past).await;
+                    let _ = lifecycle.claim().await;
+                }
+                "begin_execution" => {
+                    let _ = lifecycle.begin_execution().await;
+                }
+                "complete" => {
+                    let _ = lifecycle.complete().await;
+                }
+                "fail" => {
+                    let _ = lifecycle.fail().await;
+                }
+                "interrupt" => {
+                    let _ = lifecycle.transition_to_interrupted().await;
+                }
+                "repair_terminal_requests" => {
+                    let _ = RequestLifecycle::repair_terminal_requests(&db.node, AGENT_DID).await;
+                }
+                other => panic!("unhandled writer {other}"),
+            }
+
+            let after = fetch_request_snapshot(&db.node, &doc_id)
+                .await
+                .lifecycle_state;
+            if after != before {
+                observed.insert((before, after));
+            }
+        }
+    }
+
+    // Coverage floor. Without this the subset assertion below could be satisfied
+    // vacuously by a fixture that silently stopped driving its writer.
+    let expected: std::collections::BTreeSet<(String, String)> = [
+        ("pending", "claimed"),
+        ("pending", "dead"),
+        ("pending", "interrupted"),
+        ("claimed", "processing"),
+        ("claimed", "completed"),
+        ("claimed", "failed"),
+        ("claimed", "interrupted"),
+        ("processing", "completed"),
+        ("processing", "failed"),
+        ("processing", "interrupted"),
+    ]
+    .into_iter()
+    .map(|(from, to)| (from.to_string(), to.to_string()))
+    .collect();
+    let missing: Vec<_> = expected.difference(&observed).collect();
+    assert!(
+        missing.is_empty(),
+        "production writers stopped reaching edges this test is supposed to cover: {missing:?}"
+    );
+
+    for (from, to) in &observed {
+        let classification = rust_request_transition_classification(from, to);
+        assert!(
+            matches!(classification, "legal" | "recoveryReachable"),
+            "production writers reached {from} -> {to}, which the contract classifies {classification}"
+        );
+    }
 }
 
 /// S1 (`terminal_irreversibility`) asserted against PRODUCTION writers rather

--- a/crates/gents/tests/conformance/request_lifecycle.rs
+++ b/crates/gents/tests/conformance/request_lifecycle.rs
@@ -335,6 +335,129 @@ pub(super) async fn generated_request_transition_cases_cover_lifecycle_policy() 
     assert_eq!(recovery_reachable_count, 3);
 }
 
+/// Persisted `(status, lifecycle_state)` pair for a terminal request, mirroring
+/// the bridge documented in `proofs/README.md`: terminal work carries a terminal
+/// `lifecycle_state`, and `failed` is persisted with `status="error"`.
+fn terminal_persisted_pair(lifecycle_state: &str) -> (&'static str, &'static str) {
+    match lifecycle_state {
+        "completed" => ("completed", "completed"),
+        "failed" => ("error", "failed"),
+        "superseded" => ("superseded", "superseded"),
+        "dead" => ("dead", "dead"),
+        "interrupted" => ("interrupted", "interrupted"),
+        other => panic!("not a terminal lifecycle_state: {other}"),
+    }
+}
+
+async fn force_terminal_persisted_state(
+    node: &EmbeddedNode,
+    doc_id: &str,
+    lifecycle_state: &str,
+) {
+    let (status, lifecycle_state) = terminal_persisted_pair(lifecycle_state);
+    let escaped_doc_id = escape_graphql_string(doc_id);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                input: {{ status: "{status}", lifecycle_state: "{lifecycle_state}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "forcing terminal persisted state failed: {:?}",
+        resp.errors
+    );
+}
+
+/// S1 (`terminal_irreversibility`) asserted against PRODUCTION writers rather
+/// than against the writer inventory at the top of this file.
+///
+/// This models the race the persisted CAS filters exist for: this runtime still
+/// holds a live `RequestLifecycle` that believes it owns the request, while
+/// another actor — a recovery sweep, a replicated peer, an operator interrupt —
+/// has already terminalized the row. Every terminal writer must leave the
+/// persisted document untouched, so no `terminal -> *` edge is reachable.
+///
+/// Unlike the `illegal` branch of the generated-case test (which consults the
+/// hand-written inventory and so cannot see an unlisted writer), this drives the
+/// real writers and asserts on persisted state. Extending the same treatment to
+/// the whole illegal partition is #994.
+#[tokio::test]
+async fn terminal_persisted_requests_reject_every_live_lifecycle_writer() {
+    const TERMINAL_STATES: [&str; 5] = [
+        "completed",
+        "failed",
+        "superseded",
+        "dead",
+        "interrupted",
+    ];
+    const WRITERS: [&str; 4] = ["complete", "fail", "interrupt", "advance"];
+
+    for terminal in TERMINAL_STATES {
+        let db = test_db(&format!("terminal-irreversibility-{terminal}")).await;
+
+        for writer in WRITERS {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let session_id = uuid::Uuid::new_v4().to_string();
+            let created_at = chrono::Utc::now().to_rfc3339();
+            let doc_id =
+                create_request(&db.node, &request_id, &session_id, "pending", &created_at).await;
+            let mut lifecycle = request_lifecycle_for_case(
+                &db,
+                doc_id.clone(),
+                request_id.clone(),
+                session_id.clone(),
+                created_at.clone(),
+            );
+
+            // Take real ownership first, so the local state machine permits the
+            // call and the persisted CAS filter is what actually decides.
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            if writer == "advance" {
+                lifecycle.begin_execution().await.unwrap();
+                let response_doc_id = create_response_with_status(
+                    &db.node,
+                    &format!("resp-{request_id}"),
+                    &request_id,
+                    &session_id,
+                    "streaming",
+                )
+                .await;
+                lifecycle.set_response_doc_id(&response_doc_id);
+            }
+
+            // Another actor terminalizes the row underneath the live lifecycle.
+            force_terminal_persisted_state(&db.node, &doc_id, terminal).await;
+
+            // The writer may return Ok (no rows matched) or Err; the contract is
+            // about the persisted document, not the return value.
+            let _ = match writer {
+                "complete" => lifecycle.complete().await,
+                "fail" => lifecycle.fail().await,
+                "interrupt" => lifecycle.transition_to_interrupted().await,
+                "advance" => lifecycle.advance().await,
+                other => panic!("unhandled writer {other}"),
+            };
+
+            let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+            let (expected_status, expected_lifecycle_state) = terminal_persisted_pair(terminal);
+            assert_eq!(
+                snap.lifecycle_state, expected_lifecycle_state,
+                "writer {writer} moved a persisted {terminal} request to {} — terminal states must be irreversible (S1)",
+                snap.lifecycle_state
+            );
+            assert_eq!(
+                snap.status, expected_status,
+                "writer {writer} changed the persisted status of a {terminal} request"
+            );
+        }
+    }
+}
+
 #[tokio::test]
 async fn interactive_claim_snapshot_matches_claimed_waiting() {
     let db = test_db("interactive-claim").await;

--- a/crates/gents/tests/conformance/request_lifecycle.rs
+++ b/crates/gents/tests/conformance/request_lifecycle.rs
@@ -437,6 +437,89 @@ async fn force_terminal_persisted_state(node: &EmbeddedNode, doc_id: &str, lifec
     force_persisted_pair(node, doc_id, status, lifecycle_state).await;
 }
 
+/// Queue metadata marking a request as coalescible under `key`, the shape
+/// `reconcile_coalesced_pending_request` matches on.
+fn coalesce_metadata(key: &str) -> String {
+    serde_json::json!({
+        "queue": {
+            "source": "user",
+            "policy": "coalesce",
+            "key": key,
+            "queued_after_request_id": null,
+        }
+    })
+    .to_string()
+}
+
+async fn set_request_metadata(node: &EmbeddedNode, doc_id: &str, metadata: &str) {
+    let escaped_doc_id = escape_graphql_string(doc_id);
+    let escaped_metadata = escape_graphql_string(metadata);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                input: {{ metadata: "{escaped_metadata}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(!resp.has_errors(), "set metadata failed: {:?}", resp.errors);
+}
+
+async fn set_request_deadline(node: &EmbeddedNode, doc_id: &str, deadline: &str) {
+    let escaped_doc_id = escape_graphql_string(doc_id);
+    let escaped_deadline = escape_graphql_string(deadline);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                input: {{ deadline: "{escaped_deadline}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(!resp.has_errors(), "set deadline failed: {:?}", resp.errors);
+}
+
+/// A running subagent bridge pointing at `child_request_id`, the row
+/// `reconcile_subagent_liveness` sweeps.
+async fn create_running_subagent_bridge(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+    child_request_id: &str,
+) {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let escaped_tool_call_id = escape_graphql_string(tool_call_id);
+    let escaped_child = escape_graphql_string(child_request_id);
+    let started_at = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentToolCall(input: {{
+                tool_call_key: "{escaped_session_id}:{escaped_tool_call_id}",
+                session_id: "{escaped_session_id}",
+                message_sequence: 1,
+                tool_name: "spawn_subagent",
+                tool_call_id: "{escaped_tool_call_id}",
+                args: "{{}}",
+                result: "",
+                status: "running",
+                lifecycle_state: "running",
+                cancel_policy: "cascade",
+                await_mode: "background",
+                child_request_id: "{escaped_child}",
+                started_at: "{started_at}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create subagent bridge failed: {:?}",
+        resp.errors
+    );
+}
+
 async fn force_persisted_pair(
     node: &EmbeddedNode,
     doc_id: &str,
@@ -483,13 +566,15 @@ async fn force_persisted_pair(
 /// only a writer's `lifecycle_state` from-set therefore stays undetectable here —
 /// correctly, since the `status` predicate still makes the edge unreachable.
 ///
-/// NOT driven, and so still outside this fence:
-/// - `advance`, which issues `update_AgentResponse` only.
-/// - `queue::reconcile_coalesced_pending_request` (pending -> superseded), whose
-///   CAS requires a second coalescing duplicate to act on.
-/// - `ToolCallLifecycle::reconcile_subagent_liveness` (-> dead), which needs a
-///   running-bridge plus expired-child fixture.
-///   Both remain tracked in #994.
+/// Coverage: every legal edge except `processing -> processing`, plus all three
+/// `recoveryReachable` edges. The two sweeps are driven against real auxiliary
+/// fixtures — `reconcile_coalesced_pending_request` against an older survivor
+/// under the same coalesce key, and `reconcile_subagent_liveness` against a
+/// running bridge whose child deadline has lapsed.
+///
+/// `advance` is the sole writer deliberately excluded: it issues
+/// `update_AgentResponse` and never touches `AgentRequest`, so asserting request
+/// edges across it would be tautological.
 #[tokio::test]
 async fn production_request_writers_only_reach_contracted_edges() {
     const START_STATES: [&str; 9] = [
@@ -503,7 +588,7 @@ async fn production_request_writers_only_reach_contracted_edges() {
         "dead",
         "interrupted",
     ];
-    const WRITERS: [&str; 7] = [
+    const WRITERS: [&str; 9] = [
         "claim",
         "claim_after_ttl_lapse",
         "begin_execution",
@@ -511,6 +596,8 @@ async fn production_request_writers_only_reach_contracted_edges() {
         "fail",
         "interrupt",
         "repair_terminal_requests",
+        "coalesce_pending",
+        "subagent_liveness",
     ];
 
     let mut observed: std::collections::BTreeSet<(String, String)> = Default::default();
@@ -545,11 +632,58 @@ async fn production_request_writers_only_reach_contracted_edges() {
             //   interrupt                     -> no local guard
             //   repair_terminal_requests      -> associated fn, no local state
             match writer {
-                "claim" | "claim_after_ttl_lapse" | "repair_terminal_requests" => {}
+                "claim"
+                | "claim_after_ttl_lapse"
+                | "repair_terminal_requests"
+                | "coalesce_pending"
+                | "subagent_liveness" => {}
                 _ => {
                     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
                     lifecycle.prepare_session_with_identity().await.unwrap();
                 }
+            }
+
+            // Auxiliary rows the sweep writers act on. Built before the start
+            // state is pinned, so the sweep sees the state under test.
+            match writer {
+                "coalesce_pending" => {
+                    // An older survivor in the same session under the same
+                    // coalesce key; the request under test is the duplicate.
+                    let survivor_id = uuid::Uuid::new_v4().to_string();
+                    let survivor_created_at =
+                        (chrono::Utc::now() - chrono::Duration::seconds(30)).to_rfc3339();
+                    let survivor_doc_id = create_request(
+                        &db.node,
+                        &survivor_id,
+                        &session_id,
+                        "pending",
+                        &survivor_created_at,
+                    )
+                    .await;
+                    set_request_metadata(
+                        &db.node,
+                        &survivor_doc_id,
+                        &coalesce_metadata("conformance-key"),
+                    )
+                    .await;
+                    set_request_metadata(&db.node, &doc_id, &coalesce_metadata("conformance-key"))
+                        .await;
+                }
+                "subagent_liveness" => {
+                    // An expired child of a running bridge: a live executor
+                    // enforces its own deadline, so a lapsed non-terminal row
+                    // means the executor is gone.
+                    let past = (chrono::Utc::now() - chrono::Duration::seconds(30)).to_rfc3339();
+                    set_request_deadline(&db.node, &doc_id, &past).await;
+                    create_running_subagent_bridge(
+                        &db.node,
+                        &session_id,
+                        &format!("bridge-{request_id}"),
+                        &request_id,
+                    )
+                    .await;
+                }
+                _ => {}
             }
 
             // Then pin the persisted row to the start state under test,
@@ -601,6 +735,20 @@ async fn production_request_writers_only_reach_contracted_edges() {
                 "repair_terminal_requests" => {
                     let _ = RequestLifecycle::repair_terminal_requests(&db.node, AGENT_DID).await;
                 }
+                "coalesce_pending" => {
+                    let _ = gents::__test_internals::reconcile_coalesced_pending_request(
+                        &db.node,
+                        &session_id,
+                        AGENT_DID,
+                        gents::__test_internals::QueueSource::User,
+                        "conformance-key",
+                    )
+                    .await;
+                }
+                "subagent_liveness" => {
+                    let _ =
+                        ToolCallLifecycle::reconcile_subagent_liveness(&db.node, AGENT_DID).await;
+                }
                 other => panic!("unhandled writer {other}"),
             }
 
@@ -619,11 +767,14 @@ async fn production_request_writers_only_reach_contracted_edges() {
         ("pending", "claimed"),
         ("pending", "dead"),
         ("pending", "interrupted"),
+        ("pending", "superseded"),
         ("claimed", "processing"),
         ("claimed", "completed"),
+        ("claimed", "dead"),
         ("claimed", "failed"),
         ("claimed", "interrupted"),
         ("processing", "completed"),
+        ("processing", "dead"),
         ("processing", "failed"),
         ("processing", "interrupted"),
     ]

--- a/crates/gents/tests/conformance/request_lifecycle.rs
+++ b/crates/gents/tests/conformance/request_lifecycle.rs
@@ -471,6 +471,18 @@ async fn force_persisted_pair(
 /// real writers, see which edges they actually produce, and require that set to
 /// fall inside what the contract permits.
 ///
+/// Each writer is placed in its own locally-permitted state and the persisted row
+/// is then forced independently, so the in-memory `ensure_state` guard never
+/// short-circuits ahead of the mutation and the persisted CAS filter is what
+/// decides every case. Verified by weakening a CAS in production (dropping the
+/// `status` predicate from the terminal transition): this test then reports
+/// `production writers reached interrupted -> completed`.
+///
+/// One sensitivity limit worth knowing: fixtures force CANONICAL
+/// `(status, lifecycle_state)` pairs, and the terminal CAS conjoins both. Widening
+/// only a writer's `lifecycle_state` from-set therefore stays undetectable here —
+/// correctly, since the `status` predicate still makes the edge unreachable.
+///
 /// NOT driven, and so still outside this fence:
 /// - `advance`, which issues `update_AgentResponse` only.
 /// - `queue::reconcile_coalesced_pending_request` (pending -> superseded), whose
@@ -520,20 +532,29 @@ async fn production_request_writers_only_reach_contracted_edges() {
                 created_at.clone(),
             );
 
-            // Take ownership through the real path where the start state allows
-            // it, so the LOCAL state machine permits the call and the persisted
-            // CAS filter is what decides. Then pin the persisted row to the start
-            // state under test, as a concurrent actor would.
-            if start != "pending" {
-                assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
-                lifecycle.prepare_session_with_identity().await.unwrap();
-                if start == "processing" {
-                    lifecycle.begin_execution().await.unwrap();
-                }
-                if !matches!(start, "claimed" | "processing") {
-                    force_persisted_state(&db.node, &doc_id, start).await;
+            // Put the lifecycle in the LOCAL state this writer requires, so its
+            // in-memory `ensure_state` guard always passes and the persisted CAS
+            // filter is the only thing that can reject the write. Deriving the
+            // local state from the START STATE instead would let the guard
+            // short-circuit before any mutation was issued — a widened CAS
+            // admitting an illegal edge would then pass unnoticed.
+            //
+            //   claim / claim_after_ttl_lapse -> local Pending  (claim.rs:195)
+            //   begin_execution               -> local Claimed  (claim.rs:70)
+            //   complete / fail               -> local Claimed | Streaming
+            //   interrupt                     -> no local guard
+            //   repair_terminal_requests      -> associated fn, no local state
+            match writer {
+                "claim" | "claim_after_ttl_lapse" | "repair_terminal_requests" => {}
+                _ => {
+                    assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+                    lifecycle.prepare_session_with_identity().await.unwrap();
                 }
             }
+
+            // Then pin the persisted row to the start state under test,
+            // independently of local state, as a concurrent actor would.
+            force_persisted_state(&db.node, &doc_id, start).await;
 
             if writer == "repair_terminal_requests" {
                 create_response_with_status(

--- a/crates/gents/tests/conformance/request_lifecycle.rs
+++ b/crates/gents/tests/conformance/request_lifecycle.rs
@@ -17,14 +17,77 @@ fn rust_request_transition_action(from: &str, to: &str) -> Option<&'static str> 
     }
 }
 
+/// Production writers for edges no single `RequestContext.Action` takes, but
+/// that registered recovery sweeps perform on persisted rows (Lean:
+/// `requestRecoverySweepReachable`, cited as
+/// `boundary.request.recovery-sweep-reachable`).
+///
+/// These were previously published as `illegal`, which made the emitted
+/// contract assert that Rust has no writer for edges the product performs.
+fn rust_request_recovery_sweep_writer(from: &str, to: &str) -> Option<&'static str> {
+    match (from, to) {
+        ("claimed", "completed") => Some("RequestLifecycle::complete"),
+        ("claimed", "dead") | ("processing", "dead") => {
+            Some("ToolCallLifecycle::reconcile_subagent_liveness")
+        }
+        _ => None,
+    }
+}
+
 fn rust_request_transition_classification(from: &str, to: &str) -> &'static str {
     if rust_request_transition_action(from, to).is_some() {
         "legal"
     } else if from == "inputRequired" || to == "inputRequired" {
         "productUnreachable"
+    } else if rust_request_recovery_sweep_writer(from, to).is_some() {
+        "recoveryReachable"
     } else {
         "illegal"
     }
+}
+
+/// Drive the real production writer for a recovery-reachable edge and assert it
+/// persists the modelled post-state.
+///
+/// Only `claimed -> completed` is driven here: it is reachable through the
+/// ordinary `RequestLifecycle` surface. The two `-> dead` edges run inside
+/// `reconcile_subagent_liveness`, which needs a running-bridge plus expired-child
+/// fixture; driving them is tracked in #994.
+async fn drive_generated_request_recovery_reachable_case(case: &LeanLifecycleTransitionCase) {
+    if !(case.from == "claimed" && case.to == "completed") {
+        return;
+    }
+
+    let db = test_db("generated-request-recovery-reachable").await;
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let doc_id = create_request(&db.node, &request_id, &session_id, "pending", &created_at).await;
+    let mut lifecycle = request_lifecycle_for_case(
+        &db,
+        doc_id.clone(),
+        request_id.clone(),
+        session_id.clone(),
+        created_at.clone(),
+    );
+
+    // Claim, then complete WITHOUT begin_execution: this is terminal repair
+    // finishing a claimed request whose response already landed, and it
+    // exercises `complete()`'s persisted from-set including `claimed`.
+    assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+    lifecycle.prepare_session_with_identity().await.unwrap();
+    lifecycle.complete().await.unwrap();
+
+    let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+    assert_eq!(
+        snap.lifecycle_state, case.to,
+        "recovery-reachable Request transition {} expected {} -> {} via {:?}, got persisted lifecycle_state={}",
+        case.name,
+        case.from,
+        case.to,
+        rust_request_recovery_sweep_writer(&case.from, &case.to),
+        snap.lifecycle_state
+    );
 }
 
 fn request_lifecycle_for_case(
@@ -174,6 +237,7 @@ pub(super) async fn generated_request_transition_cases_cover_lifecycle_policy() 
     let mut legal_count = 0;
     let mut illegal_count = 0;
     let mut product_unreachable_count = 0;
+    let mut recovery_reachable_count = 0;
 
     for case in lean_request_transition_cases() {
         let rust_classification = rust_request_transition_classification(&case.from, &case.to);
@@ -198,13 +262,42 @@ pub(super) async fn generated_request_transition_cases_cover_lifecycle_policy() 
             }
             "illegal" => {
                 illegal_count += 1;
+                // NOTE: this consults the writer inventory above, not production
+                // behaviour — an unlisted writer is invisible here. Inverting the
+                // fence (drive every production writer from every state and assert
+                // the observed edge set is a subset of legal + recoveryReachable)
+                // is tracked in #994.
                 assert!(
-                    rust_request_transition_action(&case.from, &case.to).is_none(),
+                    rust_request_transition_action(&case.from, &case.to).is_none()
+                        && rust_request_recovery_sweep_writer(&case.from, &case.to).is_none(),
                     "Request transition {} is ordinary illegal but Rust has a writer path for {} -> {}",
                     case.name,
                     case.from,
                     case.to
                 );
+            }
+            "recoveryReachable" => {
+                recovery_reachable_count += 1;
+                assert!(
+                    case.action.is_none(),
+                    "Request transition {} is recovery-reachable and must be taken by no single action, got {:?}",
+                    case.name,
+                    case.action
+                );
+                assert!(
+                    rust_request_recovery_sweep_writer(&case.from, &case.to).is_some(),
+                    "Request transition {} is recovery-reachable but no Rust sweep writer is registered for {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+                assert_eq!(
+                    case.boundary.as_deref(),
+                    Some("boundary.request.recovery-sweep-reachable"),
+                    "Request transition {} must cite the recovery-sweep boundary",
+                    case.name
+                );
+                drive_generated_request_recovery_reachable_case(case).await;
             }
             "productUnreachable" => {
                 product_unreachable_count += 1;
@@ -237,8 +330,9 @@ pub(super) async fn generated_request_transition_cases_cover_lifecycle_policy() 
     }
 
     assert_eq!(legal_count, 11);
-    assert_eq!(illegal_count, 53);
+    assert_eq!(illegal_count, 50);
     assert_eq!(product_unreachable_count, 17);
+    assert_eq!(recovery_reachable_count, 3);
 }
 
 #[tokio::test]

--- a/crates/gents/tests/conformance/request_lifecycle.rs
+++ b/crates/gents/tests/conformance/request_lifecycle.rs
@@ -26,7 +26,7 @@ fn rust_request_transition_action(from: &str, to: &str) -> Option<&'static str> 
 /// contract assert that Rust has no writer for edges the product performs.
 fn rust_request_recovery_sweep_writer(from: &str, to: &str) -> Option<&'static str> {
     match (from, to) {
-        ("claimed", "completed") => Some("RequestLifecycle::complete"),
+        ("claimed", "completed") => Some("RequestLifecycle::repair_terminal_requests"),
         ("claimed", "dead") | ("processing", "dead") => {
             Some("ToolCallLifecycle::reconcile_subagent_liveness")
         }
@@ -46,13 +46,17 @@ fn rust_request_transition_classification(from: &str, to: &str) -> &'static str 
     }
 }
 
-/// Drive the real production writer for a recovery-reachable edge and assert it
-/// persists the modelled post-state.
+/// Drive the real recovery sweep named by the contract and assert it persists the
+/// modelled post-state.
 ///
-/// Only `claimed -> completed` is driven here: it is reachable through the
-/// ordinary `RequestLifecycle` surface. The two `-> dead` edges run inside
-/// `reconcile_subagent_liveness`, which needs a running-bridge plus expired-child
-/// fixture; driving them is tracked in #994.
+/// `claimed -> completed` is driven through `repair_terminal_requests` — the sweep
+/// the boundary statement actually describes — with the terminal response document
+/// the sweep requires. Driving `complete()` instead would prove something else
+/// entirely: that the ORDINARY writer can take this edge (see
+/// `ordinary_complete_also_takes_the_claimed_to_completed_edge` below).
+///
+/// The two `-> dead` edges run inside `reconcile_subagent_liveness`, which needs a
+/// running-bridge plus expired-child fixture; driving them is tracked in #994.
 async fn drive_generated_request_recovery_reachable_case(case: &LeanLifecycleTransitionCase) {
     if !(case.from == "claimed" && case.to == "completed") {
         return;
@@ -71,12 +75,29 @@ async fn drive_generated_request_recovery_reachable_case(case: &LeanLifecycleTra
         created_at.clone(),
     );
 
-    // Claim, then complete WITHOUT begin_execution: this is terminal repair
-    // finishing a claimed request whose response already landed, and it
-    // exercises `complete()`'s persisted from-set including `claimed`.
+    // Leave the row persisted `claimed`, as a crashed executor would.
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
-    lifecycle.prepare_session_with_identity().await.unwrap();
-    lifecycle.complete().await.unwrap();
+    let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+    assert_eq!(snap.lifecycle_state, "claimed");
+
+    // The sweep only repairs a stuck request whose durable response already
+    // reached a terminal outcome; without one it reports `awaiting_outcome`.
+    create_response_with_status(
+        &db.node,
+        &format!("resp-{request_id}"),
+        &request_id,
+        &session_id,
+        "complete",
+    )
+    .await;
+
+    let report = RequestLifecycle::repair_terminal_requests(&db.node, AGENT_DID)
+        .await
+        .expect("terminal repair sweep must succeed");
+    assert_eq!(
+        report.repaired, 1,
+        "terminal repair should have repaired the stuck claimed request, got {report:?}"
+    );
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(
@@ -87,6 +108,46 @@ async fn drive_generated_request_recovery_reachable_case(case: &LeanLifecycleTra
         case.to,
         rust_request_recovery_sweep_writer(&case.from, &case.to),
         snap.lifecycle_state
+    );
+}
+
+/// `complete()` accepts a persisted from-set of `{claimed, processing}`, so the
+/// ORDINARY writer can also take `claimed -> completed` — an edge the contract
+/// describes as recovery-only.
+///
+/// This is pinned as a deliberate, visible fact rather than left implicit. The
+/// wide from-set is INTENDED and should stay: a crash between `begin_execution`'s
+/// write and the completion would otherwise strand the row, and the project
+/// prefers defensive behaviour around anything that can deadlock a request.
+/// Narrowing it would trade a benign extra edge for a liveness hazard.
+///
+/// The consequence is that the edge is not exclusively a recovery concern, which
+/// is why it is published as `recoveryReachable` rather than folded into the legal
+/// transition relation.
+#[tokio::test]
+async fn ordinary_complete_also_takes_the_claimed_to_completed_edge() {
+    let db = test_db("ordinary-complete-from-claimed").await;
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let doc_id = create_request(&db.node, &request_id, &session_id, "pending", &created_at).await;
+    let mut lifecycle = request_lifecycle_for_case(
+        &db,
+        doc_id.clone(),
+        request_id.clone(),
+        session_id.clone(),
+        created_at.clone(),
+    );
+
+    // No begin_execution: the row stays persisted `claimed`.
+    assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+    lifecycle.prepare_session_with_identity().await.unwrap();
+    lifecycle.complete().await.unwrap();
+
+    let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+    assert_eq!(
+        snap.lifecycle_state, "completed",
+        "complete() from a persisted claimed row should still complete it"
     );
 }
 
@@ -349,11 +410,7 @@ fn terminal_persisted_pair(lifecycle_state: &str) -> (&'static str, &'static str
     }
 }
 
-async fn force_terminal_persisted_state(
-    node: &EmbeddedNode,
-    doc_id: &str,
-    lifecycle_state: &str,
-) {
+async fn force_terminal_persisted_state(node: &EmbeddedNode, doc_id: &str, lifecycle_state: &str) {
     let (status, lifecycle_state) = terminal_persisted_pair(lifecycle_state);
     let escaped_doc_id = escape_graphql_string(doc_id);
     let mutation = format!(
@@ -383,18 +440,28 @@ async fn force_terminal_persisted_state(
 ///
 /// Unlike the `illegal` branch of the generated-case test (which consults the
 /// hand-written inventory and so cannot see an unlisted writer), this drives the
-/// real writers and asserts on persisted state. Extending the same treatment to
-/// the whole illegal partition is #994.
+/// real writers and asserts on persisted state.
+///
+/// SCOPE — this does not cover every writer or the whole `terminal -> *`
+/// partition, and the name says only what is actually driven. Covered:
+/// `claim`, `begin_execution`, `complete`, `fail`, `transition_to_interrupted`,
+/// and the `repair_terminal_requests` recovery sweep. Deliberately excluded:
+/// `advance`, which issues `update_AgentResponse` and never touches
+/// `AgentRequest`, so asserting request irreversibility across it is
+/// tautological. Still uncovered: deduplication and expiry writers, and the
+/// remaining recovery mutations. Enumerating every writer and deriving the
+/// reachable edge set is #994.
 #[tokio::test]
-async fn terminal_persisted_requests_reject_every_live_lifecycle_writer() {
-    const TERMINAL_STATES: [&str; 5] = [
-        "completed",
-        "failed",
-        "superseded",
-        "dead",
-        "interrupted",
+async fn terminal_persisted_requests_reject_request_mutating_lifecycle_writers() {
+    const TERMINAL_STATES: [&str; 5] = ["completed", "failed", "superseded", "dead", "interrupted"];
+    const WRITERS: [&str; 6] = [
+        "claim",
+        "begin_execution",
+        "complete",
+        "fail",
+        "interrupt",
+        "repair_terminal_requests",
     ];
-    const WRITERS: [&str; 4] = ["complete", "fail", "interrupt", "advance"];
 
     for terminal in TERMINAL_STATES {
         let db = test_db(&format!("terminal-irreversibility-{terminal}")).await;
@@ -414,20 +481,26 @@ async fn terminal_persisted_requests_reject_every_live_lifecycle_writer() {
             );
 
             // Take real ownership first, so the local state machine permits the
-            // call and the persisted CAS filter is what actually decides.
-            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
-            lifecycle.prepare_session_with_identity().await.unwrap();
-            if writer == "advance" {
-                lifecycle.begin_execution().await.unwrap();
-                let response_doc_id = create_response_with_status(
+            // call and the persisted CAS filter is what actually decides. `claim`
+            // is driven from a fresh lifecycle so it exercises the claim filter
+            // itself rather than a re-claim.
+            if writer != "claim" {
+                assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+                lifecycle.prepare_session_with_identity().await.unwrap();
+            }
+
+            // `repair_terminal_requests` only acts on a request whose durable
+            // response is already terminal, so give it one — otherwise the sweep
+            // short-circuits on `awaiting_outcome` and the assertion is vacuous.
+            if writer == "repair_terminal_requests" {
+                create_response_with_status(
                     &db.node,
                     &format!("resp-{request_id}"),
                     &request_id,
                     &session_id,
-                    "streaming",
+                    "complete",
                 )
                 .await;
-                lifecycle.set_response_doc_id(&response_doc_id);
             }
 
             // Another actor terminalizes the row underneath the live lifecycle.
@@ -435,11 +508,38 @@ async fn terminal_persisted_requests_reject_every_live_lifecycle_writer() {
 
             // The writer may return Ok (no rows matched) or Err; the contract is
             // about the persisted document, not the return value.
-            let _ = match writer {
-                "complete" => lifecycle.complete().await,
-                "fail" => lifecycle.fail().await,
-                "interrupt" => lifecycle.transition_to_interrupted().await,
-                "advance" => lifecycle.advance().await,
+            match writer {
+                "claim" => {
+                    let outcome = lifecycle.claim().await;
+                    if let Ok(outcome) = outcome {
+                        assert_ne!(
+                            outcome,
+                            ClaimOutcome::Claimed,
+                            "claim() reported success against a persisted {terminal} request"
+                        );
+                    }
+                }
+                "begin_execution" => {
+                    let _ = lifecycle.begin_execution().await;
+                }
+                "complete" => {
+                    let _ = lifecycle.complete().await;
+                }
+                "fail" => {
+                    let _ = lifecycle.fail().await;
+                }
+                "interrupt" => {
+                    let _ = lifecycle.transition_to_interrupted().await;
+                }
+                "repair_terminal_requests" => {
+                    let report = RequestLifecycle::repair_terminal_requests(&db.node, AGENT_DID)
+                        .await
+                        .expect("terminal repair sweep must succeed");
+                    assert_eq!(
+                        report.repaired, 0,
+                        "terminal repair moved a persisted {terminal} request: {report:?}"
+                    );
+                }
                 other => panic!("unhandled writer {other}"),
             };
 


### PR DESCRIPTION
Fixes found by a multi-agent review of the Lean↔Rust correspondence and the runtime's engineering quality. Three commits, each independently verified.

## 1. Failed tool calls were persisted as successes

`tool_outcome_to_result` rendered a failed tool call as the `ToolError` Display text (`"tool call error: …"`), but `classify_runtime_failure` matched on the `ToolCallError:` / `JsonError:` prefixes that rig's toolset dispatcher used to stamp. When the owned loop took over dispatch (#400, D6) the two ends silently disagreed: classification returned `None`, `on_tool_result` fell through to `lc.complete(...)`, and **every tool call returning `Err` was durably recorded as a successful call** — losing its failed state, its `FailureClass`, and any structured command-policy denial. The run timeline and adapter projections then replayed those failures as successes.

The prefixes are now shared constants next to `ToolError`, referenced by both ends so a rename cannot desync them. The inner error is rendered rather than the wrapper: a policy denial arrives as a `ToolCallError` carrying denial JSON and `parse_command_policy_denial` strips the prefix and parses the remainder, so the wrapper's own text in front of the payload would downgrade every denial to an unstructured failure.

The existing test hand-wrote the string the classifier expected instead of obtaining it from the dispatcher — which is exactly why this passed while production was broken. The three new tests drive both production functions end to end.

## 2. The Request contract claimed edges were illegal that production performs

`claimed -> completed`, `claimed -> dead`, and `processing -> dead` were published as `illegal`, and the conformance test asserted "Rust has no writer path" for each. All three have real writers: `RequestLifecycle::complete` accepts a persisted from-set of `{claimed, processing}`, and the subagent-liveness sweep terminalizes an expired claimed/processing child as `dead`.

They are taken by no single `RequestContext.Action` — recovery sweeps perform them on persisted rows — so they are now classified `recoveryReachable` citing a new `boundary.request.recovery-sweep-reachable`, rather than being folded into the legal transition relation. Counts move from 11/53/17 to 11/50/17 + 3. `claimed -> completed` is driven for real against an embedded node.

Also reconciles the prose: `proofs/README.md` and the dead-preclaim-only boundary both stated `dead` was pre-claim only, contradicting the subagent-liveness sweep shipped alongside them.

## 3. Terminal irreversibility now asserted against production (#994)

The `illegal` branch of the generated-case test consults the hand-written writer inventory at the top of the file, so it reduces to "the table I wrote has no entry for this pair" — which is how the three edges above stayed misclassified.

This drives the real writers for the 40 `terminal -> *` edges covered by S1. For each terminal state it takes genuine ownership of a request (so the local state machine permits the call and the persisted CAS is what decides), has another actor terminalize the row underneath the live lifecycle, then calls every terminal writer and asserts the document did not move — the race the CAS filters exist for. Verified with a negative control.

## Verification

- `cargo test -p gents` — green
- `cargo check --workspace --all-targets` — green
- Lean builds clean; zero `sorry`s maintained

The coverage-ledger and partition-validator fences both failed until the new boundary was registered, which is them working as designed.

## Follow-ups filed

- #992 — PromptAssembly has no Lean contract extraction; its fence is social, with a test-local oracle
- #993 — Compaction proofs quantify over identity functions; the production summarize reducer is unmodelled. Includes two concrete defects: the summarize split can orphan a tool-call/result pair, and `messages_compacted` is measured in `strip(sanitize(H))` space while `drop_compacted_prefix` applies it in `strip(H)` space
- #994 — Invert the illegal-transition fence: enumerate production writers and derive the reachable edge set instead of consulting a mirror table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
