### PR TITLE
fix(runtime): decode compaction summaries with unterminated fences

### DIFF
--- a/crates/gents/src/compaction/summary.rs
+++ b/crates/gents/src/compaction/summary.rs
@@ -20,24 +20,52 @@ pub(super) fn compaction_request_prompt() -> &'static str {
 }
 
 pub(super) fn parse_summary_response(raw_summary: &str) -> Result<SummaryResponse> {
-    let trimmed = raw_summary.trim();
-    let json = trimmed
-        .strip_prefix("```json")
-        .and_then(|value| value.strip_suffix("```"))
-        .map(str::trim)
-        .or_else(|| {
-            trimmed
-                .strip_prefix("```")
-                .and_then(|value| value.strip_suffix("```"))
-                .map(str::trim)
-        })
-        .unwrap_or(trimmed);
+    let json = strip_markdown_fence(raw_summary);
 
-    let mut summary: SummaryResponse = serde_json::from_str(json)
-        .with_context(|| format!("parsing compaction summary response: {json}"))?;
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let mut summary = SummaryResponse::deserialize(&mut deserializer)
+        // `end()` rejects anything but whitespace after the object, keeping the
+        // accepted envelope narrow: no extracting an object out of prose.
+        .and_then(|value| deserializer.end().map(|()| value))
+        .with_context(|| {
+            format!(
+                "parsing compaction summary response: {}",
+                bounded_excerpt(json)
+            )
+        })?;
     dedupe_paths(&mut summary.files_read);
     dedupe_paths(&mut summary.files_modified);
     Ok(summary)
+}
+
+/// Strips a `json` or untyped Markdown fence around the summary object. The
+/// closing fence is optional: models sometimes emit a complete object after an
+/// opening fence and stop without closing it (#1015).
+fn strip_markdown_fence(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    let Some(body) = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+    else {
+        return trimmed;
+    };
+    let body = body.trim();
+    body.strip_suffix("```").map(str::trim_end).unwrap_or(body)
+}
+
+/// Malformed model responses can be multi-megabyte; diagnostics carrying them
+/// verbatim would be copied into error strings, response documents, and logs.
+const DIAGNOSTIC_EXCERPT_BYTES: usize = 256;
+
+fn bounded_excerpt(text: &str) -> String {
+    if text.len() <= DIAGNOSTIC_EXCERPT_BYTES {
+        return text.to_string();
+    }
+    let mut end = DIAGNOSTIC_EXCERPT_BYTES;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}… ({} bytes total)", &text[..end], text.len())
 }
 
 pub(super) fn format_summary(

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -439,6 +439,84 @@ fn compaction_prompt_treats_prior_turns_as_data_not_instructions() {
     assert!(prompt.contains("Your only action is to return JSON"));
 }
 
+fn summary_json_body() -> &'static str {
+    r#"{"summary":"Implemented the FEAL-4 linear cryptanalysis attack.","files_read":["src/main.rs"],"files_modified":["src/attack.rs"],"key_decisions":["Used precomputed bias tables"],"pending_questions":[]}"#
+}
+
+#[test]
+fn summary_parser_accepts_bare_json() {
+    let parsed = super::summary::parse_summary_response(summary_json_body()).unwrap();
+    assert_eq!(
+        parsed.summary,
+        "Implemented the FEAL-4 linear cryptanalysis attack."
+    );
+    assert_eq!(parsed.files_read, vec!["src/main.rs"]);
+}
+
+#[test]
+fn summary_parser_accepts_closed_json_fence() {
+    let raw = format!("```json\n{}\n```", summary_json_body());
+    let parsed = super::summary::parse_summary_response(&raw).unwrap();
+    assert_eq!(parsed.files_modified, vec!["src/attack.rs"]);
+}
+
+#[test]
+fn summary_parser_accepts_closed_untyped_fence() {
+    let raw = format!("```\n{}\n```\n", summary_json_body());
+    let parsed = super::summary::parse_summary_response(&raw).unwrap();
+    assert_eq!(parsed.key_decisions, vec!["Used precomputed bias tables"]);
+}
+
+#[test]
+fn summary_parser_accepts_unterminated_json_fence() {
+    // The DeepSeek V4 Flash shape from the Terminal-Bench run behind #1015: a
+    // complete JSON object after an opening ```json fence that is never closed.
+    let raw = format!("```json\n{}\n", summary_json_body());
+    let parsed = super::summary::parse_summary_response(&raw).unwrap();
+    assert_eq!(
+        parsed.summary,
+        "Implemented the FEAL-4 linear cryptanalysis attack."
+    );
+}
+
+#[test]
+fn summary_parser_accepts_unterminated_untyped_fence() {
+    let raw = format!("```\n{}", summary_json_body());
+    let parsed = super::summary::parse_summary_response(&raw).unwrap();
+    assert_eq!(parsed.files_read, vec!["src/main.rs"]);
+}
+
+#[test]
+fn summary_parser_rejects_json_embedded_in_prose() {
+    // The envelope must stay narrow: no greedy first-`{`/last-`}` extraction
+    // that could select an unrelated object out of arbitrary prose.
+    let raw = format!(
+        "Here is what happened: {} — let me know if you need more.",
+        summary_json_body()
+    );
+    assert!(super::summary::parse_summary_response(&raw).is_err());
+}
+
+#[test]
+fn summary_parser_rejects_trailing_prose_after_json() {
+    let raw = format!("```json\n{}\nAnything else?", summary_json_body());
+    assert!(super::summary::parse_summary_response(&raw).is_err());
+}
+
+#[test]
+fn summary_parser_bounds_malformed_response_diagnostics() {
+    // A malformed multi-megabyte response must not be copied wholesale into
+    // the error string (and from there into response documents and logs).
+    let raw = format!("```json\n{{\"summary\": \"{}", "x".repeat(4 * 1024 * 1024));
+    let err = super::summary::parse_summary_response(&raw).unwrap_err();
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.len() < 2048,
+        "diagnostic must be bounded, got {} bytes",
+        rendered.len()
+    );
+}
+
 #[derive(Clone, Default)]
 struct MockSummaryModel {
     response: String,


### PR DESCRIPTION
## Summary

Closes #1015.

The compaction summary decoder only stripped a Markdown fence when both the opening and closing fence were present. DeepSeek V4 Flash frequently returns a complete JSON summary that opens with ```` ```json ```` but never emits the closing ```` ``` ````; `parse_summary_response` then handed the opening fence straight to serde_json and aborted the entire agent request (`expected value at line 1 column 1`). Observed on four tasks in the full Terminal-Bench 2.1 run from #988.

## Changes

- **Closing fence is now optional.** `strip_markdown_fence` strips a leading ` ```json ` or untyped ` ``` ` fence and, if present, a trailing ` ``` `.
- **The envelope stays narrow.** The payload must be exactly one JSON object followed by nothing but whitespace (or the closing fence), enforced with `serde_json::Deserializer::end()` — no greedy first-`{`/last-`}` extraction that could pick an unrelated object out of prose. A regression test pins this down.
- **Bounded diagnostics.** Parse errors now embed a 256-byte, char-boundary-safe excerpt plus the total byte count instead of the full response, so a malformed multi-megabyte reply is no longer copied into error strings, response documents, and logs.

No durable-transcript or provider-input lifecycle semantics change — this is decoder plumbing at the summary boundary, so no Lean transition change is required (per the issue).

## Testing

- 8 new unit tests: bare JSON, closed `json`/untyped fences, unterminated `json`/untyped fences (the #1015 shape), JSON embedded in prose (rejected), trailing prose after the object (rejected), and a 4 MiB malformed response whose rendered diagnostic must stay under 2 KiB. Written first and observed failing against the old parser.
- `cargo test -p gents`: full package suite green (one unrelated pre-existing flake reproduced once and passed on re-run — reopened #330 with the capture).
- `cargo check --workspace --all-targets`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)