### PR TITLE
fix(migration): merge-parked unique-index conflict must not brick boot

### DIFF
--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -43,6 +43,9 @@ pub async fn ensure_migrations_with_registry(
     verify_managed_lineages(node, registry, &mut report).await?;
 
     report.materialization = materialize::materialize_all(node, registry).await?;
+    report
+        .warnings
+        .extend(report.materialization.parked_unique_conflicts.iter().cloned());
 
     info!(
         baseline_registered = report.baseline_registered,

--- a/crates/gents-migration/src/engine.rs
+++ b/crates/gents-migration/src/engine.rs
@@ -43,9 +43,13 @@ pub async fn ensure_migrations_with_registry(
     verify_managed_lineages(node, registry, &mut report).await?;
 
     report.materialization = materialize::materialize_all(node, registry).await?;
-    report
-        .warnings
-        .extend(report.materialization.parked_unique_conflicts.iter().cloned());
+    report.warnings.extend(
+        report
+            .materialization
+            .parked_unique_conflicts
+            .iter()
+            .cloned(),
+    );
 
     info!(
         baseline_registered = report.baseline_registered,

--- a/crates/gents-migration/src/materialize.rs
+++ b/crates/gents-migration/src/materialize.rs
@@ -5,8 +5,10 @@
 //! merged in #1232): advances document blobs, stored version keys, and
 //! secondary indexes without creating CRDT commits or replication events.
 
+use std::collections::BTreeMap;
+
 use defra_node::EmbeddedNode;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::error::{Error, Result};
 use crate::registry::Registry;
@@ -15,7 +17,16 @@ use crate::report::MaterializationStats;
 /// Eagerly materialize every managed collection.
 ///
 /// Returns stats on success. Any collection-level failure is a hard error —
-/// after lineage verification every managed collection is expected to exist.
+/// after lineage verification every managed collection is expected to exist —
+/// with one deliberate exception: a unique-index violation raised by a
+/// document a P2P merge already parked unindexed (#984). The merge path
+/// resolves live unique conflicts deterministically (smallest public docID
+/// keeps the index entry; the loser persists unindexed), so the same document
+/// re-raising the violation during the boot-time reindex is expected residue,
+/// not corruption. The failed reindex transaction rolls back, preserving the
+/// merge-time winner; boot skips the collection's eager pass, records the
+/// parked state in the report, and continues. A foreign stale doc must never
+/// be a poison pill.
 pub async fn materialize_all(
     node: &EmbeddedNode,
     registry: &Registry<'_>,
@@ -35,6 +46,7 @@ pub async fn materialize_collections(
         collections_failed: 0,
         skipped_upstream_missing: false,
         read_through_scans: 0,
+        parked_unique_conflicts: Vec::new(),
     };
 
     let mut failures: Vec<String> = Vec::new();
@@ -44,6 +56,17 @@ pub async fn materialize_collections(
             Ok(n) => {
                 stats.documents_materialized += n;
                 debug!(collection = %name, documents = n, "materialized collection");
+            }
+            Err(e) if is_unique_index_violation(&e) => {
+                let detail = describe_parked_unique_conflict(node, name, &e).await;
+                warn!(
+                    collection = %name,
+                    detail = %detail,
+                    "eager materialization skipped: a merge-parked unique-index \
+                     conflict makes a full reindex impossible; the merge-time \
+                     deterministic winner keeps the index entry and boot continues"
+                );
+                stats.parked_unique_conflicts.push(detail);
             }
             Err(e) => {
                 stats.collections_failed += 1;
@@ -67,4 +90,151 @@ pub async fn materialize_collections(
     }
 
     Ok(stats)
+}
+
+/// A unique-index violation surfaced through the `EmbeddedNode` anyhow chain.
+///
+/// The message is DefraDB's shared constant
+/// (`storage::corekv::Error::UniqueConstraintViolation`, also matched by the
+/// upstream HTTP layer); only this error class is tolerated at boot.
+fn is_unique_index_violation(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().contains("violates unique index"))
+}
+
+/// Best-effort identification of the parked document(s) behind a boot-time
+/// unique-index violation.
+///
+/// Scans the collection (non-index reads see parked documents), groups rows
+/// by each unique index's field values, and applies the merge path's
+/// deterministic-winner rule — the lexicographically smallest public docID
+/// holds the index entry — so the reported winner/parked split matches what
+/// the merge already persisted. Diagnostics must never fail boot: any error
+/// degrades to the raw materialization error text.
+async fn describe_parked_unique_conflict(
+    node: &EmbeddedNode,
+    collection: &str,
+    error: &anyhow::Error,
+) -> String {
+    let mut detail = format!(
+        "{collection}: eager materialization skipped ({error}); \
+         a P2P merge parked a unique-index-conflicting document unindexed (#984)"
+    );
+
+    let unique_indexes = match node.get_collection(collection) {
+        Ok(Some(version)) => version
+            .indexes
+            .into_iter()
+            .filter(|index| index.unique)
+            .collect::<Vec<_>>(),
+        Ok(None) => Vec::new(),
+        Err(e) => {
+            warn!(collection = %collection, error = %e, "parked-doc diagnostics: get_collection failed");
+            Vec::new()
+        }
+    };
+
+    for index in unique_indexes {
+        let fields: Vec<&str> = index.fields.iter().map(|f| f.name.as_str()).collect();
+        if fields.is_empty() {
+            continue;
+        }
+        let query = format!(
+            "{{ {collection} {{ _docID {} }} }}",
+            fields.join(" ")
+        );
+        let resp = node.execute(&query).await;
+        if resp.has_errors() {
+            warn!(
+                collection = %collection,
+                index = %index.name,
+                errors = ?resp.errors,
+                "parked-doc diagnostics: scan failed"
+            );
+            continue;
+        }
+        let rows = resp
+            .data
+            .as_ref()
+            .and_then(|data| data.get(collection))
+            .and_then(|rows| rows.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        // Group docIDs by the unique value tuple; >1 doc per tuple is the
+        // conflict the merge parked. All-null tuples are not unique-constrained.
+        let mut by_values: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for row in &rows {
+            let values: Vec<serde_json::Value> = fields
+                .iter()
+                .map(|f| row.get(*f).cloned().unwrap_or(serde_json::Value::Null))
+                .collect();
+            if values.iter().all(serde_json::Value::is_null) {
+                continue;
+            }
+            let Some(doc_id) = row.get("_docID").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let key = serde_json::to_string(&values).unwrap_or_default();
+            by_values.entry(key).or_default().push(doc_id.to_string());
+        }
+
+        for (values, mut doc_ids) in by_values {
+            if doc_ids.len() < 2 {
+                continue;
+            }
+            doc_ids.sort();
+            let winner = &doc_ids[0];
+            let parked = &doc_ids[1..];
+            warn!(
+                collection = %collection,
+                index = %index.name,
+                values = %values,
+                winner_doc_id = %winner,
+                parked_doc_ids = ?parked,
+                "unique index conflict parked at boot: existing deterministic \
+                 winner keeps the index entry; parked document(s) remain \
+                 readable by non-index scans"
+            );
+            detail.push_str(&format!(
+                "; index {} on {} has winner {} and parked [{}]",
+                index.name,
+                values,
+                winner,
+                parked.join(", ")
+            ));
+        }
+    }
+
+    detail
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_unique_index_violation;
+
+    #[test]
+    fn unique_index_violation_is_detected_anywhere_in_the_chain() {
+        // Shape produced by the live incident: db::Error::Storage wrapped by
+        // defra-node into anyhow, displayed through the chain.
+        let root = anyhow::anyhow!(
+            "storage error: can not index a doc's field(s) that violates unique index."
+        );
+        let wrapped = root.context("merge residue surfaces during reindex");
+        assert!(is_unique_index_violation(&wrapped));
+        assert!(is_unique_index_violation(&anyhow::anyhow!(
+            "can not index a doc's field(s) that violates unique index."
+        )));
+    }
+
+    #[test]
+    fn other_materialization_errors_stay_fatal() {
+        assert!(!is_unique_index_violation(&anyhow::anyhow!(
+            "collection not found: PeerEndpoint"
+        )));
+        assert!(!is_unique_index_violation(&anyhow::anyhow!(
+            "failed to build migration history for collection 'PeerEndpoint'"
+        )));
+    }
 }

--- a/crates/gents-migration/src/materialize.rs
+++ b/crates/gents-migration/src/materialize.rs
@@ -103,6 +103,16 @@ fn is_unique_index_violation(error: &anyhow::Error) -> bool {
         .any(|cause| cause.to_string().contains("violates unique index"))
 }
 
+/// Bare `[A-Za-z0-9_]` check for GraphQL identifier positions.
+///
+/// `escape_graphql_string` covers string literals only; collection and field
+/// names interpolate as identifiers, where validation is the only defense.
+/// Both come from trusted sources (the static registry and the node's own
+/// schema), so this is a trust-boundary backstop, not input sanitization.
+fn is_safe_graphql_identifier(name: &str) -> bool {
+    !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// Best-effort identification of the parked document(s) behind a boot-time
 /// unique-index violation.
 ///
@@ -119,8 +129,14 @@ async fn describe_parked_unique_conflict(
 ) -> String {
     let mut detail = format!(
         "{collection}: eager materialization skipped ({error}); \
-         a P2P merge parked a unique-index-conflicting document unindexed (#984)"
+         consistent with a P2P merge having parked a unique-index-conflicting \
+         document unindexed (#984)"
     );
+
+    if !is_safe_graphql_identifier(collection) {
+        warn!(collection = %collection, "parked-doc diagnostics: unsafe collection identifier");
+        return detail;
+    }
 
     let unique_indexes = match node.get_collection(collection) {
         Ok(Some(version)) => version
@@ -137,7 +153,7 @@ async fn describe_parked_unique_conflict(
 
     for index in unique_indexes {
         let fields: Vec<&str> = index.fields.iter().map(|f| f.name.as_str()).collect();
-        if fields.is_empty() {
+        if fields.is_empty() || !fields.iter().all(|f| is_safe_graphql_identifier(f)) {
             continue;
         }
         let query = format!(

--- a/crates/gents-migration/src/materialize.rs
+++ b/crates/gents-migration/src/materialize.rs
@@ -156,10 +156,7 @@ async fn describe_parked_unique_conflict(
         if fields.is_empty() || !fields.iter().all(|f| is_safe_graphql_identifier(f)) {
             continue;
         }
-        let query = format!(
-            "{{ {collection} {{ _docID {} }} }}",
-            fields.join(" ")
-        );
+        let query = format!("{{ {collection} {{ _docID {} }} }}", fields.join(" "));
         let resp = node.execute(&query).await;
         if resp.has_errors() {
             warn!(

--- a/crates/gents-migration/src/report.rs
+++ b/crates/gents-migration/src/report.rs
@@ -16,6 +16,14 @@ pub struct MaterializationStats {
     /// Always `0` with eager datastore materialization. Kept for report
     /// compatibility with the pre-#1232 GraphQL read-through path.
     pub read_through_scans: usize,
+    /// Human-readable details for collections whose eager materialization was
+    /// skipped because a P2P merge parked a unique-index-conflicting document
+    /// unindexed (#984). One entry per parked collection, naming the
+    /// collection, the offending unique index, and (best-effort) the winner
+    /// and parked docIDs. Boot proceeds: the pre-existing index state — the
+    /// merge-time deterministic winner — is preserved, and parked documents
+    /// remain readable by non-index scans.
+    pub parked_unique_conflicts: Vec<String>,
 }
 
 /// Summary returned by [`crate::ensure_migrations`].

--- a/crates/gents/tests/e2e_lifecycle.rs
+++ b/crates/gents/tests/e2e_lifecycle.rs
@@ -12,6 +12,8 @@ mod lifecycle_queue;
 mod lifecycle_recovery;
 #[path = "e2e_lifecycle/lifecycle_terminal.rs"]
 mod lifecycle_terminal;
+#[path = "e2e_lifecycle/merge_parked_unique_boot_e2e.rs"]
+mod merge_parked_unique_boot_e2e;
 #[path = "e2e_lifecycle/p2p_admission_backpressure_e2e.rs"]
 mod p2p_admission_backpressure_e2e;
 #[path = "e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs"]

--- a/crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs
+++ b/crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs
@@ -1,0 +1,240 @@
+//! Repro + fence for #984: a P2P merge that parks a unique-index-conflicting
+//! document unindexed must not brick the next boot.
+//!
+//! DefraDB's merge path resolves live unique conflicts deterministically
+//! (`db_index::index_manager::save_resolving_unique_conflict`): the
+//! lexicographically smallest public docID keeps the index entry and the
+//! loser is persisted unindexed. Boot's eager materialization
+//! (`ensure_migrations` → `materialize_collection` → `bulk_index`) previously
+//! used strict unique saves, so the parked loser re-raised
+//! `UniqueConstraintViolation` on every subsequent boot — a foreign stale doc
+//! became a permanent poison pill requiring a full home reset.
+//!
+//! This test reproduces the exact live sequence from 2026-07-31: a re-paired
+//! client replays a stale `PeerEndpoint` doc with the same unique `did`, the
+//! home merges it gracefully, and the home must then boot again — reporting
+//! the parked doc rather than dying on it.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use gents::agent::p2p_reconcile::{EmbeddedRemoteP2pAdmin, PairingFilters, RemoteP2pAdmin};
+use gents::defra_node::EmbeddedNode;
+
+use crate::support::p2p_waits::{wait_for_connected_peer, wait_for_listen_addr};
+use crate::support::{first_row, test_p2p_db, DocIdRow};
+
+const CONFLICT_DID: &str = "did:test:984-stale-endpoint";
+
+async fn create_endpoint(node: &EmbeddedNode, address: &str) -> String {
+    let mutation = format!(
+        r#"mutation {{
+            create_PeerEndpoint(input: {{
+                did: "{CONFLICT_DID}",
+                node_id: "node-{address}",
+                address: "{address}",
+                updated_at: "2026-07-31T00:00:00Z",
+                binding_sig: "sig-{address}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create_PeerEndpoint failed: {:?}",
+        resp.errors
+    );
+    let resp = node
+        .execute(&format!(
+            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{CONFLICT_DID}" }} }}) {{ _docID }} }}"#
+        ))
+        .await;
+    first_row::<DocIdRow>(&resp, "PeerEndpoint").doc_id
+}
+
+fn scan_endpoint_doc_ids(resp: &gents::defra_node::QueryResponse) -> Vec<String> {
+    assert!(!resp.has_errors(), "scan failed: {:?}", resp.errors);
+    resp.data
+        .as_ref()
+        .and_then(|d| d.get("PeerEndpoint"))
+        .and_then(|rows| rows.as_array())
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|r| r.get("_docID").and_then(|v| v.as_str()))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Unfiltered scan — reads every persisted doc, indexed or parked.
+async fn scan_endpoints(node: &EmbeddedNode) -> Vec<String> {
+    let resp = node
+        .execute(r#"{ PeerEndpoint { _docID did address } }"#)
+        .await;
+    scan_endpoint_doc_ids(&resp)
+}
+
+async fn install_replicator(sender: &Arc<EmbeddedNode>, receiver: &Arc<EmbeddedNode>) {
+    let receiver_addr = wait_for_listen_addr(receiver).await;
+    let sender_addr = wait_for_listen_addr(sender).await;
+    let collections = vec!["PeerEndpoint".to_string()];
+
+    sender
+        .p2p()
+        .expect("sender p2p")
+        .connect_peer(&receiver_addr)
+        .await
+        .expect("connect sender to receiver");
+    wait_for_connected_peer(sender).await;
+    wait_for_connected_peer(receiver).await;
+
+    sender
+        .p2p()
+        .expect("sender p2p")
+        .add_collections(collections.clone())
+        .await
+        .expect("sender p2p collections");
+    receiver
+        .p2p()
+        .expect("receiver p2p")
+        .add_collections(collections.clone())
+        .await
+        .expect("receiver p2p collections");
+    receiver
+        .p2p()
+        .expect("receiver p2p")
+        .add_replicator(
+            collections.clone(),
+            Some(&sender_addr),
+            Default::default(),
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("authorize sender as receiver-side replicator");
+
+    let sender_admin = EmbeddedRemoteP2pAdmin::new(Arc::clone(sender));
+    sender_admin
+        .add_replicator(&[receiver_addr], &collections, &PairingFilters::new())
+        .await
+        .expect("install sender to receiver replicator");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn merge_parked_unique_conflict_does_not_brick_boot() {
+    let mut home = test_p2p_db("984-home").await;
+    let client = test_p2p_db("984-client").await;
+
+    // Same unique `did` on both nodes, different content → distinct docIDs.
+    let home_doc = create_endpoint(&home.node, "/ip4/127.0.0.1/tcp/4001").await;
+    let client_doc = create_endpoint(&client.node, "/ip4/127.0.0.1/tcp/4002").await;
+    assert_ne!(home_doc, client_doc, "conflict requires distinct docIDs");
+
+    // Re-paired client replays its stale endpoint into the home: the merge
+    // path parks the deterministic loser unindexed instead of failing.
+    install_replicator(&client.node, &home.node).await;
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let docs = scan_endpoints(&home.node).await;
+        if docs.len() == 2 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "home never persisted the conflicting endpoint; scan={docs:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // The merge parked exactly one doc: the unique index resolves the did to
+    // the deterministic winner (smallest docID) while the scan sees both.
+    let winner = std::cmp::min(home_doc.clone(), client_doc.clone());
+    let parked = std::cmp::max(home_doc.clone(), client_doc.clone());
+    let filtered = home
+        .node
+        .execute(&format!(
+            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{CONFLICT_DID}" }} }}) {{ _docID }} }}"#
+        ))
+        .await;
+    let indexed = scan_endpoint_doc_ids(&filtered);
+    assert_eq!(
+        indexed,
+        vec![winner.clone()],
+        "unique index must resolve to the deterministic winner"
+    );
+
+    // Release the client so the home's restart is the only live node touching
+    // the datastore (and to mirror the live incident: server restarts alone).
+    client.node.shutdown().await;
+
+    // Boot. Pre-#984-fix this dies inside ensure_migrations with
+    // "eager materialization failed: PeerEndpoint: storage error: can not
+    // index a doc's field(s) that violates unique index."
+    //
+    // The reopen is retried on lock errors only: node shutdown does not join
+    // the P2P pending-DAG sweep loops (`run_pending_dag_resync`, 60s cadence,
+    // spawned untracked in defra-node's `setup_p2p`), so the coordinator —
+    // and through it the store — stays alive until the loop's next wake, and
+    // the in-process redb lock can lag shutdown by up to one sweep interval.
+    // A real process restart has no such lag (the OS drops the lock), so the
+    // retry models process exit, not a race in the code under test.
+    let reopen_deadline = Instant::now() + Duration::from_secs(90);
+    loop {
+        match home.simulate_process_crash().await {
+            Ok(()) => break,
+            Err(e)
+                if e.to_string().contains("is locked by another process")
+                    && Instant::now() < reopen_deadline =>
+            {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(e) => panic!("boot after a merge-parked unique-index conflict must succeed: {e}"),
+        }
+    }
+
+    // The boot must be observable about what it tolerated: the report names
+    // the parked collection and the parked docID.
+    let report = gents::migration::ensure_migrations(&home.node)
+        .await
+        .expect("ensure_migrations after boot");
+    assert_eq!(
+        report.materialization.parked_unique_conflicts.len(),
+        1,
+        "exactly one collection is parked; report={report:?}"
+    );
+    let detail = &report.materialization.parked_unique_conflicts[0];
+    assert!(
+        detail.contains("PeerEndpoint"),
+        "parked detail must name the collection: {detail}"
+    );
+    assert!(
+        detail.contains(&parked),
+        "parked detail must name the parked docID {parked}: {detail}"
+    );
+    assert!(
+        report.warnings.iter().any(|w| w.contains("PeerEndpoint")),
+        "report warnings must surface the parked collection: {:?}",
+        report.warnings
+    );
+
+    // Nothing was lost and the deterministic pick is unchanged: both docs
+    // remain persisted, and the unique index still resolves to the winner.
+    let mut docs = scan_endpoints(&home.node).await;
+    docs.sort();
+    let mut expected = vec![home_doc, client_doc];
+    expected.sort();
+    assert_eq!(docs, expected, "parked doc must survive boot");
+    let filtered = home
+        .node
+        .execute(&format!(
+            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{CONFLICT_DID}" }} }}) {{ _docID }} }}"#
+        ))
+        .await;
+    assert_eq!(
+        scan_endpoint_doc_ids(&filtered),
+        vec![winner],
+        "boot must not flip the deterministic winner"
+    );
+}

--- a/crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs
+++ b/crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs
@@ -20,17 +20,20 @@ use std::time::{Duration, Instant};
 
 use gents::agent::p2p_reconcile::{EmbeddedRemoteP2pAdmin, PairingFilters, RemoteP2pAdmin};
 use gents::defra_node::EmbeddedNode;
+use gents::graphql::escape_graphql_string;
 
 use crate::support::p2p_waits::{wait_for_connected_peer, wait_for_listen_addr};
-use crate::support::{first_row, test_p2p_db, DocIdRow};
+use crate::support::test_p2p_db;
 
 const CONFLICT_DID: &str = "did:test:984-stale-endpoint";
 
 async fn create_endpoint(node: &EmbeddedNode, address: &str) -> String {
+    let did = escape_graphql_string(CONFLICT_DID);
+    let address = escape_graphql_string(address);
     let mutation = format!(
         r#"mutation {{
             create_PeerEndpoint(input: {{
-                did: "{CONFLICT_DID}",
+                did: "{did}",
                 node_id: "node-{address}",
                 address: "{address}",
                 updated_at: "2026-07-31T00:00:00Z",
@@ -44,12 +47,21 @@ async fn create_endpoint(node: &EmbeddedNode, address: &str) -> String {
         "create_PeerEndpoint failed: {:?}",
         resp.errors
     );
+    let indexed = indexed_endpoint_doc_ids(node).await;
+    assert_eq!(indexed.len(), 1, "freshly created endpoint must be indexed");
+    indexed.into_iter().next().unwrap()
+}
+
+/// Index-backed lookup: filtering on the unique `did` resolves through the
+/// index, so only the deterministic winner is visible here.
+async fn indexed_endpoint_doc_ids(node: &EmbeddedNode) -> Vec<String> {
+    let did = escape_graphql_string(CONFLICT_DID);
     let resp = node
         .execute(&format!(
-            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{CONFLICT_DID}" }} }}) {{ _docID }} }}"#
+            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{did}" }} }}) {{ _docID }} }}"#
         ))
         .await;
-    first_row::<DocIdRow>(&resp, "PeerEndpoint").doc_id
+    scan_endpoint_doc_ids(&resp)
 }
 
 fn scan_endpoint_doc_ids(resp: &gents::defra_node::QueryResponse) -> Vec<String> {
@@ -152,15 +164,8 @@ async fn merge_parked_unique_conflict_does_not_brick_boot() {
     // the deterministic winner (smallest docID) while the scan sees both.
     let winner = std::cmp::min(home_doc.clone(), client_doc.clone());
     let parked = std::cmp::max(home_doc.clone(), client_doc.clone());
-    let filtered = home
-        .node
-        .execute(&format!(
-            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{CONFLICT_DID}" }} }}) {{ _docID }} }}"#
-        ))
-        .await;
-    let indexed = scan_endpoint_doc_ids(&filtered);
     assert_eq!(
-        indexed,
+        indexed_endpoint_doc_ids(&home.node).await,
         vec![winner.clone()],
         "unique index must resolve to the deterministic winner"
     );
@@ -226,14 +231,8 @@ async fn merge_parked_unique_conflict_does_not_brick_boot() {
     let mut expected = vec![home_doc, client_doc];
     expected.sort();
     assert_eq!(docs, expected, "parked doc must survive boot");
-    let filtered = home
-        .node
-        .execute(&format!(
-            r#"{{ PeerEndpoint(filter: {{ did: {{ _eq: "{CONFLICT_DID}" }} }}) {{ _docID }} }}"#
-        ))
-        .await;
     assert_eq!(
-        scan_endpoint_doc_ids(&filtered),
+        indexed_endpoint_doc_ids(&home.node).await,
         vec![winner],
         "boot must not flip the deterministic winner"
     );

--- a/docs/superpowers/specs/2026-07-28-lens-first-migration-design.md
+++ b/docs/superpowers/specs/2026-07-28-lens-first-migration-design.md
@@ -611,7 +611,7 @@ re-calls `set_active_collection_version(pin)` when needed and always runs
 | --- | --- | --- | --- |
 | **A** | `gents-migration`; baseline (zero production steps); unbypassable `ensure_migrations`; delete legacy; Lean + conformance | — | **done** (#931) |
 | **B** | Fixture lens; `DynamicRegistry`; inactive+fields; PatchVersioned e2e; crash-resume | — | **done** (#931) |
-| **C** | Eager `materialize_collection` driver (hard-fail on collection error) | [defradb.rs#1230](https://github.com/sourcenetwork/defradb.rs/issues/1230) via [#1232](https://github.com/sourcenetwork/defradb.rs/pull/1232) | **done** |
+| **C** | Eager `materialize_collection` driver (hard-fail on collection error, with one carve-out since #984: a unique-index violation from a merge-parked document skips that collection's eager pass and is reported, never bricking boot; see [defradb.rs#1308](https://github.com/sourcenetwork/defradb.rs/issues/1308) for the upstream half) | [defradb.rs#1230](https://github.com/sourcenetwork/defradb.rs/issues/1230) via [#1232](https://github.com/sourcenetwork/defradb.rs/pull/1232) | **done** |
 | **D** | Unknown *document* version pass-through + rolling-upgrade guidance | [defradb.rs#1231](https://github.com/sourcenetwork/defradb.rs/issues/1231) via [#1232](https://github.com/sourcenetwork/defradb.rs/pull/1232) | **done** |
 
 ### 8.10 Feature-invariant baseline


### PR DESCRIPTION
Closes #984

## The bug

A re-paired client replays a stale `PeerEndpoint` doc; the P2P merge hits the unique `did` index conflict and handles it **by design** (defradb.rs#1111): the lexicographically smallest public docID keeps the index entry, the loser is persisted unindexed, replicas converge. The server runs fine — until restart. Boot's `ensure_migrations` → eager materialization calls defradb's `materialize_collection`, which does `remove_all` + `bulk_index` with **strict** unique saves over every persisted doc. The parked loser re-raises `UniqueConstraintViolation`, gents treated any collection failure as fatal, and since materialization runs on every boot, the home was bricked until a full reset.

The asymmetry is the bug: one subsystem's documented graceful outcome was another subsystem's poison pill.

## The fix (boot tolerant + observable)

`materialize_collections` now classifies exactly this error class as merge-parked residue:

- **Safe to skip**: the failed reindex transaction upstream never commits, so the on-disk index state — the merge-time deterministic winner — survives intact. Skipping the collection's eager pass preserves the exact pick the merge made; boot re-derives nothing.
- **Observable**: a `tracing::warn!` names the collection, unique index, winner docID and parked docID(s). The parked docs are recovered by a non-index scan grouped by unique-field values with the same smallest-docID winner rule the merge uses, so the reported split matches what merge persisted. Details are recorded in a new `MaterializationStats::parked_unique_conflicts` and surfaced through `MigrationReport::warnings`. Diagnostics are best-effort and can never fail boot.
- **Everything else stays fatal**: only the unique-violation class (defradb's shared error constant) is tolerated; all other materialization failures still hard-fail as before.

## The repro test (the heart of the PR)

`crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs` drives the real incident sequence: two P2P nodes create `PeerEndpoint` docs with the same unique `did` (distinct docIDs), a replicator replays the client's doc onto the home, the test asserts the merge parked state (scan sees 2 docs, the unique index resolves to the smallest docID), then restarts the home via `simulate_process_crash` — which re-runs the production boot path.

- **Red run** (tolerance disabled): fails with the incident error verbatim — `eager materialization failed: PeerEndpoint: storage error: can not index a doc's field(s) that violates unique index.`
- **Green run**: boot succeeds; the report names PeerEndpoint and the parked docID; both docs survive; the winner is unchanged after boot.

The reopen retries on lock errors only, with a bounded deadline: `EmbeddedNode::shutdown` doesn't join the pending-DAG sweep loops, whose coordinator Arc holds the store for up to one 60s sweep interval (filed as sourcenetwork/defradb.rs#1309). A real process restart has no such lag, so the retry models process exit, not a race in the code under test.

Unit tests in `gents-migration` fence the error classifier (violation anywhere in the anyhow chain → tolerated; anything else → fatal).

## Lean

Boot-time materialization sits outside the proof boundary: "DefraDB storage-engine correctness remains external" is an explicit model boundary, and the recovery-convergence theorems (`Proofs/Recovery/`) model request-state repair, not schema/document materialization. This change alters no legal transitions and no fenced invariants, so no spec change. Recovery-semantics review notes:

- **Winner identity**: boot does not re-pick a winner — it preserves the merge-time index state (rollback semantics), and the *reporting* applies the identical smallest-public-docID rule.
- **No loss / no double-materialization**: parked docs remain persisted and scan-readable; the skipped eager pass commits nothing, so nothing is partially applied. Docs left at older schema versions continue to be lens-migrated on read.

## Upstream halves (filed, not silently half-fixed)

- sourcenetwork/defradb.rs#1308 — `bulk_index` should resolve unique conflicts with the merge's deterministic-winner rule (order-independent, converges to exactly the merge outcome), and expose a typed error so embedders don't string-match.
- sourcenetwork/defradb.rs#1309 — `setup_p2p`'s untracked sweep tasks hold the store past shutdown.
- #1036 — follow-up for #984's secondary observations (replicator POST hang, reconciler install failures), triaged as a probable coordinator wedge, independent of this fix.

## Verification

- `cargo test -p gents-migration` ✅ · `cargo test -p gents` (full package suite) ✅ · `cargo check --workspace --all-targets` ✅
- Red/green runs of the repro as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)