### PR TITLE
Desktop fuzz: exact trace replay, honest surface invariants, teardown fix (#996)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,18 @@ jobs:
         working-directory: apps/gents-desktop
         run: npm run test:ui:fuzz -- --time-limit 30s
 
+      # Bombadil has no --seed; the recorded trace is the only exact-replay
+      # handle. Upload it on success too so a failing run can be bisected
+      # against a known-good trace (npm run test:ui:fuzz -- --reproduce <dir>).
+      - name: Upload Bombadil trace
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-ui-bombadil-trace
+          if-no-files-found: ignore
+          retention-days: 30
+          path: apps/gents-desktop/test-results/bombadil
+
       - name: Upload desktop UI artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/apps/gents-desktop/tests/bombadil/run-bombadil.mjs
+++ b/apps/gents-desktop/tests/bombadil/run-bombadil.mjs
@@ -11,8 +11,24 @@ import { runWithWatchdogRetry, stopProcess } from "./runner-control.mjs";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const args = process.argv.slice(2);
+if (hasOption(args, "--seed")) {
+  console.error(
+    [
+      "[bombadil] Bombadil (0.6.x) has no PRNG seed; exploration randomness lives in the",
+      "[bombadil] host binary and cannot be replayed from a number. Exact replay uses the",
+      "[bombadil] recorded trace instead — every run writes one and prints it when it exits:",
+      "[bombadil]",
+      "[bombadil]   npm run test:ui:fuzz -- --reproduce <output-directory>",
+      "[bombadil]",
+      "[bombadil] CI uploads every run's trace as the 'desktop-ui-bombadil-trace' artifact",
+      "[bombadil] (on success too, so failures can be bisected against a known-good trace).",
+    ].join("\n"),
+  );
+  process.exit(2);
+}
 const headed = consumeFlag(args, "--headed");
 const keepRunning = consumeFlag(args, "--no-exit-on-violation");
+const replayRequested = hasOption(args, "--reproduce");
 const port = await choosePort(process.env.BOMBADIL_VITE_PORT);
 const origin = `http://127.0.0.1:${port}`;
 const harnessUrl = `${origin}/tests/ui-harness/harness.html`;
@@ -20,6 +36,7 @@ const defaultOutputPath = process.env.BOMBADIL_OUTPUT_PATH
   ? resolve(process.env.BOMBADIL_OUTPUT_PATH)
   : resolve(rootDir, "test-results", "bombadil", String(Date.now()));
 let bombadilProcess = null;
+let lastAttemptOutputPath = null;
 
 const vite = spawn(
   process.execPath,
@@ -54,7 +71,9 @@ try {
   if (!headed) {
     bombadilArgs.push("--headless");
   }
-  if (!keepRunning) {
+  // --exit-on-violation is mutually exclusive with --reproduce (a replay
+  // always runs the whole trace and reports the violations it finds).
+  if (!keepRunning && !replayRequested) {
     bombadilArgs.push("--exit-on-violation");
   }
   if (!hasOption(args, "--time-limit") && !hasOption(args, "--reproduce")) {
@@ -78,6 +97,7 @@ try {
         setOutputPath(attemptArgs, `${outputPath}-watchdog-retry-${attempt - 1}`);
       }
       const attemptOutputPath = outputPathFromArgs(attemptArgs);
+      lastAttemptOutputPath = attemptOutputPath;
       await writeRunReadme(attemptOutputPath, harnessUrl, attemptArgs);
 
       console.log(`[bombadil] harness: ${harnessUrl}`);
@@ -120,6 +140,36 @@ try {
     killProcessGroup: process.platform !== "win32",
   });
   await stopProcess(vite);
+  printReproductionHandle(lastAttemptOutputPath, process.exitCode ?? 0);
+}
+
+function printReproductionHandle(outputPath, exitCode) {
+  if (!outputPath || outputPath === "(bombadil default)" || replayRequested) {
+    return;
+  }
+  const verdict = exitCode === 0 ? "PASSED" : `FAILED (exit ${exitCode})`;
+  const lines = [
+    "",
+    "============== BOMBADIL REPRODUCTION HANDLE ==============",
+    `Result: ${verdict}`,
+    `Trace:  ${resolve(rootDir, outputPath, "trace.jsonl")}`,
+    "",
+    "Replay this exact run (Bombadil has no --seed; the trace is the seed):",
+    "",
+    `  npm run test:ui:fuzz -- --reproduce ${shellQuote(resolve(rootDir, outputPath))}`,
+    "",
+  ];
+  if (process.env.CI) {
+    lines.push(
+      "This directory is uploaded as a CI artifact — 'desktop-ui-bombadil-trace'",
+      "in the desktop-ui job, inside 'desktop-ui-qa-artifacts' in the QA sweep —",
+      "kept on success too, so a failure can be bisected against a known-good",
+      "trace. Download it, then point --reproduce at the extracted directory.",
+      "",
+    );
+  }
+  lines.push("==========================================================");
+  console.log(lines.join("\n"));
 }
 
 async function resolveChromeExecutable() {
@@ -263,6 +313,8 @@ async function writeRunReadme(outputPath, harnessUrl, bombadilArgs) {
       "- The npm wrapper starts Vite on a fresh local port before replaying.",
       "- A watchdog retry writes to the adjacent `-watchdog-retry-1` directory so both attempts remain inspectable.",
       "- Use this directory path in GitHub bug issues as the artifact reference.",
+      "- Bombadil has no --seed; `trace.jsonl` here IS the reproduction handle.",
+      "- CI uploads this directory as the `desktop-ui-bombadil-trace` artifact on every run (success included), so failures can be bisected against a known-good trace.",
       "",
     ].join("\n"),
   );

--- a/apps/gents-desktop/tests/bombadil/runner-control.mjs
+++ b/apps/gents-desktop/tests/bombadil/runner-control.mjs
@@ -77,8 +77,17 @@ export async function stopProcess(
   if (!termSignalSent) {
     return;
   }
-  const exitPromise = alreadyExited ? Promise.resolve() : waitForExit(child);
-  await Promise.race([exitPromise, delay(graceMs)]);
+  if (alreadyExited) {
+    // The leader exited on its own, so the group signal only targets surviving
+    // children (Chrome). Poll for their drain across the full SIGTERM grace —
+    // racing against the leader's (already settled) exit would reduce the
+    // grace window to zero and escalate straight to SIGKILL.
+    if (await waitForProcessGroupDrain(child.pid, graceMs, killByPid)) {
+      return;
+    }
+  } else {
+    await Promise.race([waitForExit(child), delay(graceMs)]);
+  }
 
   let sentFinalKill = false;
   if (killProcessGroup) {
@@ -100,6 +109,15 @@ export async function stopProcess(
         : Promise.resolve(true),
     ]);
     if (leaderDrain.kind === "timeout" || !groupDrained) {
+      if (alreadyExited) {
+        // The run's own exit status is authoritative; a straggling (possibly
+        // zombie, awaiting reaping) group member must not turn a finished run
+        // into a failure. Surface it loudly and leave cleanup to the OS.
+        console.warn(
+          `[bombadil] process group ${child.pid ?? "unknown"} did not drain within ${killDrainMs}ms after SIGKILL; leaving cleanup to the OS`,
+        );
+        return;
+      }
       throw new Error(
         `process group ${child.pid ?? "unknown"} did not drain within ${killDrainMs}ms after SIGKILL`,
       );

--- a/apps/gents-desktop/tests/bombadil/runner-control.test.ts
+++ b/apps/gents-desktop/tests/bombadil/runner-control.test.ts
@@ -190,6 +190,57 @@ describe("Bombadil watchdog recovery", () => {
     ]);
   });
 
+  it("gives surviving group members the full SIGTERM grace after a clean exit", async () => {
+    const child = new FakeChild(865);
+    child.finish(0);
+    const signals: Array<[number, string]> = [];
+    let polls = 0;
+
+    await stopProcess(child, {
+      killProcessGroup: true,
+      graceMs: 100,
+      killByPid: (pid: number, signal: string | number) => {
+        if (signal === 0) {
+          polls += 1;
+          if (polls < 3) return true;
+          const error = new Error("process group drained") as NodeJS.ErrnoException;
+          error.code = "ESRCH";
+          throw error;
+        }
+        signals.push([pid, String(signal)]);
+        return true;
+      },
+    });
+
+    expect(signals).toEqual([[-865, "SIGTERM"]]);
+    expect(polls).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps a finished run authoritative when its group never drains", async () => {
+    const child = new FakeChild(976);
+    child.finish(0);
+    const signals: Array<[number, string]> = [];
+
+    await expect(
+      stopProcess(child, {
+        killProcessGroup: true,
+        graceMs: 1,
+        killDrainMs: 2,
+        killByPid: (pid: number, signal: string | number) => {
+          if (signal === 0) return true;
+          signals.push([pid, String(signal)]);
+          return true;
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(signals).toEqual([
+      [-976, "SIGTERM"],
+      [-976, "SIGKILL"],
+    ]);
+    expect(child.exitCode).toBe(0);
+  });
+
   it("does not start over while a SIGKILLed process remains undrained", async () => {
     const child = new FakeChild(777);
 

--- a/apps/gents-desktop/tests/bombadil/spec.ts
+++ b/apps/gents-desktop/tests/bombadil/spec.ts
@@ -1,4 +1,4 @@
-import { always } from "@antithesishq/bombadil";
+import { always, eventually } from "@antithesishq/bombadil";
 import { extract } from "@antithesishq/bombadil/browser";
 export * from "@antithesishq/bombadil/browser/defaults";
 
@@ -157,10 +157,12 @@ const emptyPrimarySurfaceProblems = extract((state) => {
         selector,
         mounted: Boolean(surface),
         textLength: normalizeText(surface?.textContent ?? "").length,
+        declaresLoading: Boolean(
+          surface?.querySelector('[role="status"], [aria-busy="true"]'),
+        ),
       };
     })
-    .filter((surface) => surface.mounted && surface.textLength === 0)
-    .map((surface) => surface.selector);
+    .filter((surface) => surface.mounted && surface.textLength === 0);
 });
 
 export const desktop_shell_stays_mounted = always(
@@ -202,8 +204,26 @@ export const desktop_shell_does_not_stack_dialogs = always(
   () => dialogProblems.current.length === 0,
 );
 
-export const desktop_primary_surfaces_are_not_empty = always(
-  () => emptyPrimarySurfaceProblems.current.length === 0,
+// A mounted primary surface with no text and no declared loading state
+// ([role="status"] / [aria-busy="true"]) is blank — a rendering bug, caught
+// immediately.
+export const desktop_primary_surfaces_are_never_blank = always(
+  () =>
+    emptyPrimarySurfaceProblems.current.filter((surface) => !surface.declaresLoading)
+      .length === 0,
+);
+
+// The transcript panel legitimately renders a text-free loading skeleton
+// between selecting a session and its snapshot arriving (issue #996), so a
+// continuous "never textually empty" assertion is wrong by design. What the
+// app does guarantee is settling: a loading surface must produce content
+// within the bound. A skeleton stuck past the bound (e.g. a dropped session
+// subscription) still fails.
+export const desktop_primary_surfaces_settle = always(
+  eventually(() => emptyPrimarySurfaceProblems.current.length === 0).within(
+    5,
+    "seconds",
+  ),
 );
 
 export const transcript_does_not_render_adjacent_duplicate_messages = always(() => {


### PR DESCRIPTION
Fixes #996 (`desktop-ui` Bombadil smoke intermittently tripping `desktop_primary_surfaces_are_not_empty` on the transcript panel, unreproducibly).

## 1. Reproducibility: the trace is the seed

Bombadil 0.6.1 (latest) has **no `--seed`** — its exploration RNG lives in the host binary (verified against the CLI surface and binary; the issue's suggested fix assumed a knob that doesn't exist). The exact-replay handle it does provide is the recorded trace, so this PR makes that handle durable and prominent:

- Every run (pass **and** fail) prints a `BOMBADIL REPRODUCTION HANDLE` block with the trace path and the exact `npm run test:ui:fuzz -- --reproduce <dir>` command.
- CI uploads `test-results/bombadil` as the `desktop-ui-bombadil-trace` artifact on **every** run (30-day retention), so a failure can be bisected against a known-good trace after the runner is recycled.
- `--seed` is rejected with an explanation pointing at `--reproduce`.
- Fixed `--reproduce` through the wrapper, which had **never worked**: the wrapper unconditionally appended `--exit-on-violation`, which Bombadil rejects alongside `--reproduce`. Replay is now verified end-to-end.

## 2. The invariant was wrong — with evidence, not by fiat

The transcript panel renders a **designed, text-free loading skeleton** (`role="status"`, "Loading conversation") between selecting a session and its snapshot arriving. Instrumenting the harness with mutation records + a task-boundary sampler shows:

- At full speed the skeleton never even spans an observable task boundary (0 empty samples across ~6.7M task-boundary samples over reloads, conversation switches, and sends).
- Under 20× CPU throttling (≈ the loaded shared CI runner) the skeleton **commits** on the send-into-new-session and conversation-switch paths — exactly the preamble of the failing CI run (reload ×2 → switch → send) — and settles immediately after.
- There is **no dropped subscription**: session loading is selection-driven refetch (`refreshSession` effect), the panel settled in every observed case, and 25/25 unseeded baseline runs were green locally.

So the old invariant asserted "non-empty text, continuously" against a state the app never guaranteed. It is replaced by two properties that state the actual guarantees, **without losing detection**:

- `desktop_primary_surfaces_are_never_blank` — a mounted primary surface with no text and no declared loading state (`[role="status"]` / `[aria-busy="true"]`) fails **immediately**. Stronger than before for genuine blank-render bugs.
- `desktop_primary_surfaces_settle` — `eventually(...).within(5, "seconds")`: an empty surface must produce content within the bound, so a skeleton stuck past 5s (the dropped-subscription failure class) still fails.

Fence-tested: a synthetic permanently-blank panel violates the first, a synthetic permanently-stuck skeleton violates the second (both exit 2). Also verified empirically that Bombadil forgives a *pending* `eventually`/`within` obligation at test end (exit 0) and only violates an *expired* bound — the settle property cannot itself flake at the time limit.

## 3. Teardown flake found by the verification sweep, and fixed

Running the new spec 25×, one **green** run exited 1: `stopProcess` threw `process group did not drain within 2000ms after SIGKILL` while cleaning up after Bombadil had already exited 0. Two defects fixed in `runner-control.mjs`:

- With the leader already exited, the SIGTERM grace raced an already-settled promise → surviving Chrome children got **zero** grace before SIGKILL. Now the group is polled for the full grace window, and SIGKILL is skipped if it drains.
- A drain timeout threw unconditionally, letting a reap-pending straggler overturn the run's verdict. When the leader exited on its own, we now warn loudly and leave cleanup to the OS; the watchdog path (leader still alive) still throws, so a hung browser can never leak into a retry.

Both behaviors pinned with new unit tests (10/10 passing).

## Verification

- `npm run test:ui:fuzz` sweep on the new spec: 24/25 green, the single failure being the teardown defect above (reproduced, fixed, covered by tests); follow-up runs on the fixed teardown green. Baseline old-spec sweep: 25/25 green locally (the original flake needs CI-runner latency to become observable, consistent with the timing analysis).
- Desktop unit suite: 333 passing; Prettier clean.

## Recommendation on merge-blocking (issue item 3)

Keep `desktop-ui` blocking. The nondeterminism was never in what the job *tests* — it was (a) an invariant asserting a guarantee the app doesn't make and (b) a teardown race, both now fixed, and any future failure ships a downloadable trace that replays exactly. An unseeded explorer that only fails honestly and reproducibly is exactly what a required check should be. If a new flake class appears despite this, demote it then — with its trace attached to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)