### PR TITLE
Model the real compaction reducer and fix what it exposes (#993)

### DIFF
--- a/crates/gents/proofs/Proofs/Compaction.lean
+++ b/crates/gents/proofs/Proofs/Compaction.lean
@@ -1,4 +1,8 @@
 import Proofs.Compaction.State
+import Proofs.Compaction.Strip
+import Proofs.Compaction.ProviderView
+import Proofs.Compaction.Prefix
 import Proofs.Compaction.Transition
 import Proofs.Compaction.Properties
+import Proofs.Compaction.Summarize
 import Proofs.Compaction.Executable

--- a/crates/gents/proofs/Proofs/Compaction/Executable.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Executable.lean
@@ -1,6 +1,32 @@
-import Proofs.Compaction.Properties
+import Proofs.Compaction.Summarize
 
 namespace Compaction
+
+/-- The fixtures the Rust conformance driver builds, keyed by row count.
+
+`tests/conformance/streaming_compaction.rs::compaction_messages_for_case`
+constructs the same shapes out of `gents::llm::message::Message`, so the
+`safeBoundary` values below are computed from the model and checked against
+production's `compaction::pair_safe_boundary` on the corresponding Rust
+fixture. -/
+def caseFixture : Nat → List Transcript.MessageRow
+  | 1 => [⟨0, 0, 0, .user, .toolResult 1 ⟨0, 0, 0⟩⟩]
+  | 2 => [⟨0, 0, 0, .assistant, .assistantToolCalls {1}⟩,
+          ⟨1, 0, 1, .user, .toolResult 1 ⟨0, 0, 0⟩⟩]
+  | 3 => [⟨0, 0, 0, .user, .ordinary⟩,
+          ⟨1, 0, 1, .assistant, .assistantToolCalls {1}⟩,
+          ⟨2, 0, 2, .user, .toolResult 1 ⟨0, 0, 0⟩⟩]
+  | _ => []
+
+/-- The straddling split: a budget index of 2 lands between the assistant
+announcement and its result, and the boundary retreats to 1 so the turn stays
+whole in the retained tail. -/
+theorem caseFixture_boundaries_pinned :
+    pairSafeBoundary (caseFixture 3) 2 = 1 ∧
+      pairSafeBoundary (caseFixture 3) 1 = 1 ∧
+      pairSafeBoundary (caseFixture 3) 3 = 3 ∧
+      pairSafeBoundary (caseFixture 2) 1 = 0 := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> decide
 
 structure CompactionReducerCase where
   name                : String
@@ -14,6 +40,13 @@ structure CompactionReducerCase where
   gateOpen            : Bool
   safeToReduce        : Bool
   reducerIsIdentity   : Bool
+  /-- The raw token-budget index production computes before any adjustment. -/
+  splitIndex          : Nat
+  /-- Where the boundary lands after retreating to a turn boundary. Computed by
+  `pairSafeBoundary`, not asserted. -/
+  safeBoundary        : Nat
+  /-- Rows surviving the reduction. -/
+  retainedCount       : Nat
   deriving Repr
 
 def compactionReducerCases : List CompactionReducerCase := [
@@ -27,7 +60,10 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := false
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 0 }
 , { name              := "identity_preserves_pair_atomicity"
   , group             := "witness"
   , reducer           := "identity"
@@ -38,7 +74,10 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := false
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 2 }
 , { name              := "identity_preserves_message_order"
   , group             := "witness"
   , reducer           := "identity"
@@ -49,10 +88,13 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := false
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 3 }
 , { name              := "strip_preserves_pair_atomicity"
   , group             := "witness"
-  , reducer           := "strip_tool_results"
+  , reducer           := "strip"
   , legal             := true
   , preMessageCount   := 2
   , postMessageCount  := 2
@@ -60,10 +102,13 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 2 }
 , { name              := "strip_preserves_message_order"
   , group             := "witness"
-  , reducer           := "strip_tool_results"
+  , reducer           := "strip"
   , legal             := true
   , preMessageCount   := 3
   , postMessageCount  := 3
@@ -71,10 +116,13 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 3 }
 , { name              := "strip_is_strictly_idempotent"
   , group             := "witness"
-  , reducer           := "strip_tool_results"
+  , reducer           := "strip"
   , legal             := true
   , preMessageCount   := 2
   , postMessageCount  := 2
@@ -82,7 +130,10 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 2 }
 , { name              := "reduction_blocked_when_response_streaming"
   , group             := "streaming"
   , reducer           := "any_valid"
@@ -93,7 +144,10 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := false
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 1 }
 , { name              := "reduction_allowed_when_response_terminal"
   , group             := "streaming"
   , reducer           := "any_valid"
@@ -104,10 +158,13 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := true
-  , reducerIsIdentity := false }
+  , reducerIsIdentity := false
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 1 }
 , { name              := "no_orphaned_tool_results_after_strip"
   , group             := "contract"
-  , reducer           := "strip_tool_results"
+  , reducer           := "strip"
   , legal             := true
   , preMessageCount   := 2
   , postMessageCount  := 2
@@ -115,7 +172,10 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 2 }
 , { name              := "reapply_preserves_view_coherent"
   , group             := "contract"
   , reducer           := "any_valid"
@@ -126,10 +186,105 @@ def compactionReducerCases : List CompactionReducerCase := [
   , preservesOrder    := true
   , gateOpen          := true
   , safeToReduce      := true
-  , reducerIsIdentity := true }
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 2 }
+  -- The straddling split: the raw budget index falls between the assistant
+  -- announcement and its result. Left alone it orphans the result
+  -- (`raw_split_can_orphan`); the boundary retreats so the turn stays whole.
+, { name              := "summarize_retains_straddling_turn"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 2
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := false
+  , splitIndex        := 2
+  , safeBoundary      := pairSafeBoundary (caseFixture 3) 2
+  , retainedCount     := 2 }
+, { name              := "summarize_drops_whole_turns"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 2
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := false
+  , splitIndex        := 1
+  , safeBoundary      := pairSafeBoundary (caseFixture 3) 1
+  , retainedCount     := 2 }
+  -- The gate is production's, not the test's: safe_to_reduce is the function
+  -- under test, and a closed gate must leave the transcript untouched.
+, { name              := "summarize_blocked_when_response_streaming"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 3
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := false
+  , reducerIsIdentity := true
+  , splitIndex        := 2
+  , safeBoundary      := pairSafeBoundary (caseFixture 3) 2
+  , retainedCount     := 3 }
+  -- The boundary cannot retreat past the head of a turn that opens the window.
+, { name              := "summarize_cannot_split_a_leading_turn"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 2
+  , postMessageCount  := 2
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := false
+  , safeToReduce      := true
+  , reducerIsIdentity := true
+  , splitIndex        := 1
+  , safeBoundary      := pairSafeBoundary (caseFixture 2) 1
+  , retainedCount     := 2 }
+, { name              := "provider_view_is_idempotent"
+  , group             := "provider_view"
+  , reducer           := "provider_view"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 3
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 3 }
+  -- An orphaned result at the head is removed by the view, so the unsanitized
+  -- and sanitized indexings of a compacted prefix diverge. Defect 3 of #993.
+, { name              := "provider_view_drops_orphaned_result"
+  , group             := "provider_view"
+  , reducer           := "provider_view"
+  , legal             := true
+  , preMessageCount   := 1
+  , postMessageCount  := 0
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := false
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 0 }
 ]
 
 theorem compactionReducerCases_count :
-    compactionReducerCases.length = 10 := by decide
+    compactionReducerCases.length = 16 := by decide
 
 end Compaction

--- a/crates/gents/proofs/Proofs/Compaction/Prefix.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Prefix.lean
@@ -1,0 +1,298 @@
+import Proofs.Compaction.ProviderView
+
+/-!
+# The compacted-prefix index correspondence
+
+Defect 3 of #993: `messages_compacted` was measured against
+`strip(sanitize(strip H))` but applied to `strip H`. Whenever `sanitize` removed
+anything at or before the boundary the two indexings diverged — either
+summarized messages survived verbatim alongside their own summary, or messages
+that were never summarized were silently dropped from the provider view.
+
+Measuring and dropping in one space is only correct if that space is stable
+under the transcript growing. `providerView_append` is that obligation: the
+provider view of a longer history begins with the provider view of the shorter
+one, so a count recorded against `providerView H` still names the same rows in
+`providerView (H ++ new)`.
+
+The hypothesis is exactly "the suffix contributes no tool result for a call
+announced in the prefix", with two checkable sufficient conditions below. The
+second is what production satisfies: a new request appends its user prompt — an
+ordinary row — before anything else.
+-/
+
+namespace Compaction
+
+open Transcript (MessageRow MessageKind ToolResultKey)
+open PromptAssembly (sanitize dropOrphanedFrom filterCallsBy resolvedIn callsIn
+                     UniqueCallIds ProviderValid ActiveBlockValid ActiveBlockValidFrom)
+
+/-- The pending-call set `dropOrphanedFrom` threads: an assistant announcement
+replaces it, a matching tool result erases one id, anything else clears it.
+Rust mirrors this in `compaction::history::pair_safe_boundary`. -/
+def pendingAfter (pending : Finset ToolExecution.ToolCallId) :
+    List MessageRow → Finset ToolExecution.ToolCallId
+  | [] => pending
+  | row :: rest =>
+    match row.kind with
+    | .toolResult callId _ =>
+        if callId ∈ pending then pendingAfter (pending.erase callId) rest
+        else pendingAfter pending rest
+    | .assistantToolCalls callIds => pendingAfter callIds rest
+    | .ordinary => pendingAfter ∅ rest
+
+@[simp] theorem pendingAfter_nil (pending : Finset ToolExecution.ToolCallId) :
+    pendingAfter pending [] = pending := rfl
+
+theorem pendingAfter_cons_result (row : MessageRow) (rest : List MessageRow)
+    (pending : Finset ToolExecution.ToolCallId) (callId : ToolExecution.ToolCallId)
+    (key : ToolResultKey) (h : row.kind = .toolResult callId key) :
+    pendingAfter pending (row :: rest) =
+      if callId ∈ pending then pendingAfter (pending.erase callId) rest
+      else pendingAfter pending rest := by
+  simp only [pendingAfter, h]
+
+theorem pendingAfter_cons_assistant (row : MessageRow) (rest : List MessageRow)
+    (pending callIds : Finset ToolExecution.ToolCallId)
+    (h : row.kind = .assistantToolCalls callIds) :
+    pendingAfter pending (row :: rest) = pendingAfter callIds rest := by
+  simp only [pendingAfter, h]
+
+theorem pendingAfter_cons_ordinary (row : MessageRow) (rest : List MessageRow)
+    (pending : Finset ToolExecution.ToolCallId) (h : row.kind = .ordinary) :
+    pendingAfter pending (row :: rest) = pendingAfter ∅ rest := by
+  simp only [pendingAfter, h]
+
+theorem pendingAfter_strip (l : List MessageRow) :
+    ∀ pending, pendingAfter pending (strip l) = pendingAfter pending l := by
+  induction l with
+  | nil => intro _; rfl
+  | cons row rest ih =>
+      intro pending
+      rw [strip_cons]
+      cases hk : row.kind with
+      | toolResult callId key =>
+          rw [pendingAfter_cons_result (stripRow row) (strip rest) pending callId (stubKey key)
+              (strip_kind_result row callId key hk),
+            pendingAfter_cons_result row rest pending callId key hk]
+          by_cases hmem : callId ∈ pending
+          · rw [if_pos hmem, if_pos hmem, ih (pending.erase callId)]
+          · rw [if_neg hmem, if_neg hmem, ih pending]
+      | assistantToolCalls callIds =>
+          rw [pendingAfter_cons_assistant (stripRow row) (strip rest) pending callIds
+              (strip_kind_assistant row callIds hk),
+            pendingAfter_cons_assistant row rest pending callIds hk, ih callIds]
+      | ordinary =>
+          rw [pendingAfter_cons_ordinary (stripRow row) (strip rest) pending
+              (strip_kind_ordinary row hk),
+            pendingAfter_cons_ordinary row rest pending hk, ih ∅]
+
+theorem resolvedIn_append (a b : List MessageRow) :
+    resolvedIn (a ++ b) = resolvedIn a ∪ resolvedIn b := by
+  induction a with
+  | nil => simp
+  | cons row rest ih =>
+      cases hk : row.kind with
+      | assistantToolCalls callIds =>
+          rw [List.cons_append, PromptAssembly.resolvedIn_cons_assistant row _ callIds hk,
+            PromptAssembly.resolvedIn_cons_assistant row rest callIds hk, ih]
+      | toolResult callId key =>
+          rw [List.cons_append, PromptAssembly.resolvedIn_cons_result row _ callId key hk,
+            PromptAssembly.resolvedIn_cons_result row rest callId key hk, ih,
+            Finset.insert_union]
+      | ordinary =>
+          rw [List.cons_append, PromptAssembly.resolvedIn_cons_ordinary row _ hk,
+            PromptAssembly.resolvedIn_cons_ordinary row rest hk, ih]
+
+theorem dropOrphanedFrom_append (a : List MessageRow) :
+    ∀ (b : List MessageRow) (pending : Finset ToolExecution.ToolCallId),
+      dropOrphanedFrom pending (a ++ b) =
+        dropOrphanedFrom pending a ++ dropOrphanedFrom (pendingAfter pending a) b := by
+  induction a with
+  | nil => intro b pending; rfl
+  | cons row rest ih =>
+      intro b pending
+      cases hk : row.kind with
+      | toolResult callId key =>
+          rw [List.cons_append,
+            PromptAssembly.dropOrphanedFrom_cons_result row _ pending callId key hk,
+            PromptAssembly.dropOrphanedFrom_cons_result row rest pending callId key hk,
+            pendingAfter_cons_result row rest pending callId key hk]
+          by_cases hmem : callId ∈ pending
+          · rw [if_pos hmem, if_pos hmem, if_pos hmem, List.cons_append,
+              ih b (pending.erase callId)]
+          · rw [if_neg hmem, if_neg hmem, if_neg hmem, ih b pending]
+      | assistantToolCalls callIds =>
+          rw [List.cons_append,
+            PromptAssembly.dropOrphanedFrom_cons_assistant row _ pending callIds hk,
+            PromptAssembly.dropOrphanedFrom_cons_assistant row rest pending callIds hk,
+            pendingAfter_cons_assistant row rest pending callIds hk, List.cons_append,
+            ih b callIds]
+      | ordinary =>
+          rw [List.cons_append,
+            PromptAssembly.dropOrphanedFrom_cons_ordinary row _ pending hk,
+            PromptAssembly.dropOrphanedFrom_cons_ordinary row rest pending hk,
+            pendingAfter_cons_ordinary row rest pending hk, List.cons_append, ih b ∅]
+
+theorem filterCallsBy_append (a : List MessageRow) :
+    ∀ (b : List MessageRow) (resolved : Finset ToolExecution.ToolCallId),
+      filterCallsBy resolved (a ++ b) =
+        filterCallsBy resolved a ++ filterCallsBy resolved b := by
+  induction a with
+  | nil => intro b resolved; rfl
+  | cons row rest ih =>
+      intro b resolved
+      cases hk : row.kind with
+      | assistantToolCalls callIds =>
+          rw [List.cons_append,
+            PromptAssembly.filterCallsBy_cons_assistant row _ resolved callIds hk,
+            PromptAssembly.filterCallsBy_cons_assistant row rest resolved callIds hk]
+          by_cases hempty : callIds ∩ resolved = ∅
+          · rw [if_pos hempty, if_pos hempty, ih b resolved]
+          · rw [if_neg hempty, if_neg hempty, List.cons_append, ih b resolved]
+      | toolResult callId key =>
+          rw [List.cons_append,
+            PromptAssembly.filterCallsBy_cons_result row _ resolved callId key hk,
+            PromptAssembly.filterCallsBy_cons_result row rest resolved callId key hk,
+            List.cons_append, ih b resolved]
+      | ordinary =>
+          rw [List.cons_append,
+            PromptAssembly.filterCallsBy_cons_ordinary row _ resolved hk,
+            PromptAssembly.filterCallsBy_cons_ordinary row rest resolved hk,
+            List.cons_append, ih b resolved]
+
+theorem uniqueCallIds_append_disjoint :
+    ∀ {a b : List MessageRow}, UniqueCallIds (a ++ b) → Disjoint (callsIn a) (callsIn b) := by
+  intro a
+  induction a with
+  | nil => intro b _; simp
+  | cons row rest ih =>
+      intro b h
+      cases hk : row.kind with
+      | assistantToolCalls callIds =>
+          have hsplit := (PromptAssembly.uniqueCallIds_cons_assistant row (rest ++ b) callIds hk).mp h
+          have hb : Disjoint callIds (callsIn b) := by
+            rw [PromptAssembly.callsIn_append, Finset.disjoint_union_right] at hsplit
+            exact hsplit.1.2
+          rw [PromptAssembly.callsIn_cons_assistant row rest callIds hk,
+            Finset.disjoint_union_left]
+          exact ⟨hb, ih hsplit.2⟩
+      | toolResult callId key =>
+          rw [PromptAssembly.callsIn_cons_result row rest callId key hk]
+          exact ih ((PromptAssembly.uniqueCallIds_cons_result row (rest ++ b) callId key hk).mp h)
+      | ordinary =>
+          rw [PromptAssembly.callsIn_cons_ordinary row rest hk]
+          exact ih ((PromptAssembly.uniqueCallIds_cons_ordinary row (rest ++ b) hk).mp h)
+
+/-- **The prefix-stability obligation.** The provider view of a longer history
+begins with the provider view of the shorter one, provided the suffix
+contributes no tool result for a call announced in the prefix.
+
+The tail is existential on purpose: its identity is irrelevant to the
+correspondence, which only needs `providerView a` to be a prefix. -/
+theorem providerView_append (a b : List MessageRow)
+    (hclean : Disjoint (resolvedIn (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b)))
+      (callsIn a)) :
+    ∃ tail, providerView (a ++ b) = providerView a ++ tail := by
+  have hDA : callsIn (dropOrphanedFrom ∅ (strip a)) = callsIn a := by
+    rw [PromptAssembly.callsIn_dropOrphanedFrom, callsIn_strip]
+  have hdisj : Disjoint (resolvedIn (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b)))
+      (callsIn (dropOrphanedFrom ∅ (strip a))) := by
+    rw [hDA]; exact hclean
+  refine ⟨filterCallsBy
+      (resolvedIn (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b)) ∪
+        resolvedIn (dropOrphanedFrom ∅ (strip a)))
+      (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b)), ?_⟩
+  unfold providerView PromptAssembly.sanitize PromptAssembly.dropUnpairedCalls
+    PromptAssembly.dropOrphanedResults
+  rw [strip_append, dropOrphanedFrom_append, resolvedIn_append, filterCallsBy_append,
+    Finset.union_comm, PromptAssembly.filterCallsBy_irrelevant _ _ _ hdisj]
+
+theorem resolvedIn_dropOrphaned_subset (l : List MessageRow) :
+    resolvedIn (dropOrphanedFrom ∅ l) ⊆ callsIn l := by
+  simpa using PromptAssembly.resolvedIn_dropOrphanedFrom_subset l ∅
+
+/-- Sufficient condition 1: the prefix ends at a turn boundary. -/
+theorem providerView_append_of_turn_boundary (a b : List MessageRow)
+    (huniq : UniqueCallIds (a ++ b)) (hb : pendingAfter ∅ a = ∅) :
+    ∃ tail, providerView (a ++ b) = providerView a ++ tail := by
+  refine providerView_append a b ?_
+  rw [pendingAfter_strip, hb]
+  have hsub : resolvedIn (dropOrphanedFrom ∅ (strip b)) ⊆ callsIn b := by
+    rw [← callsIn_strip b]
+    exact resolvedIn_dropOrphaned_subset (strip b)
+  exact ((uniqueCallIds_append_disjoint huniq).symm).mono_left hsub
+
+/-- Sufficient condition 2, the one production satisfies: the suffix opens with
+an ordinary row, because a new request appends its user prompt before anything
+else. No result in the suffix can then attach to a call in the prefix. -/
+theorem providerView_append_of_ordinary_start (a : List MessageRow) (row : MessageRow)
+    (rest : List MessageRow) (huniq : UniqueCallIds (a ++ row :: rest))
+    (hrow : row.kind = .ordinary) :
+    ∃ tail, providerView (a ++ row :: rest) = providerView a ++ tail := by
+  refine providerView_append a (row :: rest) ?_
+  rw [strip_cons,
+    PromptAssembly.dropOrphanedFrom_cons_ordinary (stripRow row) (strip rest) _
+      (strip_kind_ordinary row hrow),
+    PromptAssembly.resolvedIn_cons_ordinary (stripRow row) _ (strip_kind_ordinary row hrow)]
+  have hsub : resolvedIn (dropOrphanedFrom ∅ (strip rest)) ⊆ callsIn (row :: rest) := by
+    rw [PromptAssembly.callsIn_cons_ordinary row rest hrow, ← callsIn_strip rest]
+    exact resolvedIn_dropOrphaned_subset (strip rest)
+  exact ((uniqueCallIds_append_disjoint huniq).symm).mono_left hsub
+
+theorem activeBlockValidFrom_append (a : List MessageRow) :
+    ∀ (b : List MessageRow) (pending : Finset ToolExecution.ToolCallId),
+      ActiveBlockValidFrom pending (a ++ b) →
+        ActiveBlockValidFrom (pendingAfter pending a) b := by
+  induction a with
+  | nil => intro b pending h; exact h
+  | cons row rest ih =>
+      intro b pending h
+      cases hk : row.kind with
+      | toolResult callId key =>
+          have hsplit :=
+            (PromptAssembly.activeBlockValidFrom_cons_result row (rest ++ b) pending callId key
+              hk).mp h
+          rw [pendingAfter_cons_result row rest pending callId key hk, if_pos hsplit.1]
+          exact ih b (pending.erase callId) hsplit.2
+      | assistantToolCalls callIds =>
+          have hsplit :=
+            (PromptAssembly.activeBlockValidFrom_cons_assistant row (rest ++ b) pending callIds
+              hk).mp h
+          rw [pendingAfter_cons_assistant row rest pending callIds hk]
+          exact ih b callIds hsplit.2
+      | ordinary =>
+          have hsplit :=
+            (PromptAssembly.activeBlockValidFrom_cons_ordinary row (rest ++ b) pending hk).mp h
+          rw [pendingAfter_cons_ordinary row rest pending hk]
+          exact ih b ∅ hsplit.2
+
+/-- Dropping at a pending-empty index of a provider view leaves a provider view.
+
+This is what makes it safe for `agent/daemon/request.rs` to drop the compacted
+prefix *after* sanitization without re-sanitizing: the writer's boundary is
+always `pairSafeBoundary`, so the drop lands where nothing is pending. -/
+theorem drop_preserves_providerValid (msgs : List MessageRow) (n : Nat)
+    (hvalid : ProviderValid msgs) (hboundary : pendingAfter ∅ (msgs.take n) = ∅) :
+    ProviderValid (msgs.drop n) := by
+  constructor
+  have hsplit : msgs.take n ++ msgs.drop n = msgs := List.take_append_drop n msgs
+  have h := activeBlockValidFrom_append (msgs.take n) (msgs.drop n) ∅
+    (by rw [hsplit]; exact hvalid.activeBlockValid)
+  rwa [hboundary] at h
+
+/-- **The correspondence the production fix rests on.** The count the compaction
+writer records against `providerView H` names exactly the rows the next
+request's reader drops from `providerView (H ++ new)`. -/
+theorem compacted_prefix_correspondence
+    {H new dropped old recent tail : List MessageRow}
+    (hstable : providerView (H ++ new) = providerView H ++ tail)
+    (hsplit : providerView H = dropped ++ old ++ recent) :
+    (providerView (H ++ new)).drop (dropped.length + old.length) = recent ++ tail := by
+  rw [hstable, hsplit]
+  have hregroup : dropped ++ old ++ recent ++ tail = (dropped ++ old) ++ (recent ++ tail) := by
+    simp [List.append_assoc]
+  rw [hregroup]
+  exact List.drop_left' (by simp)
+
+end Compaction

--- a/crates/gents/proofs/Proofs/Compaction/Prefix.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Prefix.lean
@@ -269,8 +269,9 @@ theorem activeBlockValidFrom_append (a : List MessageRow) :
 
 /-- Dropping at a pending-empty index of a provider view leaves a provider view.
 
-This is what makes it safe for `agent/daemon/request.rs` to drop the compacted
-prefix *after* sanitization without re-sanitizing: the writer's boundary is
+This is what makes dropping the compacted prefix *after* sanitization sound in
+`agent/daemon/request.rs`, and (via `sanitize_drop_noop`) what makes the
+re-narrowing that follows it free rather than corrective: the writer's boundary is
 always `pairSafeBoundary`, so the drop lands where nothing is pending. -/
 theorem drop_preserves_providerValid (msgs : List MessageRow) (n : Nat)
     (hvalid : ProviderValid msgs) (hboundary : pendingAfter ∅ (msgs.take n) = ∅) :

--- a/crates/gents/proofs/Proofs/Compaction/Prefix.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Prefix.lean
@@ -281,6 +281,68 @@ theorem drop_preserves_providerValid (msgs : List MessageRow) (n : Nat)
     (by rw [hsplit]; exact hvalid.activeBlockValid)
   rwa [hboundary] at h
 
+theorem nonemptyAnnouncements_drop (n : Nat) :
+    ∀ l : List MessageRow,
+      PromptAssembly.NonemptyAnnouncements l →
+        PromptAssembly.NonemptyAnnouncements (l.drop n) := by
+  induction n with
+  | zero => intro l h; simpa using h
+  | succ m ih =>
+      intro l h
+      cases l with
+      | nil => simpa using h
+      | cons row rest =>
+          rw [List.drop_succ_cons]
+          refine ih rest ?_
+          cases hk : row.kind with
+          | assistantToolCalls callIds =>
+              exact ((PromptAssembly.nonemptyAnnouncements_cons_assistant row rest callIds
+                hk).mp h).2
+          | toolResult callId key =>
+              exact (PromptAssembly.nonemptyAnnouncements_cons_other row rest
+                (by intro c hc; rw [hk] at hc; exact MessageKind.noConfusion hc)).mp h
+          | ordinary =>
+              exact (PromptAssembly.nonemptyAnnouncements_cons_other row rest
+                (by intro c hc; rw [hk] at hc; exact MessageKind.noConfusion hc)).mp h
+
+/-- Re-narrowing after the compacted-prefix drop is a no-op.
+
+`agent/daemon/request.rs` sanitizes again after dropping. For every count this
+runtime writes that call is provably free — the writer's boundary is always
+`pairSafeBoundary`, so the drop lands where nothing is pending. It is kept
+because counts written before that splitter existed carry no version marker and
+can land mid-turn, and because `UniqueCallIds` is a *checked* precondition
+rather than a structural guarantee (see `reused_call_id_breaks_prefix_stability`). -/
+theorem sanitize_drop_noop {msgs : List MessageRow} {n : Nat}
+    (huniq : UniqueCallIds msgs)
+    (hboundary : pendingAfter ∅ ((providerView msgs).take n) = ∅) :
+    sanitize ((providerView msgs).drop n) = (providerView msgs).drop n :=
+  PromptAssembly.sanitize_fixpoint
+    (drop_preserves_providerValid _ n (providerView_sound huniq) hboundary)
+    (nonemptyAnnouncements_drop n _ (providerView_nonempty_announcements msgs))
+
+/-- Reusing a tool-call id across turns breaks prefix stability, and therefore
+breaks the compacted-prefix correspondence.
+
+`dropUnpairedCalls` credits an announcement from the *global* resolved set, so a
+later turn that reuses an id resurrects an earlier announcement that the shorter
+view had dropped as unpaired. The prefix changes under append and a stored count
+no longer names the rows it was measured against.
+
+`UniqueCallIds` is what rules this out, and it is a real hypothesis rather than
+a structural fact: production call ids come from the provider. Rust checks it
+(`compaction::has_unique_call_ids`) and skips compaction when it fails, rather
+than assuming it. See `boundary.compaction.unique-call-ids-checked`. -/
+theorem reused_call_id_breaks_prefix_stability :
+    ∃ a b : List MessageRow,
+      pendingAfter ∅ a = ∅ ∧
+        (providerView (a ++ b)).take (providerView a).length ≠ providerView a := by
+  refine ⟨[⟨0, 0, 0, .assistant, .assistantToolCalls {1}⟩, ⟨1, 0, 1, .user, .ordinary⟩],
+          [⟨2, 0, 2, .assistant, .assistantToolCalls {1}⟩,
+           ⟨3, 0, 3, .user, .toolResult 1 ⟨0, 0, 0⟩⟩], ?_, ?_⟩
+  · decide
+  · decide
+
 /-- **The correspondence the production fix rests on.** The count the compaction
 writer records against `providerView H` names exactly the rows the next
 request's reader drops from `providerView (H ++ new)`. -/

--- a/crates/gents/proofs/Proofs/Compaction/Properties.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Properties.lean
@@ -20,12 +20,8 @@ variable {r : TranscriptReducer} [IsValidReducer r]
 
 theorem reduction_preserves_view_coherent
     {v : PromptView} (h : PromptView.ViewCoherent v) :
-    PromptView.ViewCoherent (r v) := by
-  refine ⟨?_, ?_, ?_⟩
-  · exact IsValidReducer.preservesPairs (r := r) v h.pairs
-  · exact IsValidReducer.preservesOrder (r := r) v h.ordered
-  · exact uniqueSequences_of_strictlyIncreasing
-      (IsValidReducer.preservesOrder (r := r) v h.ordered)
+    PromptView.ViewCoherent (r v) :=
+  IsValidReducer.preservesCoherent (r := r) v h
 
 theorem reduction_preserves_session_id (v : PromptView) :
     (r v).sessionId = v.sessionId :=
@@ -44,19 +40,23 @@ theorem reduction_blocked_unless_safe
 theorem reapply_preserves_view_coherent
     {v : PromptView} (h : PromptView.ViewCoherent v) :
     PromptView.ViewCoherent (r (r v)) :=
-  IsValidReducer.reapplyPreservesCoh (r := r) v h
+  IsValidReducer.preservesCoherent (r := r) (r v)
+    (IsValidReducer.preservesCoherent (r := r) v h)
 
+/-- Pair closure over a reduced view.
+
+Unlike the pre-#993 version, this is not vacuous: it is the property the real
+`summarize` reducer earns by retreating its split to a turn boundary, and
+`raw_split_can_orphan` witnesses that an unadjusted split loses it. -/
 theorem no_orphaned_tool_results_after_reduction
-    {v : PromptView}
-    (h_pre : PromptView.PairsClosedInMessages v.messages) :
+    {v : PromptView} (h_pre : PromptView.ViewCoherent v) :
     ∀ row, row ∈ (r v).messages →
       ∀ callId key, row.kind = .toolResult callId key →
         ∃ caller, caller ∈ (r v).messages ∧
           caller.role = .assistant ∧
           (∃ callIds, caller.kind = .assistantToolCalls callIds ∧
-            callId ∈ callIds) := by
-  intro row h_mem callId key h_kind
-  exact IsValidReducer.preservesPairs (r := r) v h_pre row h_mem callId key h_kind
+            callId ∈ callIds) :=
+  (IsValidReducer.preservesCoherent (r := r) v h_pre).pairs
 
 theorem retained_window_is_ordered
     {v : PromptView}
@@ -88,10 +88,5 @@ namespace Compaction
 
 theorem identity_reducer_is_strictly_idempotent (v : PromptView) :
     identityReducer (identityReducer v) = identityReducer v := rfl
-
-theorem strip_tool_results_is_strictly_idempotent (v : PromptView) :
-    stripToolResultsReducer (stripToolResultsReducer v)
-      = stripToolResultsReducer v := by
-  rw [stripToolResultsReducer_id, stripToolResultsReducer_id]
 
 end Compaction

--- a/crates/gents/proofs/Proofs/Compaction/ProviderView.lean
+++ b/crates/gents/proofs/Proofs/Compaction/ProviderView.lean
@@ -1,0 +1,128 @@
+import Proofs.Compaction.Strip
+import Proofs.PromptAssembly.Properties
+
+/-!
+# The canonical provider view
+
+Issue #993 named `strip ∘ sanitize = sanitize ∘ strip` as unproven, and
+therefore named the obvious production fix — moving the compacted-prefix drop
+past sanitization — as unlicensed:
+
+> `strip` rewrites tool-result *content* while `sanitize` drops rows based on
+> call/result *pairing*, so stripping first can change which pairs sanitize
+> considers orphaned.
+
+It does not, and `strip_sanitize_commute` is why: both sanitize stages branch
+only on a row's `MessageKind` constructor and its call ids, and `strip` fixes
+both. That settles the question affirmatively and licenses `providerView` — the
+single reduction the compaction writer and the request reader both index.
+-/
+
+namespace Compaction
+
+open Transcript (MessageRow MessageKind ToolResultKey)
+open PromptAssembly (sanitize dropOrphanedFrom filterCallsBy resolvedIn callsIn withKind
+                     UniqueCallIds ProviderValid)
+
+theorem stripRow_withKind_assistant (row : MessageRow)
+    (callIds : Finset ToolExecution.ToolCallId) :
+    stripRow (withKind row (.assistantToolCalls callIds))
+      = withKind (stripRow row) (.assistantToolCalls callIds) := rfl
+
+theorem strip_dropOrphanedFrom (l : List MessageRow) :
+    ∀ pending, strip (dropOrphanedFrom pending l) = dropOrphanedFrom pending (strip l) := by
+  induction l with
+  | nil => intro _; rfl
+  | cons row rest ih =>
+      intro pending
+      cases hk : row.kind with
+      | toolResult callId key =>
+          rw [strip_cons,
+            PromptAssembly.dropOrphanedFrom_cons_result (stripRow row) (strip rest) pending
+              callId (stubKey key) (strip_kind_result row callId key hk),
+            PromptAssembly.dropOrphanedFrom_cons_result row rest pending callId key hk]
+          by_cases hmem : callId ∈ pending
+          · rw [if_pos hmem, if_pos hmem, strip_cons, ih (pending.erase callId)]
+          · rw [if_neg hmem, if_neg hmem, ih pending]
+      | assistantToolCalls callIds =>
+          rw [strip_cons,
+            PromptAssembly.dropOrphanedFrom_cons_assistant (stripRow row) (strip rest) pending
+              callIds (strip_kind_assistant row callIds hk),
+            PromptAssembly.dropOrphanedFrom_cons_assistant row rest pending callIds hk,
+            strip_cons, ih callIds]
+      | ordinary =>
+          rw [strip_cons,
+            PromptAssembly.dropOrphanedFrom_cons_ordinary (stripRow row) (strip rest) pending
+              (strip_kind_ordinary row hk),
+            PromptAssembly.dropOrphanedFrom_cons_ordinary row rest pending hk,
+            strip_cons, ih ∅]
+
+theorem strip_filterCallsBy (l : List MessageRow) :
+    ∀ resolved, strip (filterCallsBy resolved l) = filterCallsBy resolved (strip l) := by
+  induction l with
+  | nil => intro _; rfl
+  | cons row rest ih =>
+      intro resolved
+      cases hk : row.kind with
+      | assistantToolCalls callIds =>
+          rw [strip_cons,
+            PromptAssembly.filterCallsBy_cons_assistant (stripRow row) (strip rest) resolved
+              callIds (strip_kind_assistant row callIds hk),
+            PromptAssembly.filterCallsBy_cons_assistant row rest resolved callIds hk]
+          by_cases hempty : callIds ∩ resolved = ∅
+          · rw [if_pos hempty, if_pos hempty, ih resolved]
+          · rw [if_neg hempty, if_neg hempty, strip_cons, ih resolved,
+              stripRow_withKind_assistant]
+      | toolResult callId key =>
+          rw [strip_cons,
+            PromptAssembly.filterCallsBy_cons_result (stripRow row) (strip rest) resolved
+              callId (stubKey key) (strip_kind_result row callId key hk),
+            PromptAssembly.filterCallsBy_cons_result row rest resolved callId key hk,
+            strip_cons, ih resolved]
+      | ordinary =>
+          rw [strip_cons,
+            PromptAssembly.filterCallsBy_cons_ordinary (stripRow row) (strip rest) resolved
+              (strip_kind_ordinary row hk),
+            PromptAssembly.filterCallsBy_cons_ordinary row rest resolved hk,
+            strip_cons, ih resolved]
+
+/-- The theorem #993 named as the blocker. Stripping first does *not* change
+which pairs sanitize considers orphaned. -/
+theorem strip_sanitize_commute (msgs : List MessageRow) :
+    strip (sanitize msgs) = sanitize (strip msgs) := by
+  have hres : resolvedIn (dropOrphanedFrom ∅ (strip msgs))
+      = resolvedIn (dropOrphanedFrom ∅ msgs) := by
+    rw [← strip_dropOrphanedFrom, resolvedIn_strip]
+  unfold PromptAssembly.sanitize PromptAssembly.dropUnpairedCalls
+    PromptAssembly.dropOrphanedResults
+  rw [strip_filterCallsBy, strip_dropOrphanedFrom, hres]
+
+/-- The single canonical narrowing from the durable transcript to the provider
+view. Both sides of compaction's prefix accounting index *this* list: the
+compaction writer records `messages_compacted` against it, and the request
+reader drops that many rows from it. Rust: `compaction::provider_view`. -/
+def providerView (msgs : List MessageRow) : List MessageRow := sanitize (strip msgs)
+
+theorem providerView_sound {msgs : List MessageRow} (huniq : UniqueCallIds msgs) :
+    ProviderValid (providerView msgs) :=
+  PromptAssembly.sanitize_sound (strip_preserves_uniqueCallIds huniq)
+
+/-- What lets `compact()` re-normalize its own input for free, so
+`messages_compacted` indexes the canonical space whoever the caller is. -/
+theorem providerView_idempotent {msgs : List MessageRow} (huniq : UniqueCallIds msgs) :
+    providerView (providerView msgs) = providerView msgs := by
+  unfold providerView
+  rw [strip_sanitize_commute, strip_idempotent]
+  exact PromptAssembly.sanitize_idempotent (strip_preserves_uniqueCallIds huniq)
+
+theorem providerView_nonempty_announcements (msgs : List MessageRow) :
+    PromptAssembly.NonemptyAnnouncements (providerView msgs) :=
+  PromptAssembly.nonemptyAnnouncements_sanitize _
+
+/-- Stripping commutes with the whole reduction, not just its stages. -/
+theorem strip_providerView (msgs : List MessageRow) :
+    strip (providerView msgs) = providerView msgs := by
+  unfold providerView
+  rw [strip_sanitize_commute, strip_idempotent]
+
+end Compaction

--- a/crates/gents/proofs/Proofs/Compaction/State.lean
+++ b/crates/gents/proofs/Proofs/Compaction/State.lean
@@ -1,6 +1,7 @@
 import Proofs.Basic
 import Proofs.Transcript.State
 import Proofs.StreamingResponse.State
+import Proofs.PromptAssembly.State
 
 namespace Compaction
 
@@ -26,10 +27,30 @@ def PairsClosedInMessages (msgs : List MessageRow) : Prop :=
         caller.role = .assistant ∧
         (∃ callIds, caller.kind = .assistantToolCalls callIds ∧ callId ∈ callIds)
 
+/-- Every row announcing tool calls carries the assistant role.
+
+A structural fact the transcript writer maintains — `persistAssistantMessage`
+sets `role := .assistant` alongside `kind := .assistantToolCalls`. Pair closure
+needs it: `ActiveBlockValid` locates the *announcement* for a retained result,
+and this is what makes that announcement an acceptable *caller*. -/
+def AnnouncementsAreAssistant (msgs : List MessageRow) : Prop :=
+  ∀ row, row ∈ msgs →
+    ∀ callIds, row.kind = .assistantToolCalls callIds → row.role = .assistant
+
+/-- Coherence of a prompt view.
+
+`blockValid` and `announcementsAssistant` were added with the real `summarize`
+reducer (#993). The runtime establishes both by construction — every view is
+born from `providerView`, and `providerView_sound` gives `ProviderValid` — and
+they are exactly the premises under which dropping a compacted prefix preserves
+pair closure. The previous three fields sufficed only because the modelled
+reducer was `id`. -/
 structure ViewCoherent (v : PromptView) : Prop where
-  pairs           : PairsClosedInMessages v.messages
-  ordered         : StrictlyIncreasingMessages v.messages
-  uniqueSequences : UniqueMessageSequences v.messages
+  pairs                  : PairsClosedInMessages v.messages
+  ordered                : StrictlyIncreasingMessages v.messages
+  uniqueSequences        : UniqueMessageSequences v.messages
+  blockValid             : PromptAssembly.ActiveBlockValid v.messages
+  announcementsAssistant : AnnouncementsAreAssistant v.messages
 
 def safeToReduce (v : PromptView) : Prop :=
   ∀ row, row ∈ v.messages →

--- a/crates/gents/proofs/Proofs/Compaction/Strip.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Strip.lean
@@ -1,0 +1,182 @@
+import Proofs.Compaction.State
+import Proofs.PromptAssembly.State
+
+/-!
+# The real tool-result strip
+
+The previous model of this reducer (`stubMessageKind` in
+`Proofs/Compaction/Transition.lean`) was literally
+`| .toolResult callId key => .toolResult callId key`, so every preservation
+property in `Proofs/Compaction/Properties.lean` quantified over `id`. It proved
+that doing nothing preserves meaning — true, and useless (#993).
+
+Production's `strip_tool_results` replaces each tool result's payload with a
+pointer stub and touches nothing else: same rows, same order, same call ids.
+That last part is the whole reason `strip` commutes with `sanitize`
+(`Proofs/Compaction/ProviderView.lean`), which is what licenses the production
+reordering of the compacted-prefix drop.
+-/
+
+namespace Compaction
+
+open Transcript (MessageRow MessageKind ToolResultKey)
+
+/-- The canonical pointer payload a stripped tool result carries.
+
+Production writes `[tool: NAME(ARG), call_id: ID, N bytes — see DefraDB
+AgentToolCall for full output]`; the model abstracts that to a single canonical
+payload hash. Collapsing distinct payloads is deliberate — `ViewCoherent` does
+not require `UniqueToolResultKeys`. -/
+def stubKey (key : ToolResultKey) : ToolResultKey := { key with payloadHash := 0 }
+
+@[simp] theorem stubKey_idempotent (key : ToolResultKey) :
+    stubKey (stubKey key) = stubKey key := rfl
+
+/-- Strip rewrites the *payload* of a tool result and nothing else. It never
+changes a constructor and never changes a call id. -/
+def stripKind : MessageKind → MessageKind
+  | .toolResult callId key => .toolResult callId (stubKey key)
+  | k => k
+
+def stripRow (row : MessageRow) : MessageRow := { row with kind := stripKind row.kind }
+
+def strip (msgs : List MessageRow) : List MessageRow := msgs.map stripRow
+
+@[simp] theorem stripRow_kind (row : MessageRow) :
+    (stripRow row).kind = stripKind row.kind := rfl
+
+@[simp] theorem stripRow_sequence (row : MessageRow) :
+    (stripRow row).sequence = row.sequence := rfl
+
+@[simp] theorem stripRow_role (row : MessageRow) :
+    (stripRow row).role = row.role := rfl
+
+@[simp] theorem stripRow_messageId (row : MessageRow) :
+    (stripRow row).messageId = row.messageId := rfl
+
+@[simp] theorem stripRow_sessionId (row : MessageRow) :
+    (stripRow row).sessionId = row.sessionId := rfl
+
+@[simp] theorem strip_nil : strip [] = [] := rfl
+
+@[simp] theorem strip_cons (row : MessageRow) (rest : List MessageRow) :
+    strip (row :: rest) = stripRow row :: strip rest := rfl
+
+@[simp] theorem strip_length (msgs : List MessageRow) :
+    (strip msgs).length = msgs.length := List.length_map _ _
+
+theorem strip_append (a b : List MessageRow) : strip (a ++ b) = strip a ++ strip b :=
+  List.map_append _ _ _
+
+theorem strip_take (msgs : List MessageRow) (n : Nat) :
+    strip (msgs.take n) = (strip msgs).take n := List.map_take _ _ _
+
+theorem strip_drop (msgs : List MessageRow) (n : Nat) :
+    strip (msgs.drop n) = (strip msgs).drop n := List.map_drop _ _ _
+
+theorem stripKind_idempotent (k : MessageKind) : stripKind (stripKind k) = stripKind k := by
+  cases k <;> rfl
+
+theorem stripRow_idempotent (row : MessageRow) : stripRow (stripRow row) = stripRow row := by
+  simp only [stripRow, stripRow_kind, stripKind_idempotent]
+
+/-- The honest replacement for the old `strip_tool_results_is_strictly_idempotent`,
+which was true only because the modelled strip was `id`. Production earns this
+by recognizing an existing stub instead of re-stubbing it. -/
+theorem strip_idempotent (msgs : List MessageRow) : strip (strip msgs) = strip msgs := by
+  induction msgs with
+  | nil => rfl
+  | cons row rest ih =>
+      rw [strip_cons, strip_cons, stripRow_idempotent, ih]
+
+theorem strip_kind_ordinary (row : MessageRow) (h : row.kind = .ordinary) :
+    (stripRow row).kind = .ordinary := by
+  rw [stripRow_kind, h]; rfl
+
+theorem strip_kind_assistant (row : MessageRow) (callIds : Finset ToolExecution.ToolCallId)
+    (h : row.kind = .assistantToolCalls callIds) :
+    (stripRow row).kind = .assistantToolCalls callIds := by
+  rw [stripRow_kind, h]; rfl
+
+theorem strip_kind_result (row : MessageRow) (callId : ToolExecution.ToolCallId)
+    (key : ToolResultKey) (h : row.kind = .toolResult callId key) :
+    (stripRow row).kind = .toolResult callId (stubKey key) := by
+  rw [stripRow_kind, h]; rfl
+
+theorem callsIn_strip (l : List MessageRow) :
+    PromptAssembly.callsIn (strip l) = PromptAssembly.callsIn l := by
+  induction l with
+  | nil => rfl
+  | cons row rest ih =>
+      rw [strip_cons]
+      cases hk : row.kind with
+      | ordinary =>
+          rw [PromptAssembly.callsIn_cons_ordinary _ _ (strip_kind_ordinary row hk),
+            PromptAssembly.callsIn_cons_ordinary row rest hk, ih]
+      | assistantToolCalls callIds =>
+          rw [PromptAssembly.callsIn_cons_assistant _ _ callIds
+              (strip_kind_assistant row callIds hk),
+            PromptAssembly.callsIn_cons_assistant row rest callIds hk, ih]
+      | toolResult callId key =>
+          rw [PromptAssembly.callsIn_cons_result _ _ callId (stubKey key)
+              (strip_kind_result row callId key hk),
+            PromptAssembly.callsIn_cons_result row rest callId key hk, ih]
+
+theorem resolvedIn_strip (l : List MessageRow) :
+    PromptAssembly.resolvedIn (strip l) = PromptAssembly.resolvedIn l := by
+  induction l with
+  | nil => rfl
+  | cons row rest ih =>
+      rw [strip_cons]
+      cases hk : row.kind with
+      | ordinary =>
+          rw [PromptAssembly.resolvedIn_cons_ordinary _ _ (strip_kind_ordinary row hk),
+            PromptAssembly.resolvedIn_cons_ordinary row rest hk, ih]
+      | assistantToolCalls callIds =>
+          rw [PromptAssembly.resolvedIn_cons_assistant _ _ callIds
+              (strip_kind_assistant row callIds hk),
+            PromptAssembly.resolvedIn_cons_assistant row rest callIds hk, ih]
+      | toolResult callId key =>
+          rw [PromptAssembly.resolvedIn_cons_result _ _ callId (stubKey key)
+              (strip_kind_result row callId key hk),
+            PromptAssembly.resolvedIn_cons_result row rest callId key hk, ih]
+
+theorem strip_preserves_uniqueCallIds :
+    ∀ {l : List MessageRow},
+      PromptAssembly.UniqueCallIds l → PromptAssembly.UniqueCallIds (strip l) := by
+  intro l
+  induction l with
+  | nil => intro _; trivial
+  | cons row rest ih =>
+      intro h
+      rw [strip_cons]
+      cases hk : row.kind with
+      | ordinary =>
+          rw [PromptAssembly.uniqueCallIds_cons_ordinary _ _ (strip_kind_ordinary row hk)]
+          exact ih ((PromptAssembly.uniqueCallIds_cons_ordinary row rest hk).mp h)
+      | assistantToolCalls callIds =>
+          have hsplit := (PromptAssembly.uniqueCallIds_cons_assistant row rest callIds hk).mp h
+          rw [PromptAssembly.uniqueCallIds_cons_assistant _ _ callIds
+              (strip_kind_assistant row callIds hk), callsIn_strip]
+          exact ⟨hsplit.1, ih hsplit.2⟩
+      | toolResult callId key =>
+          rw [PromptAssembly.uniqueCallIds_cons_result _ _ callId (stubKey key)
+              (strip_kind_result row callId key hk)]
+          exact ih ((PromptAssembly.uniqueCallIds_cons_result row rest callId key hk).mp h)
+
+theorem strip_preserves_strictlyIncreasing :
+    ∀ {l : List MessageRow},
+      Transcript.StrictlyIncreasingMessages l →
+        Transcript.StrictlyIncreasingMessages (strip l) := by
+  intro l
+  induction l with
+  | nil => intro _; trivial
+  | cons row rest ih =>
+      intro h
+      refine ⟨?_, ih h.2⟩
+      intro other hmem
+      obtain ⟨source, hsource, hEq⟩ := List.mem_map.mp hmem
+      subst hEq
+      simpa using h.1 source hsource
+
+end Compaction

--- a/crates/gents/proofs/Proofs/Compaction/Strip.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Strip.lean
@@ -82,7 +82,8 @@ theorem stripRow_idempotent (row : MessageRow) : stripRow (stripRow row) = strip
 
 /-- The honest replacement for the old `strip_tool_results_is_strictly_idempotent`,
 which was true only because the modelled strip was `id`. Production earns this
-by recognizing an existing stub instead of re-stubbing it. -/
+by recovering a stub's recorded facts instead of re-measuring it — it always
+rewrites, so text that merely looks like a stub cannot bypass the reduction. -/
 theorem strip_idempotent (msgs : List MessageRow) : strip (strip msgs) = strip msgs := by
   induction msgs with
   | nil => rfl

--- a/crates/gents/proofs/Proofs/Compaction/Summarize.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Summarize.lean
@@ -1,0 +1,315 @@
+import Proofs.Compaction.Prefix
+import Proofs.Compaction.Properties
+
+/-!
+# The real summarize reducer
+
+Defect 1 of #993: the modelled reducer was `id`, so pair closure was proven
+about a function that never dropped anything. Production's summarize path splits
+the transcript on a token budget at an arbitrary index, and that index can land
+between an assistant message carrying a `ToolCall` and the user message carrying
+its `ToolResult`. The call is summarized away, the result stays in the retained
+tail, and `sanitize_history_for_provider` drops the orphan at loop entry — the
+tool's output is gone from the provider view while the summary describes only
+the call.
+
+`summarize` is parameterised over the budget index rather than pinning a token
+function: what must be proven is that *whatever* index the budget picks, the
+reducer stays sound. It does, because `pairSafeBoundary` retreats the index to
+the nearest turn boundary. `raw_split_can_orphan` is the counterexample showing
+that retreat is load-bearing rather than decoration.
+-/
+
+namespace Compaction
+
+open Transcript (MessageRow MessageKind ToolResultKey)
+open PromptAssembly (ActiveBlockValid ActiveBlockValidFrom)
+
+/-! ## Fold helpers -/
+
+theorem foldrMax_eq_zero_or_mem :
+    ∀ l : List Nat, l.foldr max 0 = 0 ∨ l.foldr max 0 ∈ l := by
+  intro l
+  induction l with
+  | nil => exact Or.inl rfl
+  | cons x rest ih =>
+      rw [List.foldr_cons]
+      rcases Nat.le_total (rest.foldr max 0) x with hle | hle
+      · rw [max_eq_left hle]
+        exact Or.inr (List.mem_cons_self _ _)
+      · rw [max_eq_right hle]
+        rcases ih with h | h
+        · exact Or.inl h
+        · exact Or.inr (List.mem_cons_of_mem _ h)
+
+theorem foldrMax_le (n : Nat) :
+    ∀ l : List Nat, (∀ x ∈ l, x ≤ n) → l.foldr max 0 ≤ n := by
+  intro l
+  induction l with
+  | nil => intro _; exact Nat.zero_le n
+  | cons x rest ih =>
+      intro h
+      rw [List.foldr_cons]
+      exact max_le (h x (List.mem_cons_self _ _))
+        (ih (fun y hy => h y (List.mem_cons_of_mem _ hy)))
+
+/-! ## The pair-safe boundary -/
+
+/-- The token-budget index production computes in `split_messages_for_summary`. -/
+abbrev SplitPolicy := List MessageRow → Nat
+
+/-- The greatest `j ≤ limit` at which no tool call is awaiting its result.
+
+Production mirrors this in `compaction::history::pair_safe_boundary`: it walks
+the budget index back to the nearest turn boundary. Moving *earlier* over-retains
+by at most one turn and never loses context; moving later would summarize a turn
+the budget wanted kept. For provider-input assembly, over-retaining is the
+correct failure direction. -/
+def pairSafeBoundary (msgs : List MessageRow) (limit : Nat) : Nat :=
+  ((List.range (min limit msgs.length + 1)).filter
+    (fun j => decide (pendingAfter ∅ (msgs.take j) = ∅))).foldr max 0
+
+theorem pairSafeBoundary_le (msgs : List MessageRow) (limit : Nat) :
+    pairSafeBoundary msgs limit ≤ limit := by
+  unfold pairSafeBoundary
+  refine foldrMax_le limit _ ?_
+  intro x hx
+  have hrange : x ∈ List.range (min limit msgs.length + 1) := (List.mem_filter.mp hx).1
+  exact (Nat.lt_succ_iff.mp (List.mem_range.mp hrange)).trans (Nat.min_le_left _ _)
+
+theorem pairSafeBoundary_pending_empty (msgs : List MessageRow) (limit : Nat) :
+    pendingAfter ∅ (msgs.take (pairSafeBoundary msgs limit)) = ∅ := by
+  unfold pairSafeBoundary
+  rcases foldrMax_eq_zero_or_mem _ with h | h
+  · rw [h]; rfl
+  · exact of_decide_eq_true (List.mem_filter.mp h).2
+
+/-! ## Pair closure of the retained tail -/
+
+theorem announcementsAreAssistant_drop {msgs : List MessageRow} (n : Nat)
+    (h : PromptView.AnnouncementsAreAssistant msgs) :
+    PromptView.AnnouncementsAreAssistant (msgs.drop n) := by
+  intro row hmem callIds hkind
+  exact h row (List.drop_subset n msgs hmem) callIds hkind
+
+theorem strictlyIncreasing_drop (n : Nat) :
+    ∀ l : List MessageRow,
+      Transcript.StrictlyIncreasingMessages l →
+        Transcript.StrictlyIncreasingMessages (l.drop n) := by
+  induction n with
+  | zero => intro l h; simpa using h
+  | succ m ih =>
+      intro l h
+      cases l with
+      | nil => simpa using h
+      | cons row rest => rw [List.drop_succ_cons]; exact ih rest h.2
+
+/-- Every retained tool result has its announcement inside the same window.
+
+The generalisation over `seen` is what carries the induction: the pending set is
+always backed by an assistant announcement already walked past, and once the
+window starts with an empty pending set that backing must come from inside the
+window itself. -/
+theorem activeBlockValidFrom_pairs_closed_aux :
+    ∀ (l : List MessageRow) (pending : Finset ToolExecution.ToolCallId)
+      (seen : List MessageRow),
+      ActiveBlockValidFrom pending l →
+      PromptView.AnnouncementsAreAssistant l →
+      (∀ c ∈ pending, ∃ caller, caller ∈ seen ∧ caller.role = .assistant ∧
+        ∃ S, caller.kind = .assistantToolCalls S ∧ c ∈ S) →
+      ∀ row, row ∈ l → ∀ callId key, row.kind = .toolResult callId key →
+        ∃ caller, caller ∈ seen ++ l ∧ caller.role = .assistant ∧
+          ∃ S, caller.kind = .assistantToolCalls S ∧ callId ∈ S := by
+  intro l
+  induction l with
+  | nil => intro _ _ _ _ _ row hmem; exact absurd hmem (List.not_mem_nil row)
+  | cons r rest ih =>
+      intro pending seen hblock hroles hseen row hmem callId key hkind
+      have hroles' : PromptView.AnnouncementsAreAssistant rest := fun x hx =>
+        hroles x (List.mem_cons_of_mem r hx)
+      have hshift : ∀ x, x ∈ seen ++ [r] ++ rest → x ∈ seen ++ r :: rest := by
+        intro x hx
+        simpa [List.append_assoc] using hx
+      cases hk : r.kind with
+      | toolResult c k =>
+          have hsplit := (PromptAssembly.activeBlockValidFrom_cons_result r rest pending c k hk).mp
+            hblock
+          rcases List.mem_cons.mp hmem with hEq | hrest
+          · subst hEq
+            rw [hk] at hkind
+            injection hkind with hcEq _
+            obtain ⟨caller, hcaller, hrole, hann⟩ := hseen c hsplit.1
+            exact ⟨caller, List.mem_append_left _ hcaller, hrole, hcEq ▸ hann⟩
+          · have hseen' : ∀ c' ∈ pending.erase c, ∃ caller, caller ∈ seen ++ [r] ∧
+                caller.role = .assistant ∧
+                ∃ S, caller.kind = .assistantToolCalls S ∧ c' ∈ S := by
+              intro c' hc'
+              obtain ⟨caller, hcaller, hrole, hann⟩ := hseen c' (Finset.mem_of_mem_erase hc')
+              exact ⟨caller, List.mem_append_left _ hcaller, hrole, hann⟩
+            obtain ⟨caller, hcaller, hrole, hann⟩ :=
+              ih (pending.erase c) (seen ++ [r]) hsplit.2 hroles' hseen' row hrest callId key hkind
+            exact ⟨caller, hshift caller hcaller, hrole, hann⟩
+      | assistantToolCalls S =>
+          have hsplit :=
+            (PromptAssembly.activeBlockValidFrom_cons_assistant r rest pending S hk).mp hblock
+          rcases List.mem_cons.mp hmem with hEq | hrest
+          · subst hEq
+            rw [hk] at hkind
+            exact absurd hkind (by simp)
+          · have hseen' : ∀ c' ∈ S, ∃ caller, caller ∈ seen ++ [r] ∧
+                caller.role = .assistant ∧
+                ∃ T, caller.kind = .assistantToolCalls T ∧ c' ∈ T := by
+              intro c' hc'
+              exact ⟨r, List.mem_append_right _ (List.mem_cons_self _ _),
+                hroles r (List.mem_cons_self _ _) S hk, S, hk, hc'⟩
+            obtain ⟨caller, hcaller, hrole, hann⟩ :=
+              ih S (seen ++ [r]) hsplit.2 hroles' hseen' row hrest callId key hkind
+            exact ⟨caller, hshift caller hcaller, hrole, hann⟩
+      | ordinary =>
+          have hsplit := (PromptAssembly.activeBlockValidFrom_cons_ordinary r rest pending hk).mp
+            hblock
+          rcases List.mem_cons.mp hmem with hEq | hrest
+          · subst hEq
+            rw [hk] at hkind
+            exact absurd hkind (by simp)
+          · have hseen' : ∀ c' ∈ (∅ : Finset ToolExecution.ToolCallId),
+                ∃ caller, caller ∈ seen ++ [r] ∧ caller.role = .assistant ∧
+                  ∃ T, caller.kind = .assistantToolCalls T ∧ c' ∈ T := by
+              intro c' hc'
+              exact absurd hc' (Finset.not_mem_empty c')
+            obtain ⟨caller, hcaller, hrole, hann⟩ :=
+              ih ∅ (seen ++ [r]) hsplit.2 hroles' hseen' row hrest callId key hkind
+            exact ⟨caller, hshift caller hcaller, hrole, hann⟩
+
+theorem activeBlockValid_pairs_closed {l : List MessageRow}
+    (hblock : ActiveBlockValid l) (hroles : PromptView.AnnouncementsAreAssistant l) :
+    PromptView.PairsClosedInMessages l := by
+  intro row hmem callId key hkind
+  have h := activeBlockValidFrom_pairs_closed_aux l ∅ [] hblock hroles
+    (fun c hc => absurd hc (Finset.not_mem_empty c)) row hmem callId key hkind
+  simpa using h
+
+/-- **Pair closure over the real reducer.** Dropping at a pending-empty index of
+a provider-valid transcript cannot orphan a tool result. -/
+theorem drop_pairs_closed_of_pending_empty {msgs : List MessageRow} {n : Nat}
+    (hblock : ActiveBlockValid msgs)
+    (hroles : PromptView.AnnouncementsAreAssistant msgs)
+    (hpend : pendingAfter ∅ (msgs.take n) = ∅) :
+    PromptView.PairsClosedInMessages (msgs.drop n) := by
+  have hblock' : ActiveBlockValid (msgs.drop n) := by
+    have h := activeBlockValidFrom_append (msgs.take n) (msgs.drop n) ∅
+      (by rw [List.take_append_drop]; exact hblock)
+    rwa [hpend] at h
+  exact activeBlockValid_pairs_closed hblock' (announcementsAreAssistant_drop n hroles)
+
+theorem drop_blockValid_of_pending_empty {msgs : List MessageRow} {n : Nat}
+    (hblock : ActiveBlockValid msgs) (hpend : pendingAfter ∅ (msgs.take n) = ∅) :
+    ActiveBlockValid (msgs.drop n) := by
+  have h := activeBlockValidFrom_append (msgs.take n) (msgs.drop n) ∅
+    (by rw [List.take_append_drop]; exact hblock)
+  rwa [hpend] at h
+
+/-! ## The reducer -/
+
+open Classical in
+/-- Retain the tail from the pair-safe boundary and record a summary handle for
+everything dropped. Identity below the gate (nothing to summarize) and identity
+while the modelled `safeToReduce` gate is closed. -/
+noncomputable def summarize (policy : SplitPolicy) (handle : SummaryHandle) :
+    TranscriptReducer := fun v =>
+  if 0 < pairSafeBoundary v.messages (policy v.messages) ∧ PromptView.safeToReduce v then
+    { v with
+      messages := v.messages.drop (pairSafeBoundary v.messages (policy v.messages))
+      summary := some handle }
+  else v
+
+theorem summarize_messages_suffix (policy : SplitPolicy) (handle : SummaryHandle)
+    (v : PromptView) : (summarize policy handle v).messages <:+ v.messages := by
+  unfold summarize
+  split
+  · exact List.drop_suffix _ _
+  · exact List.suffix_refl _
+
+theorem summarize_sessionId (policy : SplitPolicy) (handle : SummaryHandle) (v : PromptView) :
+    (summarize policy handle v).sessionId = v.sessionId := by
+  unfold summarize; split <;> rfl
+
+theorem summarize_coherent (policy : SplitPolicy) (handle : SummaryHandle) (v : PromptView)
+    (h : PromptView.ViewCoherent v) : PromptView.ViewCoherent (summarize policy handle v) := by
+  unfold summarize
+  split
+  · refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    · exact drop_pairs_closed_of_pending_empty h.blockValid h.announcementsAssistant
+        (pairSafeBoundary_pending_empty _ _)
+    · exact strictlyIncreasing_drop _ _ h.ordered
+    · exact uniqueSequences_of_strictlyIncreasing (strictlyIncreasing_drop _ _ h.ordered)
+    · exact drop_blockValid_of_pending_empty h.blockValid (pairSafeBoundary_pending_empty _ _)
+    · exact announcementsAreAssistant_drop _ h.announcementsAssistant
+  · exact h
+
+noncomputable instance instIsValidReducerSummarize (policy : SplitPolicy)
+    (handle : SummaryHandle) : IsValidReducer (summarize policy handle) where
+  gate v := 0 < pairSafeBoundary v.messages (policy v.messages)
+  decGate v := Nat.decLt _ _
+  preservesCoherent := summarize_coherent policy handle
+  preservesOrder := by
+    intro v h
+    unfold summarize
+    split
+    · exact strictlyIncreasing_drop _ _ h
+    · exact h
+  preservesSession := summarize_sessionId policy handle
+  identityBelowGate := by
+    intro v hgate
+    unfold summarize
+    rw [if_neg (fun hc => hgate hc.1)]
+  identityUnlessSafe := by
+    intro v hsafe
+    unfold summarize
+    rw [if_neg (fun hc => hsafe hc.2)]
+
+/-! ## Why the boundary retreat is load-bearing -/
+
+/-- The unadjusted budget index is unsound: it can land between an assistant
+announcement and its result, orphaning the result in the retained tail.
+
+This is the counterexample the acceptance criterion asks for — reverting
+`pairSafeBoundary` in production must fail a proof, and this is the proof that
+depends on it. -/
+theorem raw_split_can_orphan :
+    ∃ (msgs : List MessageRow) (k : Nat),
+      ActiveBlockValid msgs ∧
+        PromptView.AnnouncementsAreAssistant msgs ∧
+        PromptView.PairsClosedInMessages msgs ∧
+        ¬ PromptView.PairsClosedInMessages (msgs.drop k) := by
+  refine ⟨[⟨0, 0, 0, .assistant, .assistantToolCalls {1}⟩,
+           ⟨1, 0, 1, .user, .toolResult 1 ⟨0, 0, 0⟩⟩], 1, ?_, ?_, ?_, ?_⟩
+  · refine ⟨rfl, ?_⟩
+    refine ⟨by decide, ?_⟩
+    simp [ActiveBlockValidFrom]
+  · intro row hmem callIds hkind
+    rcases List.mem_cons.mp hmem with hEq | hmem
+    · subst hEq; rfl
+    · rcases List.mem_cons.mp hmem with hEq | hmem
+      · subst hEq; exact absurd hkind (by simp)
+      · exact absurd hmem (List.not_mem_nil _)
+  · intro row hmem callId key hkind
+    rcases List.mem_cons.mp hmem with hEq | hmem
+    · subst hEq; exact absurd hkind (by simp)
+    · rcases List.mem_cons.mp hmem with hEq | hmem
+      · subst hEq
+        have hinj : MessageKind.toolResult 1 (⟨0, 0, 0⟩ : ToolResultKey)
+            = .toolResult callId key := hkind
+        injection hinj with hcEq _
+        subst hcEq
+        exact ⟨⟨0, 0, 0, .assistant, .assistantToolCalls {1}⟩, List.mem_cons_self _ _, rfl,
+          {1}, rfl, by decide⟩
+      · exact absurd hmem (List.not_mem_nil _)
+  · intro hclosed
+    obtain ⟨caller, hmem, hrole, _⟩ :=
+      hclosed ⟨1, 0, 1, .user, .toolResult 1 ⟨0, 0, 0⟩⟩ (by simp) 1 ⟨0, 0, 0⟩ rfl
+    have : caller = ⟨1, 0, 1, .user, .toolResult 1 ⟨0, 0, 0⟩⟩ := by simpa using hmem
+    subst this
+    exact absurd hrole (by decide)
+
+end Compaction

--- a/crates/gents/proofs/Proofs/Compaction/Transition.lean
+++ b/crates/gents/proofs/Proofs/Compaction/Transition.lean
@@ -1,101 +1,49 @@
 import Proofs.Compaction.State
 
+/-!
+# What makes a transcript reducer valid
+
+`preservesCoherent` replaced a pair of narrower fields (`preservesPairs`,
+`reapplyPreservesCoh`) when the real `summarize` reducer was modelled (#993).
+Pair closure of a compacted transcript is not preserved by an arbitrary drop —
+it needs the provider-validity and role structure the runtime maintains, which
+now live in `ViewCoherent`. Carrying whole-view coherence through the reducer is
+both stronger and simpler than carrying pair closure alone, and re-application
+coherence falls out of it rather than being asserted separately.
+
+`Proofs/Compaction/Properties.lean` re-derives the old theorem names from it.
+-/
+
 namespace Compaction
 
 abbrev TranscriptReducer := PromptView → PromptView
 
 class IsValidReducer (r : TranscriptReducer) where
-  gate                : PromptView → Prop
-  decGate             : ∀ v, Decidable (gate v)
-  preservesPairs      : ∀ v,
-                          PromptView.PairsClosedInMessages v.messages →
-                          PromptView.PairsClosedInMessages (r v).messages
-  preservesOrder      : ∀ v,
-                          Transcript.StrictlyIncreasingMessages v.messages →
-                          Transcript.StrictlyIncreasingMessages (r v).messages
-  preservesSession    : ∀ v, (r v).sessionId = v.sessionId
-  identityBelowGate   : ∀ v, ¬ gate v → r v = v
-  identityUnlessSafe  : ∀ v, ¬ PromptView.safeToReduce v → r v = v
-  reapplyPreservesCoh : ∀ v, PromptView.ViewCoherent v →
-                          PromptView.ViewCoherent (r (r v))
+  gate              : PromptView → Prop
+  decGate           : ∀ v, Decidable (gate v)
+  preservesCoherent : ∀ v, PromptView.ViewCoherent v → PromptView.ViewCoherent (r v)
+  preservesOrder    : ∀ v,
+                        Transcript.StrictlyIncreasingMessages v.messages →
+                        Transcript.StrictlyIncreasingMessages (r v).messages
+  preservesSession  : ∀ v, (r v).sessionId = v.sessionId
+  identityBelowGate : ∀ v, ¬ gate v → r v = v
+  identityUnlessSafe : ∀ v, ¬ PromptView.safeToReduce v → r v = v
 
 end Compaction
 
 namespace Compaction
 
-open Transcript (MessageKind)
-
-def stubMessageKind : MessageKind → MessageKind
-  | .toolResult callId key => .toolResult callId key
-  | .assistantToolCalls callIds => .assistantToolCalls callIds
-  | .ordinary => .ordinary
-
-theorem stubMessageKind_id (k : MessageKind) : stubMessageKind k = k := by
-  cases k <;> rfl
-
-def stubMessageRow (row : Transcript.MessageRow) : Transcript.MessageRow :=
-  { row with kind := stubMessageKind row.kind }
-
-theorem stubMessageRow_id (row : Transcript.MessageRow) :
-    stubMessageRow row = row := by
-  simp [stubMessageRow, stubMessageKind_id]
-
-def stubMessages : List Transcript.MessageRow → List Transcript.MessageRow :=
-  List.map stubMessageRow
-
-theorem stubMessages_id (msgs : List Transcript.MessageRow) :
-    stubMessages msgs = msgs := by
-  unfold stubMessages
-  rw [show stubMessageRow = id from funext stubMessageRow_id]
-  exact List.map_id msgs
-
-def stripToolResultsReducer : TranscriptReducer := fun v =>
-  { v with messages := stubMessages v.messages }
-
-theorem stripToolResultsReducer_id (v : PromptView) :
-    stripToolResultsReducer v = v := by
-  unfold stripToolResultsReducer
-  simp [stubMessages_id]
-
-instance instIsValidReducerStrip : IsValidReducer stripToolResultsReducer where
-  gate                := fun _ => True
-  decGate             := fun _ => .isTrue trivial
-  preservesPairs      := by
-                          intro v h
-                          rw [stripToolResultsReducer_id]
-                          exact h
-  preservesOrder      := by
-                          intro v h
-                          rw [stripToolResultsReducer_id]
-                          exact h
-  preservesSession    := by
-                          intro v
-                          rw [stripToolResultsReducer_id]
-  identityBelowGate   := by
-                          intro v h
-                          exact absurd trivial h
-  identityUnlessSafe  := by
-                          intro v _
-                          exact stripToolResultsReducer_id v
-  reapplyPreservesCoh := by
-                          intro v h
-                          rw [stripToolResultsReducer_id, stripToolResultsReducer_id]
-                          exact h
-
-end Compaction
-
-namespace Compaction
-
+/-- The degenerate reducer. Legitimate: it is what every valid reducer becomes
+below its gate. -/
 def identityReducer : TranscriptReducer := fun v => v
 
 instance instIsValidReducerIdentity : IsValidReducer identityReducer where
-  gate                := fun _ => False
-  decGate             := fun _ => .isFalse (fun h => h)
-  preservesPairs      := fun _ h => h
-  preservesOrder      := fun _ h => h
-  preservesSession    := fun _ => rfl
-  identityBelowGate   := fun _ _ => rfl
-  identityUnlessSafe  := fun _ _ => rfl
-  reapplyPreservesCoh := fun _ h => h
+  gate               := fun _ => False
+  decGate            := fun _ => .isFalse (fun h => h)
+  preservesCoherent  := fun _ h => h
+  preservesOrder     := fun _ h => h
+  preservesSession   := fun _ => rfl
+  identityBelowGate  := fun _ _ => rfl
+  identityUnlessSafe := fun _ _ => rfl
 
 end Compaction

--- a/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
@@ -71,6 +71,9 @@ def boundaryPromptAssemblyProviderInputSanitizationId : String :=
 def boundaryCompactionSafeToReduceSessionScopeId : String :=
   "boundary.compaction.safe-to-reduce-session-scope"
 
+def boundaryCompactionUniqueCallIdsCheckedId : String :=
+  "boundary.compaction.unique-call-ids-checked"
+
 def boundaryModelNatTypedIdsTimeId : String :=
   "boundary.model.nat-typed-ids-time"
 
@@ -227,6 +230,16 @@ def boundaries : List Boundary :=
         some "A row whose request has no AgentResponse row at all (a crashed run) reads unsafe in the model but safe under the session check. sanitize_history_for_provider already removes half-turns from crashed runs — an unpaired call or an orphaned result never reaches compaction's input — so what survives is a complete turn, which is safe to summarize."
     , acceptedFollowUp :=
         some "Per-message request_id linkage would close the gap exactly; it requires widening session::load_history's return shape and every caller."
+    }
+  , { id := boundaryCompactionUniqueCallIdsCheckedId
+    , domain := "Compaction"
+    , subject := "UniqueCallIds is checked, not structural"
+    , statement :=
+        "providerView_append and the compacted-prefix correspondence assume PromptAssembly.UniqueCallIds. That is a hypothesis, not a structural guarantee: tool-call ids come from the provider and no ingestion path enforces uniqueness across a session. dropUnpairedCalls credits an announcement from the globally resolved set, so a later turn reusing an id resurrects an earlier unpaired announcement and shifts the prefix under an already-stored count — Compaction.reused_call_id_breaks_prefix_stability exhibits it. agent/daemon/request.rs therefore verifies compaction::has_unique_call_ids over the provider view before compacting and skips reduction when it fails."
+    , acceptedFailureMode :=
+        some "A session whose provider reuses call ids stops compacting: the prompt grows until the request fails on context overflow rather than silently dropping rows that were never summarized. Counts already stored before a reuse appeared are still applied to a prefix that reuse may have shifted; the post-drop sanitize keeps the provider view valid, so the residual harm is bounded to context skew."
+    , acceptedFollowUp :=
+        some "Turn-scoped pair matching in dropUnpairedCalls — crediting an announcement only from the result block that immediately follows it — would make sanitize local and discharge UniqueCallIds entirely. That changes PromptAssembly.sanitize and its soundness/idempotence/fixpoint proofs (#448 territory), so it is tracked separately rather than folded into #993."
     }
   , { id := boundaryModelNatTypedIdsTimeId
     , domain := "CoreTypes"

--- a/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
@@ -68,6 +68,9 @@ def boundaryStreamingResponseIdleTimeoutDeadlineId : String :=
 def boundaryPromptAssemblyProviderInputSanitizationId : String :=
   "boundary.prompt-assembly.provider-input-sanitization"
 
+def boundaryCompactionSafeToReduceSessionScopeId : String :=
+  "boundary.compaction.safe-to-reduce-session-scope"
+
 def boundaryModelNatTypedIdsTimeId : String :=
   "boundary.model.nat-typed-ids-time"
 
@@ -214,6 +217,16 @@ def boundaries : List Boundary :=
     , subject := "provider input sanitization"
     , statement :=
         "Durable transcripts may contain unpaired assistant tool-call rows while tool execution is interrupted, failed, or in flight; provider sends must narrow loaded history through sanitize_history_for_provider so no dangling tool call reaches the backend."
+    }
+  , { id := boundaryCompactionSafeToReduceSessionScopeId
+    , domain := "Compaction"
+    , subject := "safeToReduce resolver scope"
+    , statement :=
+        "PromptView.safeToReduce requires every retained tool-result row to carry a known terminal response status. Rust resolves this at session scope: compaction::safe_to_reduce is the modelled predicate and is what the conformance case drives, while agent/daemon/request.rs backs it with a single non-terminal-AgentResponse query rather than per-message request_id linkage. All-terminal at session scope implies terminal for every row, so the refinement can only err toward unsafe, whose cost is a skipped compaction retried on the next request."
+    , acceptedFailureMode :=
+        some "A row whose request has no AgentResponse row at all (a crashed run) reads unsafe in the model but safe under the session check. sanitize_history_for_provider already removes half-turns from crashed runs — an unpaired call or an orphaned result never reaches compaction's input — so what survives is a complete turn, which is safe to summarize."
+    , acceptedFollowUp :=
+        some "Per-message request_id linkage would close the gap exactly; it requires widening session::load_history's return shape and every caller."
     }
   , { id := boundaryModelNatTypedIdsTimeId
     , domain := "CoreTypes"

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/ClientRuntime.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/ClientRuntime.lean
@@ -98,7 +98,10 @@ def compactionReducerCaseJson (witness : Compaction.CompactionReducerCase) : Str
     ++ "\"gate_open\":" ++ boolString witness.gateOpen ++ ","
     ++ "\"safe_to_reduce\":" ++ boolString witness.safeToReduce ++ ","
     ++ "\"reducer_is_identity\":"
-      ++ boolString witness.reducerIsIdentity
+      ++ boolString witness.reducerIsIdentity ++ ","
+    ++ "\"split_index\":" ++ toString witness.splitIndex ++ ","
+    ++ "\"safe_boundary\":" ++ toString witness.safeBoundary ++ ","
+    ++ "\"retained_count\":" ++ toString witness.retainedCount
     ++ "}"
 
 def recoverySweepCaseJson (witness : RecoverySweepCase) : String :=

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -957,6 +957,11 @@ def followUpHookCoverage : List CoverageEntry :=
       "Compaction.safeToReduce.sessionScopeResolver"
       boundaryCompactionSafeToReduceSessionScopeId)
       "compaction" [Surface.agentFacing]
+  , tagged (boundaryCoverage
+      "follow_up_hook"
+      "Compaction.providerViewAppend.uniqueCallIdsChecked"
+      boundaryCompactionUniqueCallIdsCheckedId)
+      "compaction" [Surface.agentFacing]
   , tagged (followUpCoverage
       "follow_up_hook"
       "PromptAssembly.Template.system_render_stable"

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -952,6 +952,11 @@ def followUpHookCoverage : List CoverageEntry :=
       "PromptAssembly.providerInput.sanitizeLoadedHistory"
       boundaryPromptAssemblyProviderInputSanitizationId)
       "compaction" [Surface.agentFacing]
+  , tagged (boundaryCoverage
+      "follow_up_hook"
+      "Compaction.safeToReduce.sessionScopeResolver"
+      boundaryCompactionSafeToReduceSessionScopeId)
+      "compaction" [Surface.agentFacing]
   , tagged (followUpCoverage
       "follow_up_hook"
       "PromptAssembly.Template.system_render_stable"

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -169,6 +169,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Background/` | Subagent/background bridge model: `BridgedState` (parent/child composed pair, `SecondLeg` subagent-vs-tool vocabulary), six bridge transitions, completion-notification/continuation composition, and property modules (B1/B2 projection, B3/B3′ cascade/detach, B4 depth, B5 link symmetry, B6 foreground blocking, B7 budget, INV-UNIQUE, delegation graph) |
 | `Proofs/Recovery/` | Recovery sweep contracts (`RecoverySweep`, outcome accounting #693, equivalence-to-uninterrupted), the registered sweep registry, and per-collection sweeps including subagent liveness (#465) and the startup restart-disposition classifier (#937) |
 | `Proofs/Session/` | Session queue model: queue sources (`background_completion`, steering), coalesce policy/keys, automated wake-up drain |
+| `Proofs/Compaction/` | Transcript reduction (#993): the payload-stubbing `strip`, the canonical `providerView = sanitize ∘ strip` with `strip_sanitize_commute` and idempotence, prefix stability under append and the compacted-prefix index correspondence, and the `summarize` reducer parameterised over the production split policy with pair closure proven over it. Fences: `tests/conformance/streaming_compaction.rs`. |
 | `Proofs/Properties/Safety.lean` | Request/process/persistence safety properties S1-S6 |
 | `Proofs/Properties/Liveness.lean` | Request/process liveness properties L1-L3 |
 | `Proofs/Properties/SchedulingSafety.lean` | Scheduler/fleet safety properties S7-S9 |
@@ -744,6 +745,50 @@ Model → conformance → Rust bindings:
 - **Cross-node subagent completion/cancel** — `tla/SubagentCompletion.tla`
   and `tla/SubagentCancelPropagation.tla` (subagent lane only; native tool
   backgrounding is single-node and carried by Lean).
+
+### Compaction
+
+`Proofs/Compaction` models transcript reduction — the one place where the
+durable transcript and the provider view diverge on purpose, and therefore the
+place where "everything persisted can be projected back out" is most at risk.
+
+Before #993 the model was vacuous: `stubMessageKind` was literally
+`| .toolResult callId key => .toolResult callId key`, so every preservation
+property quantified over `id` and proved that doing nothing preserves meaning.
+The current model quantifies over the production policy:
+
+- **`strip`** rewrites a tool result's payload into a pointer stub and touches
+  nothing else — never a constructor, never a call id. `strip_idempotent` is
+  earned by production recognizing an existing stub rather than re-stubbing it.
+- **`providerView = sanitize ∘ strip`** is the single narrowing both the
+  compaction writer and the request reader index.
+  `strip_sanitize_commute` settles the question #993 raised as unproven —
+  stripping first does *not* change which pairs `sanitize` considers orphaned —
+  and settling it affirmatively is what licenses reordering the compacted-prefix
+  drop past sanitization.
+- **`providerView_append`** proves the provider view of a longer history begins
+  with the provider view of the shorter one, given the suffix contributes no
+  result for a call announced in the prefix. Two checkable sufficient conditions
+  are provided; production satisfies the second, since a new request appends its
+  user prompt before anything else. `compacted_prefix_correspondence` is the
+  theorem the runtime fix rests on: the count the writer records names exactly
+  the rows the reader drops.
+- **`summarize`** is parameterised over the token-budget split index rather than
+  pinning a token function — what must hold is that *whatever* index the budget
+  picks, the reducer stays sound. `pairSafeBoundary` retreats that index to the
+  nearest turn boundary, and `raw_split_can_orphan` witnesses that the retreat is
+  load-bearing: an unadjusted split leaves a tool result whose call was dropped.
+
+`IsValidReducer` carries whole-view coherence (`preservesCoherent`) rather than
+pair closure alone, and `ViewCoherent` includes provider-validity and the
+assistant-role structure of announcements. Pair closure of a compacted
+transcript is not preserved by an arbitrary drop; the previous, narrower fields
+sufficed only because the modelled reducer was `id`.
+
+The runtime counterpart of `safeToReduce` is `compaction::safe_to_reduce`,
+resolved at session scope — see
+`boundary.compaction.safe-to-reduce-session-scope` for the refinement and its
+accepted failure mode.
 
 ### Client Turn Projection
 

--- a/crates/gents/src/agent/daemon/request.rs
+++ b/crates/gents/src/agent/daemon/request.rs
@@ -72,14 +72,24 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                         compacted_message_count = tracing::field::Empty,
                     ))
                     .await?;
-                // Drop in the space the count was measured in. The writer's
-                // boundary is always `pair_safe_boundary`, so the drop lands on
-                // a turn boundary and the tail is still provider-valid — no
-                // re-sanitizing needed (`Compaction.drop_preserves_providerValid`).
-                let mut history = drop_compacted_prefix(
+                // Drop in the space the count was measured in.
+                //
+                // Re-narrowing afterwards is provably free for counts this
+                // runtime wrote — their boundary is always `pair_safe_boundary`,
+                // so the drop lands on a turn boundary and the tail is already
+                // provider-valid (`Compaction.sanitize_drop_noop`). It is not
+                // free for counts written *before* the pair-safe splitter
+                // existed: those used an arbitrary budget index and carry no
+                // version marker, so an upgraded session can drop into the
+                // middle of a turn. Without this the orphan would reach
+                // `compact()`, which re-normalizes its input and would then
+                // record its count in a shifted space — reopening the very
+                // accounting defect this change closes, for exactly the sessions
+                // that predate it.
+                let mut history = compaction::sanitize_history_for_provider(drop_compacted_prefix(
                     provider_history,
                     total_compacted_messages(&compaction_entries),
-                );
+                ));
                 let mut summaries = compaction_entries
                     .into_iter()
                     .map(|entry| compaction::bounded_summary(entry.summary))
@@ -128,7 +138,25 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                             "compaction skipped: a response in this session is still streaming"
                         );
                     }
-                    gate_open
+                    // `Compaction.providerView_append` — the theorem that lets a
+                    // recorded count still name the same rows once the
+                    // transcript grows — assumes `UniqueCallIds`. Call ids come
+                    // from the provider and nothing enforces that, so it is
+                    // checked rather than assumed: a reused id resurrects an
+                    // earlier unpaired announcement and shifts the prefix under
+                    // the stored count
+                    // (`Compaction.reused_call_id_breaks_prefix_stability`).
+                    let unique_call_ids = compaction::has_unique_call_ids(&history);
+                    if gate_open && !unique_call_ids {
+                        tracing::warn!(
+                            request_id = %request.request_id,
+                            session_id = %request.session_id,
+                            behavior_id = %behavior_name,
+                            "compaction skipped: a tool-call id is announced by more than one turn, \
+                             so a recorded compacted-prefix count would not stay valid"
+                        );
+                    }
+                    gate_open && unique_call_ids
                 } else {
                     false
                 };

--- a/crates/gents/src/agent/daemon/request.rs
+++ b/crates/gents/src/agent/daemon/request.rs
@@ -46,8 +46,11 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                         history_message_count = tracing::field::Empty,
                     ))
                     .await?;
-                let (stripped_history, file_activity) =
-                    compaction::strip_tool_results(full_history);
+                // One canonical reduction, shared with the compaction writer:
+                // `messages_compacted` is measured against this list, so the
+                // prefix drop below must index the same one (#993).
+                let (provider_history, file_activity) =
+                    compaction::provider_view(full_history);
                 if !file_activity.is_empty() {
                     tracing::debug!(
                         behavior_id = %self.behavior.behavior_id,
@@ -69,11 +72,14 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                         compacted_message_count = tracing::field::Empty,
                     ))
                     .await?;
-                let history = drop_compacted_prefix(
-                    stripped_history,
+                // Drop in the space the count was measured in. The writer's
+                // boundary is always `pair_safe_boundary`, so the drop lands on
+                // a turn boundary and the tail is still provider-valid — no
+                // re-sanitizing needed (`Compaction.drop_preserves_providerValid`).
+                let mut history = drop_compacted_prefix(
+                    provider_history,
                     total_compacted_messages(&compaction_entries),
                 );
-                let mut history = compaction::sanitize_history_for_provider(history);
                 let mut summaries = compaction_entries
                     .into_iter()
                     .map(|entry| compaction::bounded_summary(entry.summary))
@@ -93,12 +99,40 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                     .await?;
                 built.estimated_tokens =
                     built.estimated_tokens.saturating_add(skill_reminder_tokens);
-                if prompt_exceeds_compaction_threshold(
+                let over_threshold = prompt_exceeds_compaction_threshold(
                     built.estimated_tokens,
                     &request.content,
                     self.behavior.context_window,
                     self.behavior.compaction_threshold,
-                ) {
+                );
+                // Runtime counterpart of Lean `PromptView.safeToReduce`,
+                // resolved at session scope: while any response in this session
+                // is still streaming, a turn is still being written into the
+                // transcript and must not be summarized away. All-terminal at
+                // session scope implies terminal for every row, so this can only
+                // err toward skipping a compaction the next request retries
+                // (`boundary.compaction.safe-to-reduce-session-scope`, #993).
+                let may_reduce = if over_threshold {
+                    let live_response =
+                        session::session_has_live_response(&self.node, &request.session_id).await?;
+                    let gate_open = if live_response {
+                        compaction::safe_to_reduce(&history, &compaction::NoneKnown)
+                    } else {
+                        compaction::safe_to_reduce(&history, &compaction::AllTerminal)
+                    };
+                    if !gate_open {
+                        tracing::info!(
+                            request_id = %request.request_id,
+                            session_id = %request.session_id,
+                            behavior_id = %behavior_name,
+                            "compaction skipped: a response in this session is still streaming"
+                        );
+                    }
+                    gate_open
+                } else {
+                    false
+                };
+                if may_reduce {
                     let result = admission::scope_call(
                         CallKind::Compaction,
                         1,

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -97,15 +97,16 @@ impl<M: CompletionModel + 'static> Compactor for DefraCompactor<M> {
     ) -> Result<CompactionResult> {
         let original_token_estimate = estimate_message_tokens(&messages);
 
-        let (stripped_messages, stripped_activity) = match options.strategy {
-            CompactionStrategy::StripToolResults | CompactionStrategy::StripThenSummarize => {
-                strip_tool_results(messages)
-            }
-            CompactionStrategy::Summarize => {
-                let activity = extract_file_activity(&messages);
-                (messages, activity)
-            }
-        };
+        // Normalize to the canonical provider view so `messages_compacted`
+        // indexes the same list `drop_compacted_prefix` will later index,
+        // whoever the caller is. Idempotent, so this is a no-op when the caller
+        // already passed a provider view — which the daemon always does.
+        //
+        // This makes `CompactionStrategy::Summarize` and `StripThenSummarize`
+        // behave identically. They already did on the daemon path, which strips
+        // unconditionally before calling here; the variant is retained for
+        // config compatibility.
+        let (stripped_messages, stripped_activity) = provider_view(messages);
 
         let stripped_token_estimate = estimate_message_tokens(&stripped_messages);
         if matches!(options.strategy, CompactionStrategy::StripToolResults)
@@ -201,6 +202,107 @@ pub fn sanitize_history_for_provider(messages: Vec<Message>) -> Vec<Message> {
     history::normalize_assistant_content_order(history::drop_unpaired_tool_calls(
         history::drop_orphaned_tool_results(messages),
     ))
+}
+
+/// The single canonical narrowing from the durable transcript to the provider
+/// view: stub tool-result payloads, then drop unpaired calls and orphaned
+/// results and normalize assistant content order.
+///
+/// Both sides of compaction's prefix accounting index *this* list. The
+/// compaction writer records `messages_compacted` against it and the request
+/// reader drops that many rows from it; measuring in one space and dropping in
+/// another was defect 3 of #993.
+///
+/// Modelled as `Compaction.providerView`, proven idempotent by
+/// `Compaction.providerView_idempotent` — which is what lets [`Compactor::compact`]
+/// re-normalize its own input for free.
+pub fn provider_view(messages: Vec<Message>) -> (Vec<Message>, FileActivity) {
+    let (stripped, activity) = strip_tool_results(messages);
+    (sanitize_history_for_provider(stripped), activity)
+}
+
+/// Greatest `j <= limit` at which no tool call is awaiting its result — the
+/// index [`Compactor::compact`] retreats its token-budget split to.
+///
+/// Re-exported so the generated conformance cases can check the production
+/// boundary against `Compaction.pairSafeBoundary`.
+pub fn pair_safe_boundary(messages: &[Message], limit: usize) -> usize {
+    history::pair_safe_boundary(messages, limit)
+}
+
+/// Mirror of Lean `StreamingResponse.Status`, with the same terminal partition,
+/// so generated conformance cases can be fed straight in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseStatus {
+    Streaming,
+    Complete,
+    Error,
+}
+
+impl ResponseStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Complete | Self::Error)
+    }
+
+    pub fn from_defra(value: &str) -> Option<Self> {
+        match value {
+            "streaming" => Some(Self::Streaming),
+            "complete" => Some(Self::Complete),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
+/// Resolves the streaming status of the response that produced a message.
+pub trait ResponseStatusIndex {
+    fn status_of(&self, message: &Message) -> Option<ResponseStatus>;
+}
+
+/// Every response in scope is terminal.
+pub struct AllTerminal;
+
+impl ResponseStatusIndex for AllTerminal {
+    fn status_of(&self, _message: &Message) -> Option<ResponseStatus> {
+        Some(ResponseStatus::Complete)
+    }
+}
+
+/// No status is known — the conservative resolution when anything in scope is
+/// still streaming.
+pub struct NoneKnown;
+
+impl ResponseStatusIndex for NoneKnown {
+    fn status_of(&self, _message: &Message) -> Option<ResponseStatus> {
+        None
+    }
+}
+
+/// Runtime counterpart of Lean `PromptView.safeToReduce`: a transcript may only
+/// be reduced when every tool result it retains belongs to a response whose
+/// status is known and terminal. Reducing under a live response can summarize
+/// away a turn that is still being written.
+///
+/// See `boundary.compaction.safe-to-reduce-session-scope` for how the daemon
+/// resolves statuses at session scope rather than per message.
+pub fn safe_to_reduce(messages: &[Message], statuses: &impl ResponseStatusIndex) -> bool {
+    messages.iter().all(|message| {
+        if !carries_tool_result(message) {
+            return true;
+        }
+        statuses
+            .status_of(message)
+            .is_some_and(ResponseStatus::is_terminal)
+    })
+}
+
+fn carries_tool_result(message: &Message) -> bool {
+    let Message::User { content } = message else {
+        return false;
+    };
+    content
+        .iter()
+        .any(|item| matches!(item, crate::llm::message::UserContent::ToolResult(_)))
 }
 
 pub fn bounded_summary(summary: String) -> String {

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -230,6 +230,19 @@ pub fn pair_safe_boundary(messages: &[Message], limit: usize) -> usize {
     history::pair_safe_boundary(messages, limit)
 }
 
+/// The real split [`Compactor::compact`] performs: everything before the
+/// boundary is summarized, everything from it is retained.
+///
+/// Exported so the generated conformance cases can sweep budgets against the
+/// live splitter rather than only against [`pair_safe_boundary`] — otherwise a
+/// change that stopped *calling* the boundary would slip through.
+pub fn split_for_summary(
+    messages: Vec<Message>,
+    keep_recent_tokens: usize,
+) -> (Vec<Message>, Vec<Message>) {
+    history::split_messages_for_summary(messages, keep_recent_tokens)
+}
+
 /// Mirror of Lean `StreamingResponse.Status`, with the same terminal partition,
 /// so generated conformance cases can be fed straight in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -106,10 +106,31 @@ impl<M: CompletionModel + 'static> Compactor for DefraCompactor<M> {
         // behave identically. They already did on the daemon path, which strips
         // unconditionally before calling here; the variant is retained for
         // config compatibility.
+        let row_count = messages.len();
         let (stripped_messages, stripped_activity) = provider_view(messages);
 
+        // `messages_compacted` is an *index* into this list, so normalization
+        // removing rows means the caller did not hand us a provider view and any
+        // count taken here would be measured in a shifted space — silently
+        // dropping rows the reader never summarized. Refuse loudly instead.
+        //
+        // For a provider view this is unreachable
+        // (`Compaction.providerView_idempotent`). It is a real guard for legacy
+        // compaction entries whose boundary predates the pair-safe splitter, and
+        // for any future caller passing a raw transcript.
+        let normalization_removed_rows = stripped_messages.len() != row_count;
+        if normalization_removed_rows {
+            tracing::warn!(
+                row_count,
+                normalized_count = stripped_messages.len(),
+                "compaction skipped: input was not a provider view, so a compacted-prefix \
+                 count taken here would not name the rows the next request drops"
+            );
+        }
+
         let stripped_token_estimate = estimate_message_tokens(&stripped_messages);
-        if matches!(options.strategy, CompactionStrategy::StripToolResults)
+        if normalization_removed_rows
+            || matches!(options.strategy, CompactionStrategy::StripToolResults)
             || !needs_compaction(&stripped_messages, context_window, options.threshold)
         {
             return Ok(CompactionResult {
@@ -307,6 +328,51 @@ pub fn safe_to_reduce(messages: &[Message], statuses: &impl ResponseStatusIndex)
             .status_of(message)
             .is_some_and(ResponseStatus::is_terminal)
     })
+}
+
+/// Runtime counterpart of Lean `PromptAssembly.UniqueCallIds`: no tool-call id
+/// is announced by more than one assistant message.
+///
+/// This is a *hypothesis* of the prefix-stability theorem, not a structural
+/// guarantee — call ids come from the provider, and nothing in the ingestion
+/// path enforces uniqueness across a session. `sanitize_history_for_provider`
+/// credits an announcement from the globally resolved set, so a later turn that
+/// reuses an id resurrects an earlier announcement the shorter view had dropped
+/// as unpaired. The prefix then changes under append and a stored
+/// `messages_compacted` no longer names the rows it was measured against.
+/// `Compaction.reused_call_id_breaks_prefix_stability` exhibits exactly that.
+///
+/// Checking it here turns the theorem's hypothesis into a precondition the
+/// runtime verifies before recording a count. See
+/// `boundary.compaction.unique-call-ids-checked` for the residual gap and the
+/// follow-up that would remove the need for the check.
+pub fn has_unique_call_ids(messages: &[Message]) -> bool {
+    let mut announced: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for message in messages {
+        let Message::Assistant { content, .. } = message else {
+            continue;
+        };
+        // Per-message first: Lean models a turn's ids as a `Finset`, so a repeat
+        // *within* one announcement collapses rather than conflicting.
+        let this_turn: std::collections::HashSet<String> = content
+            .iter()
+            .filter_map(|item| match item {
+                crate::llm::message::AssistantContent::ToolCall(tool_call) => Some(
+                    tool_call
+                        .call_id
+                        .clone()
+                        .unwrap_or_else(|| tool_call.id.clone()),
+                ),
+                _ => None,
+            })
+            .collect();
+        for call_id in this_turn {
+            if !announced.insert(call_id) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 fn carries_tool_result(message: &Message) -> bool {

--- a/crates/gents/src/compaction/history.rs
+++ b/crates/gents/src/compaction/history.rs
@@ -8,9 +8,9 @@ use super::summary::dedupe_paths;
 use super::{estimate_message_tokens, FileActivity};
 
 pub(super) fn strip_tool_results(messages: Vec<Message>) -> (Vec<Message>, FileActivity) {
+    let file_activity = extract_file_activity(&messages);
     let mut stripped_messages = Vec::with_capacity(messages.len());
     let mut tool_calls = HashMap::new();
-    let mut file_activity = FileActivity::default();
 
     for message in messages {
         match message {
@@ -29,10 +29,7 @@ pub(super) fn strip_tool_results(messages: Vec<Message>) -> (Vec<Message>, FileA
 
                 for item in content.iter() {
                     if let AssistantContent::ToolCall(tool_call) = item {
-                        let key = tool_call_key(tool_call);
-                        let info = ToolCallInfo::from(tool_call);
-                        push_file_activity(&mut file_activity, &info);
-                        tool_calls.insert(key, info);
+                        tool_calls.insert(tool_call_key(tool_call), ToolCallInfo::from(tool_call));
                     }
                 }
 
@@ -57,8 +54,6 @@ pub(super) fn strip_tool_results(messages: Vec<Message>) -> (Vec<Message>, FileA
         }
     }
 
-    dedupe_paths(&mut file_activity.files_read);
-    dedupe_paths(&mut file_activity.files_modified);
     (stripped_messages, file_activity)
 }
 
@@ -302,16 +297,48 @@ pub(super) fn pair_safe_boundary(messages: &[Message], limit: usize) -> usize {
     }
 }
 
+/// File activity credited only to tool calls that actually produced a result.
+///
+/// Classifying from the call alone recorded writes that never happened: a call
+/// whose result never arrived because the turn was interrupted or the run
+/// crashed still counted as a modification. These lists are persisted on
+/// `AgentCompactionEntry` and rendered into later prompts, so a false "Files
+/// modified" entry injects state the run never produced. Dry runs are excluded
+/// at classification time — see [`ToolCallInfo::from`].
+///
+/// A failed call that *did* return an error result is still credited: tool
+/// results carry no error flag (`gents_protocol::message::ToolResult`), so
+/// there is nothing reliable to test. That is a known over-credit, narrower
+/// than the previous one.
 pub(super) fn extract_file_activity(messages: &[Message]) -> FileActivity {
     let mut activity = FileActivity::default();
+    let mut pending: HashMap<String, ToolCallInfo> = HashMap::new();
+
     for message in messages {
-        if let Message::Assistant { content, .. } = message {
-            for item in content.iter() {
-                if let AssistantContent::ToolCall(tool_call) = item {
-                    let info = ToolCallInfo::from(tool_call);
-                    push_file_activity(&mut activity, &info);
+        match message {
+            Message::Assistant { content, .. } => {
+                let opens_turn = content
+                    .iter()
+                    .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+                if opens_turn {
+                    pending.clear();
+                }
+                for item in content.iter() {
+                    if let AssistantContent::ToolCall(tool_call) = item {
+                        pending.insert(tool_call_key(tool_call), ToolCallInfo::from(tool_call));
+                    }
                 }
             }
+            Message::User { content } => {
+                for item in content.iter() {
+                    if let UserContent::ToolResult(tool_result) = item {
+                        if let Some(info) = pending.get(&tool_result_key(tool_result)) {
+                            push_file_activity(&mut activity, info);
+                        }
+                    }
+                }
+            }
+            Message::System { .. } => {}
         }
     }
 
@@ -350,35 +377,75 @@ fn floor_char_boundary(text: &str, mut index: usize) -> usize {
 }
 
 /// Head and tail of every stub this module writes.
-///
-/// Recognizing an existing stub is what makes `strip_tool_results` idempotent.
-/// Without it a second pass re-measures the stub and reports *its* length
-/// instead of the tool's — and the request path really does strip twice, once
-/// in `agent/daemon/request.rs` and again inside `compact()`, so after a
-/// compaction the model was being told the wrong byte count.
 const STUB_HEAD: &str = "[tool: ";
 const STUB_TAIL: &str = "see DefraDB AgentToolCall for full output]";
+const STUB_JOIN: &str = " — ";
+const STUB_TRUNCATED: &str = ", truncated";
 
 /// Markers the truncation layer itself writes (`truncation::logic`,
 /// `truncation::spill`). Matching these exactly replaces a `contains("truncated")`
 /// sniff that fired on any tool output happening to mention the word.
 const TRUNCATION_MARKERS: [&str; 2] = ["[Full output: DefraDB doc ", "[Showing lines "];
 
-fn tool_result_is_stub(tool_result: &ToolResult) -> bool {
-    matches!(
-        tool_result.content.as_slice(),
-        [ToolResultContent::Text(text)]
-            if text.text.starts_with(STUB_HEAD) && text.text.ends_with(STUB_TAIL)
-    )
+/// Facts a previously written stub carries, recovered so that re-stubbing
+/// reproduces it exactly.
+struct StubFacts {
+    byte_count: usize,
+    truncated: bool,
 }
 
+/// Recover the byte count and truncation flag from stub-shaped text.
+///
+/// Shape recognition is a *hint*, never a licence to skip the rewrite: tool
+/// output is arbitrary text and a command or MCP server can return something
+/// with this shape. Misreading such a result costs a wrong byte count in the
+/// stub; skipping the rewrite would let its entire payload survive every
+/// provider-view pass, which is the thing compaction exists to prevent.
+fn parse_stub(tool_result: &ToolResult) -> Option<StubFacts> {
+    let [ToolResultContent::Text(text)] = tool_result.content.as_slice() else {
+        return None;
+    };
+    let body = text
+        .text
+        .strip_prefix(STUB_HEAD)?
+        .strip_suffix(STUB_TAIL)?
+        .strip_suffix(STUB_JOIN)?;
+    let (body, truncated) = match body.strip_suffix(STUB_TRUNCATED) {
+        Some(head) => (head, true),
+        None => (body, false),
+    };
+    let byte_count = body
+        .rsplit_once(", ")?
+        .1
+        .strip_suffix(" bytes")?
+        .parse()
+        .ok()?;
+    Some(StubFacts {
+        byte_count,
+        truncated,
+    })
+}
+
+/// Replace a tool result's payload with a pointer stub.
+///
+/// Always rewrites. When the input is already a stub the facts are recovered
+/// rather than re-measured, which makes the rewrite a fixed point — production's
+/// half of `Compaction.strip_idempotent`. The request path really does strip
+/// twice, once in `agent/daemon/request.rs` and again inside `compact()`, and
+/// before this the second pass re-measured the stub and reported *its* length
+/// instead of the tool's.
 fn strip_tool_result(
     mut tool_result: ToolResult,
     tool_calls: &HashMap<String, ToolCallInfo>,
 ) -> ToolResult {
-    if tool_result_is_stub(&tool_result) {
-        return tool_result;
-    }
+    let existing = parse_stub(&tool_result);
+    let byte_count = existing
+        .as_ref()
+        .map_or_else(|| tool_result_byte_count(&tool_result), |it| it.byte_count);
+    let truncated = existing.as_ref().map_or_else(
+        || tool_result_was_truncated(&tool_result),
+        |it| it.truncated,
+    );
 
     let call_id = tool_result_key(&tool_result);
     let info = tool_calls.get(&call_id);
@@ -390,15 +457,11 @@ fn strip_tool_result(
         .and_then(|info| info.file_path.as_deref())
         .map(|path| format!("({path})"))
         .unwrap_or_default();
-    let byte_count = tool_result_byte_count(&tool_result);
-    let truncated = if tool_result_was_truncated(&tool_result) {
-        ", truncated"
-    } else {
-        ""
-    };
+    let truncated = if truncated { STUB_TRUNCATED } else { "" };
 
     let stub = format!(
-        "[tool: {tool_name}{argument}, call_id: {call_id}, {byte_count} bytes{truncated} — {STUB_TAIL}"
+        "{STUB_HEAD}{tool_name}{argument}, call_id: {call_id}, \
+         {byte_count} bytes{truncated}{STUB_JOIN}{STUB_TAIL}"
     );
     tool_result.content = vec![ToolResultContent::Text(Text { text: stub })];
     tool_result
@@ -466,15 +529,7 @@ struct ToolCallInfo {
 pub(super) fn is_read_tool(name: &str) -> bool {
     matches!(
         name,
-        "read_file"
-            | "list_files"
-            | "glob"
-            | "grep"
-            | "read"
-            | "cat"
-            | "search"
-            | "find"
-            | "query"
+        "read_file" | "list_files" | "glob" | "grep" | "read" | "cat" | "search" | "find" | "query"
     )
 }
 
@@ -488,18 +543,25 @@ pub(super) fn is_write_tool(name: &str) -> bool {
 
 impl From<&ToolCall> for ToolCallInfo {
     fn from(tool_call: &ToolCall) -> Self {
-        let file_path = tool_call
-            .function
-            .arguments
+        let arguments = &tool_call.function.arguments;
+        let file_path = arguments
             .get("file_path")
-            .or_else(|| tool_call.function.arguments.get("path"))
+            .or_else(|| arguments.get("path"))
             .and_then(|value| value.as_str())
             .map(ToOwned::to_owned);
         let name = tool_call.function.name.clone();
+        // `edit_file` previews a diff and writes nothing under `dry_run`, so it
+        // must not be reported as a modification — it did read the file, which
+        // is what it gets credited for instead.
+        let dry_run = arguments
+            .get("dry_run")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let writes = is_write_tool(&name);
 
         Self {
-            is_read: is_read_tool(&name),
-            is_write: is_write_tool(&name),
+            is_read: is_read_tool(&name) || (writes && dry_run),
+            is_write: writes && !dry_run,
             name,
             file_path,
         }

--- a/crates/gents/src/compaction/history.rs
+++ b/crates/gents/src/compaction/history.rs
@@ -15,6 +15,18 @@ pub(super) fn strip_tool_results(messages: Vec<Message>) -> (Vec<Message>, FileA
     for message in messages {
         match message {
             Message::Assistant { id, content } => {
+                // Scope the lookup to the turn being opened. Call ids are
+                // provider-generated and can repeat across turns, so a stale
+                // entry could label a later stub with the wrong tool. Only an
+                // assistant message that actually announces calls opens a new
+                // turn — a text-only one must not orphan the pending lookups.
+                let opens_turn = content
+                    .iter()
+                    .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+                if opens_turn {
+                    tool_calls.clear();
+                }
+
                 for item in content.iter() {
                     if let AssistantContent::ToolCall(tool_call) = item {
                         let key = tool_call_key(tool_call);
@@ -216,6 +228,23 @@ pub(super) fn split_messages_for_summary(
         break;
     }
 
+    // The token budget can land the boundary between an assistant message
+    // carrying a ToolCall and the user message carrying its ToolResult. Left
+    // alone, the call is summarized away while the result stays in the retained
+    // tail, and `sanitize_history_for_provider` then drops the orphaned result
+    // at loop entry — the tool's output is lost from the provider view entirely
+    // while the summary describes only the call.
+    //
+    // Retreat to the nearest turn boundary. Moving *earlier* over-retains by at
+    // most one turn and never loses context; moving later would summarize a turn
+    // the budget wanted kept. For provider-input assembly, over-retaining is the
+    // correct failure direction.
+    //
+    // Modelled as `Compaction.pairSafeBoundary`, with
+    // `Compaction.raw_split_can_orphan` witnessing that the unadjusted index is
+    // unsound.
+    let split_index = pair_safe_boundary(&messages, split_index);
+
     if split_index == 0 {
         return (Vec::new(), messages);
     }
@@ -223,6 +252,54 @@ pub(super) fn split_messages_for_summary(
     let old_messages = messages[..split_index].to_vec();
     let recent_messages = messages[split_index..].to_vec();
     (old_messages, recent_messages)
+}
+
+/// Greatest `j <= limit` at which no tool call is awaiting its result.
+///
+/// Mirrors `Compaction.pairSafeBoundary` and the pending-set discipline in
+/// [`drop_orphaned_tool_results`]: an assistant message replaces the pending set
+/// with its own call ids, a tool result erases one, and anything else clears it.
+pub(super) fn pair_safe_boundary(messages: &[Message], limit: usize) -> usize {
+    let limit = limit.min(messages.len());
+    let mut pending: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut boundary = 0usize;
+
+    for (index, message) in messages.iter().take(limit).enumerate() {
+        if pending.is_empty() {
+            boundary = index;
+        }
+        match message {
+            Message::Assistant { content, .. } => {
+                pending = content
+                    .iter()
+                    .filter_map(|item| match item {
+                        AssistantContent::ToolCall(tool_call) => Some(tool_call_key(tool_call)),
+                        _ => None,
+                    })
+                    .collect();
+            }
+            Message::User { content } => {
+                let has_plain_content = content
+                    .iter()
+                    .any(|item| !matches!(item, UserContent::ToolResult(_)));
+                for item in content.iter() {
+                    if let UserContent::ToolResult(tool_result) = item {
+                        pending.remove(&tool_result_key(tool_result));
+                    }
+                }
+                if has_plain_content {
+                    pending.clear();
+                }
+            }
+            Message::System { .. } => pending.clear(),
+        }
+    }
+
+    if pending.is_empty() {
+        limit
+    } else {
+        boundary
+    }
 }
 
 pub(super) fn extract_file_activity(messages: &[Message]) -> FileActivity {
@@ -246,10 +323,14 @@ pub(super) fn extract_file_activity(messages: &[Message]) -> FileActivity {
 fn truncate_tool_result_content(content: ToolResultContent, max_chars: usize) -> ToolResultContent {
     match content {
         ToolResultContent::Text(text) if text.text.len() > max_chars => {
+            // `max_chars` is a byte budget but tool output is arbitrary UTF-8,
+            // so slicing at that index panics whenever it lands inside a
+            // codepoint. Floor to the nearest boundary.
+            let cut = floor_char_boundary(&text.text, max_chars);
             let truncated = format!(
                 "{}… [pre-truncated {}/{} chars for compaction]",
-                &text.text[..max_chars],
-                max_chars,
+                &text.text[..cut],
+                cut,
                 text.text.len()
             );
             ToolResultContent::Text(Text { text: truncated })
@@ -258,27 +339,67 @@ fn truncate_tool_result_content(content: ToolResultContent, max_chars: usize) ->
     }
 }
 
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+/// Head and tail of every stub this module writes.
+///
+/// Recognizing an existing stub is what makes `strip_tool_results` idempotent.
+/// Without it a second pass re-measures the stub and reports *its* length
+/// instead of the tool's — and the request path really does strip twice, once
+/// in `agent/daemon/request.rs` and again inside `compact()`, so after a
+/// compaction the model was being told the wrong byte count.
+const STUB_HEAD: &str = "[tool: ";
+const STUB_TAIL: &str = "see DefraDB AgentToolCall for full output]";
+
+/// Markers the truncation layer itself writes (`truncation::logic`,
+/// `truncation::spill`). Matching these exactly replaces a `contains("truncated")`
+/// sniff that fired on any tool output happening to mention the word.
+const TRUNCATION_MARKERS: [&str; 2] = ["[Full output: DefraDB doc ", "[Showing lines "];
+
+fn tool_result_is_stub(tool_result: &ToolResult) -> bool {
+    matches!(
+        tool_result.content.as_slice(),
+        [ToolResultContent::Text(text)]
+            if text.text.starts_with(STUB_HEAD) && text.text.ends_with(STUB_TAIL)
+    )
+}
+
 fn strip_tool_result(
     mut tool_result: ToolResult,
     tool_calls: &HashMap<String, ToolCallInfo>,
 ) -> ToolResult {
+    if tool_result_is_stub(&tool_result) {
+        return tool_result;
+    }
+
     let call_id = tool_result_key(&tool_result);
-    let tool_name = tool_calls
-        .get(&call_id)
-        .map(|info| info.name.as_str())
-        .unwrap_or("unknown");
+    let info = tool_calls.get(&call_id);
+    let tool_name = info.map_or("unknown", |info| info.name.as_str());
+    // The primary path argument is already extracted for `FileActivity`.
+    // Carrying it turns the stub from "a file was read" into "this file was
+    // read", which is most of what a pointer stub exists to do.
+    let argument = info
+        .and_then(|info| info.file_path.as_deref())
+        .map(|path| format!("({path})"))
+        .unwrap_or_default();
     let byte_count = tool_result_byte_count(&tool_result);
-    let truncated = tool_result_was_truncated(&tool_result);
-    let stub = if truncated {
-        format!(
-            "[tool: {tool_name}, call_id: {call_id}, {byte_count} bytes, truncated — see DefraDB AgentToolCall for full output]"
-        )
+    let truncated = if tool_result_was_truncated(&tool_result) {
+        ", truncated"
     } else {
-        format!(
-            "[tool: {tool_name}, call_id: {call_id}, {byte_count} bytes — see DefraDB AgentToolCall for full output]"
-        )
+        ""
     };
 
+    let stub = format!(
+        "[tool: {tool_name}{argument}, call_id: {call_id}, {byte_count} bytes{truncated} — {STUB_TAIL}"
+    );
     tool_result.content = vec![ToolResultContent::Text(Text { text: stub })];
     tool_result
 }
@@ -296,11 +417,9 @@ fn tool_result_byte_count(tool_result: &ToolResult) -> usize {
 
 fn tool_result_was_truncated(tool_result: &ToolResult) -> bool {
     tool_result.content.iter().any(|content| match content {
-        ToolResultContent::Text(text) => {
-            text.text.contains("[Full output: DefraDB doc")
-                || text.text.contains("Showing lines")
-                || text.text.contains("truncated")
-        }
+        ToolResultContent::Text(text) => TRUNCATION_MARKERS
+            .iter()
+            .any(|marker| text.text.contains(marker)),
         _ => false,
     })
 }
@@ -337,6 +456,36 @@ struct ToolCallInfo {
     is_write: bool,
 }
 
+/// Tools whose calls mean "this path was read".
+///
+/// The first group is the registered native file tools (`toolset/file_tools.rs`);
+/// the second is the generic names MCP servers commonly use. Keep this in sync
+/// with the tool registry — `every_registered_file_tool_is_classified` fails if
+/// a file tool is added without a classification, which would silently empty the
+/// compaction summary's file lists.
+pub(super) fn is_read_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "read_file"
+            | "list_files"
+            | "glob"
+            | "grep"
+            | "read"
+            | "cat"
+            | "search"
+            | "find"
+            | "query"
+    )
+}
+
+/// Tools whose calls mean "this path was modified".
+pub(super) fn is_write_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "write_file" | "edit_file" | "write" | "edit" | "replace" | "apply_patch"
+    )
+}
+
 impl From<&ToolCall> for ToolCallInfo {
     fn from(tool_call: &ToolCall) -> Self {
         let file_path = tool_call
@@ -349,11 +498,8 @@ impl From<&ToolCall> for ToolCallInfo {
         let name = tool_call.function.name.clone();
 
         Self {
-            is_read: matches!(
-                name.as_str(),
-                "read" | "cat" | "grep" | "search" | "find" | "query"
-            ),
-            is_write: matches!(name.as_str(), "write" | "edit" | "replace" | "apply_patch"),
+            is_read: is_read_tool(&name),
+            is_write: is_write_tool(&name),
             name,
             file_path,
         }

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -947,6 +947,139 @@ fn compacted_prefix_is_counted_and_dropped_in_the_same_space() {
 }
 
 #[test]
+fn legacy_counts_can_drop_mid_turn_and_must_be_re_narrowed() {
+    // Counts written before the pair-safe splitter used an arbitrary budget
+    // index and carry no version marker, so an upgraded session can drop
+    // between an assistant ToolCall and its ToolResult. Left alone the orphan
+    // reaches compact(), which re-normalizes its input and would record its
+    // next count in a shifted space — the accounting defect, reopened for
+    // exactly the sessions that predate the fix.
+    let history = vec![
+        text_msg("user", "first"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+        text_msg("assistant", "done"),
+    ];
+    let (view, _) = provider_view(history);
+
+    // A legacy count of 2 lands between the call and its result.
+    let legacy = 2usize;
+    assert_ne!(
+        super::history::pair_safe_boundary(&view, legacy),
+        legacy,
+        "the fixture must actually straddle a turn, or this proves nothing"
+    );
+
+    let dropped = view.iter().skip(legacy).cloned().collect::<Vec<_>>();
+    assert!(
+        !pair_closed_messages(&dropped),
+        "dropping at a legacy boundary orphans the result"
+    );
+
+    let repaired = sanitize_history_for_provider(dropped);
+    assert!(
+        pair_closed_messages(&repaired),
+        "re-narrowing after the drop must remove the orphan"
+    );
+
+    // And it is a no-op at a boundary this runtime would have written.
+    let safe = super::history::pair_safe_boundary(&view, legacy);
+    let safe_tail = view.into_iter().skip(safe).collect::<Vec<_>>();
+    assert_eq!(
+        sanitize_history_for_provider(safe_tail.clone()),
+        safe_tail,
+        "Compaction.sanitize_drop_noop: free for counts this runtime writes"
+    );
+}
+
+fn pair_closed_messages(messages: &[Message]) -> bool {
+    let announced = messages
+        .iter()
+        .flat_map(|message| match message {
+            Message::Assistant { content, .. } => content
+                .iter()
+                .filter_map(|item| match item {
+                    AssistantContent::ToolCall(tool_call) => Some(
+                        tool_call
+                            .call_id
+                            .clone()
+                            .unwrap_or_else(|| tool_call.id.clone()),
+                    ),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        })
+        .collect::<std::collections::HashSet<_>>();
+    messages.iter().all(|message| match message {
+        Message::User { content } => content.iter().all(|item| match item {
+            UserContent::ToolResult(tool_result) => announced.contains(
+                &tool_result
+                    .call_id
+                    .clone()
+                    .unwrap_or_else(|| tool_result.id.clone()),
+            ),
+            _ => true,
+        }),
+        _ => true,
+    })
+}
+
+#[test]
+fn reused_call_ids_are_detected() {
+    let unique = vec![
+        tool_call_msg("read_file", r#"{"path": "/a.rs"}"#),
+        tool_result_msg("call-1", "a"),
+    ];
+    assert!(has_unique_call_ids(&unique));
+
+    // The same id announced by two different turns: a later result resurrects
+    // the earlier announcement in the provider view, shifting a stored prefix
+    // count. `Compaction.reused_call_id_breaks_prefix_stability` is the model's
+    // version of this.
+    let reused = vec![
+        tool_call_msg("read_file", r#"{"path": "/a.rs"}"#),
+        text_msg("user", "next turn"),
+        tool_call_msg("read_file", r#"{"path": "/b.rs"}"#),
+        tool_result_msg("call-1", "b"),
+    ];
+    assert!(!has_unique_call_ids(&reused));
+}
+
+#[test]
+fn reused_call_ids_really_do_shift_the_provider_view_prefix() {
+    // The concrete harm the check exists to prevent, in runtime terms.
+    let prefix = vec![
+        tool_call_msg("read_file", r#"{"path": "/a.rs"}"#),
+        text_msg("user", "next turn"),
+    ];
+    let suffix = vec![
+        tool_call_msg("read_file", r#"{"path": "/b.rs"}"#),
+        tool_result_msg("call-1", "b"),
+    ];
+
+    let (short_view, _) = provider_view(prefix.clone());
+    let mut whole = prefix;
+    whole.extend(suffix);
+    let (long_view, _) = provider_view(whole);
+
+    assert_eq!(
+        short_view.len(),
+        1,
+        "the unpaired announcement is dropped while nothing resolves it"
+    );
+    assert_ne!(
+        long_view
+            .iter()
+            .take(short_view.len())
+            .cloned()
+            .collect::<Vec<_>>(),
+        short_view,
+        "reuse resurrects the earlier announcement, so the prefix is not stable"
+    );
+}
+
+#[test]
 fn safe_to_reduce_requires_every_retained_tool_result_to_be_terminal() {
     let messages = vec![
         text_msg("user", "go"),

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -613,7 +613,7 @@ fn strip_rewrites_tool_results_into_stubs() {
     let long_result = "x".repeat(5000);
     let messages = vec![
         text_msg("user", "read this file"),
-        tool_call_msg("read", r#"{"file_path": "/tmp/test.rs"}"#),
+        tool_call_msg("read_file", r#"{"path": "/tmp/test.rs"}"#),
         tool_result_msg("call-1", &long_result),
         text_msg("assistant", "I saw the file"),
     ];
@@ -622,23 +622,11 @@ fn strip_rewrites_tool_results_into_stubs() {
     assert_eq!(stripped.len(), 4);
     assert_eq!(files.files_read, vec!["/tmp/test.rs"]);
     assert!(files.files_modified.is_empty());
-
-    if let Message::User { content } = &stripped[2] {
-        if let UserContent::ToolResult(tr) = first_content(content) {
-            if let ToolResultContent::Text(text) = first_content(&tr.content) {
-                assert_eq!(
-                    text.text,
-                    "[tool: read, call_id: call-1, 5000 bytes — see DefraDB AgentToolCall for full output]"
-                );
-            } else {
-                panic!("expected text content");
-            }
-        } else {
-            panic!("expected tool result");
-        }
-    } else {
-        panic!("expected user message");
-    }
+    assert_eq!(
+        sole_tool_result_text(&stripped[2]),
+        "[tool: read_file(/tmp/test.rs), call_id: call-1, 5000 bytes \
+         — see DefraDB AgentToolCall for full output]"
+    );
 }
 
 #[test]
@@ -653,6 +641,261 @@ fn strip_extracts_read_and_modified_files() {
     let (_, files) = strip_tool_results(messages);
     assert_eq!(files.files_read, vec!["/src/main.rs"]);
     assert_eq!(files.files_modified, vec!["/src/lib.rs"]);
+}
+
+fn sole_tool_result_text(message: &Message) -> String {
+    let Message::User { content } = message else {
+        panic!("expected user message");
+    };
+    let UserContent::ToolResult(tool_result) = first_content(content) else {
+        panic!("expected tool result");
+    };
+    let ToolResultContent::Text(text) = first_content(&tool_result.content) else {
+        panic!("expected text content");
+    };
+    text.text.clone()
+}
+
+#[test]
+fn strip_is_idempotent_and_preserves_the_original_byte_count() {
+    let long_result = "x".repeat(5000);
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/tmp/test.rs"}"#),
+        tool_result_msg("call-1", &long_result),
+    ];
+
+    let (once, _) = strip_tool_results(messages);
+    let (twice, _) = strip_tool_results(once.clone());
+
+    assert_eq!(once, twice, "strip must be idempotent");
+    let stub = sole_tool_result_text(&twice[1]);
+    assert!(
+        stub.contains("5000 bytes"),
+        "reapplying strip must not re-measure the stub: {stub}"
+    );
+}
+
+#[test]
+fn strip_marks_already_truncated_output_without_sniffing_the_word() {
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "echo hi"}"#),
+        tool_result_msg("call-1", "the build log says truncated somewhere"),
+    ];
+    let (stripped, _) = strip_tool_results(messages);
+    assert!(
+        !sole_tool_result_text(&stripped[1]).contains(", truncated"),
+        "ordinary output mentioning the word must not be flagged as truncated"
+    );
+
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "echo hi"}"#),
+        tool_result_msg("call-1", "output\n[Full output: DefraDB doc bafy123]"),
+    ];
+    let (stripped, _) = strip_tool_results(messages);
+    assert!(sole_tool_result_text(&stripped[1]).contains(", truncated"));
+}
+
+#[test]
+fn pretruncation_does_not_panic_on_a_multibyte_boundary() {
+    // "é" is two bytes, so byte 2000 lands inside a codepoint.
+    let payload = format!("{}é{}", "a".repeat(1999), "b".repeat(500));
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "cat notes"}"#),
+        tool_result_msg("call-1", &payload),
+    ];
+    let truncated = super::history::pretruncate_tool_results(messages, 2000);
+    assert!(sole_tool_result_text(&truncated[1]).contains("pre-truncated"));
+}
+
+#[test]
+fn file_activity_classifies_the_registered_file_tools() {
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+        tool_call_msg("write_file", r#"{"path": "/src/lib.rs"}"#),
+        tool_result_msg("call-1", "ok"),
+        tool_call_msg("edit_file", r#"{"path": "/src/edit.rs"}"#),
+        tool_result_msg("call-1", "ok"),
+        tool_call_msg("grep", r#"{"path": "/src/grep.rs"}"#),
+        tool_result_msg("call-1", "hit"),
+        tool_call_msg("glob", r#"{"path": "/src/glob.rs"}"#),
+        tool_result_msg("call-1", "hit"),
+        tool_call_msg("list_files", r#"{"path": "/src/list.rs"}"#),
+        tool_result_msg("call-1", "hit"),
+    ];
+
+    let (_, files) = strip_tool_results(messages);
+    assert_eq!(
+        files.files_read,
+        vec![
+            "/src/glob.rs",
+            "/src/grep.rs",
+            "/src/list.rs",
+            "/src/main.rs"
+        ]
+    );
+    assert_eq!(files.files_modified, vec!["/src/edit.rs", "/src/lib.rs"]);
+}
+
+#[test]
+fn every_registered_file_tool_is_classified() {
+    // Guards against a file tool being added to toolset::file_tools without a
+    // matching classification here, which would silently empty the compaction
+    // summary's file lists — the defect this test exists to keep from recurring.
+    for name in ["read_file", "list_files", "glob", "grep"] {
+        assert!(
+            super::history::is_read_tool(name),
+            "{name} is not classified as a read tool"
+        );
+    }
+    for name in ["write_file", "edit_file"] {
+        assert!(
+            super::history::is_write_tool(name),
+            "{name} is not classified as a write tool"
+        );
+    }
+}
+
+#[test]
+fn split_never_separates_a_tool_call_from_its_result() {
+    // A budget that retains roughly the last message would land the boundary
+    // between the assistant tool call and the user tool result.
+    let messages = vec![
+        text_msg("user", &"a".repeat(4000)),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    let (old, recent) = super::history::split_messages_for_summary(messages, 40);
+
+    assert_eq!(old.len(), 1, "only the bulky user turn should be summarized");
+    assert_eq!(
+        recent.len(),
+        2,
+        "the assistant turn and its result stay together"
+    );
+    assert!(
+        matches!(&recent[0], Message::Assistant { .. }),
+        "the retained tail must start at the assistant announcement"
+    );
+}
+
+#[test]
+fn pair_safe_boundary_retreats_to_the_turn_start() {
+    let messages = vec![
+        text_msg("user", "go"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    assert_eq!(super::history::pair_safe_boundary(&messages, 2), 1);
+    assert_eq!(super::history::pair_safe_boundary(&messages, 3), 3);
+    assert_eq!(super::history::pair_safe_boundary(&messages, 1), 1);
+}
+
+#[test]
+fn provider_view_is_idempotent() {
+    let history = vec![
+        tool_result_msg("orphan-1", "result with no call"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+    let (once, _) = provider_view(history);
+    let (twice, _) = provider_view(once.clone());
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn compacted_prefix_is_counted_and_dropped_in_the_same_space() {
+    // An orphaned tool result at the head: sanitize removes it, so the
+    // unsanitized and sanitized indexings of the compacted prefix diverge.
+    // Under the old order (strip -> drop -> sanitize) a count measured in the
+    // sanitized space was applied to the unsanitized one, shifting the boundary.
+    let history = vec![
+        tool_result_msg("orphan-1", "result with no call"),
+        text_msg("user", "first real turn"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+        text_msg("assistant", "done"),
+        text_msg("user", "second turn"),
+    ];
+
+    let (view, _) = provider_view(history.clone());
+    assert_eq!(
+        view.len(),
+        5,
+        "sanitize must remove the orphaned result from the view"
+    );
+
+    // Compaction summarized the first row *of the view* — a pair-safe boundary,
+    // which is the only kind the writer ever records.
+    let compacted = 1usize;
+    assert_eq!(
+        super::history::pair_safe_boundary(&view, compacted),
+        compacted,
+        "the modelled writer only ever records a pair-safe boundary"
+    );
+    let retained = view.iter().skip(compacted).cloned().collect::<Vec<_>>();
+
+    // The next request rebuilds the view from the same durable history and
+    // drops the same count. It must land on exactly the retained rows.
+    let (reread, _) = provider_view(history.clone());
+    assert_eq!(
+        reread.into_iter().skip(compacted).collect::<Vec<_>>(),
+        retained
+    );
+
+    // The old order is the defect: the count was measured against the sanitized
+    // list but applied to the unsanitized one, which still carries the orphan at
+    // index 0. Dropping one row there removes the orphan instead of the
+    // summarized turn, so "first real turn" survives verbatim alongside its own
+    // summary.
+    let (stripped, _) = strip_tool_results(history);
+    let old_order =
+        sanitize_history_for_provider(stripped.into_iter().skip(compacted).collect::<Vec<_>>());
+    assert_eq!(
+        old_order.len(),
+        retained.len() + 1,
+        "the old order retains one row too many"
+    );
+    assert_eq!(
+        old_order.first(),
+        Some(&text_msg("user", "first real turn")),
+        "and the row it retains is the one that was summarized"
+    );
+}
+
+#[test]
+fn safe_to_reduce_requires_every_retained_tool_result_to_be_terminal() {
+    let messages = vec![
+        text_msg("user", "go"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    assert!(safe_to_reduce(&messages, &AllTerminal));
+    assert!(!safe_to_reduce(&messages, &NoneKnown));
+
+    // No tool results at all: nothing to gate on.
+    let plain = vec![text_msg("user", "go"), text_msg("assistant", "ok")];
+    assert!(safe_to_reduce(&plain, &NoneKnown));
+}
+
+struct StreamingIndex;
+
+impl ResponseStatusIndex for StreamingIndex {
+    fn status_of(&self, _message: &Message) -> Option<ResponseStatus> {
+        Some(ResponseStatus::Streaming)
+    }
+}
+
+#[test]
+fn safe_to_reduce_is_closed_while_a_response_is_streaming() {
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+    assert!(!safe_to_reduce(&messages, &StreamingIndex));
 }
 
 #[test]
@@ -779,10 +1022,11 @@ async fn integration_compaction_persists_entry_and_prompt_builder_uses_it() {
     }
 
     let history = session::load_history(&node, "session-1").await.unwrap();
-    let (stripped_history, _) = strip_tool_results(history);
+    let durable_before = history.clone();
+    let (provider_history, _) = provider_view(history);
     let result = compactor
         .compact(
-            stripped_history,
+            provider_history,
             2000,
             &CompactionOptions {
                 threshold: 0.50,
@@ -816,7 +1060,19 @@ async fn integration_compaction_persists_entry_and_prompt_builder_uses_it() {
     assert!(entries[0].summary.contains("inspected the source files"));
 
     let resumed_history = session::load_history(&node, "session-1").await.unwrap();
-    let (resumed_history, _) = strip_tool_results(resumed_history);
+    // Compaction is a projection: it writes a summary entry and drops a prefix
+    // from the *provider view*. The durable AgentMessage rows that
+    // `run_timeline` reconstructs a request's event stream from must be
+    // untouched.
+    assert_eq!(
+        durable_before, resumed_history,
+        "compaction must not mutate the durable transcript the timeline is built from"
+    );
+
+    // Read side: rebuild the same provider view and drop the same count. This
+    // is the write/read correspondence — the count was measured against
+    // `provider_view` above, so it must be applied to `provider_view` here.
+    let (resumed_history, _) = provider_view(resumed_history);
     let compacted_count = entries
         .iter()
         .map(|entry| entry.messages_compacted as usize)

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -657,6 +657,34 @@ fn sole_tool_result_text(message: &Message) -> String {
 }
 
 #[test]
+fn strip_rewrites_tool_output_that_merely_looks_like_a_stub() {
+    // A command or MCP tool can return arbitrary text, including text shaped
+    // like one of our own stubs. Recognizing the shape must never license
+    // skipping the rewrite: the payload has to go regardless, or a large result
+    // would survive every provider-view pass and defeat compaction entirely.
+    let spoof = format!(
+        "[tool: read_file(/etc/passwd), call_id: call-1, 12 bytes \
+         — see DefraDB AgentToolCall for full output]{}",
+        "P".repeat(5000)
+    );
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "cat spoof"}"#),
+        tool_result_msg("call-1", &spoof),
+    ];
+
+    let (stripped, _) = strip_tool_results(messages);
+    let out = sole_tool_result_text(&stripped[1]);
+    assert!(
+        !out.contains(&"P".repeat(5000)),
+        "the payload must not survive stripping: {out}"
+    );
+    assert!(
+        out.starts_with("[tool: bash, call_id: call-1,"),
+        "the stub is rebuilt from the real call, not from the spoofed text: {out}"
+    );
+}
+
+#[test]
 fn strip_is_idempotent_and_preserves_the_original_byte_count() {
     let long_result = "x".repeat(5000);
     let messages = vec![
@@ -738,6 +766,55 @@ fn file_activity_classifies_the_registered_file_tools() {
 }
 
 #[test]
+fn dry_run_edits_are_not_recorded_as_modifications() {
+    let messages = vec![
+        tool_call_msg(
+            "edit_file",
+            r#"{"path": "/src/preview.rs", "dry_run": true}"#,
+        ),
+        tool_result_msg("call-1", "would change 3 lines"),
+    ];
+
+    let (_, files) = strip_tool_results(messages);
+    assert!(
+        files.files_modified.is_empty(),
+        "a dry run writes nothing: {:?}",
+        files.files_modified
+    );
+    assert_eq!(
+        files.files_read,
+        vec!["/src/preview.rs"],
+        "it did read the file to build the preview"
+    );
+}
+
+#[test]
+fn calls_without_a_result_are_not_recorded_as_modifications() {
+    // The turn was interrupted before the write ran: an assistant announcement
+    // with no paired result must not be persisted under "Files modified", where
+    // it would be rendered into later prompts as state the run never produced.
+    let messages = vec![
+        tool_call_msg("write_file", r#"{"path": "/src/never_written.rs"}"#),
+        text_msg("user", "actually, stop"),
+    ];
+
+    let (_, files) = strip_tool_results(messages);
+    assert!(
+        files.files_modified.is_empty(),
+        "unpaired call must not count: {:?}",
+        files.files_modified
+    );
+
+    // The same history *with* a result does count.
+    let completed = vec![
+        tool_call_msg("write_file", r#"{"path": "/src/written.rs"}"#),
+        tool_result_msg("call-1", "ok"),
+    ];
+    let (_, files) = strip_tool_results(completed);
+    assert_eq!(files.files_modified, vec!["/src/written.rs"]);
+}
+
+#[test]
 fn every_registered_file_tool_is_classified() {
     // Guards against a file tool being added to toolset::file_tools without a
     // matching classification here, which would silently empty the compaction
@@ -768,7 +845,11 @@ fn split_never_separates_a_tool_call_from_its_result() {
 
     let (old, recent) = super::history::split_messages_for_summary(messages, 40);
 
-    assert_eq!(old.len(), 1, "only the bulky user turn should be summarized");
+    assert_eq!(
+        old.len(),
+        1,
+        "only the bulky user turn should be summarized"
+    );
     assert_eq!(
         recent.len(),
         2,

--- a/crates/gents/src/lean_vocab_test/background_transcript.rs
+++ b/crates/gents/src/lean_vocab_test/background_transcript.rs
@@ -336,4 +336,7 @@ pub(crate) struct LeanCompactionReducerCase {
     pub(crate) gate_open: bool,
     pub(crate) safe_to_reduce: bool,
     pub(crate) reducer_is_identity: bool,
+    pub(crate) split_index: usize,
+    pub(crate) safe_boundary: usize,
+    pub(crate) retained_count: usize,
 }

--- a/crates/gents/src/session.rs
+++ b/crates/gents/src/session.rs
@@ -41,7 +41,7 @@ pub(crate) use history::{
     mark_response_materialized, message_sequence_for_request_content, save_message,
     save_message_with_key_and_requester_did, save_message_with_requester_did,
 };
-pub(crate) use query::load_session_behavior_id;
+pub(crate) use query::{load_session_behavior_id, session_has_live_response};
 pub use retry::count_active_sessions;
 pub(crate) use retry::execute_mutation_with_retry;
 pub use sessions::{close_session, create_session};

--- a/crates/gents/src/session/query.rs
+++ b/crates/gents/src/session/query.rs
@@ -52,6 +52,48 @@ pub(super) async fn load_session_document_optional(
     Ok(rows.pop())
 }
 
+/// Whether any `AgentResponse` in this session is still streaming.
+///
+/// Backs the session-scope resolution of the modelled `safeToReduce` gate: a
+/// live response means a turn is still being written into this session's
+/// transcript, and compaction must not summarize a half-written turn. See
+/// `boundary.compaction.safe-to-reduce-session-scope`.
+pub(crate) async fn session_has_live_response(
+    node: &EmbeddedNode,
+    session_id: &str,
+) -> Result<bool> {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(
+                filter: {{
+                    session_id: {{ _eq: "{escaped_session_id}" }},
+                    status: {{ _eq: "streaming" }}
+                }},
+                limit: 1
+            ) {{
+                response_key
+            }}
+        }}"#
+    );
+
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "loading live responses for session_id={}: {:?}",
+            session_id,
+            resp.errors
+        );
+    }
+
+    Ok(resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentResponse"))
+        .and_then(|value| value.as_array())
+        .is_some_and(|rows| !rows.is_empty()))
+}
+
 pub(crate) async fn load_session_behavior_id(
     node: &EmbeddedNode,
     session_id: &str,

--- a/crates/gents/tests/conformance.rs
+++ b/crates/gents/tests/conformance.rs
@@ -98,6 +98,8 @@ mod client_runtime;
 mod codex_shim;
 #[path = "conformance/command_policy.rs"]
 mod command_policy;
+#[path = "conformance/compaction_gate.rs"]
+mod compaction_gate;
 #[path = "conformance/completion_retry.rs"]
 mod completion_retry;
 #[path = "conformance/composed_invariants.rs"]
@@ -307,6 +309,11 @@ async fn generated_streaming_response_idle_timeout_case_drives_daemon_contract()
 #[test]
 fn generated_compaction_reducer_cases_pin_contract() {
     streaming_compaction::generated_compaction_reducer_cases_pin_contract();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compaction_gate_blocks_reduction_while_a_response_streams() {
+    compaction_gate::compaction_gate_blocks_reduction_while_a_response_streams().await;
 }
 
 #[tokio::test]

--- a/crates/gents/tests/conformance/compaction_gate.rs
+++ b/crates/gents/tests/conformance/compaction_gate.rs
@@ -1,0 +1,396 @@
+//! Fences the *wiring* of the compaction gate, not just its predicate.
+//!
+//! `streaming_compaction.rs` drives `compaction::safe_to_reduce` and
+//! `compaction::pair_safe_boundary` directly. That checks the functions agree
+//! with `Compaction.PromptView.safeToReduce` and `Compaction.pairSafeBoundary`,
+//! but it would stay green if `BehaviorDaemon::handle_request` stopped
+//! consulting the gate altogether — the same class of gap #993 was filed for,
+//! where the conformance case reimplemented the gate inside the test.
+//!
+//! This drives a real daemon. Compaction issues a sub-completion carrying
+//! `compaction_prompt()`, so the mock backend's per-marker request counter is a
+//! direct observation of whether the daemon attempted to reduce: zero while a
+//! response in the session is still streaming, non-zero once it is terminal.
+
+use super::*;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::support::fixtures::test_identity;
+use super::support::interrupt::{create_runtime_request, BootedAgent};
+use super::support::streaming_backend::{MockStreamingBackend, StreamScript};
+
+const GATE_MODEL: &str = "default";
+const GATE_BACKEND_ID: &str = "backend-compaction-gate";
+const GATE_MARKER: &str = "compaction-gate-request";
+/// A distinctive slice of `compaction::summary::compaction_prompt()`. It only
+/// ever appears in a body the compactor sent.
+const COMPACTION_MARKER: &str = "Return JSON only with keys";
+
+/// Roughly 30k estimated tokens of history — above the 20k `keep_recent_tokens`
+/// default, so `split_messages_for_summary` yields a non-empty prefix to
+/// summarize, and above the configured budget so the threshold is crossed.
+const SEEDED_TURNS: usize = 12;
+const SEEDED_TURN_BYTES: usize = 10_000;
+const GATE_CONTEXT_WINDOW: usize = 30_000;
+const GATE_COMPACTION_THRESHOLD: f64 = 0.5;
+
+pub(super) async fn compaction_gate_blocks_reduction_while_a_response_streams() {
+    let db = test_db("compaction-gate").await;
+
+    // The compaction plan must come first: the compactor's body carries both the
+    // prompt and the seeded history, and the backend picks the first plan whose
+    // marker the body contains.
+    let backend = MockStreamingBackend::start(
+        GATE_MODEL,
+        vec![
+            StreamScript::completes(
+                COMPACTION_MARKER,
+                [r#"{"summary": "earlier turns inspected files", "files_read": [], "files_modified": [], "key_decisions": [], "pending_questions": []}"#],
+            ),
+            StreamScript::completes(GATE_MARKER, ["ok"]),
+        ],
+    )
+    .expect("start mock streaming backend");
+
+    let agent = boot_compaction_gate_agent(&db, backend.endpoint()).await;
+    let session_id = format!("session-{}", uuid::Uuid::new_v4());
+    seed_bulky_history(db.node.as_ref(), &agent.agent_did, &session_id).await;
+
+    // A concurrent request in this session is mid-stream. Its half-written turn
+    // is already in the transcript we just loaded, so reducing now could
+    // summarize away a turn that is still being written.
+    let live_request_id = format!("live-{}", uuid::Uuid::new_v4());
+    upsert_response_status(
+        db.node.as_ref(),
+        &agent.agent_did,
+        &session_id,
+        &live_request_id,
+        "streaming",
+    )
+    .await;
+
+    let blocked_request_id = format!("blocked-{}", uuid::Uuid::new_v4());
+    let blocked_doc_id = create_runtime_request(
+        db.node.as_ref(),
+        agent.agent_did.as_str(),
+        AGENT_NAME,
+        &blocked_request_id,
+        &session_id,
+        GATE_MARKER,
+    )
+    .await;
+    wait_for_terminal_request(db.node.as_ref(), &blocked_doc_id).await;
+
+    assert_eq!(
+        backend.observed_requests(COMPACTION_MARKER),
+        0,
+        "the daemon must not attempt compaction while a response in this session is streaming — \
+         removing the gate from BehaviorDaemon::handle_request fails here"
+    );
+
+    // The live response terminalizes; the very next request may reduce.
+    upsert_response_status(
+        db.node.as_ref(),
+        &agent.agent_did,
+        &session_id,
+        &live_request_id,
+        "complete",
+    )
+    .await;
+
+    let allowed_request_id = format!("allowed-{}", uuid::Uuid::new_v4());
+    let allowed_doc_id = create_runtime_request(
+        db.node.as_ref(),
+        agent.agent_did.as_str(),
+        AGENT_NAME,
+        &allowed_request_id,
+        &session_id,
+        GATE_MARKER,
+    )
+    .await;
+    wait_for_terminal_request(db.node.as_ref(), &allowed_doc_id).await;
+
+    assert!(
+        backend.observed_requests(COMPACTION_MARKER) >= 1,
+        "with every response in the session terminal the gate opens and the daemon reduces; \
+         a gate that never opens would starve compaction entirely"
+    );
+
+    agent.shutdown().await;
+}
+
+async fn boot_compaction_gate_agent(db: &support::TestDb, endpoint: &str) -> BootedAgent {
+    let identity: Arc<dyn gents::AgentIdentity> = Arc::new(test_identity("compaction-gate"));
+    upsert_gate_backend(db.node.as_ref(), endpoint).await;
+
+    let agent = gents::Gents::builder()
+        .node(db.node.clone())
+        .identity(identity)
+        .default_behavior_id(AGENT_NAME)
+        .tool_ceiling(gents::ToolCeiling::meta_only())
+        .behavior(AGENT_NAME)
+        .backend_id(GATE_BACKEND_ID)
+        .model_name(GATE_MODEL)
+        .stream_batch_ms(0)
+        .context_window(GATE_CONTEXT_WINDOW)
+        .compaction_threshold(GATE_COMPACTION_THRESHOLD)
+        .done()
+        .build()
+        .await
+        .expect("build compaction-gate agent");
+    let agent_did = agent.agent_did().to_string();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let handle = tokio::spawn(agent.run(shutdown_rx));
+    wait_for_gate_runtime_ready(db.node.as_ref(), &agent_did).await;
+
+    BootedAgent::new(shutdown_tx, handle, agent_did)
+}
+
+/// Seeds turns that each carry a paired tool call and result.
+///
+/// The pairing matters: `safeToReduce` constrains *tool-result* rows, so a
+/// transcript with none is vacuously safe to reduce and the gate would never
+/// engage. The bulk lives in the surrounding text because `provider_view` stubs
+/// tool-result payloads before the threshold is measured.
+async fn seed_bulky_history(node: &EmbeddedNode, agent_did: &str, session_id: &str) {
+    let mut sequence = 0i64;
+    for turn in 0..SEEDED_TURNS {
+        let payload = "h".repeat(SEEDED_TURN_BYTES);
+        let call_id = format!("seeded-call-{turn}");
+
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "user",
+            &format!("turn {turn}: {payload}"),
+        )
+        .await;
+        sequence += 1;
+
+        let announcement = Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::ToolCall(ToolCall {
+                id: call_id.clone(),
+                call_id: Some(call_id.clone()),
+                function: ToolFunction {
+                    name: "read_file".to_string(),
+                    arguments: json!({ "path": format!("/seed/turn-{turn}.rs") }),
+                },
+                signature: None,
+                additional_params: None,
+            })],
+        };
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "assistant",
+            &serde_json::to_string(&announcement).expect("serialize announcement"),
+        )
+        .await;
+        sequence += 1;
+
+        let result = Message::User {
+            content: vec![UserContent::ToolResult(ToolResult {
+                id: call_id.clone(),
+                call_id: Some(call_id),
+                content: vec![ToolResultContent::Text(Text {
+                    text: format!("contents of turn-{turn}.rs"),
+                })],
+            })],
+        };
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "user",
+            &serde_json::to_string(&result).expect("serialize tool result"),
+        )
+        .await;
+        sequence += 1;
+
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "assistant",
+            &format!("reply {turn}: {payload}"),
+        )
+        .await;
+        sequence += 1;
+    }
+}
+
+async fn insert_message(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    session_id: &str,
+    sequence: i64,
+    role: &str,
+    content: &str,
+) {
+    let escaped_key = escape_graphql_string(&format!("{session_id}:{sequence}"));
+    let escaped_session_id = escape_graphql_string(session_id);
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let escaped_role = escape_graphql_string(role);
+    let escaped_content = escape_graphql_string(content);
+    let timestamp = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentMessage(input: {{
+                message_key: "{escaped_key}",
+                session_id: "{escaped_session_id}",
+                agent_did: "{escaped_agent_did}",
+                requester_did: "{escaped_agent_did}",
+                request_id: "",
+                sequence: {sequence},
+                role: "{escaped_role}",
+                content: "{escaped_content}",
+                timestamp: "{timestamp}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "seed AgentMessage failed: {:?}",
+        response.errors
+    );
+}
+
+async fn upsert_response_status(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    session_id: &str,
+    request_id: &str,
+    status: &str,
+) {
+    let escaped_key = escape_graphql_string(&format!("response:{request_id}"));
+    let escaped_request_id = escape_graphql_string(request_id);
+    let escaped_session_id = escape_graphql_string(session_id);
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let escaped_status = escape_graphql_string(status);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentResponse(
+                filter: {{ response_key: {{ _eq: "{escaped_key}" }} }},
+                add: {{
+                    response_key: "{escaped_key}",
+                    request_id: "{escaped_request_id}",
+                    agent_did: "{escaped_agent_did}",
+                    requester_did: "{escaped_agent_did}",
+                    behavior_id: "{AGENT_NAME}",
+                    session_id: "{escaped_session_id}",
+                    content: "partial",
+                    status: "{escaped_status}",
+                    error_message: "",
+                    token_count: 1,
+                    progress_seq: 1,
+                    created_at: "{created_at}"
+                }},
+                update: {{ status: "{escaped_status}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "upsert AgentResponse status={status} failed: {:?}",
+        response.errors
+    );
+}
+
+async fn upsert_gate_backend(node: &EmbeddedNode, endpoint: &str) {
+    let escaped_backend_id = escape_graphql_string(GATE_BACKEND_ID);
+    let escaped_endpoint = escape_graphql_string(endpoint);
+    let escaped_model_name = escape_graphql_string(GATE_MODEL);
+    let mutation = format!(
+        r#"mutation {{
+            upsert_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{escaped_backend_id}" }} }},
+                add: {{
+                    backend_id: "{escaped_backend_id}",
+                    name: "{escaped_backend_id}",
+                    provider_kind: "OpenAiCompatible",
+                    endpoint: "{escaped_endpoint}",
+                    api_key: "",
+                    api_key_env_var: "",
+                    max_concurrent: 1,
+                    max_queue_depth: 100,
+                    enabled: true,
+                    models: ["{escaped_model_name}"],
+                    probe_status: "healthy"
+                }},
+                update: {{
+                    endpoint: "{escaped_endpoint}",
+                    enabled: true,
+                    models: ["{escaped_model_name}"],
+                    probe_status: "healthy"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "upsert compaction-gate backend failed: {:?}",
+        response.errors
+    );
+}
+
+async fn wait_for_gate_runtime_ready(node: &EmbeddedNode, agent_did: &str) {
+    let started = std::time::Instant::now();
+    loop {
+        if let Some(snapshot) = support::snapshots::fetch_runtime_snapshot(node, agent_did).await {
+            if snapshot.process_state == "ready" && snapshot.reconcile_phase == "idle" {
+                return;
+            }
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "timed out waiting for compaction-gate runtime to become ready"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn wait_for_terminal_request(node: &EmbeddedNode, request_doc_id: &str) {
+    let escaped_doc_id = escape_graphql_string(request_doc_id);
+    let started = std::time::Instant::now();
+    loop {
+        let query = format!(
+            r#"{{
+                AgentRequest(filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }}, limit: 1) {{
+                    lifecycle_state
+                }}
+            }}"#
+        );
+        let response = node.execute(&query).await;
+        if let Some(row) = first_optional_row::<LifecycleStateRow>(&response, "AgentRequest") {
+            if matches!(
+                row.lifecycle_state.as_str(),
+                "completed" | "failed" | "superseded" | "dead" | "interrupted"
+            ) {
+                return;
+            }
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(60),
+            "timed out waiting for request {request_doc_id} to reach a terminal lifecycle state"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LifecycleStateRow {
+    lifecycle_state: String,
+}

--- a/crates/gents/tests/conformance/compaction_gate.rs
+++ b/crates/gents/tests/conformance/compaction_gate.rs
@@ -112,13 +112,111 @@ pub(super) async fn compaction_gate_blocks_reduction_while_a_response_streams() 
     .await;
     wait_for_terminal_request(db.node.as_ref(), &allowed_doc_id).await;
 
+    let after_allowed = backend.observed_requests(COMPACTION_MARKER);
     assert!(
-        backend.observed_requests(COMPACTION_MARKER) >= 1,
+        after_allowed >= 1,
         "with every response in the session terminal the gate opens and the daemon reduces; \
          a gate that never opens would starve compaction entirely"
     );
 
+    // A later turn reusing an earlier call id resurrects that earlier
+    // announcement in the provider view, so a count recorded now would stop
+    // naming the rows the next request drops
+    // (`Compaction.reused_call_id_breaks_prefix_stability`). The daemon must
+    // check `has_unique_call_ids` and decline rather than record a count it
+    // cannot honour.
+    seed_reused_call_id_turn(db.node.as_ref(), &agent.agent_did, &session_id).await;
+
+    let reused_request_id = format!("reused-{}", uuid::Uuid::new_v4());
+    let reused_doc_id = create_runtime_request(
+        db.node.as_ref(),
+        agent.agent_did.as_str(),
+        AGENT_NAME,
+        &reused_request_id,
+        &session_id,
+        GATE_MARKER,
+    )
+    .await;
+    wait_for_terminal_request(db.node.as_ref(), &reused_doc_id).await;
+
+    assert_eq!(
+        backend.observed_requests(COMPACTION_MARKER),
+        after_allowed,
+        "a reused tool-call id must stop the daemon reducing — removing the \
+         has_unique_call_ids check from BehaviorDaemon::handle_request fails here"
+    );
+
     agent.shutdown().await;
+}
+
+/// Appends two turns that announce the *same* call id.
+///
+/// Both live in the freshly-appended tail, so the duplicate survives wherever
+/// the compacted-prefix boundary happens to fall — reusing an id from an
+/// already-summarized turn would not, since that announcement is no longer in
+/// the view.
+async fn seed_reused_call_id_turn(node: &EmbeddedNode, agent_did: &str, session_id: &str) {
+    // Past anything the daemon has appended for the requests already run, so
+    // these turns sort last in the loaded history.
+    let mut sequence = 10_000i64;
+    let call_id = "duplicated-call".to_string();
+
+    for round in 0..2 {
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "user",
+            &format!("reuse turn {round}: {}", "r".repeat(SEEDED_TURN_BYTES)),
+        )
+        .await;
+        sequence += 1;
+
+        let announcement = Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::ToolCall(ToolCall {
+                id: call_id.clone(),
+                call_id: Some(call_id.clone()),
+                function: ToolFunction {
+                    name: "read_file".to_string(),
+                    arguments: json!({ "path": format!("/seed/reused-{round}.rs") }),
+                },
+                signature: None,
+                additional_params: None,
+            })],
+        };
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "assistant",
+            &serde_json::to_string(&announcement).expect("serialize reused announcement"),
+        )
+        .await;
+        sequence += 1;
+
+        let result = Message::User {
+            content: vec![UserContent::ToolResult(ToolResult {
+                id: call_id.clone(),
+                call_id: Some(call_id.clone()),
+                content: vec![ToolResultContent::Text(Text {
+                    text: format!("contents of reused-{round}.rs"),
+                })],
+            })],
+        };
+        insert_message(
+            node,
+            agent_did,
+            session_id,
+            sequence,
+            "user",
+            &serde_json::to_string(&result).expect("serialize reused result"),
+        )
+        .await;
+        sequence += 1;
+    }
 }
 
 async fn boot_compaction_gate_agent(db: &support::TestDb, endpoint: &str) -> BootedAgent {
@@ -236,7 +334,10 @@ async fn insert_message(
     role: &str,
     content: &str,
 ) {
-    let escaped_key = escape_graphql_string(&format!("{session_id}:{sequence}"));
+    // The daemon persists its own turns into this session while the test runs,
+    // so the key must not be derived from the sequence alone.
+    let escaped_key =
+        escape_graphql_string(&format!("{session_id}:{sequence}:{}", uuid::Uuid::new_v4()));
     let escaped_session_id = escape_graphql_string(session_id);
     let escaped_agent_did = escape_graphql_string(agent_did);
     let escaped_role = escape_graphql_string(role);

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -272,6 +272,7 @@ fn lean_boundary_metadata_is_typed_and_reviewable() {
         "boundary.fleet-slot-accounting.derived-view",
         "boundary.command-policy.host-execution-assumptions",
         "boundary.compaction.safe-to-reduce-session-scope",
+        "boundary.compaction.unique-call-ids-checked",
         "boundary.trigger.dispatch-source-delivery",
         "boundary.persistence.abstract-lifecycle",
         "boundary.storage.hook-failure-policy",

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -271,6 +271,7 @@ fn lean_boundary_metadata_is_typed_and_reviewable() {
         "boundary.inference-slots.running-row-derived",
         "boundary.fleet-slot-accounting.derived-view",
         "boundary.command-policy.host-execution-assumptions",
+        "boundary.compaction.safe-to-reduce-session-scope",
         "boundary.trigger.dispatch-source-delivery",
         "boundary.persistence.abstract-lifecycle",
         "boundary.storage.hook-failure-policy",

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -1178,7 +1178,10 @@ fn drive_compaction_reducer_case(case: &lean_vocab_test::LeanCompactionReducerCa
     // input shapes" — not "the shapes are unchanged", which only held while the
     // modelled reducer was `id`.
     assert_eq!(
-        is_subsequence(&abstract_prompt_view(&reduced), &abstract_prompt_view(&input)),
+        is_subsequence(
+            &abstract_prompt_view(&reduced),
+            &abstract_prompt_view(&input)
+        ),
         case.preserves_order,
         "{}: preserves_order",
         case.name

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -1108,7 +1108,7 @@ impl<'de> Deserialize<'de> for DocIdRow {
 
 pub(super) fn generated_compaction_reducer_cases_pin_contract() {
     let cases = lean_compaction_reducer_cases();
-    assert_eq!(cases.len(), 10);
+    assert_eq!(cases.len(), 16);
 
     let expected_names = [
         "identity_reducer_is_no_op",
@@ -1121,6 +1121,12 @@ pub(super) fn generated_compaction_reducer_cases_pin_contract() {
         "reduction_allowed_when_response_terminal",
         "no_orphaned_tool_results_after_strip",
         "reapply_preserves_view_coherent",
+        "summarize_retains_straddling_turn",
+        "summarize_drops_whole_turns",
+        "summarize_blocked_when_response_streaming",
+        "summarize_cannot_split_a_leading_turn",
+        "provider_view_is_idempotent",
+        "provider_view_drops_orphaned_result",
     ]
     .into_iter()
     .collect::<BTreeSet<_>>();
@@ -1156,13 +1162,23 @@ fn drive_compaction_reducer_case(case: &lean_vocab_test::LeanCompactionReducerCa
         case.name
     );
     assert_eq!(
+        reduced.len(),
+        case.retained_count,
+        "{}: retained_count",
+        case.name
+    );
+    assert_eq!(
         preserves_pair_closure(&input, &reduced),
         case.preserves_pairs,
         "{}: preserves_pairs",
         case.name
     );
+    // Lean's `StrictlyIncreasingMessages` survives a reducer that *drops* rows,
+    // so the runtime analogue is "the retained shapes are a subsequence of the
+    // input shapes" — not "the shapes are unchanged", which only held while the
+    // modelled reducer was `id`.
     assert_eq!(
-        abstract_prompt_view(&input) == abstract_prompt_view(&reduced),
+        is_subsequence(&abstract_prompt_view(&reduced), &abstract_prompt_view(&input)),
         case.preserves_order,
         "{}: preserves_order",
         case.name
@@ -1185,10 +1201,21 @@ fn drive_compaction_reducer_case(case: &lean_vocab_test::LeanCompactionReducerCa
 
     if case.name == "strip_is_strictly_idempotent" {
         let reapplied = gents::compaction::strip_tool_results(reduced.clone()).0;
+        // Full payload equality, not just the structural projection: production
+        // recognizes an existing stub rather than re-measuring it, which is what
+        // `Compaction.strip_idempotent` states.
         assert_eq!(
-            abstract_prompt_view(&reduced),
-            abstract_prompt_view(&reapplied),
-            "{}: strip is idempotent on the Lean structural projection",
+            reduced, reapplied,
+            "{}: strip must be idempotent on runtime payloads, not just shapes",
+            case.name
+        );
+    }
+
+    if case.name == "provider_view_is_idempotent" {
+        let reapplied = gents::compaction::provider_view(reduced.clone()).0;
+        assert_eq!(
+            reduced, reapplied,
+            "{}: provider_view must be idempotent on runtime payloads (Compaction.providerView_idempotent)",
             case.name
         );
     }
@@ -1215,11 +1242,61 @@ fn apply_compaction_reducer(
 ) -> Vec<Message> {
     match case.reducer.as_str() {
         "identity" => input,
-        "strip_tool_results" => gents::compaction::strip_tool_results(input).0,
+        "strip" => gents::compaction::strip_tool_results(input).0,
+        "provider_view" => gents::compaction::provider_view(input).0,
+        "summarize" => drive_summarize(case, input),
         "any_valid" if case.safe_to_reduce => gents::compaction::strip_tool_results(input).0,
         "any_valid" => input,
         other => panic!("unsupported compaction reducer {other:?} for {}", case.name),
     }
+}
+
+/// Drives the summarize reducer through *production*.
+///
+/// The gate and the boundary are both production's: `safe_to_reduce` and
+/// `pair_safe_boundary` are the functions under test, checked against the model
+/// rather than reimplemented here. Before #993 this case computed the gate
+/// inside the test, so the test could not detect the gate's absence from
+/// production at all.
+fn drive_summarize(
+    case: &lean_vocab_test::LeanCompactionReducerCase,
+    input: Vec<Message>,
+) -> Vec<Message> {
+    let gate_open = if case.safe_to_reduce {
+        gents::compaction::safe_to_reduce(&input, &gents::compaction::AllTerminal)
+    } else {
+        gents::compaction::safe_to_reduce(&input, &gents::compaction::NoneKnown)
+    };
+    assert_eq!(
+        gate_open, case.safe_to_reduce,
+        "{}: production safe_to_reduce must agree with the modelled gate",
+        case.name
+    );
+
+    let boundary = gents::compaction::pair_safe_boundary(&input, case.split_index);
+    assert_eq!(
+        boundary, case.safe_boundary,
+        "{}: production pair_safe_boundary must match Compaction.pairSafeBoundary",
+        case.name
+    );
+    assert_eq!(
+        boundary > 0,
+        case.gate_open,
+        "{}: a boundary that retreats to zero leaves nothing to summarize",
+        case.name
+    );
+
+    if !gate_open || boundary == 0 {
+        return input;
+    }
+    input.into_iter().skip(boundary).collect()
+}
+
+fn is_subsequence(needle: &[String], haystack: &[String]) -> bool {
+    let mut cursor = haystack.iter();
+    needle
+        .iter()
+        .all(|item| cursor.any(|candidate| candidate == item))
 }
 
 fn compaction_messages_for_case(case: &lean_vocab_test::LeanCompactionReducerCase) -> Vec<Message> {

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -1286,6 +1286,23 @@ fn drive_summarize(
         case.name
     );
 
+    // Checking `pair_safe_boundary` alone would not notice production dropping
+    // the call to it from `split_messages_for_summary`. Sweep every budget
+    // through the live splitter and require the retained tail to stay
+    // pair-closed — the property `summarize_preserves_pairs` states, fenced
+    // against the real code path rather than a helper.
+    if pair_closed(&input) {
+        let total_tokens = gents::compaction::estimate_message_tokens(&input);
+        for budget in 0..=total_tokens + 1 {
+            let (_, recent) = gents::compaction::split_for_summary(input.clone(), budget);
+            assert!(
+                pair_closed(&recent),
+                "{}: split_for_summary orphaned a tool result at budget {budget}",
+                case.name
+            );
+        }
+    }
+
     if !gate_open || boundary == 0 {
         return input;
     }

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -1205,7 +1205,7 @@ fn drive_compaction_reducer_case(case: &lean_vocab_test::LeanCompactionReducerCa
     if case.name == "strip_is_strictly_idempotent" {
         let reapplied = gents::compaction::strip_tool_results(reduced.clone()).0;
         // Full payload equality, not just the structural projection: production
-        // recognizes an existing stub rather than re-measuring it, which is what
+        // recovers a stub's recorded facts rather than re-measuring it, which is what
         // `Compaction.strip_idempotent` states.
         assert_eq!(
             reduced, reapplied,

--- a/docs/superpowers/plans/2026-08-01-compaction-model.md
+++ b/docs/superpowers/plans/2026-08-01-compaction-model.md
@@ -1,0 +1,1792 @@
+# Compaction Model + Production Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the vacuous identity-function compaction proofs with a `summarize` reducer over the production drop/replace policy, define one canonical `providerView` reduction that both the compaction writer and the request reader index, and fix the pair-splitting, prefix-accounting, missing-gate, and tool-stripping defects the model exposes.
+
+**Architecture:** Lean first. `Proofs/Compaction` gains a real `strip`, a `providerView = sanitize ∘ strip` reduction with commutation and idempotence, prefix stability under append, and a `summarize` reducer parameterised over the token-budget split policy whose boundary is retreated to a turn boundary. Rust then exposes `compaction::provider_view` as the single narrowing both call sites use, makes `strip_tool_results` idempotent, makes `split_messages_for_summary` pair-safe, and gives `safeToReduce` a runtime counterpart.
+
+**Tech Stack:** Lean 4 + Mathlib (`crates/gents/proofs`, `lake`), Rust (`crates/gents`), DefraDB via `defra_node::EmbeddedNode`, generated Lean→Rust conformance contract JSON.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-compaction-model-design.md`
+
+## Global Constraints
+
+- **Zero `sorry`s.** `cd crates/gents/proofs && lake build` must be clean. If a proof obligation cannot be discharged, stop and say so — do not ship a `sorry` or a plausible-looking reorder. This is provider-input assembly; a wrong fix corrupts context silently instead of failing loudly.
+- **Gate with the full package suite**, not `--lib`: `cargo test -p gents`.
+- **Compile the whole workspace before pushing**: `cargo check --workspace --all-targets`.
+- **Always `graphql::escape_graphql_string()`** for anything interpolated into a GraphQL string.
+- **Never emit `[]` in a DefraDB mutation** — emit `null`.
+- `tracing`, never `println`.
+- Lean proof *bodies* are developed against `lake build`; this plan pins the exact **statements** and names later tasks depend on, plus the existing lemma toolkit each proof draws from. Statements and names are contractual; tactic scripts are not.
+- Every new Lean contract group needs a `CoverageLedger.lean` row **and** a matching entry in `crates/gents/tests/support/conformance_consumers.rs` in the same commit, or `lean_contract_coverage_ledger_accounts_for_every_emitted_domain` fails.
+
+---
+
+## File Structure
+
+**Lean — created**
+
+| File | Responsibility |
+|------|----------------|
+| `crates/gents/proofs/Proofs/Compaction/Strip.lean` | The real payload-stubbing `strip` and its shape lemmas |
+| `crates/gents/proofs/Proofs/Compaction/ProviderView.lean` | `providerView = sanitize ∘ strip`, commutation, idempotence, soundness |
+| `crates/gents/proofs/Proofs/Compaction/Prefix.lean` | `pendingAfter`, append/prefix stability, the compacted-prefix correspondence |
+| `crates/gents/proofs/Proofs/Compaction/Summarize.lean` | `SplitPolicy`, `pairSafeBoundary`, the `summarize` reducer, its `IsValidReducer` instance, `raw_split_can_orphan` |
+
+**Lean — modified**
+
+| File | Change |
+|------|--------|
+| `Proofs/Compaction.lean` | Import the four new modules |
+| `Proofs/Compaction/Transition.lean` | Retire `stubMessageKind`/`stripToolResultsReducer` and their identity instance; keep `IsValidReducer` and `identityReducer` |
+| `Proofs/Compaction/Properties.lean` | Drop `strip_tool_results_is_strictly_idempotent` (moves to `Strip.lean` as a real theorem) |
+| `Proofs/Compaction/Executable.lean` | Extend `CompactionReducerCase`; replace `strip_tool_results` rows; add `summarize` and `provider_view_prefix` rows |
+| `Proofs/Conformance/Contracts/Json/ClientRuntime.lean` | Emit the new case fields |
+| `Proofs/Conformance/CoverageLedger.lean` | Ledger rows for the new groups + the `safeToReduce` boundary |
+| `Proofs/Conformance/Boundaries.lean` | `boundary.compaction.safe-to-reduce-session-scope` |
+
+**Rust — modified**
+
+| File | Change |
+|------|--------|
+| `crates/gents/src/compaction/history.rs` | Idempotent strip + stub format, tool classification, UTF-8 fix, scoped call map, `pair_safe_boundary`, pair-safe split |
+| `crates/gents/src/compaction.rs` | `provider_view`, `safe_to_reduce`, `ResponseStatus`/`ResponseStatusIndex`, `compact()` normalizes its input |
+| `crates/gents/src/agent/daemon/request.rs` | View-then-drop; session response-status resolver; gate the compaction call |
+| `crates/gents/src/compaction/tests.rs` | New unit tests; update `integration_compaction_persists_entry_and_prompt_builder_uses_it` to the new space |
+| `crates/gents/tests/conformance/streaming_compaction.rs` | Drive `summarize` + `provider_view_prefix` cases; call `safe_to_reduce` |
+| `crates/gents/tests/support/conformance_consumers.rs` | Registry entries for the new consumers |
+
+---
+
+## Task 1: Lean — the real `strip`
+
+Today `stubMessageKind` is `| .toolResult callId key => .toolResult callId key` and `stubMessageRow_id` proves it is `id`. That is why every compaction theorem is vacuous. Replace it with a strip that genuinely rewrites the payload while preserving everything `sanitize` inspects.
+
+**Files:**
+- Create: `crates/gents/proofs/Proofs/Compaction/Strip.lean`
+- Modify: `crates/gents/proofs/Proofs/Compaction.lean`
+
+**Interfaces:**
+- Consumes: `Transcript.MessageRow`, `Transcript.MessageKind`, `Transcript.ToolResultKey`, `PromptAssembly.callsIn`, `PromptAssembly.resolvedIn`
+- Produces: `Compaction.stubKey`, `Compaction.stripKind`, `Compaction.stripRow`, `Compaction.strip`, `Compaction.strip_idempotent`, `Compaction.strip_length`, `Compaction.callsIn_strip`, `Compaction.resolvedIn_strip`, `Compaction.strip_kind_ordinary`, `Compaction.strip_kind_assistant`, `Compaction.strip_kind_result`, `Compaction.strip_sequence`
+
+- [ ] **Step 1: Write the module with statements**
+
+```lean
+import Proofs.Compaction.State
+import Proofs.PromptAssembly.State
+
+namespace Compaction
+
+open Transcript (MessageRow MessageKind ToolResultKey)
+
+/-- The canonical pointer payload a stripped tool result carries. Production
+writes `[tool: NAME(ARG), call_id: ID, N bytes — see DefraDB AgentToolCall for
+full output]`; the model abstracts that to a single canonical payload hash. -/
+def stubKey (key : ToolResultKey) : ToolResultKey := { key with payloadHash := 0 }
+
+@[simp] theorem stubKey_idempotent (key : ToolResultKey) :
+    stubKey (stubKey key) = stubKey key := rfl
+
+/-- Strip rewrites the *payload* of a tool result and nothing else. It never
+changes a constructor and never changes a call id, which is exactly why it
+commutes with `sanitize` (see `Proofs/Compaction/ProviderView.lean`). -/
+def stripKind : MessageKind → MessageKind
+  | .toolResult callId key => .toolResult callId (stubKey key)
+  | k => k
+
+def stripRow (row : MessageRow) : MessageRow := { row with kind := stripKind row.kind }
+
+def strip (msgs : List MessageRow) : List MessageRow := msgs.map stripRow
+
+theorem stripKind_idempotent (k : MessageKind) : stripKind (stripKind k) = stripKind k
+theorem stripRow_idempotent (row : MessageRow) : stripRow (stripRow row) = stripRow row
+theorem strip_idempotent (msgs : List MessageRow) : strip (strip msgs) = strip msgs
+@[simp] theorem strip_length (msgs : List MessageRow) : (strip msgs).length = msgs.length
+@[simp] theorem strip_nil : strip [] = []
+@[simp] theorem strip_cons (row : MessageRow) (rest : List MessageRow) :
+    strip (row :: rest) = stripRow row :: strip rest
+theorem strip_append (a b : List MessageRow) : strip (a ++ b) = strip a ++ strip b
+@[simp] theorem strip_sequence (row : MessageRow) : (stripRow row).sequence = row.sequence
+@[simp] theorem strip_role (row : MessageRow) : (stripRow row).role = row.role
+
+theorem strip_kind_ordinary (row : MessageRow) (h : row.kind = .ordinary) :
+    (stripRow row).kind = .ordinary
+theorem strip_kind_assistant (row : MessageRow) (callIds : Finset ToolExecution.ToolCallId)
+    (h : row.kind = .assistantToolCalls callIds) :
+    (stripRow row).kind = .assistantToolCalls callIds
+theorem strip_kind_result (row : MessageRow) (callId : ToolExecution.ToolCallId)
+    (key : ToolResultKey) (h : row.kind = .toolResult callId key) :
+    (stripRow row).kind = .toolResult callId (stubKey key)
+
+theorem callsIn_strip (l : List MessageRow) :
+    PromptAssembly.callsIn (strip l) = PromptAssembly.callsIn l
+theorem resolvedIn_strip (l : List MessageRow) :
+    PromptAssembly.resolvedIn (strip l) = PromptAssembly.resolvedIn l
+
+theorem strip_preserves_uniqueCallIds {l : List MessageRow} :
+    PromptAssembly.UniqueCallIds l → PromptAssembly.UniqueCallIds (strip l)
+theorem strip_preserves_strictlyIncreasing {l : List MessageRow} :
+    Transcript.StrictlyIncreasingMessages l → Transcript.StrictlyIncreasingMessages (strip l)
+
+end Compaction
+```
+
+- [ ] **Step 2: Add the import**
+
+In `crates/gents/proofs/Proofs/Compaction.lean`, add `import Proofs.Compaction.Strip` as the second line (after `Proofs.Compaction.State`).
+
+- [ ] **Step 3: Build and iterate the proof bodies**
+
+Run: `cd crates/gents/proofs && lake build Proofs.Compaction.Strip`
+Expected: clean, zero `sorry`.
+
+Proof toolkit: everything is `List.map` over a `cases hk : row.kind` split. `callsIn_strip` / `resolvedIn_strip` mirror the induction in `PromptAssembly.Properties.callsIn_dropOrphanedFrom` using `callsIn_cons_*` / `resolvedIn_cons_*` rewritten through `strip_kind_*`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gents/proofs/Proofs/Compaction/Strip.lean crates/gents/proofs/Proofs/Compaction.lean
+git commit -m "proofs(compaction): model the real payload-stubbing strip
+
+stubMessageKind was literally identity, which is why every compaction
+theorem quantified over id. strip now rewrites the tool-result payload
+while preserving constructors and call ids — the shape sanitize inspects.
+
+Refs #993"
+```
+
+---
+
+## Task 2: Lean — `providerView`, commutation, idempotence
+
+Issue #993 flagged `strip ∘ sanitize = sanitize ∘ strip` as unproven and therefore blocking the obvious reorder. Prove it, then define the single reduction both production call sites will use.
+
+**Files:**
+- Create: `crates/gents/proofs/Proofs/Compaction/ProviderView.lean`
+- Modify: `crates/gents/proofs/Proofs/Compaction.lean`
+
+**Interfaces:**
+- Consumes: Task 1's `strip` and shape lemmas; `PromptAssembly.sanitize`, `sanitize_sound`, `sanitize_idempotent`, `dropOrphanedFrom`, `filterCallsBy`, `withKind`
+- Produces: `Compaction.providerView`, `Compaction.strip_dropOrphanedFrom`, `Compaction.strip_filterCallsBy`, `Compaction.strip_sanitize_commute`, `Compaction.providerView_idempotent`, `Compaction.providerView_sound`, `Compaction.providerView_nonempty_announcements`
+
+- [ ] **Step 1: Write the module**
+
+```lean
+import Proofs.Compaction.Strip
+import Proofs.PromptAssembly.Properties
+
+namespace Compaction
+
+open Transcript (MessageRow MessageKind)
+open PromptAssembly (sanitize dropOrphanedFrom filterCallsBy resolvedIn callsIn
+                     UniqueCallIds ProviderValid)
+
+/-- `strip` commutes with the two sanitize stages because both branch only on
+`row.kind`'s constructor and its call ids, which `strip` fixes. -/
+theorem strip_dropOrphanedFrom (l : List MessageRow) :
+    ∀ pending, strip (dropOrphanedFrom pending l) = dropOrphanedFrom pending (strip l)
+
+theorem strip_filterCallsBy (l : List MessageRow) :
+    ∀ resolved, strip (filterCallsBy resolved l) = filterCallsBy resolved (strip l)
+
+/-- The theorem issue #993 named as the blocker for reordering the compacted
+prefix drop past sanitization. -/
+theorem strip_sanitize_commute (msgs : List MessageRow) :
+    strip (sanitize msgs) = sanitize (strip msgs)
+
+/-- The one canonical narrowing from the durable transcript to the provider
+view. Both the compaction writer (`messages_compacted`) and the request reader
+(`drop_compacted_prefix`) index *this* list. -/
+def providerView (msgs : List MessageRow) : List MessageRow := sanitize (strip msgs)
+
+theorem providerView_sound (msgs : List MessageRow) (huniq : UniqueCallIds msgs) :
+    ProviderValid (providerView msgs)
+
+theorem providerView_idempotent (msgs : List MessageRow) (huniq : UniqueCallIds msgs) :
+    providerView (providerView msgs) = providerView msgs
+
+theorem providerView_nonempty_announcements (msgs : List MessageRow) :
+    PromptAssembly.NonemptyAnnouncements (providerView msgs)
+
+end Compaction
+```
+
+- [ ] **Step 2: Add the import to the barrel, build, iterate**
+
+Run: `cd crates/gents/proofs && lake build Proofs.Compaction.ProviderView`
+
+Proof toolkit for `strip_filterCallsBy`: the assistant branch produces `withKind row (.assistantToolCalls (callIds ∩ resolved))`; discharge with `stripRow (withKind row (.assistantToolCalls S)) = withKind (stripRow row) (.assistantToolCalls S)` — `stripKind` fixes assistant kinds, so both sides are `{ row with kind := .assistantToolCalls S }`. `providerView_idempotent` chains `strip_sanitize_commute`, `strip_idempotent`, and the existing `PromptAssembly.sanitize_idempotent` (which needs `UniqueCallIds`, supplied by `strip_preserves_uniqueCallIds`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gents/proofs/Proofs/Compaction/ProviderView.lean crates/gents/proofs/Proofs/Compaction.lean
+git commit -m "proofs(compaction): prove strip and sanitize commute; define providerView
+
+Settles the question #993 raised as unproven, and settles it
+affirmatively, so moving the compacted-prefix drop past sanitization is
+licensed rather than assumed.
+
+Refs #993"
+```
+
+---
+
+## Task 3: Lean — prefix stability and the compacted-prefix correspondence
+
+This is defect 3: the count is measured in one list and applied to another. The obligation is that `providerView` extends by append, so a count recorded against `providerView H` still names the same rows in `providerView (H ++ new)`.
+
+**Files:**
+- Create: `crates/gents/proofs/Proofs/Compaction/Prefix.lean`
+- Modify: `crates/gents/proofs/Proofs/Compaction.lean`
+
+**Interfaces:**
+- Consumes: Task 2's `providerView`, `strip_sanitize_commute`; `PromptAssembly.filterCallsBy_irrelevant`, `callsIn_append`, `UniqueCallIds.of_append_right`
+- Produces: `Compaction.pendingAfter`, `Compaction.dropOrphanedFrom_append`, `Compaction.providerView_append`, `Compaction.providerView_append_of_turn_boundary`, `Compaction.compacted_prefix_correspondence`, `Compaction.drop_preserves_providerValid`
+
+- [ ] **Step 1: Write the module**
+
+```lean
+import Proofs.Compaction.ProviderView
+
+namespace Compaction
+
+open Transcript (MessageRow)
+open PromptAssembly (sanitize dropOrphanedFrom filterCallsBy resolvedIn callsIn
+                     UniqueCallIds ProviderValid ActiveBlockValidFrom)
+
+/-- The pending-call set `dropOrphanedFrom` threads: an assistant announcement
+replaces it, a matching tool result erases one id, anything else clears it. -/
+def pendingAfter (pending : Finset ToolExecution.ToolCallId) :
+    List MessageRow → Finset ToolExecution.ToolCallId
+  | [] => pending
+  | row :: rest =>
+    match row.kind with
+    | .toolResult callId _ =>
+        if callId ∈ pending then pendingAfter (pending.erase callId) rest
+        else pendingAfter pending rest
+    | .assistantToolCalls callIds => pendingAfter callIds rest
+    | .ordinary => pendingAfter ∅ rest
+
+theorem dropOrphanedFrom_append (a b : List MessageRow) (pending : Finset ToolExecution.ToolCallId) :
+    dropOrphanedFrom pending (a ++ b) =
+      dropOrphanedFrom pending a ++ dropOrphanedFrom (pendingAfter pending a) b
+
+/-- General form: `providerView` extends by append whenever the suffix
+contributes no tool result for a call announced in the prefix. -/
+theorem providerView_append (a b : List MessageRow)
+    (huniq : UniqueCallIds (strip a ++ strip b))
+    (hclean : Disjoint
+        (resolvedIn (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b)))
+        (callsIn a)) :
+    providerView (a ++ b) =
+      providerView a ++
+        filterCallsBy (resolvedIn (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b)))
+          (dropOrphanedFrom (pendingAfter ∅ (strip a)) (strip b))
+
+/-- Checkable sufficient condition: the prefix ends at a turn boundary. This is
+what production satisfies — every new request appends its user prompt (an
+ordinary row) before anything else, so no result in the suffix can attach to a
+call in the prefix. -/
+theorem providerView_append_of_turn_boundary (a b : List MessageRow)
+    (huniq : UniqueCallIds (strip a ++ strip b))
+    (hb : pendingAfter ∅ (strip a) = ∅) :
+    ∃ tail, providerView (a ++ b) = providerView a ++ tail
+
+/-- Dropping at a pending-empty index of a provider view leaves a provider
+view. This is what makes it safe for `agent/daemon/request.rs` to drop the
+compacted prefix *after* sanitization without re-sanitizing. -/
+theorem drop_preserves_providerValid (msgs : List MessageRow) (n : Nat)
+    (hvalid : ProviderValid msgs)
+    (hboundary : pendingAfter ∅ (msgs.take n) = ∅) :
+    ProviderValid (msgs.drop n)
+
+/-- The correspondence the production fix rests on: the count the compaction
+writer records against `providerView H` names exactly the rows the next
+request's reader drops from `providerView (H ++ new)`. -/
+theorem compacted_prefix_correspondence
+    {H new dropped old recent tail : List MessageRow}
+    (hstable : providerView (H ++ new) = providerView H ++ tail)
+    (hsplit : providerView H = dropped ++ old ++ recent) :
+    (providerView (H ++ new)).drop (dropped.length + old.length) = recent ++ tail
+
+end Compaction
+```
+
+- [ ] **Step 2: Add the import, build, iterate**
+
+Run: `cd crates/gents/proofs && lake build Proofs.Compaction.Prefix`
+
+Proof toolkit: `dropOrphanedFrom_append` is a straight induction on `a` mirroring `dropOrphanedFrom_cons_*`. `providerView_append` then needs `filterCallsBy` to distribute over `++` (a one-line induction) plus the existing `PromptAssembly.filterCallsBy_irrelevant` to discharge `filterCallsBy (Rsuffix ∪ Rprefix) prefix = filterCallsBy Rprefix prefix` under `hclean`. `providerView_append_of_turn_boundary` derives `hclean` from `hb`: starting from `∅`, `dropOrphanedFrom` in the suffix keeps only results whose calls were announced inside the suffix, so `resolvedIn ⊆ callsIn b`, and `UniqueCallIds (a ++ b)` gives `Disjoint (callsIn a) (callsIn b)`. `compacted_prefix_correspondence` is `List.drop_append` arithmetic once `hstable` and `hsplit` are rewritten.
+
+**If `providerView_append` resists:** stop, report which sub-obligation failed, and do not proceed to Task 9's reorder. The whole production fix is licensed by this theorem.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gents/proofs/Proofs/Compaction/Prefix.lean crates/gents/proofs/Proofs/Compaction.lean
+git commit -m "proofs(compaction): prove the compacted-prefix index correspondence
+
+providerView extends by append at a turn boundary, so a count recorded
+against providerView H names the same rows in providerView (H ++ new).
+Defect 3 in #993 is that production measured in one space and dropped in
+another; this is the theorem that makes measuring and dropping in one
+space correct.
+
+Refs #993"
+```
+
+---
+
+## Task 4: Lean — `summarize` over the real policy
+
+This is defects 1 and the modelled half of 2. `summarize` is parameterised over the token-budget split policy — the thing production actually computes — and retreats its boundary to a turn boundary so pair-closure holds.
+
+**Files:**
+- Create: `crates/gents/proofs/Proofs/Compaction/Summarize.lean`
+- Modify: `crates/gents/proofs/Proofs/Compaction.lean`, `Proofs/Compaction/Transition.lean`, `Proofs/Compaction/Properties.lean`
+
+**Interfaces:**
+- Consumes: Task 3's `pendingAfter`, `drop_preserves_providerValid`; `Compaction.IsValidReducer`, `PromptView`, `PromptView.safeToReduce`, `PromptView.PairsClosedInMessages`
+- Produces: `Compaction.SplitPolicy`, `Compaction.pairSafeBoundary`, `Compaction.pairSafeBoundary_le`, `Compaction.pairSafeBoundary_pending_empty`, `Compaction.summarize`, `Compaction.instIsValidReducerSummarize`, `Compaction.summarize_messages_suffix`, `Compaction.raw_split_can_orphan`
+
+- [ ] **Step 1: Write the module**
+
+```lean
+import Proofs.Compaction.Prefix
+import Proofs.Compaction.Transition
+
+namespace Compaction
+
+open Transcript (MessageRow)
+
+/-- The token-budget index production computes in `split_messages_for_summary`.
+The model is parameterised over it rather than pinning a token function: what
+must be proven is that *whatever* index the budget picks, the reducer is sound. -/
+abbrev SplitPolicy := List MessageRow → Nat
+
+/-- The greatest `j ≤ limit` at which no tool call is awaiting its result.
+Production mirrors this in `compaction::history::pair_safe_boundary`. -/
+def pairSafeBoundary (msgs : List MessageRow) (limit : Nat) : Nat :=
+  ((List.range (min limit msgs.length + 1)).filter
+    (fun j => pendingAfter ∅ (msgs.take j) = ∅)).foldr Nat.max 0
+
+theorem pairSafeBoundary_le (msgs : List MessageRow) (limit : Nat) :
+    pairSafeBoundary msgs limit ≤ limit
+
+theorem pairSafeBoundary_pending_empty (msgs : List MessageRow) (limit : Nat) :
+    pendingAfter ∅ (msgs.take (pairSafeBoundary msgs limit)) = ∅
+
+/-- The production reducer: retain the tail from the pair-safe boundary and
+record a summary handle for everything dropped. -/
+def summarize (policy : SplitPolicy) (handle : SummaryHandle) : TranscriptReducer :=
+  fun v =>
+    if PromptView.safeToReduce v ∧ 0 < pairSafeBoundary v.messages (policy v.messages) then
+      { v with
+        messages := v.messages.drop (pairSafeBoundary v.messages (policy v.messages))
+        summary  := some handle }
+    else v
+
+theorem summarize_messages_suffix (policy : SplitPolicy) (handle : SummaryHandle)
+    (v : PromptView) : (summarize policy handle v).messages <:+ v.messages
+
+/-- Pair closure over the *real* reducer. The `ActiveBlockValid` hypothesis is
+discharged in production by the input being a `providerView` — which is why
+defect 1's fix depends on defect 3's. -/
+theorem summarize_preserves_pairs (policy : SplitPolicy) (handle : SummaryHandle)
+    (v : PromptView) (hblock : PromptAssembly.ActiveBlockValid v.messages) :
+    PromptView.PairsClosedInMessages v.messages →
+      PromptView.PairsClosedInMessages (summarize policy handle v).messages
+
+instance instIsValidReducerSummarize (policy : SplitPolicy) (handle : SummaryHandle)
+    (hblock : ∀ v : PromptView, PromptAssembly.ActiveBlockValid v.messages) :
+    IsValidReducer (summarize policy handle)
+
+/-- Without the boundary retreat the reducer is unsound: an unadjusted budget
+index can land between an assistant tool-call row and its result row, leaving
+the result orphaned in the retained tail. This is the counterexample that makes
+`pairSafeBoundary` load-bearing rather than decoration. -/
+theorem raw_split_can_orphan :
+    ∃ (msgs : List MessageRow) (k : Nat),
+      PromptAssembly.ActiveBlockValid msgs ∧
+        ¬ PromptView.PairsClosedInMessages (msgs.drop k)
+
+end Compaction
+```
+
+- [ ] **Step 2: Retire the vacuous reducer**
+
+Delete from `Proofs/Compaction/Transition.lean` (lines 24–85): `stubMessageKind`, `stubMessageKind_id`, `stubMessageRow`, `stubMessageRow_id`, `stubMessages`, `stubMessages_id`, `stripToolResultsReducer`, `stripToolResultsReducer_id`, `instIsValidReducerStrip`. Keep the `IsValidReducer` class and the `identityReducer` namespace — `identityReducer` remains the legitimate degenerate below-gate reducer.
+
+Delete from `Proofs/Compaction/Properties.lean` (lines 92–96): `strip_tool_results_is_strictly_idempotent`. Its honest replacement is `Compaction.strip_idempotent` from Task 1.
+
+- [ ] **Step 3: Write the counterexample witness**
+
+`raw_split_can_orphan` is discharged by a concrete two-row list — an assistant announcement followed by its result — split at `k = 1`:
+
+```lean
+theorem raw_split_can_orphan :
+    ∃ (msgs : List MessageRow) (k : Nat),
+      PromptAssembly.ActiveBlockValid msgs ∧
+        ¬ PromptView.PairsClosedInMessages (msgs.drop k) := by
+  refine ⟨[⟨0, 0, 0, .assistant, .assistantToolCalls {1}⟩,
+           ⟨1, 0, 1, .user, .toolResult 1 ⟨0, 0, 0⟩⟩], 1, ?_, ?_⟩
+  · -- ActiveBlockValid: announcement then its result
+    simp [PromptAssembly.ActiveBlockValid, PromptAssembly.ActiveBlockValidFrom]
+  · -- the retained tail holds the result with no caller
+    intro h
+    obtain ⟨caller, hmem, hrole, _⟩ := h _ (by simp) 1 ⟨0, 0, 0⟩ rfl
+    simp at hmem
+    subst hmem
+    exact absurd hrole (by decide)
+```
+
+- [ ] **Step 4: Build and iterate**
+
+Run: `cd crates/gents/proofs && lake build`
+Expected: clean, zero `sorry`, and the whole `Proofs` library still builds after the Transition/Properties deletions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gents/proofs/Proofs/Compaction/
+git commit -m "proofs(compaction): model the real summarize reducer
+
+Replaces the identity stripToolResultsReducer with a summarize reducer
+parameterised over the production token-budget split policy, and proves
+pair closure over it. raw_split_can_orphan is the counterexample showing
+the unadjusted budget index is unsound, so the boundary retreat is
+load-bearing.
+
+Refs #993"
+```
+
+---
+
+## Task 5: Lean — contract cases, ledger, boundary
+
+**Files:**
+- Modify: `crates/gents/proofs/Proofs/Compaction/Executable.lean`, `Proofs/Conformance/Contracts/Json/ClientRuntime.lean`, `Proofs/Conformance/CoverageLedger.lean`, `Proofs/Conformance/Boundaries.lean`
+
+**Interfaces:**
+- Produces: `CompactionReducerCase` with three new fields; case names `summarize_retains_straddling_turn`, `summarize_drops_whole_turns`, `summarize_blocked_when_response_streaming`, `provider_view_is_idempotent`, `provider_view_prefix_is_stable`; JSON keys `split_index`, `safe_boundary`, `retained_count`
+
+- [ ] **Step 1: Extend the case structure**
+
+In `Proofs/Compaction/Executable.lean`, add to `CompactionReducerCase` after `reducerIsIdentity`:
+
+```lean
+  splitIndex          : Nat
+  safeBoundary        : Nat
+  retainedCount       : Nat
+```
+
+Set `splitIndex := 0`, `safeBoundary := 0`, `retainedCount := postMessageCount` on the existing rows that do not exercise a split. Rename the three `strip_tool_results` rows' reducer string from `"strip_tool_results"` to `"strip"` and keep their names.
+
+- [ ] **Step 2: Add the new rows**
+
+Add to `compactionReducerCases`, computed from the model rather than hand-asserted:
+
+```lean
+, { name              := "summarize_retains_straddling_turn"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 2
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := false
+  , splitIndex        := 2
+  , safeBoundary      := 1
+  , retainedCount     := 2 }
+, { name              := "summarize_drops_whole_turns"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 2
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := false
+  , splitIndex        := 1
+  , safeBoundary      := 1
+  , retainedCount     := 2 }
+, { name              := "summarize_blocked_when_response_streaming"
+  , group             := "summarize"
+  , reducer           := "summarize"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 3
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := false
+  , reducerIsIdentity := true
+  , splitIndex        := 2
+  , safeBoundary      := 1
+  , retainedCount     := 3 }
+, { name              := "provider_view_is_idempotent"
+  , group             := "provider_view"
+  , reducer           := "provider_view"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 3
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 0
+  , retainedCount     := 3 }
+, { name              := "provider_view_prefix_is_stable"
+  , group             := "provider_view"
+  , reducer           := "provider_view"
+  , legal             := true
+  , preMessageCount   := 3
+  , postMessageCount  := 3
+  , preservesPairs    := true
+  , preservesOrder    := true
+  , gateOpen          := true
+  , safeToReduce      := true
+  , reducerIsIdentity := true
+  , splitIndex        := 0
+  , safeBoundary      := 1
+  , retainedCount     := 3 }
+```
+
+Update `compactionReducerCases_count` to `= 15`.
+
+- [ ] **Step 3: Emit the new fields**
+
+In `Proofs/Conformance/Contracts/Json/ClientRuntime.lean`, in `compactionReducerCaseJson`, replace the trailing `reducer_is_identity` line with:
+
+```lean
+    ++ "\"reducer_is_identity\":" ++ boolString witness.reducerIsIdentity ++ ","
+    ++ "\"split_index\":" ++ toString witness.splitIndex ++ ","
+    ++ "\"safe_boundary\":" ++ toString witness.safeBoundary ++ ","
+    ++ "\"retained_count\":" ++ toString witness.retainedCount
+    ++ "}"
+```
+
+- [ ] **Step 4: Add the boundary**
+
+In `Proofs/Conformance/Boundaries.lean`, add the id near the other boundary ids:
+
+```lean
+def boundaryCompactionSafeToReduceSessionScopeId : String :=
+  "boundary.compaction.safe-to-reduce-session-scope"
+```
+
+and the entry in `boundaries`:
+
+```lean
+  , { id := boundaryCompactionSafeToReduceSessionScopeId
+    , domain := "Compaction"
+    , subject := "safeToReduce resolver scope"
+    , statement :=
+        "PromptView.safeToReduce requires every retained tool-result row to carry a known terminal response status. Rust resolves this at session scope: compaction::safe_to_reduce is the modelled predicate, and agent/daemon/request.rs backs it with a single non-terminal-AgentResponse query rather than per-message request_id linkage. All-terminal at session scope implies terminal for every row, so the refinement can only err toward unsafe, whose cost is a skipped compaction retried on the next request."
+    , acceptedFailureMode :=
+        some "A row whose request has no AgentResponse row at all (crashed run) reads unsafe in the model but safe under the session check. sanitize_history_for_provider already removes half-turns from crashed runs — an unpaired call or an orphaned result never reaches compaction's input — so what survives is a complete turn, which is safe to summarize."
+    }
+```
+
+- [ ] **Step 5: Ledger rows**
+
+In `Proofs/Conformance/CoverageLedger.lean`, next to the existing `compaction_reducer_cases` row, add:
+
+```lean
+  , tagged (boundaryCoverage
+      "follow_up_hook"
+      "Compaction.safeToReduce.sessionScopeResolver"
+      boundaryCompactionSafeToReduceSessionScopeId)
+      "compaction" [Surface.agentFacing]
+```
+
+- [ ] **Step 6: Build and verify JSON**
+
+```bash
+cd crates/gents/proofs && lake build Proofs.Conformance.Contracts \
+  && lake env lean --run Proofs/Conformance/Contracts.lean | grep -o '"compaction_reducer_cases":\[[^]]*\]' | head -c 600
+```
+Expected: 15 objects, each carrying `split_index`, `safe_boundary`, `retained_count`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/gents/proofs/Proofs/
+git commit -m "proofs(compaction): emit summarize and provider-view contract cases
+
+Refs #993"
+```
+
+---
+
+## Task 6: Rust — idempotent strip with an argument-bearing stub
+
+**Files:**
+- Modify: `crates/gents/src/compaction/history.rs:169-306`
+- Test: `crates/gents/src/compaction/tests.rs`
+
+**Interfaces:**
+- Produces: `history::tool_result_is_stub`, and the stub format `[tool: NAME(ARG), call_id: ID, N bytes — see DefraDB AgentToolCall for full output]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `crates/gents/src/compaction/tests.rs`:
+
+```rust
+#[test]
+fn strip_is_idempotent_and_preserves_the_original_byte_count() {
+    let long_result = "x".repeat(5000);
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/tmp/test.rs"}"#),
+        tool_result_msg("call-1", &long_result),
+    ];
+
+    let (once, _) = strip_tool_results(messages);
+    let (twice, _) = strip_tool_results(once.clone());
+
+    assert_eq!(once, twice, "strip must be idempotent");
+    let stub = sole_tool_result_text(&twice[1]);
+    assert!(
+        stub.contains("5000 bytes"),
+        "reapplying strip must not re-measure the stub: {stub}"
+    );
+}
+
+#[test]
+fn strip_stub_carries_the_primary_argument() {
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/src/compaction/history.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    let (stripped, _) = strip_tool_results(messages);
+    assert_eq!(
+        sole_tool_result_text(&stripped[1]),
+        "[tool: read_file(/src/compaction/history.rs), call_id: call-1, 12 bytes \
+         — see DefraDB AgentToolCall for full output]"
+    );
+}
+
+#[test]
+fn strip_marks_already_truncated_output_without_sniffing_the_word() {
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "echo hi"}"#),
+        tool_result_msg("call-1", "the build log says truncated somewhere"),
+    ];
+    let (stripped, _) = strip_tool_results(messages);
+    assert!(
+        !sole_tool_result_text(&stripped[1]).contains(", truncated"),
+        "ordinary output mentioning the word must not be flagged as truncated"
+    );
+
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "echo hi"}"#),
+        tool_result_msg("call-1", "output\n[Full output: DefraDB doc bafy123]"),
+    ];
+    let (stripped, _) = strip_tool_results(messages);
+    assert!(sole_tool_result_text(&stripped[1]).contains(", truncated"));
+}
+
+fn sole_tool_result_text(message: &Message) -> String {
+    let Message::User { content } = message else {
+        panic!("expected user message");
+    };
+    let UserContent::ToolResult(tool_result) = first_content(content) else {
+        panic!("expected tool result");
+    };
+    let ToolResultContent::Text(text) = first_content(&tool_result.content) else {
+        panic!("expected text content");
+    };
+    text.text.clone()
+}
+```
+
+Also update the existing `strip_rewrites_tool_results_into_stubs` (line 612) expected string to the new argument-bearing format, and change its `tool_call_msg("read", ...)` to `tool_call_msg("read_file", r#"{"path": "/tmp/test.rs"}"#)`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p gents --lib compaction::tests::strip_ -- --nocapture`
+Expected: FAIL — idempotence test shows the stub re-measured, argument test shows the old format.
+
+- [ ] **Step 3: Implement**
+
+In `crates/gents/src/compaction/history.rs`, replace `strip_tool_result`, `tool_result_was_truncated`, and `truncate_tool_result_content`:
+
+```rust
+/// Tail shared by every stub this module writes. Used to recognize a stub on
+/// reapplication so `strip_tool_results` is idempotent: without it, a second
+/// pass re-measures the stub and reports *its* length instead of the tool's,
+/// which is what the model sees after a compaction.
+const STUB_TAIL: &str = "see DefraDB AgentToolCall for full output]";
+const STUB_HEAD: &str = "[tool: ";
+
+/// Markers the truncation layer itself writes (`truncation::logic`,
+/// `truncation::spill`). Matching these exactly replaces a `contains("truncated")`
+/// sniff that fired on any tool output mentioning the word.
+const TRUNCATION_MARKERS: [&str; 2] = ["[Full output: DefraDB doc ", "[Showing lines "];
+
+fn tool_result_is_stub(tool_result: &ToolResult) -> bool {
+    matches!(
+        tool_result.content.as_slice(),
+        [ToolResultContent::Text(text)]
+            if text.text.starts_with(STUB_HEAD) && text.text.ends_with(STUB_TAIL)
+    )
+}
+
+fn strip_tool_result(
+    mut tool_result: ToolResult,
+    tool_calls: &HashMap<String, ToolCallInfo>,
+) -> ToolResult {
+    if tool_result_is_stub(&tool_result) {
+        return tool_result;
+    }
+
+    let call_id = tool_result_key(&tool_result);
+    let info = tool_calls.get(&call_id);
+    let tool_name = info.map_or("unknown", |info| info.name.as_str());
+    let argument = info
+        .and_then(|info| info.file_path.as_deref())
+        .map(|path| format!("({path})"))
+        .unwrap_or_default();
+    let byte_count = tool_result_byte_count(&tool_result);
+    let truncated = if tool_result_was_truncated(&tool_result) {
+        ", truncated"
+    } else {
+        ""
+    };
+
+    let stub = format!(
+        "[tool: {tool_name}{argument}, call_id: {call_id}, {byte_count} bytes{truncated} — {STUB_TAIL}"
+    );
+    tool_result.content = vec![ToolResultContent::Text(Text { text: stub })];
+    tool_result
+}
+
+fn tool_result_was_truncated(tool_result: &ToolResult) -> bool {
+    tool_result.content.iter().any(|content| match content {
+        ToolResultContent::Text(text) => TRUNCATION_MARKERS
+            .iter()
+            .any(|marker| text.text.contains(marker)),
+        _ => false,
+    })
+}
+
+fn truncate_tool_result_content(content: ToolResultContent, max_chars: usize) -> ToolResultContent {
+    match content {
+        ToolResultContent::Text(text) if text.text.len() > max_chars => {
+            // `max_chars` is a byte budget; slicing at a byte index that is not
+            // a char boundary panics. Floor to the nearest boundary the way
+            // toolset::edit_match does.
+            let cut = floor_char_boundary(&text.text, max_chars);
+            let truncated = format!(
+                "{}… [pre-truncated {}/{} chars for compaction]",
+                &text.text[..cut],
+                cut,
+                text.text.len()
+            );
+            ToolResultContent::Text(Text { text: truncated })
+        }
+        other => other,
+    }
+}
+
+fn floor_char_boundary(text: &str, mut index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p gents --lib compaction::tests -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gents/src/compaction/history.rs crates/gents/src/compaction/tests.rs
+git commit -m "fix(compaction): make strip idempotent and carry the tool argument
+
+The path already stripped twice (request.rs, then again inside compact),
+and the second pass re-stubbed the stub — so after a compaction the model
+was told the stub's byte count, not the tool's. Recognize a stub and pass
+it through. The stub now names the file it read, and the truncated flag
+matches the truncation layer's own markers instead of sniffing for the
+word 'truncated' in arbitrary output.
+
+Refs #993"
+```
+
+---
+
+## Task 7: Rust — tool classification and scoped call map
+
+`ToolCallInfo::from` classifies against `"write" | "edit" | "replace" | "apply_patch"`; the real tools are `write_file` and `edit_file`, so `files_modified` has always been empty. `is_read` matches exactly one real tool, `grep`.
+
+**Files:**
+- Modify: `crates/gents/src/compaction/history.rs:10-51,340-361`
+- Test: `crates/gents/src/compaction/tests.rs`
+
+**Interfaces:**
+- Produces: `history::is_read_tool`, `history::is_write_tool`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn file_activity_classifies_the_registered_file_tools() {
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+        tool_call_msg("write_file", r#"{"path": "/src/lib.rs"}"#),
+        tool_result_msg("call-1", "ok"),
+        tool_call_msg("edit_file", r#"{"path": "/src/edit.rs"}"#),
+        tool_result_msg("call-1", "ok"),
+        tool_call_msg("grep", r#"{"path": "/src/grep.rs"}"#),
+        tool_result_msg("call-1", "hit"),
+        tool_call_msg("glob", r#"{"path": "/src/glob.rs"}"#),
+        tool_result_msg("call-1", "hit"),
+        tool_call_msg("list_files", r#"{"path": "/src/list.rs"}"#),
+        tool_result_msg("call-1", "hit"),
+    ];
+
+    let (_, files) = strip_tool_results(messages);
+    assert_eq!(
+        files.files_read,
+        vec!["/src/glob.rs", "/src/grep.rs", "/src/list.rs", "/src/main.rs"]
+    );
+    assert_eq!(files.files_modified, vec!["/src/edit.rs", "/src/lib.rs"]);
+}
+
+#[test]
+fn every_registered_file_tool_is_classified() {
+    // Guards against a file tool being added to toolset::file_tools without a
+    // matching classification here, which would silently empty the compaction
+    // summary's file lists — the defect this test exists to prevent recurring.
+    for name in ["read_file", "list_files", "glob", "grep"] {
+        assert!(super::history::is_read_tool(name), "{name} unclassified");
+    }
+    for name in ["write_file", "edit_file"] {
+        assert!(super::history::is_write_tool(name), "{name} unclassified");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p gents --lib compaction::tests::file_activity_classifies -- --nocapture`
+Expected: FAIL — `files_modified` is empty, `files_read` holds only `/src/grep.rs`.
+
+- [ ] **Step 3: Implement**
+
+Replace the `From<&ToolCall> for ToolCallInfo` impl at the bottom of `history.rs`:
+
+```rust
+/// Tools whose calls mean "this path was read". The first group is the
+/// registered native file tools (`toolset/file_tools.rs`); the second is the
+/// generic names MCP servers commonly use.
+pub(super) fn is_read_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "read_file"
+            | "list_files"
+            | "glob"
+            | "grep"
+            | "read"
+            | "cat"
+            | "search"
+            | "find"
+            | "query"
+    )
+}
+
+/// Tools whose calls mean "this path was modified".
+pub(super) fn is_write_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "write_file" | "edit_file" | "write" | "edit" | "replace" | "apply_patch"
+    )
+}
+
+impl From<&ToolCall> for ToolCallInfo {
+    fn from(tool_call: &ToolCall) -> Self {
+        let file_path = tool_call
+            .function
+            .arguments
+            .get("file_path")
+            .or_else(|| tool_call.function.arguments.get("path"))
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned);
+        let name = tool_call.function.name.clone();
+
+        Self {
+            is_read: is_read_tool(&name),
+            is_write: is_write_tool(&name),
+            name,
+            file_path,
+        }
+    }
+}
+```
+
+Then scope the call map in `strip_tool_results` so a reused call id from an earlier turn cannot label a later stub with the wrong tool name — clear it when an assistant message opens a new turn:
+
+```rust
+            Message::Assistant { id, content } => {
+                // Scope the lookup to the turn being opened: call ids are
+                // provider-generated and can repeat across turns, and a stale
+                // entry would label a later stub with the wrong tool.
+                tool_calls.clear();
+                for item in content.iter() {
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p gents --lib compaction::tests -- --nocapture`
+Expected: PASS. The pre-existing `strip_extracts_read_and_modified_files` (line 645) uses `"read"`/`"write"`, which the legacy aliases still cover, so it stays green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gents/src/compaction/history.rs crates/gents/src/compaction/tests.rs
+git commit -m "fix(compaction): classify the tools that actually exist
+
+ToolCallInfo classified writes against write/edit/replace/apply_patch; the
+registered tools are write_file and edit_file, so files_modified has always
+been empty and only grep ever landed in files_read. Masked because the
+summarizing model's own file lists were merged on top. Also scope the
+call-id lookup per turn so a reused id cannot mislabel a later stub.
+
+Refs #993"
+```
+
+---
+
+## Task 8: Rust — pair-safe split boundary
+
+**Files:**
+- Modify: `crates/gents/src/compaction/history.rs:197-226`
+- Test: `crates/gents/src/compaction/tests.rs`
+
+**Interfaces:**
+- Produces: `history::pair_safe_boundary(messages: &[Message], limit: usize) -> usize`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn split_never_separates_a_tool_call_from_its_result() {
+    // A budget that retains roughly the last message would land the boundary
+    // between the assistant tool call and the user tool result.
+    let messages = vec![
+        text_msg("user", &"a".repeat(4000)),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    let (old, recent) = super::history::split_messages_for_summary(messages, 40);
+
+    assert_eq!(old.len(), 1, "only the bulky user turn should be summarized");
+    assert_eq!(recent.len(), 2, "the assistant turn and its result stay together");
+    assert!(
+        matches!(&recent[0], Message::Assistant { .. }),
+        "the retained tail must start at the assistant announcement"
+    );
+}
+
+#[test]
+fn pair_safe_boundary_retreats_to_the_turn_start() {
+    let messages = vec![
+        text_msg("user", "go"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    assert_eq!(super::history::pair_safe_boundary(&messages, 2), 1);
+    assert_eq!(super::history::pair_safe_boundary(&messages, 3), 3);
+    assert_eq!(super::history::pair_safe_boundary(&messages, 1), 1);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p gents --lib compaction::tests::split_never_separates -- --nocapture`
+Expected: FAIL — `recent.len()` is 1; the assistant call was summarized while its result stayed behind.
+
+- [ ] **Step 3: Implement**
+
+Add to `history.rs` and use it in `split_messages_for_summary`:
+
+```rust
+/// Greatest `j <= limit` at which no tool call is awaiting its result.
+///
+/// Mirrors `Compaction.pairSafeBoundary` and the pending-set discipline in
+/// `drop_orphaned_tool_results`: an assistant message replaces the pending set
+/// with its own call ids, a tool result erases one, and anything else clears it.
+pub(super) fn pair_safe_boundary(messages: &[Message], limit: usize) -> usize {
+    let limit = limit.min(messages.len());
+    let mut pending: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut boundary = 0usize;
+
+    for (index, message) in messages.iter().take(limit).enumerate() {
+        if pending.is_empty() {
+            boundary = index;
+        }
+        match message {
+            Message::Assistant { content, .. } => {
+                pending = content
+                    .iter()
+                    .filter_map(|item| match item {
+                        AssistantContent::ToolCall(tool_call) => Some(tool_call_key(tool_call)),
+                        _ => None,
+                    })
+                    .collect();
+            }
+            Message::User { content } => {
+                let has_plain_content = content
+                    .iter()
+                    .any(|item| !matches!(item, UserContent::ToolResult(_)));
+                for item in content.iter() {
+                    if let UserContent::ToolResult(tool_result) = item {
+                        pending.remove(&tool_result_key(tool_result));
+                    }
+                }
+                if has_plain_content {
+                    pending.clear();
+                }
+            }
+            Message::System { .. } => pending.clear(),
+        }
+    }
+
+    if pending.is_empty() {
+        limit
+    } else {
+        boundary
+    }
+}
+```
+
+and in `split_messages_for_summary`, between the budget loop and the `split_index == 0` check:
+
+```rust
+    // The token budget can land the boundary between an assistant message
+    // carrying a ToolCall and the user message carrying its ToolResult. Left
+    // alone, the call is summarized away while the result stays in the retained
+    // tail, and sanitize_history_for_provider then drops the orphaned result at
+    // loop entry — the tool's output is lost from the provider view entirely
+    // while the summary describes only the call.
+    //
+    // Retreat to the nearest turn boundary. Moving *earlier* over-retains by at
+    // most one turn and never loses context; moving later would summarize a turn
+    // the budget wanted kept. For provider-input assembly, over-retaining is the
+    // correct failure direction. Modelled as `Compaction.pairSafeBoundary`, with
+    // `Compaction.raw_split_can_orphan` witnessing that the unadjusted index is
+    // unsound.
+    let split_index = pair_safe_boundary(&messages, split_index);
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p gents --lib compaction::tests -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/gents/src/compaction/history.rs crates/gents/src/compaction/tests.rs
+git commit -m "fix(compaction): never split a tool call from its result
+
+split_messages_for_summary cut on a token budget at an arbitrary index, so
+the boundary could land between an assistant ToolCall and its ToolResult.
+The call was summarized away, the result stayed in the retained tail, and
+sanitize_history_for_provider dropped the orphan at loop entry — the tool
+output vanished from the provider view while the summary described only
+the call. Retreat the boundary to the nearest turn start.
+
+Refs #993"
+```
+
+---
+
+## Task 9: Rust — `provider_view` and the prefix-accounting fix
+
+**Files:**
+- Modify: `crates/gents/src/compaction.rs:92-204`, `crates/gents/src/agent/daemon/request.rs:49-76`
+- Test: `crates/gents/src/compaction/tests.rs`
+
+**Interfaces:**
+- Consumes: Task 6's idempotent `strip_tool_results`, Task 8's `pair_safe_boundary`
+- Produces: `compaction::provider_view(Vec<Message>) -> (Vec<Message>, FileActivity)`
+
+- [ ] **Step 1: Write the failing regression test**
+
+```rust
+#[test]
+fn compacted_prefix_is_counted_and_dropped_in_the_same_space() {
+    // An orphaned tool result at the head: sanitize removes it, so the
+    // unsanitized and sanitized indexings of the compacted prefix diverge.
+    // Under the old order (strip -> drop -> sanitize) the count measured in the
+    // sanitized space was applied to the unsanitized one, shifting the boundary.
+    let history = vec![
+        tool_result_msg("orphan-1", "result with no call"),
+        text_msg("user", "first real turn"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+        text_msg("assistant", "done"),
+        text_msg("user", "second turn"),
+    ];
+
+    let (view, _) = provider_view(history.clone());
+    assert_eq!(
+        view.len(),
+        5,
+        "sanitize must remove the orphaned result from the view"
+    );
+
+    // Compaction summarized the first two rows *of the view*.
+    let compacted = 2usize;
+    let retained = view.iter().skip(compacted).cloned().collect::<Vec<_>>();
+
+    // The next request rebuilds the view from the same durable history and
+    // drops the same count. It must land on exactly the retained rows.
+    let (reread, _) = provider_view(history);
+    assert_eq!(reread.into_iter().skip(compacted).collect::<Vec<_>>(), retained);
+}
+
+#[test]
+fn provider_view_is_idempotent() {
+    let history = vec![
+        tool_result_msg("orphan-1", "result with no call"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+    let (once, _) = provider_view(history);
+    let (twice, _) = provider_view(once.clone());
+    assert_eq!(once, twice);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p gents --lib compaction::tests::provider_view -- --nocapture`
+Expected: FAIL with "cannot find function `provider_view`".
+
+- [ ] **Step 3: Implement `provider_view`**
+
+In `crates/gents/src/compaction.rs`, below `sanitize_history_for_provider`:
+
+```rust
+/// The single canonical narrowing from the durable transcript to the provider
+/// view: stub tool-result payloads, then drop unpaired calls and orphaned
+/// results and normalize assistant content order.
+///
+/// Both sides of compaction's prefix accounting index *this* list. The
+/// compaction writer records `messages_compacted` against it and the request
+/// reader drops that many rows from it; measuring in one space and dropping in
+/// another is defect 3 of #993. Modelled as `Compaction.providerView`, proven
+/// idempotent by `Compaction.providerView_idempotent` — which is what lets
+/// `compact()` re-normalize its own input for free.
+pub fn provider_view(messages: Vec<Message>) -> (Vec<Message>, FileActivity) {
+    let (stripped, activity) = strip_tool_results(messages);
+    (sanitize_history_for_provider(stripped), activity)
+}
+```
+
+- [ ] **Step 4: Normalize `compact()`'s input**
+
+Replace the strategy match at `compaction.rs:100-108` with:
+
+```rust
+        // Normalize to the canonical provider view so `messages_compacted`
+        // indexes the same list `drop_compacted_prefix` will later index,
+        // whoever the caller is. Idempotent, so this is a no-op when the caller
+        // already passed a provider view — which the daemon always does.
+        //
+        // This makes `CompactionStrategy::Summarize` and `StripThenSummarize`
+        // behave identically. They already did in the daemon path, which strips
+        // unconditionally before calling here; the variant is retained for
+        // config compatibility.
+        let (stripped_messages, stripped_activity) = provider_view(messages);
+```
+
+- [ ] **Step 5: Rewire the daemon**
+
+In `crates/gents/src/agent/daemon/request.rs`, replace lines 49-50 with:
+
+```rust
+                let (provider_history, file_activity) =
+                    compaction::provider_view(full_history);
+```
+
+replace lines 72-76 with:
+
+```rust
+                // Drop in the same space the count was measured in. The drop
+                // lands on a turn boundary (the writer's boundary is always
+                // `pair_safe_boundary`), so the tail is still provider-valid
+                // and needs no re-sanitizing —
+                // `Compaction.drop_preserves_providerValid`.
+                let mut history = drop_compacted_prefix(
+                    provider_history,
+                    total_compacted_messages(&compaction_entries),
+                );
+```
+
+- [ ] **Step 6: Update the existing integration test**
+
+`integration_compaction_persists_entry_and_prompt_builder_uses_it` (`compaction/tests.rs:678`) currently round-trips through `strip_tool_results` on both sides, which is the old space. Change both `let (…, _) = strip_tool_results(history);` sites to `let (…, _) = provider_view(history);`.
+
+- [ ] **Step 7: Run the full package suite**
+
+Run: `cargo test -p gents`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/gents/src/compaction.rs crates/gents/src/compaction/tests.rs crates/gents/src/agent/daemon/request.rs
+git commit -m "fix(compaction): count and drop the compacted prefix in one space
+
+messages_compacted indexed strip(sanitize(strip(H))) while
+drop_compacted_prefix applied it to strip(H). Whenever sanitize removed
+anything at or before the boundary the two diverged: either summarized
+messages survived alongside their own summary, or messages that were
+never summarized were silently dropped from the provider view.
+
+Both call sites now go through compaction::provider_view. The reorder is
+licensed by Compaction.strip_sanitize_commute and the drop needs no
+re-sanitizing by Compaction.drop_preserves_providerValid.
+
+Refs #993"
+```
+
+---
+
+## Task 10: Rust — `safe_to_reduce` and its daemon resolver
+
+**Files:**
+- Modify: `crates/gents/src/compaction.rs`, `crates/gents/src/agent/daemon/request.rs`
+- Test: `crates/gents/src/compaction/tests.rs`
+
+**Interfaces:**
+- Produces: `compaction::ResponseStatus` (`Streaming`/`Complete`/`Error`), `compaction::ResponseStatusIndex` trait with `fn status_of(&self, message: &Message) -> Option<ResponseStatus>`, `compaction::safe_to_reduce(&[Message], &impl ResponseStatusIndex) -> bool`, `compaction::AllTerminal`, `compaction::NoneKnown`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn safe_to_reduce_requires_every_retained_tool_result_to_be_terminal() {
+    let messages = vec![
+        text_msg("user", "go"),
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+
+    assert!(safe_to_reduce(&messages, &AllTerminal));
+    assert!(!safe_to_reduce(&messages, &NoneKnown));
+
+    // No tool results at all: nothing to gate on.
+    let plain = vec![text_msg("user", "go"), text_msg("assistant", "ok")];
+    assert!(safe_to_reduce(&plain, &NoneKnown));
+}
+
+struct StreamingIndex;
+impl ResponseStatusIndex for StreamingIndex {
+    fn status_of(&self, _message: &Message) -> Option<ResponseStatus> {
+        Some(ResponseStatus::Streaming)
+    }
+}
+
+#[test]
+fn safe_to_reduce_is_closed_while_a_response_is_streaming() {
+    let messages = vec![
+        tool_call_msg("read_file", r#"{"path": "/src/main.rs"}"#),
+        tool_result_msg("call-1", "fn main() {}"),
+    ];
+    assert!(!safe_to_reduce(&messages, &StreamingIndex));
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test -p gents --lib compaction::tests::safe_to_reduce -- --nocapture`
+Expected: FAIL with "cannot find function `safe_to_reduce`".
+
+- [ ] **Step 3: Implement the predicate**
+
+In `crates/gents/src/compaction.rs`:
+
+```rust
+/// Mirror of Lean `StreamingResponse.Status`, with the same terminal partition,
+/// so generated conformance cases can be fed straight in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseStatus {
+    Streaming,
+    Complete,
+    Error,
+}
+
+impl ResponseStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Complete | Self::Error)
+    }
+
+    pub fn from_defra(value: &str) -> Option<Self> {
+        match value {
+            "streaming" => Some(Self::Streaming),
+            "complete" => Some(Self::Complete),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+
+/// Resolves the streaming status of the response that produced a message.
+pub trait ResponseStatusIndex {
+    fn status_of(&self, message: &Message) -> Option<ResponseStatus>;
+}
+
+/// Every response in scope is terminal.
+pub struct AllTerminal;
+impl ResponseStatusIndex for AllTerminal {
+    fn status_of(&self, _message: &Message) -> Option<ResponseStatus> {
+        Some(ResponseStatus::Complete)
+    }
+}
+
+/// No status is known — the conservative resolution when anything in scope is
+/// still streaming.
+pub struct NoneKnown;
+impl ResponseStatusIndex for NoneKnown {
+    fn status_of(&self, _message: &Message) -> Option<ResponseStatus> {
+        None
+    }
+}
+
+/// Runtime counterpart of Lean `PromptView.safeToReduce`: a transcript may only
+/// be reduced when every tool result it retains belongs to a response whose
+/// status is known and terminal. Reducing under a live response can summarize
+/// away a turn that is still being written.
+///
+/// See `boundary.compaction.safe-to-reduce-session-scope` for how the daemon
+/// resolves statuses at session scope rather than per message.
+pub fn safe_to_reduce(messages: &[Message], statuses: &impl ResponseStatusIndex) -> bool {
+    messages.iter().all(|message| {
+        let carries_tool_result = matches!(message, Message::User { content }
+            if content.iter().any(|item| matches!(item, crate::llm::message::UserContent::ToolResult(_))));
+        if !carries_tool_result {
+            return true;
+        }
+        statuses
+            .status_of(message)
+            .is_some_and(ResponseStatus::is_terminal)
+    })
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test -p gents --lib compaction::tests::safe_to_reduce -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the daemon resolver**
+
+In `crates/gents/src/agent/daemon/request.rs`, add below `total_compacted_messages`:
+
+```rust
+/// Session-scope resolution of the modelled `safeToReduce` gate: if any
+/// response in this session is still non-terminal, no status is treated as
+/// known, so the gate closes. All-terminal at session scope implies terminal
+/// for every row, so this can only err toward skipping a compaction — which the
+/// next request retries. See `boundary.compaction.safe-to-reduce-session-scope`.
+async fn session_has_live_response(
+    node: &defra_node::EmbeddedNode,
+    session_id: &str,
+) -> Result<bool> {
+    let escaped_session_id = crate::graphql::escape_graphql_string(session_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(
+                filter: {{
+                    session_id: {{ _eq: "{escaped_session_id}" }},
+                    status: {{ _eq: "streaming" }}
+                }}
+            ) {{
+                response_key
+            }}
+        }}"#
+    );
+    let resp = crate::session::execute_query_timed(node, &query, "session_live_responses").await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "loading live responses for session_id={}: {:?}",
+            session_id,
+            resp.errors
+        );
+    }
+    Ok(resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentResponse"))
+        .and_then(|value| value.as_array())
+        .is_some_and(|rows| !rows.is_empty()))
+}
+```
+
+and gate the compaction call in `handle_request` — replace the `if prompt_exceeds_compaction_threshold(...) {` condition body's opening with a pre-check:
+
+```rust
+                if prompt_exceeds_compaction_threshold(
+                    built.estimated_tokens,
+                    &request.content,
+                    self.behavior.context_window,
+                    self.behavior.compaction_threshold,
+                ) {
+                    let live_response =
+                        session_has_live_response(&self.node, &request.session_id).await?;
+                    let gate_open = if live_response {
+                        compaction::safe_to_reduce(&history, &compaction::NoneKnown)
+                    } else {
+                        compaction::safe_to_reduce(&history, &compaction::AllTerminal)
+                    };
+                    if !gate_open {
+                        tracing::info!(
+                            request_id = %request.request_id,
+                            session_id = %request.session_id,
+                            behavior_id = %behavior_name,
+                            "compaction skipped: a response in this session is still streaming"
+                        );
+                    }
+                    if gate_open {
+```
+
+with a matching closing brace before the existing `built = self.prompt_builder...` re-build (the re-build must still run so the prompt reflects whatever `history` currently is).
+
+- [ ] **Step 6: Verify `execute_query_timed` visibility**
+
+Run: `cargo check -p gents`
+If `session::execute_query_timed` is not visible from `agent::daemon::request`, widen it to `pub(crate)` in `crates/gents/src/session/query.rs` and re-export from `session`.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `cargo test -p gents`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/gents/src/compaction.rs crates/gents/src/compaction/tests.rs crates/gents/src/agent/daemon/request.rs crates/gents/src/session/query.rs
+git commit -m "feat(compaction): give safeToReduce a runtime counterpart
+
+The gate existed only in Lean, and the conformance case reimplemented it
+inside the test, so the test could not detect its absence from production.
+compaction::safe_to_reduce is the modelled predicate; the daemon resolves
+statuses at session scope and skips compaction while any response in the
+session is still streaming.
+
+Refs #993"
+```
+
+---
+
+## Task 11: Rust — conformance test drives the new contract
+
+**Files:**
+- Modify: `crates/gents/tests/conformance/streaming_compaction.rs:1109-1246`, `crates/gents/src/lean_vocab_test/background_transcript.rs:326-339`, `crates/gents/tests/support/conformance_consumers.rs`
+
+**Interfaces:**
+- Consumes: Task 5's contract fields; Tasks 8/9/10's production functions
+
+- [ ] **Step 1: Extend the case struct**
+
+In `crates/gents/src/lean_vocab_test/background_transcript.rs`, add to `LeanCompactionReducerCase`:
+
+```rust
+    pub(crate) split_index: usize,
+    pub(crate) safe_boundary: usize,
+    pub(crate) retained_count: usize,
+```
+
+- [ ] **Step 2: Update the expected-name set and count**
+
+In `streaming_compaction.rs`, change `assert_eq!(cases.len(), 10);` to `15` and add to `expected_names`:
+
+```rust
+        "summarize_retains_straddling_turn",
+        "summarize_drops_whole_turns",
+        "summarize_blocked_when_response_streaming",
+        "provider_view_is_idempotent",
+        "provider_view_prefix_is_stable",
+```
+
+- [ ] **Step 3: Replace the in-test gate with a production call**
+
+Replace `apply_compaction_reducer` so no case branches on `case.safe_to_reduce` itself — the gate is now production's:
+
+```rust
+fn apply_compaction_reducer(
+    case: &lean_vocab_test::LeanCompactionReducerCase,
+    input: Vec<Message>,
+) -> Vec<Message> {
+    match case.reducer.as_str() {
+        "identity" => input,
+        "strip" => gents::compaction::strip_tool_results(input).0,
+        "provider_view" => gents::compaction::provider_view(input).0,
+        "summarize" => {
+            // The gate is production's, not the test's: safe_to_reduce is the
+            // function under test, fed the Lean case's status.
+            let gate_open = if case.safe_to_reduce {
+                gents::compaction::safe_to_reduce(&input, &gents::compaction::AllTerminal)
+            } else {
+                gents::compaction::safe_to_reduce(&input, &gents::compaction::NoneKnown)
+            };
+            assert_eq!(
+                gate_open, case.safe_to_reduce,
+                "{}: production safe_to_reduce must agree with the modelled gate",
+                case.name
+            );
+            if !gate_open {
+                return input;
+            }
+            let boundary = gents::compaction::pair_safe_boundary(&input, case.split_index);
+            assert_eq!(
+                boundary, case.safe_boundary,
+                "{}: production pair_safe_boundary must match the modelled boundary",
+                case.name
+            );
+            input.into_iter().skip(boundary).collect()
+        }
+        "any_valid" if case.safe_to_reduce => gents::compaction::strip_tool_results(input).0,
+        "any_valid" => input,
+        other => panic!("unsupported compaction reducer {other:?} for {}", case.name),
+    }
+}
+```
+
+Add a `retained_count` assertion in `drive_compaction_reducer_case` after the `post_message_count` check:
+
+```rust
+    assert_eq!(
+        reduced.len(),
+        case.retained_count,
+        "{}: retained_count",
+        case.name
+    );
+```
+
+- [ ] **Step 4: Export `pair_safe_boundary`**
+
+In `crates/gents/src/compaction.rs`, add:
+
+```rust
+/// Re-exported for the generated conformance cases, which check the production
+/// boundary against `Compaction.pairSafeBoundary`.
+pub fn pair_safe_boundary(messages: &[Message], limit: usize) -> usize {
+    history::pair_safe_boundary(messages, limit)
+}
+```
+
+- [ ] **Step 5: Run**
+
+Run: `cargo test -p gents --test conformance generated_compaction_reducer_cases_pin_contract -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 6: Run the ledger check**
+
+Run: `cargo test -p gents lean_contract_coverage_ledger_accounts_for_every_emitted_domain -- --nocapture`
+Expected: PASS. If it fails naming an unaccounted domain, add the matching `consumerCoverage` row in `CoverageLedger.lean` and the registry entry in `conformance_consumers.rs`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/gents/tests/ crates/gents/src/lean_vocab_test/ crates/gents/src/compaction.rs
+git commit -m "test(compaction): drive the summarize and provider-view contract from production
+
+The streaming_compaction case implemented safeToReduce inside the test, so
+it could not detect the gate's absence. It now calls
+gents::compaction::safe_to_reduce and gents::compaction::pair_safe_boundary
+and asserts they agree with the model.
+
+Refs #993"
+```
+
+---
+
+## Task 12: `run_timeline` round-trip after compaction
+
+Compaction is a projection — it writes an `AgentCompactionEntry` and never mutates `AgentMessage` rows. Prove the timeline is unperturbed.
+
+**Files:**
+- Modify: `crates/gents/src/compaction/tests.rs`
+
+- [ ] **Step 1: Write the test**
+
+Append to `integration_compaction_persists_entry_and_prompt_builder_uses_it`, or add as a sibling using the same fixture setup:
+
+```rust
+#[tokio::test]
+async fn compaction_leaves_the_persisted_timeline_untouched() {
+    // Compaction is a projection: it writes a summary entry and drops a prefix
+    // from the *provider view*. The durable AgentMessage rows the run timeline
+    // reconstructs from must be byte-identical before and after.
+    let (node, compactor) = compaction_fixture().await;
+    seed_compactable_session(&node).await;
+
+    let before = session::load_history(&node, "session-1").await.unwrap();
+
+    let (view, _) = provider_view(before.clone());
+    let result = compactor
+        .compact(
+            view,
+            2000,
+            &CompactionOptions {
+                threshold: 0.50,
+                keep_recent_tokens: 200,
+                strategy: CompactionStrategy::StripThenSummarize,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    session::save_compaction_entry(
+        &node,
+        "session-1",
+        "did:test:test",
+        &result.summary.clone().unwrap(),
+        &result.files_read,
+        &result.files_modified,
+        result.messages_compacted,
+        result.original_token_estimate,
+        result.compacted_token_estimate,
+    )
+    .await
+    .unwrap();
+
+    let after = session::load_history(&node, "session-1").await.unwrap();
+    assert_eq!(
+        before, after,
+        "compaction must not mutate the durable transcript the timeline is built from"
+    );
+}
+```
+
+Extract `compaction_fixture()` and `seed_compactable_session()` from the existing integration test body (lines 678-760) so both tests share them rather than duplicating the seeding loop.
+
+- [ ] **Step 2: Run**
+
+Run: `cargo test -p gents --lib compaction::tests::compaction_leaves_the_persisted_timeline -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gents/src/compaction/tests.rs
+git commit -m "test(compaction): assert compaction leaves the durable transcript untouched
+
+Refs #993"
+```
+
+---
+
+## Task 13: Acceptance demonstration, gates, PR
+
+- [ ] **Step 1: Demonstrate the pair-splitting regression fails**
+
+Temporarily replace the boundary retreat in `history.rs` with `let split_index = split_index;` and comment out the `pairSafeBoundary` call inside Lean's `summarize`.
+
+Run: `cargo test -p gents --lib compaction::tests::split_never_separates -- --nocapture`
+Expected: FAIL.
+
+Run: `cargo test -p gents --test conformance generated_compaction_reducer_cases_pin_contract -- --nocapture`
+Expected: FAIL on `summarize_retains_straddling_turn`.
+
+Run: `cd crates/gents/proofs && lake build`
+Expected: FAIL — `summarize_preserves_pairs` no longer holds.
+
+Record the three failure messages for the PR body, then `git checkout -- .` to restore.
+
+- [ ] **Step 2: Run the gates**
+
+```bash
+cd crates/gents/proofs && lake build && cd -
+grep -rn "sorry" crates/gents/proofs/Proofs/ | grep -v "sorry-free" || echo "no sorries"
+cargo test -p gents
+cargo check --workspace --all-targets
+```
+All must pass.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin compaction-model
+gh pr create --base main --title "Model the real compaction reducer and fix what it exposes (#993)" --body "..."
+```
+
+The PR body must carry: the four defects and their fixes; the split-direction decision and its rationale; the `safeToReduce` session-scope boundary and its accepted failure mode; the five tool-stripping fixes; the acceptance demonstration output from Step 1; and the deployment note that pre-existing `AgentCompactionEntry` counts were measured in `sanitize(drop(strip H))` space and are applied in `drop(sanitize(strip H))` space, which coincide unless sanitize removed a row before the boundary — the case already broken today.
+
+---
+
+## Self-Review
+
+**Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| 1.1 real `strip` | 1 |
+| 1.2 `providerView` + commutation + idempotence | 2 |
+| 1.3 prefix stability + correspondence + `drop_preserves_providerValid` | 3 |
+| 1.4 `summarize` + `pairSafeBoundary` + `IsValidReducer` + `raw_split_can_orphan` + retiring the vacuous reducer | 4 |
+| 1.5 contract JSON + ledger + boundary | 5 |
+| 2.1 `provider_view` + call-site rewiring | 9 |
+| 2.2 idempotent strip | 6 |
+| 2.3 pair-safe split | 8 |
+| 2.4 `safe_to_reduce` + resolver | 10 |
+| 2.5 (a) classification, (e) map scoping | 7 |
+| 2.5 (b) UTF-8, (c) truncation markers, (d) stub argument | 6 |
+| 3.1 pair-closure regression | 8 |
+| 3.2 prefix regression | 9 |
+| 3.3 strip idempotence | 6 |
+| 3.4 `safe_to_reduce` tests + conformance calls production | 10, 11 |
+| 3.5 tool classification test | 7 |
+| 3.6 UTF-8 pre-truncation test | 6 |
+| 3.7 `run_timeline` round-trip | 12 |
+| Acceptance demonstration | 13 |
+| Deployment note | 13 |
+
+No gaps.
+
+**Note on Task 6**: the UTF-8 test named in spec 3.6 is not written out in Task 6's test block. Adding it there now:
+
+```rust
+#[test]
+fn pretruncation_does_not_panic_on_a_multibyte_boundary() {
+    // "é" is two bytes; a 2001-byte payload puts byte 2000 inside a codepoint.
+    let payload = format!("{}é{}", "a".repeat(1999), "b".repeat(500));
+    let messages = vec![
+        tool_call_msg("bash", r#"{"command": "cat notes"}"#),
+        tool_result_msg("call-1", &payload),
+    ];
+    let truncated = super::history::pretruncate_tool_results(messages, 2000);
+    assert!(sole_tool_result_text(&truncated[1]).contains("pre-truncated"));
+}
+```
+
+**Type consistency**: `pair_safe_boundary` is `pub(super)` in `history.rs` (Task 8) and re-exported as `compaction::pair_safe_boundary` (Task 11) — the conformance test calls the re-export, `compaction/tests.rs` calls `super::history::pair_safe_boundary`. `provider_view` returns `(Vec<Message>, FileActivity)` in Task 9 and is destructured as such in Tasks 9, 11, 12. `ResponseStatusIndex::status_of` takes `&Message` and returns `Option<ResponseStatus>` consistently in Task 10 and Task 11. Lean `pendingAfter` takes the pending set first and the list second in Tasks 3 and 4.
+
+**Placeholder scan**: no TBDs. Lean proof bodies are deliberately given as statements + toolkit, flagged in Global Constraints; every Rust step carries the actual code.

--- a/docs/superpowers/specs/2026-08-01-compaction-model-design.md
+++ b/docs/superpowers/specs/2026-08-01-compaction-model-design.md
@@ -1,0 +1,356 @@
+# Compaction: model the real reducer, fix what it exposes (#993)
+
+Status: approved design, not yet implemented.
+Branch: `compaction-model`. Single PR against `main`.
+
+## Problem
+
+`Proofs/Compaction/Transition.lean` proves preservation properties about
+**identity functions**. `stubMessageKind` is literally
+`| .toolResult callId key => .toolResult callId key`, and
+`stripToolResultsReducer_id` proves the reducer is `id`. Every theorem in
+`Proofs/Compaction/Properties.lean` is therefore vacuous with respect to the
+production summarize path in `crates/gents/src/compaction/`, which really does
+drop and rewrite transcript rows.
+
+Three production defects live in the gap:
+
+1. **The summarize split can orphan a tool-call/result pair.**
+   `split_messages_for_summary` cuts on a token budget at an arbitrary index.
+   When the boundary lands between an assistant message carrying a `ToolCall`
+   and the user message carrying its `ToolResult`, the call is summarized away
+   while the result stays in the retained tail. `sanitize_history_for_provider`
+   then drops the orphaned result at loop entry, so the tool's output is lost
+   from the provider view entirely while the summary describes only the call.
+
+2. **`safeToReduce` has no runtime counterpart.** The gate exists in Lean. The
+   conformance case in `tests/conformance/streaming_compaction.rs:1219`
+   implements the gate *inside the test* (`"any_valid" if case.safe_to_reduce`),
+   so the test cannot detect its absence from production.
+
+3. **The compacted-prefix accounting mismatch.** `agent/daemon/request.rs:105`
+   hands `compact()` the sanitized history and `compaction.rs:181` records
+   `messages_compacted = old_messages.len()` — a count indexing
+   `strip(sanitize(strip(H)))`. On the next request, `request.rs:72` applies
+   that count to `stripped_history` *before* sanitization runs — i.e. to
+   `strip(H)`. Whenever `sanitize_history_for_provider` removes anything at or
+   before the boundary the two indexings diverge: either summarized messages
+   survive verbatim alongside their own summary, or messages that were never
+   summarized are silently dropped from the provider view. The second is the
+   dangerous direction, and the skew compounds because `total_compacted_messages`
+   sums across entries.
+
+## Context: what compaction is here
+
+Two distinct mechanisms, and the defects live in the seam between them.
+
+**Tool-result stripping** (`strip_tool_results`) runs unconditionally on every
+request. `agent/daemon/request.rs:50` strips the entire loaded history before
+prompt assembly; each persisted `ToolResult`'s content becomes a pointer stub.
+No rows are dropped — same rows, same order, same call ids, payload text
+swapped. The current turn's own results are not in loaded history yet (they
+live in `new_messages` inside the owned loop), so in practice prior rounds
+become pointers while the live round stays full.
+
+**Summarize compaction** fires only when the assembled prompt crosses
+`context_window * threshold`. `compact()` splits history into `old` + `recent`
+on a token budget, summarizes `old` through a sub-completion, persists an
+`AgentCompactionEntry { summary, messages_compacted }`, and returns `recent`.
+Later requests inject the summary as a prompt layer and skip the first
+`Σ messages_compacted` rows. The durable transcript is never mutated;
+compaction is a projection.
+
+The provider view is:
+
+```
+[preamble] + [summaries] + drop_prefix(sanitize(strip(H))) + [prompt]
+```
+
+## Decisions
+
+**Split-boundary direction: move earlier.** When the budget index straddles a
+turn, the retained tail grows to include the whole assistant turn and its
+results. Cost is at most one turn of over-retention; nothing is lost. Moving
+the boundary later would summarize away a turn the budget wanted kept, which is
+information loss in exchange for staying under budget. For provider-input
+assembly, over-retaining is the correct failure direction. Documented at the
+call site.
+
+**`safeToReduce` counterpart: pure predicate + session-level resolver.**
+`compaction::safe_to_reduce` mirrors the Lean predicate exactly and is what the
+conformance test drives. The daemon backs it with a single "is any
+`AgentResponse` in this session non-terminal?" query rather than per-message
+`request_id` → response linkage. This is a sound over-approximation: if every
+response in the session is terminal then every row's owning response is
+terminal, so the modelled predicate holds. It can only err toward *unsafe*,
+whose cost is a skipped compaction retried on the next request.
+
+The one asymmetry: a row whose request has no `AgentResponse` row at all
+(crashed run) reads unsafe in the model but safe under the session check. In
+practice `sanitize` already deletes half-turns from crashed runs — an unpaired
+call or an orphaned result never reaches compaction's input — so what survives
+is a complete turn, which is safe to summarize. Recorded as a
+`Boundaries.lean` entry carrying that argument, not left in a comment.
+
+**`strip_tool_results` becomes idempotent.** Today the path strips twice
+(`request.rs`, then again inside `compact()`), and the second pass re-stubs the
+stub, so the pointer reports the *stub's* byte count instead of the real
+output's. Recognizing an existing stub fixes the misleading count and makes
+`provider_view = sanitize ∘ strip` a genuine idempotent reduction, which is
+what the canonical-reduction argument in Part 1.2 needs.
+
+## Part 1 — Lean
+
+### 1.1 A real `strip`
+
+Replace the identity `stubMessageKind` with a strip that rewrites the payload:
+
+```lean
+def stubKey (key : ToolResultKey) : ToolResultKey := { key with payloadHash := 0 }
+
+def stripKind : MessageKind → MessageKind
+  | .toolResult callId key => .toolResult callId (stubKey key)
+  | k => k
+
+def strip (msgs : List MessageRow) : List MessageRow := msgs.map stripRow
+```
+
+Theorems: `strip_idempotent`, `strip_length`, and the shape lemmas
+`callsIn (strip l) = callsIn l` and `resolvedIn (strip l) = resolvedIn l`.
+Strip touches payload; never constructors, never call ids. `stubKey` collapsing
+distinct payload hashes is deliberate and harmless — `ViewCoherent` does not
+require `UniqueToolResultKeys`.
+
+### 1.2 One canonical reduction
+
+```lean
+def providerView (msgs : List MessageRow) : List MessageRow :=
+  PromptAssembly.sanitize (strip msgs)
+```
+
+- `strip_sanitize_commute : strip (sanitize m) = sanitize (strip m)`.
+  Both `dropOrphanedFrom` and `filterCallsBy` branch only on the constructor
+  and call ids of `row.kind`, which `strip` preserves; `stripRow` commutes with
+  `withKind` on assistant rows because `stripKind` fixes them.
+- `providerView_idempotent` — from `strip_idempotent`, `strip_sanitize_commute`,
+  and the existing `sanitize_idempotent` (needs `UniqueCallIds`).
+- `providerView_sound : ProviderValid (providerView m)` — from `sanitize_sound`
+  plus `strip` preserving `UniqueCallIds`.
+
+This settles the question issue #993 raised as unproven, and settles it
+affirmatively, so reordering the drop past sanitization is licensed rather than
+assumed.
+
+`normalize_assistant_content_order` (the third stage of the Rust `sanitize`)
+reorders content *within* an assistant message and has no counterpart in the
+Lean model, which has no content ordering. Explicit model boundary.
+
+### 1.3 Prefix stability — the #3 obligation
+
+Define `pendingAfter` — the pending-call set `dropOrphanedFrom` threads.
+
+```lean
+theorem providerView_append_of_turn_boundary
+    (huniq : UniqueCallIds (a ++ b)) (hb : pendingAfter ∅ a = ∅) :
+    providerView (a ++ b) = providerView a ++ tailView a b
+```
+
+With the production-shaped corollary: `b` begins with an ordinary row, because
+every new request appends its user prompt before anything else. Then the
+correspondence the fix actually rests on — the count the compaction writer
+records names exactly the rows the next request's reader drops:
+
+```lean
+theorem compacted_prefix_correspondence
+    (hstable : providerView (H ++ new) = providerView H ++ tail)
+    (hsplit  : providerView H = dropped ++ old ++ recent) :
+    (providerView (H ++ new)).drop (dropped.length + old.length) = recent ++ tail
+```
+
+Plus `drop_at_turn_boundary_preserves_ProviderValid`, which is what makes it
+safe to drop the compacted prefix *after* sanitization without re-sanitizing:
+because `total_compacted_messages` is always produced by `pairSafeBoundary`, the
+drop lands on a turn boundary and the tail is still provider-valid.
+
+### 1.4 `summarize` — the #1 obligation, and the modelled gate behind #2
+
+```lean
+abbrev SplitPolicy := List MessageRow → Nat        -- the token-budget index
+
+def pairSafeBoundary (msgs : List MessageRow) (k : Nat) : Nat
+  -- greatest j ≤ k with pendingAfter ∅ (msgs.take j) = ∅
+
+def summarize (policy : SplitPolicy) (h : SummaryHandle) : TranscriptReducer
+```
+
+`pairSafeBoundary_le` and `pairSafeBoundary_pending_empty` establish the
+adjustment is a retreat to a turn boundary. An `IsValidReducer` instance for
+`summarize` then discharges:
+
+- `preservesPairs` — the real pair-closure theorem, requiring
+  `ActiveBlockValid v.messages`. That hypothesis holds precisely because the
+  input is a `providerView`, so #1's fix *depends on* #3's fix; they compose
+  rather than sitting side by side.
+- `preservesOrder` — `drop` preserves `StrictlyIncreasingMessages`.
+- `preservesSession`, `identityBelowGate`, `identityUnlessSafe`,
+  `reapplyPreservesCoh`. `identityUnlessSafe` is the modelled `safeToReduce`
+  gate that Part 2.4 gives a runtime counterpart.
+- `summarize_messages_suffix : (summarize … v).messages <:+ v.messages` — the
+  link between the recorded count and the retained rows.
+
+And the negative theorem, without which `pairSafeBoundary` is decoration:
+
+```lean
+theorem raw_split_can_orphan :
+    ∃ msgs k, ActiveBlockValid msgs ∧ ¬ PairsClosedInMessages (msgs.drop k)
+```
+
+a concrete witness discharged by `decide`.
+
+`stripToolResultsReducer` and its vacuous `IsValidReducer` instance are retired
+in favour of the real `strip`-based reducer. `identityReducer` stays — it is the
+legitimate degenerate reducer for the below-gate case.
+
+### 1.5 Contract JSON and coverage ledger
+
+- Extend `CompactionReducerCase` with `split_index`, `safe_boundary`, and
+  `retained_count`.
+- New case groups: `summarize` (including a case where the raw budget index
+  straddles a pair and the safe boundary retreats), and `provider_view_prefix`.
+- `CoverageLedger.lean`: rows for the new groups; a `boundaryCoverage` entry for
+  the session-level `safeToReduce` refinement; consumer registry entries in
+  `crates/gents/tests/support/conformance_consumers.rs` in the same change.
+
+## Part 2 — Rust
+
+### 2.1 `provider_view`: one reduction, both call sites
+
+```rust
+pub fn provider_view(messages: Vec<Message>) -> (Vec<Message>, FileActivity)
+// = sanitize_history_for_provider(strip_tool_results(messages))
+```
+
+`agent/daemon/request.rs` becomes view-then-drop; the post-drop `sanitize` call
+disappears, licensed by `drop_at_turn_boundary_preserves_ProviderValid`.
+`compact()` normalizes its own input through `provider_view` so
+`messages_compacted` indexes the canonical space regardless of caller — free,
+by idempotence.
+
+`sanitize_history_for_provider` stays public: `loop_stream.rs` and
+`tests/conformance/prompt_assembly.rs` both consume it directly.
+
+### 2.2 `strip_tool_results` idempotent
+
+Recognize an existing stub by exact shape (`[tool: ` prefix and the
+`see DefraDB AgentToolCall for full output]` suffix) and pass it through
+untouched, preserving the original byte count. This also replaces the
+`tool_result_was_truncated` substring sniffing (defect 3 below).
+
+### 2.3 `split_messages_for_summary` pair-safe
+
+After picking `split_index` on the token budget, retreat to the greatest
+`j ≤ split_index` where the pending-call set is empty, mirroring
+`pairSafeBoundary`. The pending discipline matches `drop_orphaned_tool_results`:
+an assistant message sets pending to its call ids, a tool result erases one, any
+other message clears it.
+
+### 2.4 `safe_to_reduce`
+
+```rust
+pub trait ResponseStatusIndex {
+    fn status_of(&self, message: &Message) -> Option<ResponseStatus>;
+}
+pub fn safe_to_reduce(messages: &[Message], statuses: &impl ResponseStatusIndex) -> bool;
+```
+
+`ResponseStatus` is a small enum in `compaction` mirroring Lean's
+`StreamingResponse.Status` (`streaming` / `complete` / `error`) with the same
+terminal partition, so the conformance case can feed Lean's values straight in.
+
+Daemon resolver: one query for non-terminal `AgentResponse` rows in the session;
+any hit resolves every status to unknown, so the gate closes and compaction is
+skipped with a `tracing::info`. The conformance case calls this function with
+Lean's synthetic statuses instead of branching on `case.safe_to_reduce` itself.
+
+### 2.5 Tool-stripping defect fixes
+
+Found while auditing `compaction/history.rs`; in-module and low risk. Lettered
+to keep them distinct from the three headline defects above.
+
+**(a)** **`files_modified` is always empty.** `ToolCallInfo::from` classifies by tool
+   name against `"write" | "edit" | "replace" | "apply_patch"`; the real tools
+   are `write_file` and `edit_file` (`toolset/file_tools.rs:422,492`). Nothing
+   matches, ever. `is_read` (`"read" | "cat" | "grep" | "search" | "find" |
+   "query"`) matches exactly one real tool, `grep` — `read_file`, `list_files`,
+   and `glob` are invisible. Masked to date because the LLM's own
+   `files_read`/`files_modified` are merged on top. Fix: classify against the
+   actual registered tool names, and add a unit test that fails if a file tool
+   is added without being classified.
+
+**(b)** **UTF-8 panic.** `truncate_tool_result_content` guards on
+   `text.text.len() > max_chars` (bytes) then slices `&text.text[..max_chars]`,
+   which panics when that index lands mid-codepoint. Unreachable under
+   `StripThenSummarize` (stubs are short ASCII) but live under
+   `CompactionStrategy::Summarize`, where raw tool output flows through. Fix:
+   floor to a char boundary, as `toolset/edit_match.rs:484` already does.
+
+**(c)** **`tool_result_was_truncated` substring sniffing.**
+   `contains("truncated")` fires on any tool output mentioning the word.
+   Subsumed by the stub marker from 2.2.
+
+**(d)** **The stub carries no arguments.** Becomes
+   `[tool: read_file(/src/compaction/history.rs), call_id: call-7, 4213 bytes
+   — see DefraDB AgentToolCall for full output]`. The path is already extracted
+   for `FileActivity`. Turns the stub from "a file was read" into "this file was
+   read", which is most of what a pointer stub exists to do.
+
+**(e)** **The `tool_calls` map is never scoped.** It accumulates across the whole
+   history, so a reused call id from an earlier turn can label a later stub with
+   the wrong tool name. Scope it per assistant turn.
+
+## Part 3 — Tests
+
+1. **Pair-closure regression** — history where the budget index lands between an
+   assistant `ToolCall` and its `ToolResult`; assert the retained tail contains
+   both.
+2. **Sanitize-shrinks-inside-the-compacted-region regression (#3)** — build `H`
+   where sanitize removes a row at or before the boundary, run two compaction
+   rounds, assert the provider view after the second is exactly `recent ++ new`:
+   no row both summarized and retained, no row dropped that was never
+   summarized.
+3. **Strip idempotence** — reapplication is a no-op and the byte count still
+   describes the original output.
+4. **`safe_to_reduce`** — unit tests; the conformance case calls production.
+5. **Tool classification** — `write_file`/`edit_file` land in `files_modified`,
+   `read_file`/`grep`/`glob`/`list_files` in `files_read`.
+6. **UTF-8 pre-truncation** — multibyte content at the cut index does not panic.
+7. **`run_timeline` round-trip after compaction** — reconstruct a request's
+   event stream from persisted rows with a compaction entry present and assert
+   it is unchanged. Compaction is a projection; it must not perturb the
+   timeline.
+
+**Acceptance demonstration.** Revert `pairSafeBoundary`, confirm both the Lean
+proof and the conformance test fail, restore. Recorded in the PR body.
+
+## Deployment note
+
+Existing `AgentCompactionEntry` rows carry counts measured in
+`sanitize(drop(strip H))` space; the new reader applies them in
+`drop(sanitize(strip H))` space. These coincide unless sanitize removes a row
+before the boundary — the exact case that is already broken today. No
+migration. Called out in the PR body.
+
+## Risk
+
+`providerView_append` is the one proof not yet seen all the way through. If it
+resists, the work stops and says so rather than shipping a `sorry` or a
+plausible-looking reorder. This is provider-input assembly: a wrong fix here
+corrupts context silently instead of failing loudly.
+
+## Gates
+
+```
+cd crates/gents/proofs && lake build     # zero sorries
+cargo test -p gents                      # full package suite, not --lib
+cargo check --workspace --all-targets    # catches desktop/example crates
+```


### PR DESCRIPTION
Closes #993.

`Proofs/Compaction/Transition.lean` proved its preservation properties about **identity functions**. `stubMessageKind` was literally:

```lean
| .toolResult callId key => .toolResult callId key
```

and `stripToolResultsReducer_id` proved the reducer was `id`. The model proved that doing nothing preserves meaning — true, and useless. This models the production reducer and fixes the three defects that were hiding behind the vacuous proofs, plus five more found while auditing the stripping code.

---

## 1. The model now quantifies over the production policy

Four new modules under `Proofs/Compaction/`:

**`Strip.lean`** — a strip that actually rewrites the tool-result payload while preserving constructors and call ids. `strip_idempotent` replaces the old `strip_tool_results_is_strictly_idempotent`, which was true only because the modelled strip was `id`.

**`ProviderView.lean`** — `strip_sanitize_commute` settles the question the issue raised as unproven:

> `strip` rewrites tool-result *content* while `sanitize` drops rows based on call/result *pairing*, so stripping first can change which pairs sanitize considers orphaned.

It does not, and the proof says why: both sanitize stages branch only on a row's `MessageKind` constructor and its call ids, and `strip` fixes both. Settling it **affirmatively** is what licenses the reorder in §2. `providerView = sanitize ∘ strip` is then the single reduction both production call sites index, and it is idempotent.

**`Prefix.lean`** — `providerView_append` proves the provider view of a longer history begins with the provider view of the shorter one, given the suffix contributes no result for a call announced in the prefix. Two checkable sufficient conditions; production satisfies the second, since a new request appends its user prompt (an ordinary row) before anything else. `compacted_prefix_correspondence` is the theorem the runtime fix rests on. `sanitize_drop_noop` is why re-narrowing after the drop costs nothing for counts this runtime writes — see the review notes below for why it is nonetheless kept.

**`Summarize.lean`** — the reducer parameterised over the real token-budget split index rather than pinning a token function: what must hold is that *whatever* index the budget picks, the reducer stays sound. `pairSafeBoundary` retreats that index to the nearest turn boundary, and pair closure is proven over the result.

`lake build` clean, zero `sorry`s.

### Reviewer attention: the class changed

`IsValidReducer.preservesPairs` and `reapplyPreservesCoh` collapse into a single `preservesCoherent`, and `ViewCoherent` gains `blockValid` and `announcementsAssistant`.

This is not tidying. Pair closure of a compacted transcript is **not** preserved by an arbitrary drop — `[assistant{1}, result 1, result 1]` is pair-closed and dropping two rows orphans the survivor. It needs the provider-validity and assistant-role structure the runtime actually maintains, which is now where it belongs. The previous three `ViewCoherent` fields sufficed only because the modelled reducer was `id`. `Properties.lean` re-derives every previous theorem name from the new field.

---

## 2. Defect: the compacted-prefix accounting mismatch

`messages_compacted` indexed `strip(sanitize(strip H))` while `drop_compacted_prefix` applied it to `strip H`. Whenever `sanitize` removed anything at or before the boundary the two diverged — either summarized messages survived verbatim alongside their own summary, or messages that were never summarized were silently dropped from the provider view. The skew compounded, because `total_compacted_messages` sums across entries.

Both call sites now go through `compaction::provider_view`. `compact()` re-normalizes its own input so the count indexes the canonical space whoever the caller is — free, by idempotence.

`compacted_prefix_is_counted_and_dropped_in_the_same_space` pins the exact divergence: with an orphaned result at the head, the old order retains one row too many, and the row it retains is the one that was summarized.

**Side effect worth noting:** `CompactionStrategy::Summarize` and `StripThenSummarize` now behave identically. They already did on the daemon path, which strips unconditionally before calling `compact()`. The variant is retained for config compatibility.

---

## 3. Defect: the summarize split could orphan a tool-call/result pair

`split_messages_for_summary` cut on a token budget at an arbitrary index. When the boundary landed between an assistant `ToolCall` and its `ToolResult`, the call was summarized away, the result stayed in the retained tail, and `sanitize_history_for_provider` dropped the orphan at loop entry — the tool's output vanished from the provider view while the summary described only the call.

The boundary now retreats to the nearest turn boundary.

**Direction decided deliberately:** moving *earlier* over-retains by at most one turn and never loses context; moving later would summarize a turn the budget wanted kept. For provider-input assembly, over-retaining is the correct failure direction. Documented at the call site and in the Lean docstring.

---

## 4. Defect: `safeToReduce` had no runtime counterpart

The gate existed only in Lean, and `tests/conformance/streaming_compaction.rs` implemented it *inside the test* (`"any_valid" if case.safe_to_reduce`), so the test could not detect its absence from production at all.

`compaction::safe_to_reduce` is the modelled predicate and is what the conformance case now drives. The daemon backs it with a single "is any `AgentResponse` in this session non-terminal?" query rather than per-message `request_id` linkage.

That is a sound over-approximation — all-terminal at session scope implies terminal for every row — so it can only err toward *unsafe*, whose cost is a skipped compaction retried on the next request. `boundary.compaction.safe-to-reduce-session-scope` records it, along with the one asymmetry (a row whose request has no response row reads unsafe in the model but safe under the session check; `sanitize` already removes half-turns from crashed runs, so what survives is a complete turn) and the follow-up that would close it exactly.

**Availability note:** a session with a wedged `streaming` response now blocks compaction until the stream idle timeout or restart recovery terminalizes it. The request then fails loudly on context overflow rather than silently losing context — the right failure direction here — but it is a behavior change worth knowing about.

---

## 5. Five tool-stripping defects found while auditing `compaction/history.rs`

- **`files_modified` was always empty.** `ToolCallInfo` classified writes against `write`/`edit`/`replace`/`apply_patch`; the registered tools are `write_file` and `edit_file` (`toolset/file_tools.rs:422,492`). Nothing matched, ever. `is_read` matched exactly one real tool, `grep` — `read_file`, `list_files`, and `glob` were invisible too. Masked because the summarizing model's own file lists were merged on top. `every_registered_file_tool_is_classified` keeps it from recurring.
- **A UTF-8 panic.** `truncate_tool_result_content` guarded on `text.len() > max_chars` (bytes) then sliced `&text[..max_chars]`, which panics when the cut lands inside a codepoint. Unreachable under `StripThenSummarize` (stubs are short ASCII) but live under `CompactionStrategy::Summarize`.
- **`strip` was not idempotent.** The path already stripped twice — `request.rs`, then again inside `compact()` — and the second pass re-stubbed the stub, so after a compaction the model was told the *stub's* byte count (~140) instead of the tool's (4213). It now always rewrites, recovering the original count from a stub-shaped input rather than re-measuring it.
- **`tool_result_was_truncated` sniffed for the bare word "truncated"** and fired on any output mentioning it. Now matches the truncation layer's own markers.
- **The stub carried no argument.** It now names the file: `[tool: read_file(/src/compaction/history.rs), call_id: call-7, 4213 bytes — …]`. The path was already extracted for `FileActivity`.

Also scoped the `tool_calls` lookup per turn so a reused call id cannot mislabel a later stub.

---

## Acceptance: the regression was introduced and watched to fail

Reverting the boundary retreat in `split_messages_for_summary` and in Lean's `summarize`:

```
error: Proofs/Compaction/Summarize.lean:243:8: application type mismatch
error: Proofs/Compaction/Summarize.lean:246:58: application type mismatch
```
(`summarize_coherent` can no longer discharge pair closure)

```
test compaction::tests::split_never_separates_a_tool_call_from_its_result ... FAILED
  assertion `left == right` failed: only the bulky user turn should be summarized
    left: 2, right: 1
```

The conformance case initially would *not* have caught it — it checked `pair_safe_boundary` but not that production still calls it. The summarize cases now sweep every budget through `split_for_summary` and require the retained tail to stay pair-closed. Re-verified with the regression in place:

```
test generated_compaction_reducer_cases_pin_contract ... FAILED
  summarize_retains_straddling_turn: split_for_summary orphaned a tool result at budget 0
```

Restored; all three green again.

## Contract cases

Six new rows across `summarize` and `provider_view` groups. The `safe_boundary` values are **computed by `Compaction.pairSafeBoundary`**, not hand-asserted, and checked against production's `pair_safe_boundary` on the corresponding Rust fixture.

The driver's `preserves_order` check changes from "shapes are unchanged" to "retained shapes are a subsequence of the input shapes" — the old form was only adequate while the modelled reducer was `id`, since `StrictlyIncreasingMessages` survives a reducer that drops rows. Strip and provider-view idempotence are now asserted on full runtime payloads rather than the structural projection, which is what the theorems actually state.

## Two rounds of review, folded in

**Round 1** — `cargo fmt` (I had not run it; that was the CI failure). Stub recognition no longer licenses skipping the rewrite: a tool can return stub-shaped text, and returning early let its payload survive every provider-view pass, so `strip_tool_result` now always rewrites and recovers the byte count from a stub-shaped input instead. File activity is credited at the *result*, not the call, so `dry_run` edits and interrupted turns no longer land in "Files modified". And `conformance/compaction_gate.rs` drives a real `BehaviorDaemon` — the previous case called the predicates directly and would have stayed green if the daemon stopped consulting them.

**Round 2, two P1s:**

*Legacy entries can drop mid-turn.* I had removed the post-drop sanitize on the strength of `drop_preserves_providerValid`, whose precondition only holds for counts the pair-safe splitter wrote. Entries predating it used an arbitrary index and carry no version marker. The main loop re-sanitizes at entry so no orphan reaches the provider, but one *does* reach `compact()`, which re-normalizes and would record its next count in a shifted space — the accounting defect, reopened for exactly the sessions that predate the fix. Re-narrowing is restored, and `Compaction.sanitize_drop_noop` proves it free for counts this runtime writes. `compact()` now also refuses to summarize when normalization removes rows, turning any non-provider-view input into a loud skip.

*`UniqueCallIds` is assumed but not enforced.* Correct, and the model now says so: `Compaction.reused_call_id_breaks_prefix_stability` exhibits a concrete pair where a reused id resurrects an earlier unpaired announcement and the prefix stops being stable — proven by `decide`. `compaction::has_unique_call_ids` checks the hypothesis over the provider view and the daemon declines to reduce when it fails. `boundary.compaction.unique-call-ids-checked` records the residual gap and names the real fix: turn-scoped pair matching in `dropUnpairedCalls` would make `sanitize` local and discharge the hypothesis entirely, but that rewrites `PromptAssembly.sanitize` and its soundness/idempotence/fixpoint proofs — #448 territory, tracked separately rather than folded in here.

Both gate conditions are now fenced at the daemon wiring, and each was verified to fail with its check removed.

## Deployment note

Existing `AgentCompactionEntry` rows carry counts measured in `sanitize(drop(strip H))` space; the new reader applies them in `drop(sanitize(strip H))` space. These coincide unless `sanitize` removed a row before the boundary — the exact case that is already broken today. Where they do not coincide, the restored post-drop sanitize keeps the provider view valid and `compact()` declines to record a new count, so the residual harm is bounded to context skew rather than silent row loss. No migration.

## Gates

```
cd crates/gents/proofs && lake build     # clean, zero sorries
cargo test -p gents                      # full package suite
cargo check --workspace --all-targets    # clean (warning count unchanged from base)
```

Design and plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
