### PR TITLE
fix: admission slot accounting — waiter leak, crash-orphan recovery order, drain race (#1001)

### DIFF
--- a/crates/gents/proofs/Proofs/InferenceCall.lean
+++ b/crates/gents/proofs/Proofs/InferenceCall.lean
@@ -3,3 +3,4 @@ import Proofs.InferenceCall.Transition
 import Proofs.InferenceCall.Executable
 import Proofs.InferenceCall.Properties
 import Proofs.InferenceCall.SlotAccounting
+import Proofs.InferenceCall.ControllerBookkeeping

--- a/crates/gents/proofs/Proofs/InferenceCall/ControllerBookkeeping.lean
+++ b/crates/gents/proofs/Proofs/InferenceCall/ControllerBookkeeping.lean
@@ -39,10 +39,17 @@ The load-bearing facts are:
   every terminal outcome — including the queued-persist failure path —
   contributes zero to both counters (the S9 analog for in-memory bookkeeping).
 
+The model's `release` action drops the permit and in-flight contributions
+atomically. Rust refines that edge by returning the semaphore permit
+*before* decrementing `in_flight` on every release path — the release can
+synchronously install a replacement controller, so the reverse order would
+let a drained controller briefly hold an outstanding permit.
+
 No contract JSON is emitted for this module; the Rust fence is
 `crates/gents/src/admission/tests.rs`
 (`queued_persist_failure_releases_queue_capacity`,
-`assigned_permit_is_visible_to_drain_detection`), which drives the real
+`assigned_permit_is_visible_to_drain_detection`,
+`drained_signal_implies_permit_returned`), which drives the real
 controller through these paths and asserts the modeled contributions.
 -/
 

--- a/crates/gents/proofs/Proofs/InferenceCall/ControllerBookkeeping.lean
+++ b/crates/gents/proofs/Proofs/InferenceCall/ControllerBookkeeping.lean
@@ -1,0 +1,268 @@
+import Proofs.InferenceCall.SlotAccounting
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+
+open scoped BigOperators
+
+/-!
+# In-memory admission controller bookkeeping (#1001)
+
+`Proofs/InferenceCall/SlotAccounting.lean` reasons about *persisted* running
+rows. The runtime additionally keeps two in-memory counters on each
+`BackendAdmissionController` (`crates/gents/src/admission/controller.rs`) that
+the persisted model abstracts over:
+
+- the **queue-waiter** counter bounding `max_queue_depth`, and
+- the **in-flight** counter that drain detection (`is_drained`) reads before
+  `AdmissionRegistry::reconcile` installs a replacement controller.
+
+Issue #1001 found two defects that live exactly in that gap:
+
+1. a fallible durable write between the waiter increment and the guard that
+   decrements it leaked queue capacity on persist failure, and
+2. in-flight admissions were counted only *after* semaphore acquisition, so a
+   permit-holder in the acquire→count window was invisible to `is_drained`,
+   letting reconcile install a fresh full-capacity controller while an old
+   permit was live.
+
+This module models one call's path through `acquire` as a phase machine and
+assigns each phase its waiter / in-flight / semaphore-permit contribution.
+The load-bearing facts are:
+
+- `permit_implies_in_flight` / `drained_no_outstanding_permits`: with
+  in-flight counted from `enteredAcquire` (acquisition *intent*), a drained
+  controller holds no permits, so `replacement_preserves_capacity` keeps the
+  per-backend bound after a controller swap.
+- `late_admission_counting_unsound`: counting in-flight only at `admitted`
+  (the pre-fix Rust behavior) violates that invariant — the model rejects the
+  buggy counting rather than merely not mentioning it.
+- `persist_error_releases_waiter` and `terminal_phase_releases_bookkeeping`:
+  every terminal outcome — including the queued-persist failure path —
+  contributes zero to both counters (the S9 analog for in-memory bookkeeping).
+
+No contract JSON is emitted for this module; the Rust fence is
+`crates/gents/src/admission/tests.rs`
+(`queued_persist_failure_releases_queue_capacity`,
+`assigned_permit_is_visible_to_drain_detection`), which drives the real
+controller through these paths and asserts the modeled contributions.
+-/
+
+namespace InferenceCall
+namespace ControllerBookkeeping
+
+/-- Phases of a single call's path through `BackendAdmissionController::acquire`. -/
+inductive AdmissionPhase where
+  /-- Inside `acquire`, before any semaphore outcome. Counted in flight. -/
+  | enteredAcquire
+  /-- Waiter counted; the durable queued row has not been written yet. -/
+  | queuedUnpersisted
+  /-- Waiter counted; queued row durable; parked on the semaphore. -/
+  | queuedWaiting
+  /-- A semaphore permit is issued to this call, including the window where the
+      permit is assigned to a parked waiter that has not resumed yet. -/
+  | permitIssued
+  /-- The permit was transferred into a live `AdmissionPermit`. -/
+  | admitted
+  /-- Terminal without admission: closed backend, full queue, or persist error. -/
+  | rejected
+  /-- Terminal after admission: the `AdmissionPermit` released capacity. -/
+  | released
+  deriving DecidableEq, Repr
+
+namespace AdmissionPhase
+
+def isTerminalPhase : AdmissionPhase → Prop
+  | .rejected => True
+  | .released => True
+  | _ => False
+
+instance : DecidablePred isTerminalPhase := by
+  intro p
+  cases p <;> simp [isTerminalPhase] <;> infer_instance
+
+/-- Units held against `max_queue_depth` (the Rust `waiters` counter). -/
+def waiterContribution : AdmissionPhase → Nat
+  | .queuedUnpersisted => 1
+  | .queuedWaiting => 1
+  | _ => 0
+
+/-- Units visible to drain detection (the Rust `in_flight` counter read by
+    `is_drained`). Counted from acquisition intent, not from admission. -/
+def inFlightContribution : AdmissionPhase → Nat
+  | .rejected => 0
+  | .released => 0
+  | _ => 1
+
+/-- Outstanding semaphore permits attributable to this call. -/
+def permitContribution : AdmissionPhase → Nat
+  | .permitIssued => 1
+  | .admitted => 1
+  | _ => 0
+
+/-- The pre-fix Rust counting: an admission became visible to drain detection
+    only after the permit was already transferred. Kept only as the witness
+    vocabulary for `late_admission_counting_unsound`. -/
+def lateInFlightContribution : AdmissionPhase → Nat
+  | .admitted => 1
+  | _ => 0
+
+end AdmissionPhase
+
+open AdmissionPhase
+
+/-- Transition vocabulary mirroring the branches of
+    `BackendAdmissionController::acquire`. -/
+inductive Action where
+  /-- The controller observed `closed` before acquiring. -/
+  | rejectClosed
+  /-- `try_acquire_owned` succeeded immediately. -/
+  | tryAcquireIssued
+  /-- The waiter CAS succeeded under `max_queue_depth`. -/
+  | enterQueue
+  /-- The waiter CAS refused and the post-refusal retry found no permit. -/
+  | rejectQueueFull
+  /-- The durable queued row was written. -/
+  | persistQueuedOk
+  /-- The durable queued write failed (issue #1001 defect 1 path). -/
+  | persistQueuedErr
+  /-- The semaphore granted the parked waiter a permit. -/
+  | queueAcquireIssued
+  /-- The semaphore closed while the waiter was parked. -/
+  | queueRejectClosed
+  /-- The permit was transferred into a live `AdmissionPermit`. -/
+  | admit
+  /-- The running write failed and the permit was returned. -/
+  | rejectRunningPersistErr
+  /-- The `AdmissionPermit` released capacity. -/
+  | release
+  deriving DecidableEq, Repr
+
+def step? : AdmissionPhase → Action → Option AdmissionPhase
+  | .enteredAcquire, .rejectClosed => some .rejected
+  | .enteredAcquire, .tryAcquireIssued => some .permitIssued
+  | .enteredAcquire, .enterQueue => some .queuedUnpersisted
+  | .enteredAcquire, .rejectQueueFull => some .rejected
+  | .queuedUnpersisted, .persistQueuedOk => some .queuedWaiting
+  | .queuedUnpersisted, .persistQueuedErr => some .rejected
+  | .queuedWaiting, .queueAcquireIssued => some .permitIssued
+  | .queuedWaiting, .queueRejectClosed => some .rejected
+  | .permitIssued, .admit => some .admitted
+  | .permitIssued, .rejectRunningPersistErr => some .rejected
+  | .admitted, .release => some .released
+  | _, _ => none
+
+def replay? : AdmissionPhase → List Action → Option AdmissionPhase
+  | p, [] => some p
+  | p, action :: rest =>
+      match step? p action with
+      | some p' => replay? p' rest
+      | none => none
+
+/-- Every phase that holds a semaphore permit is visible to drain detection.
+    This is the invariant the pre-fix Rust counting violated. -/
+theorem permit_implies_in_flight (p : AdmissionPhase) :
+    permitContribution p ≤ inFlightContribution p := by
+  cases p <;> simp [permitContribution, inFlightContribution]
+
+/-- Every counted queue waiter is also visible to drain detection. -/
+theorem waiter_implies_in_flight (p : AdmissionPhase) :
+    waiterContribution p ≤ inFlightContribution p := by
+  cases p <;> simp [waiterContribution, inFlightContribution]
+
+/-- Counting in-flight admissions only at `admitted` — incrementing after
+    semaphore acquisition, as the pre-#1001 Rust did — is unsound:
+    `permitIssued` holds a permit invisibly. -/
+theorem late_admission_counting_unsound :
+    ¬ ∀ p : AdmissionPhase, permitContribution p ≤ lateInFlightContribution p := by
+  intro h
+  have := h .permitIssued
+  simp [permitContribution, lateInFlightContribution] at this
+
+/-- Terminal admission outcomes hold no bookkeeping: no waiter unit, no
+    in-flight unit, no permit. The in-memory S9 analog. -/
+theorem terminal_phase_releases_bookkeeping
+    {p : AdmissionPhase} (h_terminal : isTerminalPhase p) :
+    waiterContribution p = 0 ∧ inFlightContribution p = 0 ∧ permitContribution p = 0 := by
+  cases p <;>
+    simp [isTerminalPhase] at h_terminal <;>
+    simp [waiterContribution, inFlightContribution, permitContribution]
+
+/-- The queued-persist failure path is terminal and releases the waiter unit.
+    Issue #1001 defect 1: the pre-fix Rust left the waiter counted forever on
+    this path, permanently shrinking queue capacity toward `QueueFull`. -/
+theorem persist_error_releases_waiter
+    {p q : AdmissionPhase}
+    (h_step : step? p .persistQueuedErr = some q) :
+    isTerminalPhase q ∧ waiterContribution q = 0 ∧ inFlightContribution q = 0 := by
+  cases p <;> simp [step?] at h_step
+  simp [← h_step, isTerminalPhase, waiterContribution, inFlightContribution]
+
+/-- Steps never step out of a terminal phase. -/
+theorem terminal_phase_no_successor
+    {p : AdmissionPhase} (h_terminal : isTerminalPhase p) (action : Action) :
+    step? p action = none := by
+  cases p <;> cases action <;>
+    first
+      | rfl
+      | simp [isTerminalPhase] at h_terminal
+
+/-- Every non-terminal phase has a finite legal path to a terminal phase
+    (tier-1 reachability: no admission phase is modeled as stuck). -/
+theorem nonterminal_reaches_terminal
+    (p : AdmissionPhase) (h_live : ¬ isTerminalPhase p) :
+    ∃ (actions : List Action) (q : AdmissionPhase),
+      replay? p actions = some q ∧ isTerminalPhase q := by
+  cases p with
+  | enteredAcquire =>
+      exact ⟨[.rejectClosed], .rejected, by simp [replay?, step?], by simp [isTerminalPhase]⟩
+  | queuedUnpersisted =>
+      exact ⟨[.persistQueuedErr], .rejected, by simp [replay?, step?], by simp [isTerminalPhase]⟩
+  | queuedWaiting =>
+      exact ⟨[.queueRejectClosed], .rejected, by simp [replay?, step?], by simp [isTerminalPhase]⟩
+  | permitIssued =>
+      exact ⟨[.admit, .release], .released, by simp [replay?, step?], by simp [isTerminalPhase]⟩
+  | admitted =>
+      exact ⟨[.release], .released, by simp [replay?, step?], by simp [isTerminalPhase]⟩
+  | rejected => exact absurd (by simp [isTerminalPhase]) h_live
+  | released => exact absurd (by simp [isTerminalPhase]) h_live
+
+/-- Aggregate in-flight count over a controller's calls (what `is_drained`
+    reads, in the style of `reconstructedSlotCount`). -/
+def controllerInFlight (callIds : Finset Nat) (phase : Nat → AdmissionPhase) : Nat :=
+  ∑ callId ∈ callIds, inFlightContribution (phase callId)
+
+/-- Aggregate outstanding semaphore permits over a controller's calls. -/
+def controllerPermits (callIds : Finset Nat) (phase : Nat → AdmissionPhase) : Nat :=
+  ∑ callId ∈ callIds, permitContribution (phase callId)
+
+/-- Drain detection: no call is visible in flight. -/
+def drained (callIds : Finset Nat) (phase : Nat → AdmissionPhase) : Prop :=
+  controllerInFlight callIds phase = 0
+
+/-- A drained controller holds no outstanding semaphore permits — including
+    permits assigned to parked waiters that have not resumed. Issue #1001
+    defect 3: with post-acquisition counting this is false, and reconcile
+    could replace a controller that still had a live permit. -/
+theorem drained_no_outstanding_permits
+    {callIds : Finset Nat} {phase : Nat → AdmissionPhase}
+    (h_drained : drained callIds phase) :
+    controllerPermits callIds phase = 0 := by
+  have h_le : controllerPermits callIds phase ≤ controllerInFlight callIds phase :=
+    Finset.sum_le_sum fun callId _ => permit_implies_in_flight (phase callId)
+  have h_zero : controllerInFlight callIds phase = 0 := h_drained
+  omega
+
+/-- Installing a replacement controller after drain preserves the backend
+    capacity bound: the old controller contributes zero permits, so the
+    combined outstanding permits stay within `max_concurrent`. -/
+theorem replacement_preserves_capacity
+    {oldIds newIds : Finset Nat}
+    {oldPhase newPhase : Nat → AdmissionPhase}
+    {maxConcurrent : Nat}
+    (h_drained : drained oldIds oldPhase)
+    (h_new : controllerPermits newIds newPhase ≤ maxConcurrent) :
+    controllerPermits oldIds oldPhase + controllerPermits newIds newPhase ≤ maxConcurrent := by
+  rw [drained_no_outstanding_permits h_drained]
+  omega
+
+end ControllerBookkeeping
+end InferenceCall

--- a/crates/gents/proofs/Proofs/Recovery.lean
+++ b/crates/gents/proofs/Proofs/Recovery.lean
@@ -1,3 +1,4 @@
 import Proofs.Recovery.Contract
 import Proofs.Recovery.Sweeps
 import Proofs.Recovery.ContractCases
+import Proofs.Recovery.StartupOrder

--- a/crates/gents/proofs/Proofs/Recovery/StartupOrder.lean
+++ b/crates/gents/proofs/Proofs/Recovery/StartupOrder.lean
@@ -1,0 +1,177 @@
+import Proofs.Recovery.Sweeps.RequestResponse
+import Proofs.Recovery.Sweeps.Inference
+
+/-!
+# Startup recovery ordering: requests before inference calls (#1001)
+
+`inferenceCallRecoverySweep` is pinned `cadence := .startup`, but its Rust
+implementation (`InferenceCall::recover_all`) is *parent-gated*: it skips any
+queued/running call whose linked `AgentRequest` is not interrupted or terminal.
+That gate is deliberate — a live parent means the call may still be owned by a
+running loop — but it makes the sweep's convergence depend on the request sweep
+having run first.
+
+After a crash, the parents of every stale call are exactly the requests stuck
+in `claimed`/`processing`. The pre-#1001 startup ran the inference sweep
+*before* `RequestLifecycle::recover_all`, so the gate skipped every
+crash-orphaned call, no later sweep re-ran it, and orphaned `running` rows
+survived a full session — understating backend capacity
+(`Proofs/InferenceCall/SlotAccounting.lean` counts running rows as held slots)
+until a second restart.
+
+This module models the gate and pins the ordering contract:
+
+- `inference_first_skips_crash_orphan` / `inference_before_request_leaves_call_live`
+  state the defect: with the sweeps in the wrong order, a crash-orphaned call
+  is untouched and a running orphan still holds its slot after startup.
+- `request_before_inference_converges` is the contract the runtime implements:
+  running the request sweep first terminalizes the parent (its durable outcome
+  exists because response recovery writes one for every stuck request), after
+  which the gated inference sweep terminalizes the call and its slot
+  contribution reaches zero in the same startup pass.
+
+The Rust fence is
+`tests/conformance/recovery_sweeps.rs::startup_recovery_order_terminalizes_crash_orphaned_calls`,
+which drives the real ordered startup sweep (`gents::startup_recovery`) over a
+seeded crash state.
+-/
+
+namespace Recovery
+
+/-- A crash-orphaned pair: a stuck parent request and the live inference call
+    linked to it by `request_id`. -/
+structure OrphanedCallState where
+  parent : RequestRecoveryRow
+  call : InferenceCallRecoveryRow
+  deriving Repr
+
+/-- The parent gate of `InferenceCall::recover_all` (`recovery_outcome` in
+    `crates/gents/src/admission/recovery.rs`): an interrupted parent cancels,
+    a terminal parent terminalizes by call state, a live parent is skipped. -/
+def gatedInferenceCause :
+    RequestState → InferenceCallState → Option InferenceRecoveryCause
+  | .interrupted, .queued => some .interruptedParent
+  | .interrupted, .running => some .interruptedParent
+  | .completed, .queued => some .staleQueued
+  | .completed, .running => some .staleRunning
+  | .failed, .queued => some .staleQueued
+  | .failed, .running => some .staleRunning
+  | .superseded, .queued => some .staleQueued
+  | .superseded, .running => some .staleRunning
+  | .dead, .queued => some .staleQueued
+  | .dead, .running => some .staleRunning
+  | _, _ => none
+
+/-- The startup inference-call sweep as the runtime actually runs it: the
+    registered recover function behind the parent gate. -/
+def gatedInferenceSweep (s : OrphanedCallState) : OrphanedCallState :=
+  match gatedInferenceCause s.parent.request.state s.call.call.state with
+  | some cause => { s with call := inferenceCallRecover { s.call with cause := cause } }
+  | none => s
+
+/-- The startup request sweep applied to the parent row. -/
+def requestSweep (s : OrphanedCallState) : OrphanedCallState :=
+  if requestRecoveryStale s.parent then { s with parent := requestRecover s.parent } else s
+
+/-- The crash shape: the parent is stuck `claimed`/`processing` with a durable
+    outcome (response recovery guarantees one exists for every stuck request),
+    and the linked call is still `queued`/`running`. -/
+def crashOrphaned (s : OrphanedCallState) : Prop :=
+  (s.parent.request.state = .claimed ∨ s.parent.request.state = .processing) ∧
+    s.parent.durableOutcome ≠ .absent ∧
+    (s.call.call.state = .queued ∨ s.call.call.state = .running)
+
+/-- The defect gate shape: with a crash-stuck (non-terminal) parent, the gated
+    inference sweep is a no-op on the call. -/
+theorem inference_first_skips_crash_orphan
+    {s : OrphanedCallState} (h_crash : crashOrphaned s) :
+    (gatedInferenceSweep s).call = s.call := by
+  rcases h_crash with ⟨h_parent, _h_outcome, _h_call⟩
+  cases h_parent with
+  | inl h_claimed => simp [gatedInferenceSweep, gatedInferenceCause, h_claimed]
+  | inr h_processing => simp [gatedInferenceSweep, gatedInferenceCause, h_processing]
+
+/-- Issue #1001 defect 2, stated end to end: running the inference sweep
+    before the request sweep leaves a crash-orphaned call in its live state —
+    a running orphan still holds its backend slot after startup recovery, and
+    no later sweep runs at `.startup` cadence again. -/
+theorem inference_before_request_leaves_call_live
+    {s : OrphanedCallState} (h_crash : crashOrphaned s) :
+    (requestSweep (gatedInferenceSweep s)).call.call.state = .queued ∨
+      (requestSweep (gatedInferenceSweep s)).call.call.state = .running := by
+  have h_call : (gatedInferenceSweep s).call = s.call :=
+    inference_first_skips_crash_orphan h_crash
+  have h_after : (requestSweep (gatedInferenceSweep s)).call = s.call := by
+    unfold requestSweep
+    split <;> simp [h_call]
+  rw [h_after]
+  exact h_crash.2.2
+
+/-- The ordering contract the runtime implements: request sweep first, then
+    the gated inference sweep. One startup pass terminalizes the parent,
+    releases its admission, terminalizes the orphaned call, and drops its
+    slot contribution to zero. -/
+theorem request_before_inference_converges
+    {s : OrphanedCallState} (h_crash : crashOrphaned s) :
+    let s' := gatedInferenceSweep (requestSweep s)
+    isTerminal s'.parent.request.state ∧
+      s'.parent.request.admission = .released ∧
+      isTerminal s'.call.call.state ∧
+      ∀ bid : BackendId, s'.call.call.slotContribution bid = 0 := by
+  rcases h_crash with ⟨h_parent, h_outcome, h_call⟩
+  have h_stale : requestRecoveryStale s.parent := ⟨h_parent, h_outcome⟩
+  have h_sweep : requestSweep s = { s with parent := requestRecover s.parent } := by
+    simp [requestSweep, h_stale]
+  rw [h_sweep]
+  cases h_outcome_value : s.parent.durableOutcome with
+  | absent => exact absurd h_outcome_value h_outcome
+  | completed =>
+      cases h_call with
+      | inl h_queued =>
+          refine ⟨?_, ?_, ?_, ?_⟩ <;>
+            simp [gatedInferenceSweep, gatedInferenceCause, requestRecover,
+              recoveredRequestState, h_outcome_value, h_queued, inferenceCallRecover,
+              HasTerminal.isTerminal, RequestState.instHasTerminal,
+              InferenceCallState.instHasTerminal, InferenceCall.slotContribution,
+              InferenceCall.holdsBackendSlot, InferenceCallState.holdsBackendSlot]
+      | inr h_running =>
+          refine ⟨?_, ?_, ?_, ?_⟩ <;>
+            simp [gatedInferenceSweep, gatedInferenceCause, requestRecover,
+              recoveredRequestState, h_outcome_value, h_running, inferenceCallRecover,
+              HasTerminal.isTerminal, RequestState.instHasTerminal,
+              InferenceCallState.instHasTerminal, InferenceCall.slotContribution,
+              InferenceCall.holdsBackendSlot, InferenceCallState.holdsBackendSlot]
+  | failed =>
+      cases h_call with
+      | inl h_queued =>
+          refine ⟨?_, ?_, ?_, ?_⟩ <;>
+            simp [gatedInferenceSweep, gatedInferenceCause, requestRecover,
+              recoveredRequestState, h_outcome_value, h_queued, inferenceCallRecover,
+              HasTerminal.isTerminal, RequestState.instHasTerminal,
+              InferenceCallState.instHasTerminal, InferenceCall.slotContribution,
+              InferenceCall.holdsBackendSlot, InferenceCallState.holdsBackendSlot]
+      | inr h_running =>
+          refine ⟨?_, ?_, ?_, ?_⟩ <;>
+            simp [gatedInferenceSweep, gatedInferenceCause, requestRecover,
+              recoveredRequestState, h_outcome_value, h_running, inferenceCallRecover,
+              HasTerminal.isTerminal, RequestState.instHasTerminal,
+              InferenceCallState.instHasTerminal, InferenceCall.slotContribution,
+              InferenceCall.holdsBackendSlot, InferenceCallState.holdsBackendSlot]
+  | interrupted =>
+      cases h_call with
+      | inl h_queued =>
+          refine ⟨?_, ?_, ?_, ?_⟩ <;>
+            simp [gatedInferenceSweep, gatedInferenceCause, requestRecover,
+              recoveredRequestState, h_outcome_value, h_queued, inferenceCallRecover,
+              HasTerminal.isTerminal, RequestState.instHasTerminal,
+              InferenceCallState.instHasTerminal, InferenceCall.slotContribution,
+              InferenceCall.holdsBackendSlot, InferenceCallState.holdsBackendSlot]
+      | inr h_running =>
+          refine ⟨?_, ?_, ?_, ?_⟩ <;>
+            simp [gatedInferenceSweep, gatedInferenceCause, requestRecover,
+              recoveredRequestState, h_outcome_value, h_running, inferenceCallRecover,
+              HasTerminal.isTerminal, RequestState.instHasTerminal,
+              InferenceCallState.instHasTerminal, InferenceCall.slotContribution,
+              InferenceCall.holdsBackendSlot, InferenceCallState.holdsBackendSlot]
+
+end Recovery

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -147,7 +147,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Basic.lean` | Shared opaque ids, `Time`, and terminal-state helpers |
 | `Proofs/Process.lean` | Process lifecycle model plus executable `Action`, `step?`, and `replay?` |
 | `Proofs/Request.lean` | Barrel for request state, transitions, executable semantics, and local properties |
-| `Proofs/InferenceCall.lean` | Barrel for inference-call state, transitions, slot accounting, and cancellation properties |
+| `Proofs/InferenceCall.lean` | Barrel for inference-call state, transitions, slot accounting, cancellation properties, and in-memory controller bookkeeping (#1001) |
 | `Proofs/Persistence.lean` | Persistence lifecycle model plus executable `Action`, `step?`, and `replay?` |
 | `Proofs/StorageObservation.lean` | Daemon-visible storage observation model and persistence bridge |
 | `Proofs/CrossMachineComposed.lean` | Cross-machine composition and guards; global `WellFormed` (list-level coherence, detached persistence/linkage, unique call ids, no early tools, invFG) established at `initial` and preserved by every transition (#555) |
@@ -167,7 +167,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/P2PBackpressure.lean` | Obligation model (no conformance bridge): success-ack backing, pending-DAG capacity, strict push-slot release on timeout |
 | `Proofs/PeerRegistryDiscovery/DirectoryProjection.lean` | Agent directory projection (machine index v1): source-owned membership, foreign-row preservation, idempotent convergence, write-free settled fixpoint, retraction soundness. Fence: `tests/conformance/directory_projection.rs`. |
 | `Proofs/Background/` | Subagent/background bridge model: `BridgedState` (parent/child composed pair, `SecondLeg` subagent-vs-tool vocabulary), six bridge transitions, completion-notification/continuation composition, and property modules (B1/B2 projection, B3/B3′ cascade/detach, B4 depth, B5 link symmetry, B6 foreground blocking, B7 budget, INV-UNIQUE, delegation graph) |
-| `Proofs/Recovery/` | Recovery sweep contracts (`RecoverySweep`, outcome accounting #693, equivalence-to-uninterrupted), the registered sweep registry, and per-collection sweeps including subagent liveness (#465) and the startup restart-disposition classifier (#937) |
+| `Proofs/Recovery/` | Recovery sweep contracts (`RecoverySweep`, outcome accounting #693, equivalence-to-uninterrupted), the registered sweep registry, per-collection sweeps including subagent liveness (#465) and the startup restart-disposition classifier (#937), and the startup sweep ordering contract (`StartupOrder.lean`, #1001: the parent-gated inference-call sweep converges only after request repair) |
 | `Proofs/Session/` | Session queue model: queue sources (`background_completion`, steering), coalesce policy/keys, automated wake-up drain |
 | `Proofs/Properties/Safety.lean` | Request/process/persistence safety properties S1-S6 |
 | `Proofs/Properties/Liveness.lean` | Request/process liveness properties L1-L3 |
@@ -188,7 +188,7 @@ Semantic submodules:
 | Barrel | Submodules |
 |--------|------------|
 | `Proofs.Request` | `State`, `Transition`, `Executable`, `Properties` |
-| `Proofs.InferenceCall` | `State`, `Transition`, `Executable`, `Properties`, `SlotAccounting` |
+| `Proofs.InferenceCall` | `State`, `Transition`, `Executable`, `Properties`, `SlotAccounting`, `ControllerBookkeeping` |
 | `Proofs.RuntimeReconcile` | `State`, `Transition`, `Executable` |
 | `Proofs.ApplyReconcile` | `Collections`, `Manifest`, `Diff`, `Apply`, `ApplyProperties`, `Prefix`, `RuntimeBridge`, `Convergence` |
 | `Proofs.Triggers` | `Types`, `Dispatch`, `Reachability`, `SerialSupport`, `Serial`, `LatestOnly`, `Lineage` |

--- a/crates/gents/src/admission/controller.rs
+++ b/crates/gents/src/admission/controller.rs
@@ -219,6 +219,8 @@ impl BackendAdmissionController {
         // write; that is intentional — queued rows hold no reconstructed slot
         // and the startup inference-call sweep terminalizes them.
         if let Err(error) = persist_existing_call_running(node.clone(), &call).await {
+            // Permit before in-flight release, as in `start_permit`.
+            drop(permit);
             return Err(super::persistence::completion_persistence_error(error));
         }
         in_flight.disarm();
@@ -242,7 +244,16 @@ impl BackendAdmissionController {
         cancel_observer: Option<CancellationToken>,
         terminal_failure_observer: Option<Arc<Mutex<Option<String>>>>,
     ) -> Result<AdmissionPermit, CompletionError> {
-        let doc_id = persist_call_started(node.clone(), &call).await?;
+        let doc_id = match persist_call_started(node.clone(), &call).await {
+            Ok(doc_id) => doc_id,
+            Err(error) => {
+                // Return the permit before `in_flight` drops and releases:
+                // parameters drop in reverse declaration order, which would
+                // otherwise let a drained signal precede the permit return.
+                drop(permit);
+                return Err(error);
+            }
+        };
         in_flight.disarm();
         Ok(AdmissionPermit::new(
             node,
@@ -311,6 +322,10 @@ impl BackendAdmissionController {
 impl BackendAdmissionController {
     pub(super) fn queue_waiters_for_test(&self) -> usize {
         self.waiters.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn available_permits_for_test(&self) -> usize {
+        self.semaphore.available_permits()
     }
 }
 

--- a/crates/gents/src/admission/controller.rs
+++ b/crates/gents/src/admission/controller.rs
@@ -21,7 +21,12 @@ pub(super) struct BackendAdmissionController {
     pub(super) config: BackendAdmissionConfig,
     semaphore: Arc<Semaphore>,
     waiters: AtomicUsize,
-    running: AtomicUsize,
+    /// Admissions counted from acquisition *intent* (before any semaphore
+    /// outcome) until release. Drain detection reads this counter, so a
+    /// semaphore permit — including one assigned to a parked waiter whose
+    /// task has not resumed — is never invisible to `is_drained()` (#1001;
+    /// Lean `InferenceCall.ControllerBookkeeping.permit_implies_in_flight`).
+    in_flight: AtomicUsize,
     closed: AtomicBool,
     registry: Weak<AdmissionRegistryInner>,
 }
@@ -39,7 +44,7 @@ impl BackendAdmissionController {
             config,
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
             waiters: AtomicUsize::new(0),
-            running: AtomicUsize::new(0),
+            in_flight: AtomicUsize::new(0),
             closed: AtomicBool::new(false),
             registry,
         })
@@ -59,7 +64,7 @@ impl BackendAdmissionController {
     }
 
     pub(super) fn is_drained(&self) -> bool {
-        self.running.load(Ordering::SeqCst) == 0
+        self.in_flight.load(Ordering::SeqCst) == 0
     }
 
     pub(super) async fn acquire(
@@ -69,6 +74,12 @@ impl BackendAdmissionController {
         cancel_observer: Option<CancellationToken>,
         terminal_failure_observer: Option<Arc<Mutex<Option<String>>>>,
     ) -> Result<AdmissionPermit, CompletionError> {
+        // Count this admission in flight before touching the semaphore, and
+        // release it on every non-admitted exit. `AdmissionRegistry::reconcile`
+        // closes and then checks `is_drained()`; the closed flag and this
+        // counter are both SeqCst, so an acquirer that missed the close is
+        // always visible to that check.
+        let in_flight = InFlightGuard::new(self.clone());
         if self.is_closed() {
             let call = self.call_record(pending, 0);
             if let Err(error) =
@@ -89,6 +100,7 @@ impl BackendAdmissionController {
                         node,
                         permit,
                         call,
+                        in_flight,
                         cancel_observer,
                         terminal_failure_observer,
                     )
@@ -120,6 +132,7 @@ impl BackendAdmissionController {
                                 node,
                                 permit,
                                 call,
+                                in_flight,
                                 cancel_observer,
                                 terminal_failure_observer,
                             )
@@ -160,14 +173,26 @@ impl BackendAdmissionController {
         };
 
         let call = self.call_record(pending, queue_depth);
-        let doc_id = super::persistence::persist_call_queued(node.clone(), &call)
-            .await
-            .map_err(super::persistence::completion_persistence_error)?;
-        let queued_guard = QueuedCallGuard {
+        // The guard exists before the fallible durable write: a persist error
+        // must still release the waiter unit, or each failure permanently
+        // shrinks the queue toward `QueueFull` (#1001; Lean
+        // `InferenceCall.ControllerBookkeeping.persist_error_releases_waiter`).
+        // It arms terminal-persist-on-drop only once the queued row is durable
+        // — before that there is no row to terminalize.
+        let mut queued_guard = QueuedCallGuard {
             node: node.clone(),
             controller: self.clone(),
             call: call.clone(),
-            persist_on_drop: true,
+            persist_on_drop: false,
+        };
+        let doc_id = match super::persistence::persist_call_queued(node.clone(), &call).await {
+            Ok(doc_id) => {
+                queued_guard.arm();
+                doc_id
+            }
+            Err(error) => {
+                return Err(super::persistence::completion_persistence_error(error));
+            }
         };
         let permit = match self.semaphore.clone().acquire_owned().await {
             Ok(permit) => permit,
@@ -190,11 +215,13 @@ impl BackendAdmissionController {
             }
         };
         drop(queued_guard.disarm());
-        self.running.fetch_add(1, Ordering::SeqCst);
+        // A failure here leaves the durable row `queued` with no terminal
+        // write; that is intentional — queued rows hold no reconstructed slot
+        // and the startup inference-call sweep terminalizes them.
         if let Err(error) = persist_existing_call_running(node.clone(), &call).await {
-            self.release_running();
             return Err(super::persistence::completion_persistence_error(error));
         }
+        in_flight.disarm();
         Ok(AdmissionPermit::new(
             node,
             self,
@@ -211,25 +238,21 @@ impl BackendAdmissionController {
         node: Arc<EmbeddedNode>,
         permit: OwnedSemaphorePermit,
         call: InferenceCallRecord,
+        in_flight: InFlightGuard,
         cancel_observer: Option<CancellationToken>,
         terminal_failure_observer: Option<Arc<Mutex<Option<String>>>>,
     ) -> Result<AdmissionPermit, CompletionError> {
-        self.running.fetch_add(1, Ordering::SeqCst);
-        match persist_call_started(node.clone(), &call).await {
-            Ok(doc_id) => Ok(AdmissionPermit::new(
-                node,
-                self,
-                permit,
-                call,
-                doc_id,
-                cancel_observer,
-                terminal_failure_observer,
-            )),
-            Err(error) => {
-                self.release_running();
-                Err(error)
-            }
-        }
+        let doc_id = persist_call_started(node.clone(), &call).await?;
+        in_flight.disarm();
+        Ok(AdmissionPermit::new(
+            node,
+            self,
+            permit,
+            call,
+            doc_id,
+            cancel_observer,
+            terminal_failure_observer,
+        ))
     }
 
     fn try_enter_queue(&self) -> Option<usize> {
@@ -252,8 +275,8 @@ impl BackendAdmissionController {
         self.waiters.fetch_sub(1, Ordering::SeqCst);
     }
 
-    pub(super) fn release_running(&self) {
-        let previous = self.running.fetch_sub(1, Ordering::SeqCst);
+    pub(super) fn release_in_flight(&self) {
+        let previous = self.in_flight.fetch_sub(1, Ordering::SeqCst);
         if previous == 1 && self.is_closed() {
             if let Some(registry) = self.registry.upgrade() {
                 let backend_id = self.backend_id.clone();
@@ -284,6 +307,13 @@ impl BackendAdmissionController {
     }
 }
 
+#[cfg(test)]
+impl BackendAdmissionController {
+    pub(super) fn queue_waiters_for_test(&self) -> usize {
+        self.waiters.load(Ordering::SeqCst)
+    }
+}
+
 pub(super) struct QueuedCallGuard {
     node: Arc<EmbeddedNode>,
     controller: Arc<BackendAdmissionController>,
@@ -292,9 +322,44 @@ pub(super) struct QueuedCallGuard {
 }
 
 impl QueuedCallGuard {
+    fn arm(&mut self) {
+        self.persist_on_drop = true;
+    }
+
     pub(super) fn disarm(mut self) -> Self {
         self.persist_on_drop = false;
         self
+    }
+}
+
+/// Holds one unit of the controller's `in_flight` count from acquisition
+/// intent until either the admission is handed to an `AdmissionPermit`
+/// (`disarm`; the permit's drop releases through `release_in_flight`) or the
+/// acquire path exits without admitting.
+struct InFlightGuard {
+    controller: Arc<BackendAdmissionController>,
+    armed: bool,
+}
+
+impl InFlightGuard {
+    fn new(controller: Arc<BackendAdmissionController>) -> Self {
+        controller.in_flight.fetch_add(1, Ordering::SeqCst);
+        Self {
+            controller,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.controller.release_in_flight();
+        }
     }
 }
 

--- a/crates/gents/src/admission/permit.rs
+++ b/crates/gents/src/admission/permit.rs
@@ -12,7 +12,7 @@ use super::stream_guard::StreamGuardLifecycle;
 pub(crate) struct AdmissionPermit {
     node: Arc<EmbeddedNode>,
     controller: Arc<BackendAdmissionController>,
-    _permit: OwnedSemaphorePermit,
+    permit: Option<OwnedSemaphorePermit>,
     call: InferenceCallRecord,
     _doc_id: String,
     terminal: Option<PermitTerminal>,
@@ -41,7 +41,7 @@ impl AdmissionPermit {
         Self {
             node,
             controller,
-            _permit: permit,
+            permit: Some(permit),
             call,
             _doc_id: doc_id,
             terminal: None,
@@ -132,6 +132,13 @@ impl StreamGuardLifecycle for AdmissionPermit {
 
 impl Drop for AdmissionPermit {
     fn drop(&mut self) {
+        // Return the semaphore permit before the in-flight release: the
+        // release can synchronously install a replacement controller, and a
+        // drained controller must hold no outstanding permits (#1001; Lean
+        // `InferenceCall.ControllerBookkeeping.drained_no_outstanding_permits`).
+        // Field drop runs only after this body — including the observer lock
+        // below — so the permit must be taken explicitly here.
+        drop(self.permit.take());
         self.controller.release_in_flight();
         if self.finished {
             return;

--- a/crates/gents/src/admission/permit.rs
+++ b/crates/gents/src/admission/permit.rs
@@ -132,7 +132,7 @@ impl StreamGuardLifecycle for AdmissionPermit {
 
 impl Drop for AdmissionPermit {
     fn drop(&mut self) {
-        self.controller.release_running();
+        self.controller.release_in_flight();
         if self.finished {
             return;
         }

--- a/crates/gents/src/admission/tests.rs
+++ b/crates/gents/src/admission/tests.rs
@@ -1150,3 +1150,185 @@ async fn dropped_permit_without_cancelled_token_persists_failed_terminal() {
     );
     assert_reconstructed_slot_count(&rows, "backend-a", 0);
 }
+
+fn pending_call(request_id: &str, backend_id: &str) -> super::controller::PendingCallMetadata {
+    super::controller::PendingCallMetadata {
+        call_id: format!("call-{request_id}"),
+        runtime_instance_id: "runtime-test".to_string(),
+        request_id: request_id.to_string(),
+        call_seq: 1,
+        backend_id: backend_id.to_string(),
+        behavior_id: "default".to_string(),
+        agent_did: "did:test:test".to_string(),
+        call_kind: CallKind::Inference,
+        attempt: 1,
+    }
+}
+
+fn call_state_for_request(rows: &[Value], request_id: &str) -> Option<String> {
+    rows.iter()
+        .find(|row| row.get("request_id").and_then(Value::as_str) == Some(request_id))
+        .and_then(|row| row.get("call_state").and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+}
+
+/// Issue #1001 defect 1. A failed durable queued write must release the
+/// queue-waiter unit; pre-fix, the waiter counter leaked one unit per persist
+/// failure and `max_queue_depth` failures wedged the backend at `QueueFull`
+/// while idle. Lean:
+/// `InferenceCall.ControllerBookkeeping.persist_error_releases_waiter`.
+#[tokio::test]
+async fn queued_persist_failure_releases_queue_capacity() {
+    let node = test_node().await;
+    // A node without ensured schemas rejects InferenceCall writes, forcing
+    // the durable queued write inside the queue path to fail while the
+    // in-memory counters run their real paths.
+    let schemaless = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+    let controller = super::controller::BackendAdmissionController::new(
+        1,
+        config("backend-queue-leak", 1, 1),
+        std::sync::Weak::new(),
+    );
+
+    let held = controller
+        .clone()
+        .acquire(
+            node.clone(),
+            pending_call("req-leak-a", "backend-queue-leak"),
+            None,
+            None,
+        )
+        .await
+        .expect("first admission fills the only slot");
+
+    let error = match controller
+        .clone()
+        .acquire(
+            schemaless,
+            pending_call("req-leak-b", "backend-queue-leak"),
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(_) => panic!("queued persist must fail without schemas"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("persisting InferenceCall failed"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        controller.queue_waiters_for_test(),
+        0,
+        "persist failure leaked a queue-waiter unit (#1001)"
+    );
+
+    // Queue capacity must be intact: the next caller queues instead of being
+    // wedged into QueueFull, and completes once the held permit releases.
+    let queued = tokio::spawn(controller.clone().acquire(
+        node.clone(),
+        pending_call("req-leak-c", "backend-queue-leak"),
+        None,
+        None,
+    ));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    drop(held);
+    let permit = tokio::time::timeout(Duration::from_secs(30), queued)
+        .await
+        .expect("queued acquire must not hang")
+        .expect("queued acquire task join")
+        .expect("queue capacity must be available after the failed persist");
+    drop(permit);
+}
+
+/// Issue #1001 defect 3. A permit assigned to a parked waiter whose task has
+/// not resumed must stay visible to drain detection; pre-fix, the in-flight
+/// count was incremented only after the acquire resumed, so
+/// `AdmissionRegistry::reconcile` could observe a closed controller as
+/// drained and install a fresh full-capacity controller while the old permit
+/// was live, briefly exceeding `max_concurrent`. Lean:
+/// `InferenceCall.ControllerBookkeeping.drained_no_outstanding_permits`.
+#[tokio::test]
+async fn assigned_permit_is_visible_to_drain_detection() {
+    use std::future::Future;
+
+    let node = test_node().await;
+    let controller = super::controller::BackendAdmissionController::new(
+        1,
+        config("backend-drain-race", 1, 4),
+        std::sync::Weak::new(),
+    );
+
+    let held = controller
+        .clone()
+        .acquire(
+            node.clone(),
+            pending_call("req-drain-a", "backend-drain-race"),
+            None,
+            None,
+        )
+        .await
+        .expect("first admission fills the only slot");
+
+    // Park a second acquire in the queue, driving it manually with a no-op
+    // waker so the runtime never resumes it: the semaphore can then hand it
+    // the released permit while its task is unpolled — the acquire→count
+    // window from #1001.
+    let mut queued = Box::pin(controller.clone().acquire(
+        node.clone(),
+        pending_call("req-drain-b", "backend-drain-race"),
+        None,
+        None,
+    ));
+    let waker = futures::task::noop_waker();
+    let mut cx = std::task::Context::from_waker(&waker);
+    let parked_deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        assert!(
+            queued.as_mut().poll(&mut cx).is_pending(),
+            "queued acquire cannot complete while the permit is held"
+        );
+        let rows = call_rows(node.as_ref()).await;
+        if call_state_for_request(&rows, "req-drain-b").as_deref() == Some("queued") {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < parked_deadline,
+            "queued InferenceCall row never became durable"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    // The durable write is the last await before the semaphore park; a few
+    // more polls carry the future onto the semaphore waiter list so the
+    // released permit below is assigned rather than returned to the pool.
+    // The assertions do not depend on this heuristic landing: in-flight is
+    // counted from acquisition intent, so `is_drained()` stays false either
+    // way — and pre-#1001 it reported drained either way.
+    for _ in 0..20 {
+        assert!(queued.as_mut().poll(&mut cx).is_pending());
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // Releasing the held permit assigns it to the parked waiter without the
+    // waiter's task running.
+    drop(held);
+
+    assert!(
+        !controller.is_drained(),
+        "controller with an assigned-but-unresumed permit reported drained (#1001)"
+    );
+
+    let permit = tokio::time::timeout(Duration::from_secs(30), queued)
+        .await
+        .expect("queued acquire resumes once the permit is assigned")
+        .expect("the parked waiter holds a real permit");
+    assert!(!controller.is_drained());
+    drop(permit);
+    assert!(
+        controller.is_drained(),
+        "released admission must drain the controller"
+    );
+}

--- a/crates/gents/src/admission/tests.rs
+++ b/crates/gents/src/admission/tests.rs
@@ -1332,3 +1332,60 @@ async fn assigned_permit_is_visible_to_drain_detection() {
         "released admission must drain the controller"
     );
 }
+
+/// Issue #1001 review follow-up: the drained signal must imply the semaphore
+/// permit is already returned. `release_in_flight` can synchronously install
+/// a replacement controller (`controller_drained` → `install_pending_if_ready`),
+/// so if the permit outlived the release, a fresh full-capacity controller
+/// could coexist with an outstanding old permit — and the window is unbounded
+/// because `AdmissionPermit::drop` locks the terminal-failure observer after
+/// the release. Holding that lock from the test stalls the drop mid-body
+/// deterministically. Lean:
+/// `InferenceCall.ControllerBookkeeping.drained_no_outstanding_permits`.
+#[tokio::test]
+async fn drained_signal_implies_permit_returned() {
+    let node = test_node().await;
+    let controller = super::controller::BackendAdmissionController::new(
+        1,
+        config("backend-drain-order", 1, 4),
+        std::sync::Weak::new(),
+    );
+    let observer: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+
+    let permit = controller
+        .clone()
+        .acquire(
+            node.clone(),
+            pending_call("req-drain-order-a", "backend-drain-order"),
+            None,
+            Some(observer.clone()),
+        )
+        .await
+        .expect("admission fills the only slot");
+    controller.close();
+
+    // Stall the drop after its in-flight release point: the drop body locks
+    // the observer before it finishes, and the permit field cannot be
+    // destroyed until the body returns.
+    let stall = observer.lock().unwrap();
+    let dropper = std::thread::spawn(move || drop(permit));
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while !controller.is_drained() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "permit drop never released the in-flight unit"
+        );
+        std::thread::yield_now();
+    }
+
+    assert_eq!(
+        controller.available_permits_for_test(),
+        1,
+        "drained controller must hold no outstanding semaphore permits (#1001)"
+    );
+
+    drop(stall);
+    dropper.join().expect("permit drop thread");
+    assert_eq!(controller.available_permits_for_test(), 1);
+    assert!(controller.is_drained());
+}

--- a/crates/gents/src/agent/runtime/startup.rs
+++ b/crates/gents/src/agent/runtime/startup.rs
@@ -9,15 +9,13 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use super::context::{RuntimeContext, StartupBarrier};
-use crate::admission::{AdmissionRegistry, BackendAdmissionConfig, InferenceCall};
+use crate::admission::{AdmissionRegistry, BackendAdmissionConfig};
 use crate::agent::reconcile::GenerationSupervisor;
 use crate::agent::{DocumentResolveContext, Gents, ProcessLifecycleState};
 use crate::backend_registry;
 use crate::health_checker::{spawn_health_checker, ServiceHealthMap};
-use crate::lifecycle::RequestLifecycle;
 use crate::runtime_snapshot::ResolvedRuntimeSnapshot;
 use crate::runtime_status::{ReconcilePhase, RuntimeStatusHandle};
-use crate::tool_call_lifecycle::ToolCallLifecycle;
 use crate::tool_surface::{ToolRuntimeContext, ToolSurface};
 
 enum BackgroundTaskResult {
@@ -638,9 +636,12 @@ pub(in crate::agent) async fn run_agent(
 }
 
 async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_behavior_id: &str) {
+    // Sweep order lives in `startup_recovery`, not here: the inference-call
+    // sweep is parent-gated and must run after request repair (#1001).
+    let outcome = crate::startup_recovery::run_startup_recovery(node, agent_did).await;
     let mut recovered_any = false;
 
-    match ToolCallLifecycle::recover_all(node, agent_did).await {
+    match outcome.tool_calls {
         Ok(report) => {
             if report.tool_calls_recovered > 0 {
                 recovered_any = true;
@@ -660,7 +661,7 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
         }
     }
 
-    match InferenceCall::recover_all(node, agent_did).await {
+    match outcome.inference_calls {
         Ok(report) => {
             if report.calls_recovered > 0 {
                 recovered_any = true;
@@ -680,7 +681,7 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
         }
     }
 
-    match RequestLifecycle::recover_all(node, agent_did).await {
+    match outcome.requests {
         Ok(report) => {
             if report.requests_recovered > 0 {
                 recovered_any = true;

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -40,6 +40,7 @@ pub mod oauth_credential;
 pub mod openai_wire;
 pub mod p2p_observability;
 pub mod startup_readiness;
+pub mod startup_recovery;
 pub mod xai_grok_oauth;
 pub mod xai_oauth_login;
 pub mod xai_oauth_refresh;

--- a/crates/gents/src/startup_recovery.rs
+++ b/crates/gents/src/startup_recovery.rs
@@ -1,0 +1,54 @@
+//! Ordered startup recovery sweeps.
+//!
+//! Lean pins the inference-call recovery sweep at `.startup` cadence
+//! (`Proofs/Recovery/Sweeps/Inference.lean`), and its implementation
+//! (`InferenceCall::recover_all`) is parent-gated: a queued/running call whose
+//! linked request is not interrupted or terminal is skipped, because a live
+//! parent may still own the call. That gate makes the sweep's convergence
+//! depend on ordering: after a crash the parents of every stale call are
+//! exactly the requests stuck in `claimed`/`processing`, so the request sweep
+//! must run first (issue #1001; `Proofs/Recovery/StartupOrder.lean`,
+//! `Recovery.request_before_inference_converges`).
+//!
+//! Keeping the ordered sequence in one place makes it drivable by conformance
+//! tests instead of burying the order as ad hoc calls in the startup observer,
+//! mirroring `periodic_recovery`.
+
+use defra_node::EmbeddedNode;
+
+use crate::admission::{InferenceCall, InferenceCallRecoveryReport};
+use crate::lifecycle::{RecoveryReport, RequestLifecycle};
+use crate::tool_call_lifecycle::{ToolCallLifecycle, ToolCallRecoveryReport};
+
+/// Per-sweep results of one ordered startup recovery pass. Each sweep runs
+/// even when an earlier one failed — startup recovery is best-effort per
+/// collection and retried on the next startup.
+#[derive(Debug)]
+pub struct StartupRecoveryOutcome {
+    pub tool_calls: anyhow::Result<ToolCallRecoveryReport>,
+    pub requests: anyhow::Result<RecoveryReport>,
+    pub inference_calls: anyhow::Result<InferenceCallRecoveryReport>,
+}
+
+/// Run the startup recovery sweeps in dependency order:
+///
+/// 1. **Tool calls** — the restart-disposition classifier (#937) must observe
+///    parent liveness as persisted at the crash, before request repair
+///    terminalizes those parents.
+/// 2. **Requests/responses/conversations** — terminalizes crash-stuck
+///    `claimed`/`processing` requests from their durable response outcome
+///    (creating the missing error response first when the crash predates it).
+/// 3. **Inference calls** — parent-gated; runs last so crash-orphaned
+///    queued/running rows observe terminal parents and are terminalized in
+///    this same pass instead of surviving until the next restart
+///    (`Recovery.request_before_inference_converges`).
+pub async fn run_startup_recovery(node: &EmbeddedNode, agent_did: &str) -> StartupRecoveryOutcome {
+    let tool_calls = ToolCallLifecycle::recover_all(node, agent_did).await;
+    let requests = RequestLifecycle::recover_all(node, agent_did).await;
+    let inference_calls = InferenceCall::recover_all(node, agent_did).await;
+    StartupRecoveryOutcome {
+        tool_calls,
+        requests,
+        inference_calls,
+    }
+}

--- a/crates/gents/tests/conformance.rs
+++ b/crates/gents/tests/conformance.rs
@@ -191,6 +191,11 @@ async fn subagent_liveness_reconciliation_converges_expired_processing_to_zero()
 }
 
 #[tokio::test]
+async fn startup_recovery_order_terminalizes_crash_orphaned_calls() {
+    recovery_sweeps::startup_recovery_order_terminalizes_crash_orphaned_calls().await;
+}
+
+#[tokio::test]
 async fn single_claimer_watcher_never_claims_foreign_replica() {
     replicated_request_convergence::single_claimer_watcher_never_claims_foreign_replica().await;
 }

--- a/crates/gents/tests/conformance/recovery_sweeps.rs
+++ b/crates/gents/tests/conformance/recovery_sweeps.rs
@@ -459,6 +459,70 @@ async fn drive_queued_descendant_recovery_case(case: &lean_vocab_test::LeanRecov
     );
 }
 
+/// Issue #1001 defect 2: the startup inference-call sweep is parent-gated, so
+/// it must run after request repair. Drives the real ordered startup sweep
+/// (`gents::startup_recovery::run_startup_recovery`) over a crash shape — a
+/// parent stuck `processing` with a linked `running` call and no live loop —
+/// and requires the orphan to terminalize in the FIRST startup pass.
+/// Lean: `Recovery.request_before_inference_converges`
+/// (`Proofs/Recovery/StartupOrder.lean`).
+pub(super) async fn startup_recovery_order_terminalizes_crash_orphaned_calls() {
+    let db = test_db("startup-recovery-order-1001").await;
+    let request_id = "startup-order-1001-request";
+    let session_id = "startup-order-1001-session";
+    create_request(
+        &db.node,
+        request_id,
+        session_id,
+        "processing",
+        RECOVERY_CREATED_AT,
+    )
+    .await;
+    insert_inference_call(&db.node, request_id, "running").await;
+
+    let outcome = gents::startup_recovery::run_startup_recovery(&db.node, AGENT_DID).await;
+    let requests = outcome.requests.expect("startup request recovery");
+    assert!(
+        requests.requests_recovered >= 1,
+        "crash-stuck parent must terminalize at startup: {requests:?}"
+    );
+    let calls = outcome.inference_calls.expect("startup inference recovery");
+    assert_eq!(
+        calls.calls_recovered, 1,
+        "crash-orphaned running call must be terminalized in the first startup \
+         pass, not survive until the next restart (#1001)"
+    );
+
+    let parent = fetch_request_recovery_row(&db.node, request_id).await;
+    assert_eq!(
+        parent.lifecycle_state.as_str(),
+        "failed",
+        "crash-stuck parent repairs to failed from its recovery error response"
+    );
+    let row = fetch_inference_recovery_row(&db.node, request_id).await;
+    assert_eq!(
+        row.call_state.as_str(),
+        "failed",
+        "orphaned running call must not keep holding a reconstructed slot"
+    );
+    let slot_row = InferenceCallSlotRow::new(BACKEND_ID, row.call_state.as_str());
+    assert_eq!(
+        reconstructed_running_slot_count([slot_row], BACKEND_ID),
+        0,
+        "post-recovery rows must reconstruct zero held slots"
+    );
+
+    let second = gents::startup_recovery::run_startup_recovery(&db.node, AGENT_DID).await;
+    assert_eq!(
+        second
+            .inference_calls
+            .expect("second startup inference recovery")
+            .calls_recovered,
+        0,
+        "startup recovery must be idempotent across restarts"
+    );
+}
+
 pub(super) async fn subagent_liveness_reconciliation_converges_expired_processing_to_zero() {
     let db = test_db("recovery-465-convergence").await;
 


### PR DESCRIPTION
Fixes the three verified defects from #1001. All three live in the gap between the Lean slot model (persisted running rows) and the in-memory bookkeeping the model abstracted over, so the model was extended first, then the Rust brought into conformance.

## Lean (model first)

- **`Proofs/InferenceCall/ControllerBookkeeping.lean`** — models one call's path through `BackendAdmissionController::acquire` as a phase machine with per-phase waiter / in-flight / semaphore-permit contributions.
  - `permit_implies_in_flight` + `drained_no_outstanding_permits` + `replacement_preserves_capacity`: a drained controller holds no permits — including one assigned to a parked waiter — so installing a replacement preserves the capacity bound **only** when in-flight is counted from acquisition intent.
  - `late_admission_counting_unsound`: the pre-fix counting (increment after acquisition) is rejected by the model, not merely unmentioned.
  - `persist_error_releases_waiter` / `terminal_phase_releases_bookkeeping`: every terminal admission outcome — including queued-persist failure — holds no waiter or in-flight unit (the in-memory S9 analog).
- **`Proofs/Recovery/StartupOrder.lean`** — models the parent gate of `InferenceCall::recover_all`. `inference_before_request_leaves_call_live` states defect 2 end-to-end (wrong order ⇒ a running orphan keeps its slot after startup); `request_before_inference_converges` is the ordering contract the runtime now implements. The sweep cadence deliberately stays `.startup` — a periodic inference sweep would race the permit-drop's spawned terminal persistence and is not needed once the order is right.

`lake build` clean, zero `sorry`s.

## Rust

1. **Queue-waiter leak** (`admission/controller.rs`): `QueuedCallGuard` is constructed *before* the fallible `persist_call_queued` and arms terminal-persist-on-drop only once the row is durable. A persist error now releases the waiter unit instead of permanently shrinking the queue toward `QueueFull`.
2. **Crash-orphan recovery order**: new `startup_recovery` module runs the ordered startup sweeps (tool calls → requests → inference calls), consumed by startup's `log_recovery` (tool calls stay first so the #937 restart-disposition classifier still observes crash-time parent liveness). Crash-orphaned `running` rows now terminalize on the **first** restart.
3. **`is_drained()` race** (`admission/controller.rs`): `running` is replaced by an `in_flight` counter incremented at acquisition intent and released through an RAII guard on every non-admitted exit (handed off to `AdmissionPermit` on success). A permit in the acquire→resume window — including one assigned to a parked waiter whose task hasn't run — is never invisible to reconcile's drain check. SeqCst on the closed flag + counter closes the close/check vs. count/check-closed interleaving.

## Regression tests (each watched failing before the fix)

| Defect | Test | Pre-fix failure |
|---|---|---|
| 1 | `admission::tests::queued_persist_failure_releases_queue_capacity` | waiter counter left at 1; asserts the counter and that queue capacity still admits |
| 2 | `conformance::startup_recovery_order_terminalizes_crash_orphaned_calls` | orphaned call left `running` after driving the real ordered sweep over a seeded crash state |
| 3 | `admission::tests::assigned_permit_is_visible_to_drain_detection` | `is_drained()` reported true while a parked waiter (noop-waker-driven) held an assigned permit |

## Gates

- `cargo test -p gents` — all suites pass (1194 lib, 326 conformance, all e2e)
- `cargo check --workspace --all-targets` — clean, zero warnings
- `cargo fmt --all -- --check` — clean
- `lake build` — clean, zero `sorry`s

One unrelated e2e failure (`panicking_background_tool_terminalizes_and_notifies`) occurred in a run that overlapped a disk-full window on the build host; it passed 3/3 reruns and in the final full-suite run.

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)