### PR TITLE
fix(runtime): retry empty compaction completions on a bounded immediate ladder

### DIFF
--- a/crates/gents/src/agent/completion_retry.rs
+++ b/crates/gents/src/agent/completion_retry.rs
@@ -159,13 +159,34 @@ impl CompletionRetryPolicy {
     }
 
     /// No retry at all: an empty transport ladder, no resample, no repair. For
-    /// internal sub-completions (compaction, title generation) that are not a
-    /// user execution origin — they fail fast and are re-driven, if at all, by
-    /// their own caller, and must not inherit the scheduled ladder's
-    /// minutes-scale, deadline-less backoff (#648).
+    /// internal sub-completions that already retry at their own layer (title
+    /// generation's `generate_title_with_fallback`) — the inner completion
+    /// must not also inherit the scheduled ladder's minutes-scale,
+    /// deadline-less backoff (#648).
     pub fn no_retry() -> Self {
         Self {
             transport_backoff: Vec::new(),
+            max_resample: 0,
+            allow_repair: false,
+        }
+    }
+
+    /// Small, fixed, immediate, deadline-aware recovery budget for internal
+    /// tool-free sub-completions with no caller-level retry (compaction). Like
+    /// [`Self::no_retry`] it never inherits an execution origin's ladder
+    /// (#648), but it keeps the already-modelled retract-and-resample
+    /// recovery available: an empty-output turn or transient transport
+    /// failure gets three attempts on the crate-conventional three-slot
+    /// ladder — the first immediate (jitter floors it at 100ms) — before
+    /// failing deterministically (#1016). No resample or repair: those are
+    /// parse-400 remedies for tool-calling requests.
+    pub fn internal_immediate() -> Self {
+        Self {
+            transport_backoff: vec![
+                Duration::ZERO,
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+            ],
             max_resample: 0,
             allow_repair: false,
         }

--- a/crates/gents/src/agent/completion_retry/tests.rs
+++ b/crates/gents/src/agent/completion_retry/tests.rs
@@ -365,6 +365,59 @@ fn interactive_default_allows_a_single_short_retry_then_fails() {
 }
 
 #[test]
+fn internal_immediate_carries_a_small_fixed_ladder_with_no_resample_or_repair() {
+    // #1016: internal tool-free sub-completions (compaction) recover on a
+    // fixed 0s/1s/2s ladder — the crate-wide three-retry convention with an
+    // immediate first slot — and never on the origin ladders.
+    let policy = CompletionRetryPolicy::internal_immediate();
+    assert_eq!(
+        policy.transport_backoff,
+        vec![
+            Duration::ZERO,
+            Duration::from_secs(1),
+            Duration::from_secs(2)
+        ]
+    );
+    assert_eq!(policy.max_resample, 0);
+    assert!(!policy.allow_repair);
+}
+
+#[test]
+fn internal_immediate_retracts_three_times_then_fails() {
+    // The empty-output path is the no-effect mid-stream failure: each retry
+    // must be a retract-and-resample (never close-and-continue), the first at
+    // the 100ms jitter floor, and the fourth failure is terminal.
+    let mut state = CompletionRetryState::new(CompletionRetryPolicy::internal_immediate());
+    let now = Utc::now();
+
+    let expected_ranges = [(100, 100), (750, 1_250), (1_500, 2_500)];
+    for (low_ms, high_ms) in expected_ranges {
+        match state.on_mid_stream_failure(false, now, None) {
+            MidStreamDirective::RetractAndResample { delay } => {
+                assert_in_range(delay, low_ms, high_ms);
+            }
+            other => panic!("expected RetractAndResample, got {other:?}"),
+        }
+    }
+    match state.on_mid_stream_failure(false, now, None) {
+        MidStreamDirective::Fail { reason } => assert!(reason.contains("exhausted")),
+        other => panic!("expected Fail, got {other:?}"),
+    }
+}
+
+#[test]
+fn internal_immediate_is_deadline_aware() {
+    // Even the immediate slot respects the request deadline: a delay that
+    // cannot fit fails fast rather than sleeping into certain death.
+    let mut state = CompletionRetryState::new(CompletionRetryPolicy::internal_immediate());
+    let now = Utc::now();
+    match state.on_mid_stream_failure(false, now, Some(now)) {
+        MidStreamDirective::Fail { reason } => assert!(reason.contains("deadline")),
+        other => panic!("expected Fail, got {other:?}"),
+    }
+}
+
+#[test]
 fn default_for_origin_maps_interactive_and_scheduled() {
     use crate::lifecycle::ExecutionOrigin;
 

--- a/crates/gents/src/agent/daemon.rs
+++ b/crates/gents/src/agent/daemon.rs
@@ -115,6 +115,24 @@ impl<M: CompletionModel + 'static> BehaviorDaemon<M> {
         }
     }
 
+    /// Request-scoped compaction options: the daemon-lifetime knobs plus the
+    /// claimed deadline of the request this compaction serves. The deadline is
+    /// a required argument so no call site can omit it — the compactor's
+    /// stored config is daemon-lifetime and carries no deadline, so this is
+    /// the only path by which compaction recovery becomes deadline-aware
+    /// (#1016). Both entry points force summarization: they fire only after
+    /// the caller has established the assembled input is over budget.
+    pub(super) fn compaction_options_for_request(
+        &self,
+        deadline: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> CompactionOptions {
+        CompactionOptions {
+            force_summarize: true,
+            deadline,
+            ..self.compaction_options.clone()
+        }
+    }
+
     pub(super) fn with_approval_required_tools(mut self, tools: Vec<String>) -> Self {
         self.approval_required_tools = Arc::new(tools);
         self

--- a/crates/gents/src/agent/daemon/inference.rs
+++ b/crates/gents/src/agent/daemon/inference.rs
@@ -198,8 +198,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 loop_config.deadline = request_deadline;
                 let turn_compactor = self.compactor.clone();
                 let turn_context_window = self.behavior.context_window;
-                let mut turn_compaction_options = self.compaction_options.clone();
-                turn_compaction_options.force_summarize = true;
+                let turn_compaction_options = self.compaction_options_for_request(request_deadline);
                 let turn_node = self.node.clone();
                 let turn_session_id = request.session_id.clone();
                 let turn_request_id = request.request_id.clone();

--- a/crates/gents/src/agent/daemon/request.rs
+++ b/crates/gents/src/agent/daemon/request.rs
@@ -3,7 +3,7 @@ use tracing::Instrument;
 
 use super::{BehaviorDaemon, HandleRequestOutcome};
 use crate::admission::{self, AdmissionCallContext, CallKind};
-use crate::compaction::{self, CompactionOptions, Compactor};
+use crate::compaction::{self, Compactor};
 use crate::prompt::PromptBuilder;
 use crate::runtime_trace::RequestTraceAttrs;
 use crate::session;
@@ -168,15 +168,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                         self.compactor.compact(
                             history,
                             self.behavior.context_window,
-                            &CompactionOptions {
-                                strategy: self.behavior.compaction_strategy.clone(),
-                                // This branch is driven by the complete assembled
-                                // provider input, including preamble, incoming
-                                // request, and reserved output. Rechecking only
-                                // history against 75% can incorrectly no-op.
-                                force_summarize: true,
-                                ..self.compaction_options.clone()
-                            },
+                            &self.compaction_options_for_request(lifecycle.claimed_deadline_at()),
                         ),
                     )
                     .await?;

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -24,6 +24,12 @@ pub struct CompactionOptions {
     /// The caller has already established that the complete provider input is
     /// over budget. Skip the history-only threshold recheck and summarize.
     pub force_summarize: bool,
+    /// The claimed deadline of the request this compaction serves. The
+    /// compactor's stored config is daemon-lifetime and carries no deadline,
+    /// so this is the only path by which the internal retry ladder's
+    /// deadline fail-fast can engage (#1016); `None` leaves recovery bounded
+    /// only by the ladder itself.
+    pub deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl Default for CompactionOptions {
@@ -34,6 +40,7 @@ impl Default for CompactionOptions {
             keep_recent_tokens: 20000,
             strategy: CompactionStrategy::StripThenSummarize,
             force_summarize: false,
+            deadline: None,
         }
     }
 }
@@ -189,6 +196,12 @@ impl<M: CompletionModel + 'static> Compactor for DefraCompactor<M> {
         summary_config.tool_choice = None;
         summary_config.turn_compactor = None;
         summary_config.max_turns = 0;
+        // Both deadlines are hard stops when present; recovery must respect
+        // the earlier one.
+        summary_config.deadline = match (options.deadline, summary_config.deadline) {
+            (Some(from_options), Some(from_config)) => Some(from_options.min(from_config)),
+            (from_options, from_config) => from_options.or(from_config),
+        };
         let raw_summary = crate::agent::loop_stream::run_loop_to_text(
             (*self.model).clone(),
             None,

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -89,8 +89,11 @@ impl<M: CompletionModel> DefraCompactor<M> {
         // Compaction is an internal, non-persisting sub-completion, not a user
         // execution origin; it must not inherit the parent's retry ladder (which
         // for scheduled origins is a deadline-less 5s/30s/120s backoff that would
-        // block inline compaction for minutes). Fail fast instead (#648).
-        config.retry_policy = crate::agent::completion_retry::CompletionRetryPolicy::no_retry();
+        // block inline compaction for minutes) (#648). But it has no caller-level
+        // retry either, so zero recovery made one empty provider turn abort the
+        // whole user request: use the bounded immediate internal budget (#1016).
+        config.retry_policy =
+            crate::agent::completion_retry::CompletionRetryPolicy::internal_immediate();
         Self { model, config }
     }
 }

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -713,46 +713,25 @@ impl CompletionModel for CountingFailModel {
     }
 }
 
-#[tokio::test]
-async fn compaction_fails_fast_without_retrying_on_transient_error() {
-    // #648: compaction is an internal sub-completion, not a user execution
-    // origin. A transient provider failure must fail fast, NOT inherit the
-    // scheduled retry ladder (5s/30s/120s, deadline-less) that would block
-    // inline compaction for minutes. `DefraCompactor::new` forces `no_retry`
-    // even when handed a `scheduled_default` config, so exactly one provider
-    // call is made and `compact` returns promptly with the error.
+#[tokio::test(start_paused = true)]
+async fn transient_compaction_failures_follow_the_internal_immediate_policy() {
+    // #648 established that compaction, an internal sub-completion, must not
+    // inherit the scheduled retry ladder (5s/30s/120s, deadline-less), which
+    // would block inline compaction for minutes. #1016 replaces the resulting
+    // zero-recovery rule with a small, fixed, immediate internal budget:
+    // `DefraCompactor::new` forces `internal_immediate` even when handed a
+    // `scheduled_default` config, so a persistently transient provider error
+    // makes exactly 1 + 3 provider calls and fails deterministically within
+    // seconds (virtual time here; the 10s timeout would require the scheduled
+    // ladder to trip it).
     let model = CountingFailModel::new();
     let calls = model.calls();
-    let config = crate::agent::loop_stream::LoopConfig {
-        preamble: None,
-        context_message: None,
-        temperature: None,
-        max_tokens: None,
-        additional_params: None,
-        tool_choice: None,
-        on_rendered_request: None,
-        turn_compactor: None,
-        context_window: crate::config::DEFAULT_CONTEXT_WINDOW,
-        compaction_threshold: crate::config::DEFAULT_COMPACTION_THRESHOLD,
-        retry_policy: crate::agent::completion_retry::CompletionRetryPolicy::scheduled_default(),
-        deadline: None,
-        max_turns: 0,
-    };
-    let compactor = DefraCompactor::new(std::sync::Arc::new(model), config);
-
-    let messages: Vec<Message> = (0..12)
-        .flat_map(|turn| {
-            [
-                text_msg("user", &"x".repeat(800)),
-                text_msg("assistant", &format!("response {turn} {}", "y".repeat(400))),
-            ]
-        })
-        .collect();
+    let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
 
     let result = tokio::time::timeout(
-        std::time::Duration::from_secs(3),
+        std::time::Duration::from_secs(10),
         compactor.compact(
-            messages,
+            summary_worthy_messages(),
             500,
             &CompactionOptions {
                 threshold: 0.50,
@@ -766,7 +745,8 @@ async fn compaction_fails_fast_without_retrying_on_transient_error() {
 
     assert!(
         result.is_ok(),
-        "compaction must fail fast, not run the scheduled retry ladder (#648)"
+        "compaction must recover on the internal immediate ladder, never the \
+         scheduled one (#648/#1016)"
     );
     assert!(
         result.unwrap().is_err(),
@@ -774,8 +754,214 @@ async fn compaction_fails_fast_without_retrying_on_transient_error() {
     );
     assert_eq!(
         calls.load(std::sync::atomic::Ordering::SeqCst),
-        1,
-        "compaction must not retry: exactly one provider call"
+        4,
+        "transient failures consume exactly the internal ladder: 1 initial + 3 retries"
+    );
+}
+
+fn summary_worthy_messages() -> Vec<Message> {
+    (0..12)
+        .flat_map(|turn| {
+            [
+                text_msg("user", &"x".repeat(800)),
+                text_msg("assistant", &format!("response {turn} {}", "y".repeat(400))),
+            ]
+        })
+        .collect()
+}
+
+fn scheduled_origin_config() -> crate::agent::loop_stream::LoopConfig {
+    crate::agent::loop_stream::LoopConfig {
+        preamble: None,
+        context_message: None,
+        temperature: None,
+        max_tokens: None,
+        additional_params: None,
+        tool_choice: None,
+        on_rendered_request: None,
+        turn_compactor: None,
+        context_window: crate::config::DEFAULT_CONTEXT_WINDOW,
+        compaction_threshold: crate::config::DEFAULT_COMPACTION_THRESHOLD,
+        retry_policy: crate::agent::completion_retry::CompletionRetryPolicy::scheduled_default(),
+        deadline: None,
+        max_turns: 0,
+    }
+}
+
+fn valid_summary_json() -> String {
+    serde_json::json!({
+        "summary": "Older turns were compacted.",
+        "files_read": [],
+        "files_modified": [],
+        "key_decisions": [],
+        "pending_questions": []
+    })
+    .to_string()
+}
+
+/// Replays a fixed script of streamed responses, one per provider call, and
+/// panics on any call past the script's end — over-retrying is a test failure,
+/// not a silent loop. `Clone` shares the script and counter (the loop clones
+/// the model).
+#[derive(Clone)]
+struct ScriptedSummaryModel {
+    calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    script: Arc<Mutex<std::collections::VecDeque<Vec<RawStreamingChoice<()>>>>>,
+    requests: Arc<Mutex<Vec<CompletionRequest>>>,
+}
+
+impl ScriptedSummaryModel {
+    fn new(script: Vec<Vec<RawStreamingChoice<()>>>) -> Self {
+        Self {
+            calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            script: Arc::new(Mutex::new(script.into_iter().collect())),
+            requests: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn empty_turn() -> Vec<RawStreamingChoice<()>> {
+        vec![RawStreamingChoice::FinalResponse(())]
+    }
+
+    fn summary_turn() -> Vec<RawStreamingChoice<()>> {
+        vec![
+            RawStreamingChoice::Message(valid_summary_json()),
+            RawStreamingChoice::FinalResponse(()),
+        ]
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for ScriptedSummaryModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self::new(Vec::new())
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        unreachable!("compaction summarizes via the owned loop, which streams");
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.requests.lock().unwrap().push(request);
+        let turn = self
+            .script
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("provider called past the scripted internal retry budget");
+        let items: Vec<Result<RawStreamingChoice<()>, CompletionError>> =
+            turn.into_iter().map(Ok).collect();
+        Ok(StreamingCompletionResponse::stream(Box::pin(
+            futures::stream::iter(items),
+        )))
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn empty_compaction_completion_is_retracted_and_immediately_resampled() {
+    // #1016: a provider turn that ends with no visible output (reasoning only)
+    // is not a usable summary, but no tool effect has run, so the owned loop
+    // can retract and resample it. With `no_retry` this aborted the whole user
+    // request; the internal immediate policy must recover on the second call.
+    let model = ScriptedSummaryModel::new(vec![
+        ScriptedSummaryModel::empty_turn(),
+        ScriptedSummaryModel::summary_turn(),
+    ]);
+    let calls = model.calls.clone();
+    let requests = model.requests.clone();
+    let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
+
+    let result = compactor
+        .compact(
+            summary_worthy_messages(),
+            500,
+            &CompactionOptions {
+                threshold: 0.50,
+                keep_recent_tokens: 50,
+                strategy: CompactionStrategy::Summarize,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("an empty first attempt must be retracted and resampled, not fatal");
+
+    assert!(
+        result.summary.is_some(),
+        "the resampled attempt's summary must be used"
+    );
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        2,
+        "exactly one retract-and-resample: two provider calls"
+    );
+
+    // No tool effect can be replayed: the compaction sub-completion carries no
+    // tools, and the resample re-issues the identical request the retracted
+    // attempt saw.
+    let requests = requests.lock().unwrap();
+    for request in requests.iter() {
+        assert!(
+            request.tools.is_empty(),
+            "compaction requests must not offer tools"
+        );
+    }
+    let rendered: Vec<String> = requests
+        .iter()
+        .map(|request| serde_json::to_string(&request.chat_history).unwrap())
+        .collect();
+    assert_eq!(
+        rendered[0], rendered[1],
+        "the resample must re-issue the retracted attempt's exact input"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn repeated_empty_compaction_completions_fail_after_the_internal_budget() {
+    // #1016: recovery is bounded. A provider that never produces visible
+    // output exhausts the fixed internal ladder deterministically — 1 initial
+    // call + 3 immediate retries — and then fails.
+    let model = ScriptedSummaryModel::new(vec![
+        ScriptedSummaryModel::empty_turn(),
+        ScriptedSummaryModel::empty_turn(),
+        ScriptedSummaryModel::empty_turn(),
+        ScriptedSummaryModel::empty_turn(),
+    ]);
+    let calls = model.calls.clone();
+    let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
+
+    let error = compactor
+        .compact(
+            summary_worthy_messages(),
+            500,
+            &CompactionOptions {
+                threshold: 0.50,
+                keep_recent_tokens: 50,
+                strategy: CompactionStrategy::Summarize,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("persistently empty output must fail once the internal budget is spent");
+
+    assert!(
+        error.to_string().contains("no visible output"),
+        "the failure must name the empty-output condition: {error}"
+    );
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        4,
+        "empty-output retracts consume exactly the internal ladder: 1 initial + 3 retries"
     );
 }
 

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -927,6 +927,43 @@ async fn empty_compaction_completion_is_retracted_and_immediately_resampled() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn expired_deadline_stops_compaction_recovery_at_one_provider_call() {
+    // #1016 review: the internal ladder is deadline-aware only if the request's
+    // claimed deadline actually reaches the compactor — the daemon-lifetime
+    // config it stores has `deadline: None`. `CompactionOptions.deadline` is
+    // the request-scoped carrier: with it already expired, an empty first
+    // attempt must fail on the deadline check instead of consuming the ladder.
+    let model = ScriptedSummaryModel::new(vec![ScriptedSummaryModel::empty_turn()]);
+    let calls = model.calls.clone();
+    let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
+
+    let error = compactor
+        .compact(
+            summary_worthy_messages(),
+            500,
+            &CompactionOptions {
+                threshold: 0.50,
+                keep_recent_tokens: 50,
+                strategy: CompactionStrategy::Summarize,
+                deadline: Some(chrono::Utc::now() - chrono::Duration::seconds(60)),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("an expired deadline must fail fast, not resample");
+
+    assert!(
+        error.to_string().contains("deadline"),
+        "the failure must name the deadline, not budget exhaustion: {error}"
+    );
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "no retry may be taken once the deadline has passed"
+    );
+}
+
+#[tokio::test(start_paused = true)]
 async fn repeated_empty_compaction_completions_fail_after_the_internal_budget() {
     // #1016: recovery is bounded. A provider that never produces visible
     // output exhausts the fixed internal ladder deterministically — 1 initial


### PR DESCRIPTION
Closes #1016.

## Problem

Internal compaction sub-completions forced `CompletionRetryPolicy::no_retry()`, so a provider turn that emitted reasoning but no visible summary aborted the whole user request on the first attempt (`compaction summary inference failed ... completion produced no visible output: transport retry budget exhausted after 0 attempt(s)`). Observed eight times in the full Terminal-Bench 2.1 run from #988. The no-retry rule existed to keep compaction off the scheduled origin's minutes-scale 5s/30s/120s ladder (#648) — it never required zero recovery.

## Change

- **`CompletionRetryPolicy::internal_immediate()`** — a small, fixed, immediate, deadline-aware recovery budget for internal tool-free sub-completions with no caller-level retry: transport ladder `[0s, 1s, 2s]` (the crate-wide three-retry convention; the first slot lands at the 100ms jitter floor), `max_resample: 0`, `allow_repair: false`. Deadline fail-fast applies to every slot, including the immediate one.
- **`DefraCompactor::new` forces `internal_immediate()`** instead of `no_retry()`. Because compaction is tool-free, the empty-output recovery is exactly the already-modelled `CompletionRetry.retract` transition — retract the streamed reasoning, resample the identical request; no tool effect exists to replay.
- **Title generation keeps `no_retry()`** — `generate_title_with_fallback` already retries at its own layer (#648's original concern), and the doc comments now spell out that split.
- **No Lean changes** — the Lean `Budget` is parametric and retract/resample plus its invariants are already proven; only budget values changed, so the CompletionRetry conformance surface is untouched.

## Acceptance criteria → tests

- *Empty first attempt is retracted and immediately resampled*: `empty_compaction_completion_is_retracted_and_immediately_resampled` — succeeds in exactly 2 provider calls; asserts the resample re-issues byte-identical chat history and that no request offers tools (nothing to replay).
- *Small fixed budget, no scheduled-ladder inheritance*: `internal_immediate_carries_a_small_fixed_ladder_with_no_resample_or_repair`, `internal_immediate_retracts_three_times_then_fails` (delay-range fenced per slot), and the reworked #648 fence `transient_compaction_failures_follow_the_internal_immediate_policy`, which hands the compactor a `scheduled_default` config and proves the override (virtual-time bounded).
- *Deterministic failure after the budget*: `repeated_empty_compaction_completions_fail_after_the_internal_budget` — exactly 1 + 3 provider calls, then the empty-output error surfaces; the scripted mock panics on any call past the script, so over-retrying can't pass silently.
- *Deadline awareness*: `internal_immediate_is_deadline_aware`.

All tests were written first and watched fail against `no_retry()` (the empty-output test reproduces the Terminal-Bench error string verbatim) before the policy change.

## Verification

- `cargo test -p gents` — full package suite green (lib 1236 passed + all integration binaries, 0 failures).
- `cargo check --workspace --all-targets` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)