### PR TITLE
Validate GraphQL collection identifiers at the trust boundary

### DIFF
--- a/crates/gents-protocol/src/graphql.rs
+++ b/crates/gents-protocol/src/graphql.rs
@@ -101,6 +101,47 @@ pub struct GraphqlSessionShape {
     pub tool_results: Vec<AgentToolResultRow>,
 }
 
+/// Validate `name` against the GraphQL `Name` grammar:
+/// `[_A-Za-z][_0-9A-Za-z]*` (ASCII only). Anything interpolated into a
+/// GraphQL document in identifier position MUST pass this check first —
+/// escaping does not exist for identifiers.
+pub fn validate_graphql_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        Some(c) => {
+            return Err(anyhow!(
+                "invalid identifier {name:?}: must start with a letter or underscore, got {c:?}"
+            ))
+        }
+        None => return Err(anyhow!("invalid identifier: empty string")),
+    }
+    if let Some(c) = name
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
+    {
+        return Err(anyhow!(
+            "invalid identifier {name:?}: only ASCII letters, digits, and underscore are allowed, got {c:?}"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a value used as a **collection name** in identifier position
+/// (e.g. `EventTrigger.source_collection`). On top of the Name grammar this
+/// rejects the `__` prefix, which the GraphQL spec reserves for
+/// introspection — a "collection" of `__Type` or `__schema` would aim a
+/// query at the introspection surface instead of a document collection.
+pub fn validate_collection_identifier(name: &str) -> Result<()> {
+    validate_graphql_name(name)?;
+    if name.starts_with("__") {
+        return Err(anyhow!(
+            "invalid collection name {name:?}: the __ prefix is reserved for GraphQL introspection"
+        ));
+    }
+    Ok(())
+}
+
 pub fn escape_graphql_string(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
@@ -585,7 +626,14 @@ pub fn graphql_input_literal(value: &Value) -> Result<String> {
         Value::Object(map) => {
             let rendered = map
                 .iter()
-                .map(|(key, value)| Ok(format!("{key}: {}", graphql_input_literal(value)?)))
+                .map(|(key, value)| {
+                    // Keys render in identifier position, where escaping
+                    // cannot apply. Values reaching here are caller-supplied
+                    // (self-config patches are agent-authored), so an
+                    // unvalidated key is an injection into the mutation.
+                    validate_graphql_name(key)?;
+                    Ok(format!("{key}: {}", graphql_input_literal(value)?))
+                })
                 .collect::<Result<Vec<_>>>()?;
             Ok(format!("{{ {} }}", rendered.join(", ")))
         }
@@ -1015,6 +1063,30 @@ mod tests {
         assert!(rendered.contains("enabled: true"));
         assert!(rendered.contains(r#"name: "alpha""#));
         assert!(rendered.contains(r#"tags: ["a", "b"]"#));
+    }
+
+    #[test]
+    fn graphql_input_literal_rejects_object_keys_that_are_not_graphql_names() {
+        // Object keys land in identifier position in the rendered literal,
+        // where escaping does not apply. A self-config patch value is
+        // agent-controlled, so a non-Name key is an injection, not a typo.
+        let hostile = serde_json::json!({
+            "endpoint": {
+                r#"x: 1 }, api_key: "leaked" }) { _docID } #"#: 1
+            }
+        });
+        let err = graphql_input_literal(&hostile)
+            .expect_err("a non-Name object key must be rejected, not spliced");
+        assert!(
+            err.to_string().contains("identifier"),
+            "error should name the identifier rule: {err}"
+        );
+
+        // Well-formed nested keys still render.
+        let ok = serde_json::json!({ "outer": { "inner_1": "v" } });
+        assert!(graphql_input_literal(&ok)
+            .expect("valid Name keys render")
+            .contains("inner_1: \"v\""));
     }
 
     #[test]

--- a/crates/gents-protocol/src/graphql.rs
+++ b/crates/gents-protocol/src/graphql.rs
@@ -142,6 +142,90 @@ pub fn validate_collection_identifier(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a caller-supplied GraphQL **filter-object fragment** — a value
+/// spliced into a query whole, as `EventTrigger.filter` is.
+///
+/// This is the third interpolation position, and neither of the other two
+/// defenses reaches it: escaping would destroy the object syntax, and the
+/// value is not an identifier. What makes it checkable is that a break-out
+/// must unbalance the fragment — to escape it has to close a `]`, `}` or
+/// `)` it never opened. So: require one balanced object literal, built only
+/// from the tokens a filter legitimately needs.
+///
+/// Deliberately strict. `(`, `)` and `#` never appear in a filter object,
+/// but each is load-bearing for an attack (`)` closes the enclosing field's
+/// argument list, `#` comments out the query's own tail), so they are
+/// rejected outright rather than balance-tracked.
+pub fn validate_graphql_filter_fragment(filter: &str) -> Result<()> {
+    let trimmed = filter.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("invalid filter: empty"));
+    }
+    if !trimmed.starts_with('{') {
+        return Err(anyhow!("invalid filter: must be an object literal"));
+    }
+
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut closed_at: Option<usize> = None;
+
+    for (index, ch) in trimmed.char_indices() {
+        if in_string {
+            match ch {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        // A depth-0 token after the object already closed means the value is
+        // not a single fragment — trailing text is someone else's query.
+        if closed_at.is_some() && !ch.is_whitespace() {
+            return Err(anyhow!(
+                "invalid filter: trailing content after the object literal"
+            ));
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' | '[' => stack.push(ch),
+            '}' | ']' => {
+                let opener = stack
+                    .pop()
+                    .ok_or_else(|| anyhow!("invalid filter: unbalanced {ch:?} at byte {index}"))?;
+                let expected = if ch == '}' { '{' } else { '[' };
+                if opener != expected {
+                    return Err(anyhow!(
+                        "invalid filter: mismatched {opener:?} closed by {ch:?} at byte {index}"
+                    ));
+                }
+                if stack.is_empty() {
+                    closed_at = Some(index);
+                }
+            }
+            ':' | ',' => {}
+            c if c.is_ascii_alphanumeric() || c == '_' => {}
+            // Numeric literals: -1, 1.5, 1e9, 1e+9.
+            '-' | '+' | '.' => {}
+            c if c.is_whitespace() => {}
+            c => {
+                return Err(anyhow!(
+                "invalid filter: character {c:?} at byte {index} is not allowed in a filter object"
+            ))
+            }
+        }
+    }
+
+    if in_string {
+        return Err(anyhow!("invalid filter: unterminated string literal"));
+    }
+    if !stack.is_empty() {
+        return Err(anyhow!("invalid filter: unclosed {:?}", stack.last()));
+    }
+    Ok(())
+}
+
 pub fn escape_graphql_string(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {
@@ -1063,6 +1147,50 @@ mod tests {
         assert!(rendered.contains("enabled: true"));
         assert!(rendered.contains(r#"name: "alpha""#));
         assert!(rendered.contains(r#"tags: ["a", "b"]"#));
+    }
+
+    #[test]
+    fn validate_graphql_filter_fragment_accepts_real_filters() {
+        for filter in [
+            r#"{ kind: { _eq: "signup" } }"#,
+            r#"{ status: { _in: ["a", "b"] } }"#,
+            r#"{ _and: [ { a: { _eq: 1 } }, { b: { _gt: -2.5 } } ] }"#,
+            r#"{ name: { _like: "%needs \"quotes\"%" } }"#,
+            "{ enabled: { _eq: true } }",
+        ] {
+            assert!(
+                validate_graphql_filter_fragment(filter).is_ok(),
+                "{filter:?} is a legitimate filter and must pass"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_graphql_filter_fragment_rejects_break_outs() {
+        for filter in [
+            // The confirmed #1038 payload: closes the enclosing _and array,
+            // object and paren, then appends its own selection.
+            r#"{} ] }, limit: 1) { _docID } AgentBehavior(filter: { _and: [ {} ] }, limit: 1) { system_prompt } PocEvent(filter: { _and: [ {}"#,
+            // Unbalanced / stray delimiters.
+            "{ a: 1 } }",
+            "{ a: 1 ]",
+            "{ a: 1 }) { x } (",
+            // Two top-level values.
+            "{ a: 1 } { b: 2 }",
+            // A comment can hide the rest of a line.
+            "{ a: 1 } # trailing",
+            // Not an object at all.
+            "kind",
+            "",
+            "   ",
+            // Unterminated string literal.
+            r#"{ a: { _eq: "open } }"#,
+        ] {
+            assert!(
+                validate_graphql_filter_fragment(filter).is_err(),
+                "{filter:?} must be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/gents/src/agent/document_view/snapshot.rs
+++ b/crates/gents/src/agent/document_view/snapshot.rs
@@ -608,6 +608,26 @@ fn resolve_event_triggers(
             unavailable_event_triggers.insert(trigger_id);
             continue;
         }
+        // Same reasoning for the filter fragment: a trigger can reach the
+        // snapshot without passing self-config (replicated from a peer), and
+        // the fragment is spliced whole into the probe query.
+        if let Some(filter) = trigger
+            .filter
+            .as_deref()
+            .map(str::trim)
+            .filter(|filter| !filter.is_empty())
+        {
+            if let Err(error) = crate::graphql::validate_graphql_filter_fragment(filter) {
+                tracing::warn!(
+                    trigger_id = %trigger_id,
+                    %error,
+                    "event trigger quarantined: filter is not a well-formed \
+                     GraphQL filter object",
+                );
+                unavailable_event_triggers.insert(trigger_id);
+                continue;
+            }
+        }
 
         let resolved_task = ResolvedTask {
             task_id: task.task_id.clone(),

--- a/crates/gents/src/agent/document_view/snapshot.rs
+++ b/crates/gents/src/agent/document_view/snapshot.rs
@@ -592,6 +592,22 @@ fn resolve_event_triggers(
             unavailable_event_triggers.insert(trigger_id);
             continue;
         }
+        // Self-config rejects invalid names at write time, but trigger
+        // documents can also arrive without passing that boundary (e.g.
+        // replicated from a peer). `source_collection` lands in GraphQL
+        // identifier positions where escaping cannot apply, so a
+        // non-conforming name is quarantined here rather than activated.
+        if let Err(error) = crate::graphql::validate_collection_identifier(&source_collection) {
+            tracing::warn!(
+                trigger_id = %trigger_id,
+                source_collection = %source_collection,
+                %error,
+                "event trigger quarantined: source_collection is not a valid \
+                 GraphQL collection identifier",
+            );
+            unavailable_event_triggers.insert(trigger_id);
+            continue;
+        }
 
         let resolved_task = ResolvedTask {
             task_id: task.task_id.clone(),

--- a/crates/gents/src/agent/document_view/tests.rs
+++ b/crates/gents/src/agent/document_view/tests.rs
@@ -1212,6 +1212,81 @@ async fn resolve_marks_event_trigger_unavailable_when_task_missing_or_disabled()
     );
 }
 
+/// `source_collection` is interpolated into GraphQL identifier positions by
+/// the event source, where escaping cannot apply. A trigger document whose
+/// `source_collection` is not a valid GraphQL Name (query injection) or is
+/// `__`-prefixed (introspection-reserved) must be quarantined at resolve
+/// time, never activated. This covers documents that bypass self-config
+/// validation entirely (e.g. replicated from a peer).
+#[tokio::test]
+async fn resolve_quarantines_event_trigger_with_invalid_source_collection() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let identity = Arc::new(test_identity("document-view-resolve-trigger-injection"));
+    bind_default_behavior_backend(
+        node.as_ref(),
+        identity.did(),
+        "backend-resolve-trigger-injection",
+        "http://127.0.0.1:8131/v1",
+    )
+    .await;
+
+    let default_behavior_id = crate::default_behavior_id_for_agent(identity.did());
+    create_task_bound(
+        node.as_ref(),
+        "task-trigger-injection",
+        &default_behavior_id,
+        "enabled task",
+        true,
+    )
+    .await;
+    create_event_trigger(
+        node.as_ref(),
+        "trigger-injection",
+        "task-trigger-injection",
+        "Msg(limit: 1) { _docID } Foo",
+        "created",
+        "serial",
+    )
+    .await;
+    create_event_trigger(
+        node.as_ref(),
+        "trigger-introspection",
+        "task-trigger-injection",
+        "__Type",
+        "created",
+        "serial",
+    )
+    .await;
+
+    let resolve_context = DocumentResolveContext {
+        identity: identity.clone(),
+        tool_ceiling: ToolCeiling::readonly(),
+        backend_health: crate::backend_health::BackendHealthMap::new(),
+    };
+    let view = load_document_runtime_view(node.as_ref(), identity.did())
+        .await
+        .expect("document view should load");
+
+    let snapshot =
+        resolve_document_runtime_snapshot_from_view(node.as_ref(), &resolve_context, &view)
+            .await
+            .expect("resolve should succeed");
+
+    assert!(
+        snapshot.active_event_triggers.is_empty(),
+        "no injection-shaped trigger may activate, got {:?}",
+        snapshot.active_event_triggers.keys().collect::<Vec<_>>()
+    );
+    for trigger_id in ["trigger-injection", "trigger-introspection"] {
+        assert!(
+            snapshot.unavailable_event_triggers.contains(trigger_id),
+            "{trigger_id} should be quarantined in unavailable_event_triggers: {:?}",
+            snapshot.unavailable_event_triggers
+        );
+    }
+}
+
 #[tokio::test]
 async fn resolve_marks_schedule_unavailable_when_task_missing_or_disabled() {
     let node = test_node().await;

--- a/crates/gents/src/config_client/patch.rs
+++ b/crates/gents/src/config_client/patch.rs
@@ -432,9 +432,20 @@ impl SelfConfigTarget {
 pub type SelfConfigPatch = Vec<(String, Option<Value>)>;
 
 /// Admissibility (Lean `admissible`): the typed surface rejects — rather than
-/// silently drops — any patch naming a field outside the writable set.
+/// silently drops — any patch naming a field outside the writable set, or
+/// carrying a value that is not a scalar.
+///
+/// The value-shape rule restores the model: Lean's `FieldValue` is a
+/// `String` (`proofs/Proofs/SelfConfig/Apply.lean`), while the tool schema
+/// is `additionalProperties: true` and accepts arbitrary JSON. Every
+/// writable column across all six targets is a scalar or a list of scalars,
+/// so nothing legitimate is refused here — and an object value would reach
+/// the mutation renderer, where its keys land in identifier position.
 pub fn ensure_admissible(target: SelfConfigTarget, patch: &SelfConfigPatch) -> Result<()> {
-    for (field, _) in patch {
+    for (field, value) in patch {
+        if let Some(value) = value {
+            ensure_scalar_patch_value(target, field, value)?;
+        }
         if !target.is_writable(field) {
             if target.all_fields().contains(&field.as_str()) {
                 bail!(
@@ -451,6 +462,24 @@ pub fn ensure_admissible(target: SelfConfigTarget, patch: &SelfConfigPatch) -> R
         }
     }
     Ok(())
+}
+
+fn ensure_scalar_patch_value(target: SelfConfigTarget, field: &str, value: &Value) -> Result<()> {
+    let shape = match value {
+        Value::Object(_) => "an object",
+        Value::Array(items)
+            if items
+                .iter()
+                .any(|item| !item.is_string() && !item.is_number() && !item.is_boolean()) =>
+        {
+            "a list with a non-scalar element"
+        }
+        _ => return Ok(()),
+    };
+    bail!(
+        "field {field} on {collection} must be a scalar or a list of scalars, got {shape}",
+        collection = target.collection_name(),
+    )
 }
 
 /// In-memory partial merge (Lean `applyPatch`): only writable fields change;

--- a/crates/gents/src/defra_query/render.rs
+++ b/crates/gents/src/defra_query/render.rs
@@ -40,15 +40,7 @@ fn render_value(value: &Value) -> Result<String> {
 }
 
 pub(crate) fn validate_identifier(name: &str) -> Result<()> {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        _ => bail!("invalid identifier {name:?}: must start with a letter or underscore"),
-    }
-    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-        bail!("invalid identifier {name:?}: only letters, digits, and underscore are allowed");
-    }
-    Ok(())
+    crate::graphql::validate_graphql_name(name)
 }
 
 #[cfg(test)]

--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -1,12 +1,16 @@
 //! Shared GraphQL utility functions used across Gents runtime modules.
 //!
-//! Two distinct defenses live here, one per grammatical position:
+//! Two defenses live here, one per grammatical position:
 //! - [`escape_graphql_string`] for values interpolated inside **string
 //!   literals** — escaping makes any content safe to embed.
 //! - [`validate_graphql_name`] / [`validate_collection_identifier`] for
 //!   values interpolated as bare **identifiers** (collection names, field
 //!   names). Identifiers sit outside string literals, so escaping cannot
 //!   apply; validation against the GraphQL Name grammar is the only defense.
+//!
+//! A third position — a raw **object/fragment** spliced in whole, as
+//! `EventTrigger.filter` is by the trigger engine's filter probe — is
+//! covered by neither, and has no defense here yet. See #1038.
 
 use anyhow::{bail, Result};
 

--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -16,7 +16,9 @@
 //! `EventTrigger.filter` is by the trigger engine's filter probe — is
 //! covered by neither. See #1038.
 
-pub use gents_protocol::graphql::{validate_collection_identifier, validate_graphql_name};
+pub use gents_protocol::graphql::{
+    validate_collection_identifier, validate_graphql_filter_fragment, validate_graphql_name,
+};
 
 pub fn escape_graphql_string(s: &str) -> String {
     s.replace('\\', "\\\\")

--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -1,18 +1,22 @@
 //! Shared GraphQL utility functions used across Gents runtime modules.
 //!
-//! Two defenses live here, one per grammatical position:
+//! Two defenses apply, one per grammatical position:
 //! - [`escape_graphql_string`] for values interpolated inside **string
 //!   literals** — escaping makes any content safe to embed.
 //! - [`validate_graphql_name`] / [`validate_collection_identifier`] for
 //!   values interpolated as bare **identifiers** (collection names, field
-//!   names). Identifiers sit outside string literals, so escaping cannot
-//!   apply; validation against the GraphQL Name grammar is the only defense.
+//!   names, mutation input keys). Identifiers sit outside string literals,
+//!   so escaping cannot apply; validation against the GraphQL Name grammar
+//!   is the only defense.
+//!
+//! The identifier validators live in `gents-protocol` so the mutation
+//! renderer there shares this crate's definition, and are re-exported here.
 //!
 //! A third position — a raw **object/fragment** spliced in whole, as
 //! `EventTrigger.filter` is by the trigger engine's filter probe — is
-//! covered by neither, and has no defense here yet. See #1038.
+//! covered by neither. See #1038.
 
-use anyhow::{bail, Result};
+pub use gents_protocol::graphql::{validate_collection_identifier, validate_graphql_name};
 
 pub fn escape_graphql_string(s: &str) -> String {
     s.replace('\\', "\\\\")
@@ -20,44 +24,6 @@ pub fn escape_graphql_string(s: &str) -> String {
         .replace('\n', "\\n")
         .replace('\r', "\\r")
         .replace('\t', "\\t")
-}
-
-/// Validate `name` against the GraphQL `Name` grammar:
-/// `[_A-Za-z][_0-9A-Za-z]*` (ASCII only). Anything interpolated into a
-/// GraphQL query in identifier position MUST pass this check first —
-/// escaping does not exist for identifiers.
-pub fn validate_graphql_name(name: &str) -> Result<()> {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
-        Some(c) => {
-            bail!("invalid identifier {name:?}: must start with a letter or underscore, got {c:?}")
-        }
-        None => bail!("invalid identifier: empty string"),
-    }
-    if let Some(c) = name
-        .chars()
-        .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
-    {
-        bail!("invalid identifier {name:?}: only ASCII letters, digits, and underscore are allowed, got {c:?}");
-    }
-    Ok(())
-}
-
-/// Validate a value used as a **collection name** in identifier position
-/// (e.g. `EventTrigger.source_collection`). On top of the Name grammar this
-/// rejects the `__` prefix, which the GraphQL spec reserves for
-/// introspection — a "collection" of `__Type` or `__schema` would aim the
-/// runtime's queries at the introspection surface instead of a document
-/// collection.
-pub fn validate_collection_identifier(name: &str) -> Result<()> {
-    validate_graphql_name(name)?;
-    if name.starts_with("__") {
-        bail!(
-            "invalid collection name {name:?}: the __ prefix is reserved for GraphQL introspection"
-        );
-    }
-    Ok(())
 }
 
 pub fn response_has_documents(value: &serde_json::Value) -> bool {

--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -1,4 +1,14 @@
 //! Shared GraphQL utility functions used across Gents runtime modules.
+//!
+//! Two distinct defenses live here, one per grammatical position:
+//! - [`escape_graphql_string`] for values interpolated inside **string
+//!   literals** — escaping makes any content safe to embed.
+//! - [`validate_graphql_name`] / [`validate_collection_identifier`] for
+//!   values interpolated as bare **identifiers** (collection names, field
+//!   names). Identifiers sit outside string literals, so escaping cannot
+//!   apply; validation against the GraphQL Name grammar is the only defense.
+
+use anyhow::{bail, Result};
 
 pub fn escape_graphql_string(s: &str) -> String {
     s.replace('\\', "\\\\")
@@ -6,6 +16,44 @@ pub fn escape_graphql_string(s: &str) -> String {
         .replace('\n', "\\n")
         .replace('\r', "\\r")
         .replace('\t', "\\t")
+}
+
+/// Validate `name` against the GraphQL `Name` grammar:
+/// `[_A-Za-z][_0-9A-Za-z]*` (ASCII only). Anything interpolated into a
+/// GraphQL query in identifier position MUST pass this check first —
+/// escaping does not exist for identifiers.
+pub fn validate_graphql_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        Some(c) => {
+            bail!("invalid identifier {name:?}: must start with a letter or underscore, got {c:?}")
+        }
+        None => bail!("invalid identifier: empty string"),
+    }
+    if let Some(c) = name
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && *c != '_')
+    {
+        bail!("invalid identifier {name:?}: only ASCII letters, digits, and underscore are allowed, got {c:?}");
+    }
+    Ok(())
+}
+
+/// Validate a value used as a **collection name** in identifier position
+/// (e.g. `EventTrigger.source_collection`). On top of the Name grammar this
+/// rejects the `__` prefix, which the GraphQL spec reserves for
+/// introspection — a "collection" of `__Type` or `__schema` would aim the
+/// runtime's queries at the introspection surface instead of a document
+/// collection.
+pub fn validate_collection_identifier(name: &str) -> Result<()> {
+    validate_graphql_name(name)?;
+    if name.starts_with("__") {
+        bail!(
+            "invalid collection name {name:?}: the __ prefix is reserved for GraphQL introspection"
+        );
+    }
+    Ok(())
 }
 
 pub fn response_has_documents(value: &serde_json::Value) -> bool {

--- a/crates/gents/src/graphql/tests.rs
+++ b/crates/gents/src/graphql/tests.rs
@@ -1,6 +1,65 @@
 use super::*;
 
 #[test]
+fn validate_graphql_name_accepts_conforming_names() {
+    for name in [
+        "AgentResponse",
+        "_docID",
+        "_eq",
+        "snake_case_2",
+        "a",
+        "_",
+        "WebhookEvent",
+    ] {
+        assert!(
+            validate_graphql_name(name).is_ok(),
+            "{name:?} conforms to the GraphQL Name grammar and must pass"
+        );
+    }
+}
+
+#[test]
+fn validate_graphql_name_rejects_nonconforming_names() {
+    for name in [
+        "",
+        "1abc",
+        "Msg (limit: 1) { _docID }",
+        "a b",
+        "a-b",
+        "a.b",
+        "Msg{",
+        "a\"b",
+        "a\nb",
+        "naïve",
+        "名前",
+        "a\u{200b}b",
+        " AgentResponse",
+        "AgentResponse ",
+    ] {
+        assert!(
+            validate_graphql_name(name).is_err(),
+            "{name:?} violates the GraphQL Name grammar and must be rejected"
+        );
+    }
+}
+
+#[test]
+fn validate_collection_identifier_rejects_introspection_reserved_names() {
+    for name in ["__Type", "__schema", "__typename", "__"] {
+        assert!(
+            validate_collection_identifier(name).is_err(),
+            "{name:?} is GraphQL-reserved (__ prefix) and must be rejected as a collection"
+        );
+    }
+    assert!(validate_collection_identifier("AgentResponse").is_ok());
+    assert!(
+        validate_collection_identifier("_Private").is_ok(),
+        "a single leading underscore is a legal Name and not introspection-reserved"
+    );
+    assert!(validate_collection_identifier("Msg) { x } (").is_err());
+}
+
+#[test]
 fn test_escape_graphql_string() {
     assert_eq!(escape_graphql_string("hello"), "hello");
     assert_eq!(escape_graphql_string("he\"llo"), "he\\\"llo");

--- a/crates/gents/src/self_config/mod.rs
+++ b/crates/gents/src/self_config/mod.rs
@@ -437,6 +437,20 @@ fn automation_request(
                             bail!("event_trigger.{field} is required");
                         }
                     }
+                    // `source_collection` is interpolated into GraphQL
+                    // identifier positions by the trigger engine, where
+                    // escaping cannot apply — the value must BE a valid
+                    // collection identifier or the write is rejected here,
+                    // at the privilege boundary.
+                    let source_collection = merged
+                        .get("source_collection")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    if let Err(error) =
+                        crate::graphql::validate_collection_identifier(source_collection)
+                    {
+                        bail!("event_trigger.source_collection: {error}");
+                    }
                 }
                 _ => unreachable!("automation targets only"),
             }

--- a/crates/gents/src/self_config/mod.rs
+++ b/crates/gents/src/self_config/mod.rs
@@ -451,6 +451,20 @@ fn automation_request(
                     {
                         bail!("event_trigger.source_collection: {error}");
                     }
+                    // `filter` is spliced into the trigger engine's probe as
+                    // a whole object fragment, which escaping cannot protect
+                    // and identifier validation does not cover (#1038).
+                    if let Some(filter) = merged
+                        .get("filter")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|filter| !filter.is_empty())
+                    {
+                        if let Err(error) = crate::graphql::validate_graphql_filter_fragment(filter)
+                        {
+                            bail!("event_trigger.filter: {error}");
+                        }
+                    }
                 }
                 _ => unreachable!("automation targets only"),
             }

--- a/crates/gents/src/streaming/queries.rs
+++ b/crates/gents/src/streaming/queries.rs
@@ -54,10 +54,11 @@ pub(super) async fn load_response_state(
     node: &EmbeddedNode,
     doc_id: &str,
 ) -> Result<Option<PersistedResponseState>> {
+    let escaped_doc_id = crate::graphql::escape_graphql_string(doc_id);
     let query = format!(
         r#"{{
             AgentResponse(
-                filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
                 limit: 1
             ) {{
                 _docID
@@ -98,10 +99,11 @@ pub(super) async fn load_response_state_by_key(
     node: &EmbeddedNode,
     response_key: &str,
 ) -> Result<Option<PersistedResponseState>> {
+    let escaped_response_key = crate::graphql::escape_graphql_string(response_key);
     let query = format!(
         r#"{{
             AgentResponse(
-                filter: {{ response_key: {{ _eq: "{response_key}" }} }},
+                filter: {{ response_key: {{ _eq: "{escaped_response_key}" }} }},
                 limit: 1
             ) {{
                 _docID

--- a/crates/gents/src/streaming/tests.rs
+++ b/crates/gents/src/streaming/tests.rs
@@ -945,3 +945,36 @@ async fn parallel_stream_flushes_do_not_surface_transaction_conflicts() {
 
     let _ = fs::remove_dir_all(&data_path);
 }
+
+/// A hostile `response_key` containing quote/brace characters must be
+/// escaped into the filter's string literal — the query stays well-formed
+/// and simply matches nothing (`Ok(None)`), never a GraphQL parse error.
+#[tokio::test]
+async fn load_response_state_by_key_escapes_hostile_key() {
+    let (node, data_path) = build_test_node("hostile-response-key").await;
+    let result =
+        super::queries::load_response_state_by_key(&node, r#"k" }) { __typename } x("#).await;
+    assert!(
+        result
+            .expect("hostile response_key must not break the query")
+            .is_none(),
+        "hostile key matches nothing"
+    );
+    let _ = fs::remove_dir_all(&data_path);
+}
+
+/// Same contract for `load_response_state`: the doc_id is a content-addressed
+/// id in practice, but the query layer must not rely on that — a hostile
+/// value is escaped, not interpolated raw.
+#[tokio::test]
+async fn load_response_state_escapes_hostile_doc_id() {
+    let (node, data_path) = build_test_node("hostile-doc-id").await;
+    let result = super::queries::load_response_state(&node, r#"d" }) { __typename } x("#).await;
+    assert!(
+        result
+            .expect("hostile doc_id must not break the query")
+            .is_none(),
+        "hostile doc_id matches nothing"
+    );
+    let _ = fs::remove_dir_all(&data_path);
+}

--- a/crates/gents/src/trigger_engine/event_source.rs
+++ b/crates/gents/src/trigger_engine/event_source.rs
@@ -408,20 +408,17 @@ impl EventSource {
     /// transient GraphQL failure doesn't brick the source.
     ///
     /// Trust boundary: `source_collection` is validated as a collection
-    /// identifier above, and the `_docID` value from the event payload IS
-    /// escaped.
+    /// identifier above, and the `_docID` from the event payload is escaped.
     ///
-    /// `trigger.filter` is NOT. It is interpolated directly as a
-    /// filter-object fragment, a third grammatical position that neither
-    /// `escape_graphql_string` (which escapes scalar string literals and
-    /// would break the object syntax) nor identifier validation covers.
-    /// This doc used to claim the value was operator-authored and rejected
-    /// at apply time if ill-formed; that is true only of the CLI apply path
-    /// (`gents-cli` desired_state::validate runs a filter syntax probe).
-    /// Since `filter` became an agent-writable self-config field it is
-    /// reachable with no validation at all, and a crafted value can close
-    /// the enclosing `_and: [ ... ] }` and append its own selections to this
-    /// query. Tracked in #1038 — do not treat this as a closed boundary.
+    /// `trigger.filter` is neither. It is spliced in as a filter-object
+    /// fragment — a position where escaping would break the object syntax
+    /// and identifier validation does not apply — and it is agent-writable
+    /// via self-config with nothing on that path checking it. A crafted
+    /// value can close the enclosing `_and: [ ... ] }` and append its own
+    /// selections here. The CLI apply probe is not a check either: it
+    /// executes the filter rather than validating it, in a different
+    /// embedding than this one. Tracked in #1038 — this is an open hole,
+    /// not a closed boundary.
     async fn probe_filter(
         &self,
         source_doc_id: &str,
@@ -470,7 +467,8 @@ impl EventSource {
         collection: &str,
         source_doc_id: &str,
     ) -> anyhow::Result<serde_json::Value> {
-        crate::graphql::validate_collection_identifier(collection)?;
+        // `fields_for` validates this same binding and `?`-propagates before
+        // the query below is built, so it is the one gate for both sites.
         let fields = self
             .source_schema_cache
             .fields_for(collection, &self.node)

--- a/crates/gents/src/trigger_engine/event_source.rs
+++ b/crates/gents/src/trigger_engine/event_source.rs
@@ -407,14 +407,21 @@ impl EventSource {
     /// itself errored — the caller treats errors as "skip this fire" so a
     /// transient GraphQL failure doesn't brick the source.
     ///
-    /// Trust boundary: `trigger.filter` is operator-authored and validated
-    /// at apply time (the apply path rejects ill-formed filter objects
-    /// before the trigger ever lands in `active_event_triggers`). It's
-    /// interpolated directly as a filter-object fragment — we do NOT run
-    /// it through `escape_graphql_string`, because that helper escapes
-    /// scalar string literals and would break the object syntax. The
-    /// `_docID` value, which comes from the event payload (external
-    /// input), IS escaped.
+    /// Trust boundary: `source_collection` is validated as a collection
+    /// identifier above, and the `_docID` value from the event payload IS
+    /// escaped.
+    ///
+    /// `trigger.filter` is NOT. It is interpolated directly as a
+    /// filter-object fragment, a third grammatical position that neither
+    /// `escape_graphql_string` (which escapes scalar string literals and
+    /// would break the object syntax) nor identifier validation covers.
+    /// This doc used to claim the value was operator-authored and rejected
+    /// at apply time if ill-formed; that is true only of the CLI apply path
+    /// (`gents-cli` desired_state::validate runs a filter syntax probe).
+    /// Since `filter` became an agent-writable self-config field it is
+    /// reachable with no validation at all, and a crafted value can close
+    /// the enclosing `_and: [ ... ] }` and append its own selections to this
+    /// query. Tracked in #1038 — do not treat this as a closed boundary.
     async fn probe_filter(
         &self,
         source_doc_id: &str,

--- a/crates/gents/src/trigger_engine/event_source.rs
+++ b/crates/gents/src/trigger_engine/event_source.rs
@@ -407,18 +407,16 @@ impl EventSource {
     /// itself errored — the caller treats errors as "skip this fire" so a
     /// transient GraphQL failure doesn't brick the source.
     ///
-    /// Trust boundary: `source_collection` is validated as a collection
-    /// identifier above, and the `_docID` from the event payload is escaped.
+    /// Trust boundary, one defense per interpolation position:
+    /// `source_collection` is validated as a collection identifier, the
+    /// `_docID` from the event payload is escaped, and `trigger.filter` —
+    /// spliced in whole as an object fragment, where escaping would break
+    /// the syntax — is checked as a balanced filter object. A break-out has
+    /// to close an `]`, `}` or `)` it never opened, which is what that
+    /// check rejects.
     ///
-    /// `trigger.filter` is neither. It is spliced in as a filter-object
-    /// fragment — a position where escaping would break the object syntax
-    /// and identifier validation does not apply — and it is agent-writable
-    /// via self-config with nothing on that path checking it. A crafted
-    /// value can close the enclosing `_and: [ ... ] }` and append its own
-    /// selections here. The CLI apply probe is not a check either: it
-    /// executes the filter rather than validating it, in a different
-    /// embedding than this one. Tracked in #1038 — this is an open hole,
-    /// not a closed boundary.
+    /// Note the CLI apply probe is not a substitute: it executes the filter
+    /// rather than validating it, in a different embedding than this one.
     async fn probe_filter(
         &self,
         source_doc_id: &str,
@@ -430,6 +428,9 @@ impl EventSource {
             .as_deref()
             .map(str::trim)
             .filter(|f| !f.is_empty());
+        if let Some(filter) = user_filter {
+            crate::graphql::validate_graphql_filter_fragment(filter)?;
+        }
         let filter_literal = match user_filter {
             Some(f) => format!(
                 r#"{{ _docID: {{ _eq: "{id}" }}, _and: [ {user_filter} ] }}"#,

--- a/crates/gents/src/trigger_engine/event_source.rs
+++ b/crates/gents/src/trigger_engine/event_source.rs
@@ -98,6 +98,7 @@ impl SourceSchemaCache {
         collection: &str,
         node: &EmbeddedNode,
     ) -> anyhow::Result<Vec<String>> {
+        crate::graphql::validate_collection_identifier(collection)?;
         let mut guard = self.by_collection.lock().await;
         if let Some(fields) = guard.get(collection) {
             return Ok(fields.clone());
@@ -209,10 +210,30 @@ impl EventSource {
     }
 
     pub(crate) async fn reconcile_subscriptions(&mut self, snapshot: &ActiveRuntimeSnapshot) {
+        // Resolve-time quarantine keeps identifier-invalid source
+        // collections out of active_event_triggers, but this source must
+        // not trust that another code path assembled the snapshot the same
+        // way: names that fail the collection-identifier check never enter
+        // the desired set, so no seed/rescan/probe query is built from them.
         let desired: HashSet<String> = snapshot
             .active_event_triggers()
             .values()
             .map(|t| t.source_collection.clone())
+            .filter(
+                |collection| match crate::graphql::validate_collection_identifier(collection) {
+                    Ok(()) => true,
+                    Err(error) => {
+                        tracing::warn!(
+                            source_collection = %collection,
+                            generation = snapshot.generation,
+                            %error,
+                            "event source refusing to observe source collection: \
+                             not a valid GraphQL collection identifier",
+                        );
+                        false
+                    }
+                },
+            )
             .collect();
 
         let added: Vec<String> = desired
@@ -261,6 +282,7 @@ impl EventSource {
     }
 
     async fn seed_seen_docs_for_collection(&mut self, collection: &str) -> anyhow::Result<()> {
+        crate::graphql::validate_collection_identifier(collection)?;
         let query = format!(
             r#"query {{ {collection}(limit: {limit}) {{ _docID }} }}"#,
             collection = collection,
@@ -306,6 +328,7 @@ impl EventSource {
     }
 
     async fn load_doc_ids_for_collection(&self, collection: &str) -> anyhow::Result<Vec<String>> {
+        crate::graphql::validate_collection_identifier(collection)?;
         let query = format!(
             r#"query {{ {collection}(limit: {limit}) {{ _docID }} }}"#,
             collection = collection,
@@ -397,6 +420,7 @@ impl EventSource {
         source_doc_id: &str,
         trigger: &crate::runtime_snapshot::ResolvedEventTrigger,
     ) -> anyhow::Result<bool> {
+        crate::graphql::validate_collection_identifier(&trigger.source_collection)?;
         let user_filter = trigger
             .filter
             .as_deref()
@@ -439,6 +463,7 @@ impl EventSource {
         collection: &str,
         source_doc_id: &str,
     ) -> anyhow::Result<serde_json::Value> {
+        crate::graphql::validate_collection_identifier(collection)?;
         let fields = self
             .source_schema_cache
             .fields_for(collection, &self.node)

--- a/crates/gents/src/trigger_engine/tests/event_source.rs
+++ b/crates/gents/src/trigger_engine/tests/event_source.rs
@@ -1197,3 +1197,50 @@ async fn event_source_tries_all_triggers_when_first_filter_misses() {
 
     cancel.cancel();
 }
+
+/// Defense-in-depth at the query-build boundary: even if a snapshot arrives
+/// carrying a trigger whose `source_collection` is not a valid GraphQL
+/// collection identifier (resolve-time quarantine bypassed — e.g. a snapshot
+/// assembled by a different code path), `reconcile_subscriptions` must
+/// refuse to admit the collection into the desired set, so no seed / rescan
+/// / probe query is ever built from it.
+#[tokio::test]
+async fn event_source_reconcile_excludes_invalid_source_collection_identifiers() {
+    let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+    let task = resolved_task("ignored");
+    let snapshot = snapshot_with_event_triggers(
+        1,
+        HashMap::from([
+            (
+                "trigger-injection".to_string(),
+                resolved_event_trigger(
+                    "trigger-injection",
+                    "Msg(limit: 1) { _docID } Foo",
+                    task.clone(),
+                ),
+            ),
+            (
+                "trigger-introspection".to_string(),
+                resolved_event_trigger("trigger-introspection", "__Type", task.clone()),
+            ),
+            (
+                "trigger-clean".to_string(),
+                resolved_event_trigger("trigger-clean", "CollectionClean", task),
+            ),
+        ]),
+    );
+    let (_tx, rx) = watch::channel(snapshot.clone());
+
+    let cancel = CancellationToken::new();
+    let mut source = EventSource::new(rx, node.clone(), cancel.clone());
+    source.reconcile_subscriptions(snapshot.as_ref()).await;
+
+    assert_eq!(
+        source.subscribed_collections(),
+        vec!["CollectionClean".to_string()],
+        "only the grammar-valid, non-reserved collection may enter the \
+         desired set; identifier-invalid names must be excluded",
+    );
+}

--- a/crates/gents/tests/e2e_runtime/self_config_tools.rs
+++ b/crates/gents/tests/e2e_runtime/self_config_tools.rs
@@ -363,6 +363,74 @@ async fn configure_automation_creates_owned_chain_and_rejects_foreign_tasks() {
     assert!(error.contains("protected"), "{error}");
 }
 
+/// `source_collection` is agent-writable and later interpolated into GraphQL
+/// identifier positions by the trigger engine, where escaping cannot apply.
+/// The self-config apply path is the trust boundary: it must reject any
+/// value that is not a valid GraphQL collection identifier, so a principal
+/// cannot shape the queries the runtime issues.
+#[tokio::test]
+async fn configure_automation_rejects_injection_shaped_source_collection() {
+    let db = test_db("self-config-trigger-injection").await;
+    seed_config(&db.node).await;
+    let tools = build_self_config_tools(
+        db.node.clone(),
+        AGENT_DID.to_string(),
+        &tool_config(&["automation"], false, false),
+    );
+
+    call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "task", "id": "watcher-task", "patch": {
+            "name": "Watcher",
+            "prompt_template": "React to new docs",
+        }}),
+    )
+    .await
+    .expect("task create commits");
+
+    for hostile in [
+        "Msg(limit: 1) { _docID } Foo",
+        "AgentResponse { content } #",
+        "__Type",
+        "a b",
+        "naïve",
+    ] {
+        let Err(error) = call_tool(
+            &tools,
+            "configure_automation",
+            json!({ "kind": "event_trigger", "id": "watcher-trigger", "patch": {
+                "task_id": "watcher-task",
+                "source_collection": hostile,
+                "event_kind": "created",
+                "concurrency": "serial",
+            }}),
+        )
+        .await
+        else {
+            panic!("injection-shaped source_collection {hostile:?} must be rejected");
+        };
+        assert!(
+            error.contains("identifier") || error.contains("collection"),
+            "rejection for {hostile:?} should name the identifier rule: {error}"
+        );
+    }
+
+    let output = call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "event_trigger", "id": "watcher-trigger", "patch": {
+            "task_id": "watcher-task",
+            "source_collection": "CustomerSignup",
+            "event_kind": "created",
+            "concurrency": "serial",
+        }}),
+    )
+    .await
+    .expect("a grammar-valid source_collection commits");
+    assert!(output.contains("\"created\": true"), "{output}");
+}
+
 #[tokio::test]
 async fn writes_carry_the_agent_identity() {
     let db = test_db("self-config-identity").await;

--- a/crates/gents/tests/e2e_runtime/self_config_tools.rs
+++ b/crates/gents/tests/e2e_runtime/self_config_tools.rs
@@ -285,6 +285,102 @@ async fn get_my_config_reports_documents_and_never_the_api_key() {
     );
 }
 
+/// A patch value is a scalar in the model (`FieldValue := String` in
+/// `proofs/Proofs/SelfConfig/Apply.lean`), but the tool schema accepts
+/// arbitrary JSON. An object value used to reach the mutation renderer,
+/// whose object keys land in identifier position — letting a patch on one
+/// writable field write a protected field, or a document in another
+/// collection entirely. Both must be refused before anything commits.
+#[tokio::test]
+async fn configure_rejects_non_scalar_patch_values() {
+    let db = test_db("self-config-nonscalar").await;
+    seed_config(&db.node).await;
+    let tools = build_self_config_tools(
+        db.node.clone(),
+        AGENT_DID.to_string(),
+        &tool_config(&["backend", "automation"], false, false),
+    );
+
+    let error = call_tool(
+        &tools,
+        "configure_backend",
+        json!({ "patch": { "endpoint": {
+            r#"x: 1 }, api_key: "leaked-by-injection", endpoint: "http://injected/v1""#: 1
+        }}}),
+    )
+    .await
+    .expect_err("an object-valued patch must be refused");
+    assert!(
+        error.contains("scalar") || error.contains("identifier"),
+        "rejection should name the value-shape rule: {error}"
+    );
+
+    let stored = db
+        .node
+        .execute(
+            r#"query { InferenceBackend(filter: { backend_id: { _eq: "self-config-backend" } }) { endpoint api_key } }"#,
+        )
+        .await;
+    let row = stored
+        .data
+        .as_ref()
+        .and_then(|data| data.get("InferenceBackend"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("backend row");
+    assert_eq!(
+        row["endpoint"], "http://127.0.0.1:11434/v1",
+        "the injected endpoint must not have landed"
+    );
+    assert_eq!(
+        row["api_key"], "sk-secret-should-never-leak",
+        "a patch on a writable field must not reach the protected api_key"
+    );
+
+    call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "task", "id": "nonscalar-task", "patch": { "enabled": true } }),
+    )
+    .await
+    .expect("task create commits");
+    let error = call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "event_trigger", "id": "nonscalar-trigger", "patch": {
+            "task_id": "nonscalar-task",
+            "source_collection": "CustomerSignup",
+            "event_kind": "created",
+            "filter": {
+                r#"x: 1 }) { _docID } create_AgentBehavior(input: { behavior_id: "evil-injected", agent_did: "did:key:zAttacker" }) { _docID } #"#: 1
+            },
+        }}),
+    )
+    .await
+    .expect_err("an object-valued filter must be refused");
+    assert!(
+        error.contains("scalar") || error.contains("identifier"),
+        "rejection should name the value-shape rule: {error}"
+    );
+
+    let forged = db
+        .node
+        .execute(r#"query { AgentBehavior(filter: { behavior_id: { _eq: "evil-injected" } }) { behavior_id } }"#)
+        .await;
+    let rows = forged
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentBehavior"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        rows.is_empty(),
+        "no document may be forged in another collection: {rows:?}"
+    );
+}
+
 #[tokio::test]
 async fn configure_automation_creates_owned_chain_and_rejects_foreign_tasks() {
     let db = test_db("self-config-automation").await;
@@ -429,6 +525,42 @@ async fn configure_automation_rejects_injection_shaped_source_collection() {
     .await
     .expect("a grammar-valid source_collection commits");
     assert!(output.contains("\"created\": true"), "{output}");
+
+    // Patching an existing trigger is the realistic attack shape — commit a
+    // benign one, then flip the field. Create and patch share a branch today
+    // because the check reads the merged doc; this keeps them from drifting.
+    let error = call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "event_trigger", "id": "watcher-trigger", "patch": {
+            "source_collection": "Msg(limit: 1) { _docID } Foo",
+        }}),
+    )
+    .await
+    .expect_err("patching source_collection to a hostile value must be rejected");
+    assert!(
+        error.contains("identifier") || error.contains("collection"),
+        "rejection should name the identifier rule: {error}"
+    );
+
+    let stored = db
+        .node
+        .execute(
+            r#"query { EventTrigger(filter: { trigger_id: { _eq: "watcher-trigger" } }) { source_collection } }"#,
+        )
+        .await;
+    let row = stored
+        .data
+        .as_ref()
+        .and_then(|data| data.get("EventTrigger"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("trigger row");
+    assert_eq!(
+        row["source_collection"], "CustomerSignup",
+        "the rejected patch must not have landed"
+    );
 }
 
 #[tokio::test]

--- a/crates/gents/tests/e2e_runtime/self_config_tools.rs
+++ b/crates/gents/tests/e2e_runtime/self_config_tools.rs
@@ -381,6 +381,67 @@ async fn configure_rejects_non_scalar_patch_values() {
     );
 }
 
+/// `filter` is spliced into the trigger engine's probe as a whole object
+/// fragment. The confirmed #1038 payload closes the enclosing `_and: [ ... ]`
+/// and appends its own selections; it must not be writable.
+#[tokio::test]
+async fn configure_automation_rejects_break_out_filter_fragments() {
+    let db = test_db("self-config-filter-injection").await;
+    seed_config(&db.node).await;
+    let tools = build_self_config_tools(
+        db.node.clone(),
+        AGENT_DID.to_string(),
+        &tool_config(&["automation"], false, false),
+    );
+
+    call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "task", "id": "filter-task", "patch": { "enabled": true } }),
+    )
+    .await
+    .expect("task create commits");
+
+    for hostile in [
+        r#"{} ] }, limit: 1) { _docID } AgentBehavior(filter: { _and: [ {} ] }, limit: 1) { system_prompt } X(filter: { _and: [ {}"#,
+        "{ a: 1 } # ",
+        "{ a: 1 }) { x } (",
+    ] {
+        let Err(error) = call_tool(
+            &tools,
+            "configure_automation",
+            json!({ "kind": "event_trigger", "id": "filter-trigger", "patch": {
+                "task_id": "filter-task",
+                "source_collection": "CustomerSignup",
+                "event_kind": "created",
+                "filter": hostile,
+            }}),
+        )
+        .await
+        else {
+            panic!("break-out filter {hostile:?} must be rejected");
+        };
+        assert!(
+            error.contains("filter"),
+            "rejection should name the filter rule: {error}"
+        );
+    }
+
+    let output = call_tool(
+        &tools,
+        "configure_automation",
+        json!({ "kind": "event_trigger", "id": "filter-trigger", "patch": {
+            "task_id": "filter-task",
+            "source_collection": "CustomerSignup",
+            "event_kind": "created",
+            "filter": r#"{ kind: { _eq: "signup" } }"#,
+        }}),
+    )
+    .await
+    .expect("a well-formed filter still commits");
+    assert!(output.contains("\"created\": true"), "{output}");
+}
+
 #[tokio::test]
 async fn configure_automation_creates_owned_chain_and_rejects_foreign_tasks() {
     let db = test_db("self-config-automation").await;


### PR DESCRIPTION
Closes #1003

## The trust boundary, not the syntax

`EventTrigger.source_collection` is **agent-writable via self-config** and lands in GraphQL **identifier** positions in four trigger-engine queries (`seed_seen_docs_for_collection`, `fields_for`, `probe_filter`, `fetch_source_doc`). Identifiers sit outside string literals, so `escape_graphql_string()` — the codebase's standing sharp-edge rule — cannot apply there, and the only validation was a presence check. In a system whose premise is that DIDs and document ACLs bound what a principal may touch, that let a principal shape the queries the runtime issues. Escaping can't fix identifier positions; validation is the only defense.

## What changed

**Canonical validator** (`graphql.rs`): `validate_graphql_name` enforces the GraphQL Name grammar (`[_A-Za-z][_0-9A-Za-z]*`, ASCII only); `validate_collection_identifier` additionally rejects the spec-reserved `__` prefix so a "collection" of `__Type`/`__schema` cannot aim runtime queries at the introspection surface. `defra_query`'s existing `validate_identifier` now delegates to it — one seam, no query-builder abstraction.

**Enforced at three layers**, so no single bypass reaches a query string:
1. **Write time** — the self-config apply path rejects a non-conforming `source_collection` (covered by an e2e test driving injection payloads through `configure_automation`).
2. **Reconcile time** — snapshot resolve quarantines non-conforming triggers into `unavailable_event_triggers` with a `tracing::warn`. This covers trigger documents that never pass self-config, e.g. replicated from a peer.
3. **Query-build time** — the event source re-validates in `reconcile_subscriptions` (invalid names never enter the desired-collections set) and at every query-building function, so a snapshot assembled by any other path still cannot reach `format!`.

**The issue's second, unverified site is now verified and fixed**: `streaming/queries.rs` interpolated `response_key` (line 104) *and* `doc_id` (line 60) unescaped. The new tests demonstrate a hostile key previously produced a GraphQL parse error — a live syntax break, not a theoretical one. Both are now escaped; a hostile value matches nothing instead of breaking the query.

**Sweep result**: audited the other dynamic-collection interpolation sites (`defra_query/query.rs`, `defra_write`, `config_client/patch.rs`). They are already validated, or take collection names from the static `SelfConfigTarget` enum — no other agent-writable value reaches identifier position.

## Notes for review

- A grammar-valid but *unknown* collection name (e.g. `NoSuchCollection`) still reaches a query and fails harmlessly at execution with a warn/skip — it cannot change query shape. A schema-catalog allowlist was considered and left out: reconcile-time resolve has no reliable catalog snapshot for app collections that may land later, and the grammar check alone closes the injection channel.
- A validated Name cannot contain `"` or `\`, so the `__type(name: "{name}")` string-literal site in `fields_for` is safe by the same check.
- Tests were written first and observed failing (including the streaming parse-error repro) before the fixes landed.

Gates: `cargo test -p gents` fully green; `cargo check --workspace --all-targets` clean; rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)