### PR TITLE
ci: fix the main-only full CLI suite — lean toolchain + explicit backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,10 @@ jobs:
 
       - name: Install elan
         # Runtime conformance and desktop-bridge tests both load the generated
-        # Lean contract.
-        if: matrix.suite == 'runtime' || matrix.suite == 'desktop'
+        # Lean contract. The FULL CLI suite (main pushes only — PR runs use
+        # the smoke subset) loads it too, via gents-cli's lean_apply_write_
+        # boundary and identity_decide fences.
+        if: matrix.suite == 'runtime' || matrix.suite == 'desktop' || (matrix.suite == 'cli' && github.event_name != 'pull_request')
         run: |
           curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
@@ -155,11 +157,11 @@ jobs:
       # contract. Mathlib publishes matching precompiled artifacts; without
       # this cache Lake recompiles the dependency graph in every clean checkout.
       - name: Prepare persistent Lean build cache
-        if: matrix.suite == 'runtime' || matrix.suite == 'desktop'
+        if: matrix.suite == 'runtime' || matrix.suite == 'desktop' || (matrix.suite == 'cli' && github.event_name != 'pull_request')
         run: .github/scripts/setup-lean-build-cache.sh
 
       - name: Download precompiled Mathlib artifacts
-        if: matrix.suite == 'runtime' || matrix.suite == 'desktop'
+        if: matrix.suite == 'runtime' || matrix.suite == 'desktop' || (matrix.suite == 'cli' && github.event_name != 'pull_request')
         working-directory: crates/gents/proofs
         # Lean 4.18's LLVM 15 linker emits a native cache executable that
         # macOS 26 rejects. Running the same checked-in entry point through the

--- a/crates/gents-cli/src/commands/codex_shim/background.rs
+++ b/crates/gents-cli/src/commands/codex_shim/background.rs
@@ -299,6 +299,11 @@ mod tests {
         let node = Arc::new(
             EmbeddedNode::builder()
                 .data_path(tempdir.path().join("node"))
+                // Explicit backend, matching this crate's convention
+                // (`persistent_node_builder`): the builder's default is Redb,
+                // whose defra-node feature is only transitively enabled — the
+                // CI cli shard builds without it.
+                .with_storage_backend(gents::defra_node::StorageBackend::RocksDb)
                 .build()
                 .await
                 .expect("embedded node"),

--- a/crates/gents-cli/src/commands/config/behavior.rs
+++ b/crates/gents-cli/src/commands/config/behavior.rs
@@ -551,7 +551,7 @@ pub(super) async fn behavior_show(args: ConfigShowArgs) -> Result<()> {
 mod tests {
     use std::sync::Arc;
 
-    use defra_node::EmbeddedNode;
+    use defra_node::{EmbeddedNode, StorageBackend};
     use gents::agent::persona_ops::{
         apply_persona_request, PersonaCatalogView, PersonaOp, PersonaRequestDoc,
     };
@@ -579,6 +579,11 @@ mod tests {
         let tempdir = tempfile::tempdir()?;
         let node = EmbeddedNode::builder()
             .data_path(tempdir.path().join("data"))
+            // Explicit backend, matching this crate's convention
+            // (`persistent_node_builder`): the builder's default is Redb,
+            // whose defra-node feature is only transitively enabled — the CI
+            // cli shard builds without it.
+            .with_storage_backend(StorageBackend::RocksDb)
             .build()
             .await
             .expect("embedded node boots");


### PR DESCRIPTION
Main's CI has been red since #1011 landed (Aug 4): the **full** CLI suite — which only runs on non-PR events; PR runs use the smoke subset, so PR CI never sees this — fails 4 tests on the `studio-2` cli shard, with an identical signature on the #1011, #1014, and #1028 merge commits.

## Two independent causes, two fixes

1. **No Lean toolchain on the cli shard.** The elan/lake setup steps were gated to `runtime|desktop`, but `gents-cli`'s `lean_apply_write_boundary_tests` and `identity_decide` fences build the Lean conformance contract at test time → `failed to build Lean conformance contract target ... No such file or directory`. The three Lean setup steps (elan install, persistent Lean build cache, Mathlib artifacts) now also run for `cli` on **non-PR events only** — PR latency, the point of #1011, is untouched.
2. **Two tests relied on the embedded-node builder's default backend (Redb).** defra-node's `redb` default feature isn't in the cli shard's build, so both die with `Redb backend requested but the redb feature is not enabled`. Every other in-process node in the crate pins RocksDb explicitly (the `persistent_node_builder` convention); these two (`codex_shim::background` watcher test, `config::behavior` persona drift guard) now do the same.

## Verification caveat, stated up front

PR CI cannot prove the lean-step half — the full CLI suite doesn't run on pull_request events by design. The proof is the **first main push after merge** (which will be this PR's own merge commit). The backend pins are exercised on any run that compiles the cli shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
