### PR TITLE
Kill the CLI-suite flake class: parallel-run contention (#990, #933, #989)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,4 +43,5 @@ The few things you can't discover until they bite:
 - **Gate with the full package suite** (`cargo test -p gents`), not `--lib` — integration tests are separate compile units and `--lib` will happily pass while they don't build.
 - **Compile the whole workspace before pushing** (`cargo check --workspace --all-targets`) — the test gate above still skips examples, the desktop crates, and many test targets, so a new required struct field breaks their construction sites silently until CI (or the next unrelated PR). CI enforces this in `rust-and-cli`; run it locally first.
 - **Flaky tests are defects.** The formal-verification investment exists to eliminate that class; capture, file, and fix — never shrug.
+- **Create worktrees with `make worktree BRANCH=<branch>`**, not bare `git worktree add`. It clones `target/` and `proofs/.lake` from the current checkout via APFS clonefile; a cold worktree costs ~40 min of recompilation (sccache can't cache build scripts, proc-macro expansion, or linking) and hours of Mathlib. Note `cargo check` artifacts don't warm `cargo test` — warm with `cargo build --tests -p <crate>` if tests are the goal.
 - `tracing`, never `println`.

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,16 @@ help:
 	@echo "  make live-cli              Run live CLI smoke test"
 	@echo "  make live-agent            Run ignored live runtime tests"
 	@echo "  make live-desktop-smoke    Run live desktop smoke suites"
+	@echo
+	@echo "Worktrees:"
+	@echo "  make worktree BRANCH=<branch> [DIR=<dest>] [BASE=<ref>]"
+	@echo "                             Create a worktree with target/ and proofs/.lake"
+	@echo "                             cloned from this checkout (APFS clonefile)"
+
+.PHONY: worktree
+worktree:
+	@test -n "$(BRANCH)" || { echo "usage: make worktree BRANCH=<branch> [DIR=<dest>] [BASE=<ref>]" >&2; exit 2; }
+	@scripts/worktree-bootstrap.sh "$(BRANCH)" $(DIR) $(BASE)
 
 .PHONY: build build-cli build-cli-headless build-desktop build-desktop-ui
 build:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ help:
 .PHONY: worktree
 worktree:
 	@test -n "$(BRANCH)" || { echo "usage: make worktree BRANCH=<branch> [DIR=<dest>] [BASE=<ref>]" >&2; exit 2; }
-	@scripts/worktree-bootstrap.sh "$(BRANCH)" $(DIR) $(BASE)
+	@WORKTREE_DIR="$(DIR)" WORKTREE_BASE="$(BASE)" scripts/worktree-bootstrap.sh "$(BRANCH)"
 
 .PHONY: build build-cli build-cli-headless build-desktop build-desktop-ui
 build:

--- a/crates/gents-cli/src/commands/codex_shim/store.rs
+++ b/crates/gents-cli/src/commands/codex_shim/store.rs
@@ -1,13 +1,21 @@
 use anyhow::Result;
 use gents::defra_node::{EmbeddedNode, QueryRequest};
+use gents::retry::{
+    defradb_conflict_retry_backoff, execute_graphql_with_conflict_retry,
+    is_defradb_transaction_conflict_text, DEFRA_DB_CONFLICT_MAX_RETRIES,
+};
 use gents_protocol::transcript::present_persisted_message;
 use serde_json::{json, Value};
 
 use super::progress::response_field_is_blank;
 use crate::materialized_message_query;
 
+/// All shim reads and auto-committed writes go through the runtime's bounded
+/// DefraDB conflict retry (#440): right after startup the runtime's own
+/// reconciliation writes are still in flight, and an unretried auto-commit
+/// surfaces a raw `transaction conflict` to the Codex client (#933).
 pub(super) async fn query_node_json(node: &EmbeddedNode, query: &str) -> Result<Value> {
-    let response = node.execute(query).await;
+    let response = execute_graphql_with_conflict_retry(node, query, "codex shim store").await;
     if response.has_errors() {
         anyhow::bail!("GENTS Codex shim query failed: {:?}", response.errors);
     }
@@ -24,6 +32,31 @@ pub(super) async fn query_node_json(node: &EmbeddedNode, query: &str) -> Result<
 /// `config skill` CLI path (#340). Mirrors the Local arm of
 /// `config_writes::txn::ConfigApplyTxn`.
 pub(super) async fn execute_committed(node: &EmbeddedNode, mutation: &str) -> Result<Value> {
+    let mut retry_index = 0;
+    loop {
+        match execute_committed_once(node, mutation).await {
+            Ok(value) => return Ok(value),
+            Err(error)
+                if retry_index < DEFRA_DB_CONFLICT_MAX_RETRIES
+                    && is_defradb_transaction_conflict_text(&format!("{error:#}")) =>
+            {
+                let backoff = defradb_conflict_retry_backoff(retry_index);
+                retry_index += 1;
+                tracing::warn!(
+                    retry_count = retry_index,
+                    max_retries = DEFRA_DB_CONFLICT_MAX_RETRIES,
+                    backoff_ms = backoff.as_millis() as u64,
+                    error = %error,
+                    "retrying Codex shim committed mutation after transaction conflict"
+                );
+                tokio::time::sleep(backoff).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+async fn execute_committed_once(node: &EmbeddedNode, mutation: &str) -> Result<Value> {
     let handle = node
         .runner()
         .begin_txn(false)

--- a/crates/gents-cli/src/commands/codex_shim/store.rs
+++ b/crates/gents-cli/src/commands/codex_shim/store.rs
@@ -30,7 +30,9 @@ pub(super) async fn query_node_json(node: &EmbeddedNode, query: &str) -> Result<
 /// COMMIT does. Routing skill enable/disable writes through here lets a running
 /// agent pick up Codex-driven toggles without a restart — matching the
 /// `config skill` CLI path (#340). Mirrors the Local arm of
-/// `config_writes::txn::ConfigApplyTxn`.
+/// `gents::config_client::txn::ConfigApplyTxn`, plus a bounded conflict retry
+/// that arm does not have (#933): a conflicted cycle commits nothing, so a
+/// successful call still emits exactly one Update event.
 pub(super) async fn execute_committed(node: &EmbeddedNode, mutation: &str) -> Result<Value> {
     let mut retry_index = 0;
     loop {

--- a/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
+++ b/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
@@ -105,16 +105,23 @@ struct ReasoningCursor {
     progress_seq: Option<String>,
     segment: u64,
     /// Text of the most recently completed segment, retained while the durable
-    /// row may still serve it stale — i.e. until the runtime's reset-tail write
-    /// (an observed empty tail) proves the buffer was actually cleared. Without
-    /// it, re-observing the unchanged text after a boundary manufactures a
-    /// full replay on a fresh segment (#1040); the Lean contract
-    /// `reset_before_terminal_suppresses_durable_replay` forbids exactly that.
+    /// row may still serve it stale. Cleared once staleness is disproven: an
+    /// observed empty tail (the runtime's reset-tail write landed), an advanced
+    /// `reasoning_progress_seq`, growth, divergence, `prime()`, or `reset()`.
+    /// Without it, re-observing the unchanged text after a boundary
+    /// manufactures a full replay on a fresh segment (#1040). The Lean
+    /// contract `reset_before_terminal_suppresses_durable_replay` forbids the
+    /// same replay at the terminal boundary; this cursor bookkeeping is what
+    /// establishes that contract's no-live-delta precondition mid-stream.
     completed_preview: String,
-    /// `reasoning_progress_seq` observed when the segment completed: a stale
-    /// re-read carries the same value, a genuine byte-identical rewrite has
-    /// advanced it (`write_reasoning` bumps it on every append).
+    /// `reasoning_progress_seq` from the last observation attributable to the
+    /// completed segment (the poll BEFORE the boundary read — the boundary
+    /// read itself may already carry a post-reset rewrite's advanced seq).
+    /// A stale re-read matches it; a genuine byte-identical rewrite has
+    /// advanced past it (`write_reasoning` bumps the seq on every append).
     completed_reasoning_seq: Option<String>,
+    /// `reasoning_progress_seq` seen on the previous `observe` call.
+    observed_reasoning_seq: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -962,6 +969,8 @@ impl ReasoningCursor {
             && progress_seq.is_some()
             && self.progress_seq != progress_seq;
         self.progress_seq = progress_seq;
+        let previous_reasoning_seq = self.observed_reasoning_seq.take();
+        self.observed_reasoning_seq = reasoning_seq.clone();
         let explicit_boundary = current.is_empty() && !self.observed_preview.is_empty();
         let previous_preview = self.observed_preview.clone();
         let completed_item_id = ((progress_boundary || explicit_boundary)
@@ -969,7 +978,7 @@ impl ReasoningCursor {
         .then(|| self.active_item_id(request_id));
         if completed_item_id.is_some() {
             self.completed_preview = std::mem::take(&mut self.observed_preview);
-            self.completed_reasoning_seq = reasoning_seq.clone();
+            self.completed_reasoning_seq = previous_reasoning_seq.or_else(|| reasoning_seq.clone());
             self.active_item_id = None;
             self.segment = self.segment.saturating_add(1);
         }
@@ -1022,6 +1031,32 @@ impl ReasoningCursor {
                         text: suffix.to_string(),
                     }),
                 };
+            } else if !progress_boundary {
+                // The durable reasoning column is a bounded rolling tail
+                // (MAX_LIVE_REASONING_BYTES); once the completed segment's
+                // stored tail was at capacity, growth rolls the window instead
+                // of prefix-extending it. On a stale-window poll (no fresh
+                // boundary), recover the unseen suffix via overlap so the
+                // already-completed bytes are not re-streamed. Boundary-call
+                // divergence keeps full-text semantics (pinned by
+                // reasoning_cursor_uses_progress_boundary_when_empty_write_was_missed).
+                let overlap = suffix_prefix_overlap(&self.completed_preview, current);
+                self.completed_preview.clear();
+                self.completed_reasoning_seq = None;
+                if overlap > 0 {
+                    self.observed_preview = current.to_string();
+                    let item_id = self
+                        .active_item_id
+                        .get_or_insert_with(|| reasoning_item_id(request_id, self.segment))
+                        .clone();
+                    return ReasoningObservation {
+                        completed_item_id,
+                        delta: Some(ReasoningDelta {
+                            item_id,
+                            text: current[overlap..].to_string(),
+                        }),
+                    };
+                }
             } else {
                 self.completed_preview.clear();
                 self.completed_reasoning_seq = None;
@@ -1069,6 +1104,7 @@ impl ReasoningCursor {
         self.active_item_id = Some(item_id);
         self.completed_preview.clear();
         self.completed_reasoning_seq = None;
+        self.observed_reasoning_seq = None;
     }
 
     fn active_item_id(&self, request_id: &str) -> String {
@@ -1084,6 +1120,7 @@ impl ReasoningCursor {
         self.segment = 0;
         self.completed_preview.clear();
         self.completed_reasoning_seq = None;
+        self.observed_reasoning_seq = None;
     }
 }
 
@@ -1774,6 +1811,64 @@ mod tests {
             .expect("post-reset reasoning streams from scratch");
         assert_eq!(fresh.item_id, "gents-reasoning-request-1");
         assert_eq!(fresh.text, "durable thought");
+    }
+
+    #[test]
+    fn reasoning_cursor_streams_identical_rewrite_that_landed_with_the_boundary() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe(
+                "request-1",
+                "durable thought",
+                Some("1".to_string()),
+                Some("5".to_string()),
+            )
+            .delta
+            .expect("first reasoning delta");
+
+        // Reset-tail AND a byte-identical rewrite both landed inside the poll
+        // gap: the boundary read itself already carries the NEW segment's seq.
+        let boundary = cursor.observe(
+            "request-1",
+            "durable thought",
+            Some("2".to_string()),
+            Some("7".to_string()),
+        );
+        assert!(boundary.completed_item_id.is_some());
+
+        // The completed-segment memory must hold the PRE-boundary seq, so the
+        // genuinely new identical segment streams on the next poll.
+        let fresh = cursor
+            .observe(
+                "request-1",
+                "durable thought",
+                Some("2".to_string()),
+                Some("7".to_string()),
+            )
+            .delta
+            .expect("identical rewrite observed at the boundary must still stream");
+        assert_eq!(fresh.item_id, "gents-reasoning-request-1-segment-1");
+        assert_eq!(fresh.text, "durable thought");
+    }
+
+    #[test]
+    fn reasoning_cursor_streams_only_rolled_suffix_when_stale_tail_rolls() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe("request-1", "first middle", Some("1".to_string()), None)
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe("request-1", "first middle", Some("2".to_string()), None);
+        assert!(boundary.completed_item_id.is_some());
+
+        // The bounded tail rolled past the completed segment without an
+        // observed reset: only the unseen portion may stream.
+        let rolled = cursor
+            .observe("request-1", "middle last", Some("2".to_string()), None)
+            .delta
+            .expect("rolled suffix after boundary");
+        assert_eq!(rolled.item_id, "gents-reasoning-request-1-segment-1");
+        assert_eq!(rolled.text, " last");
     }
 
     #[test]

--- a/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
+++ b/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
@@ -380,8 +380,7 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
                     &current.request_id,
                     reasoning,
                     response_row.and_then(|row| scalar_marker(Some(row), "progress_seq")),
-                    response_row
-                        .and_then(|row| scalar_marker(Some(row), "reasoning_progress_seq")),
+                    response_row.and_then(|row| scalar_marker(Some(row), "reasoning_progress_seq")),
                 );
                 if let Some(item_id) = observation.completed_item_id {
                     projection
@@ -1491,13 +1490,23 @@ mod tests {
         assert_eq!(first.text, "inspect");
 
         let appended = cursor
-            .observe("request-1", "inspect then test", Some("1".to_string()), None)
+            .observe(
+                "request-1",
+                "inspect then test",
+                Some("1".to_string()),
+                None,
+            )
             .delta
             .expect("appended reasoning delta");
         assert_eq!(appended.item_id, first.item_id);
         assert_eq!(appended.text, " then test");
         assert_eq!(
-            cursor.observe("request-1", "inspect then test", Some("1".to_string()), None),
+            cursor.observe(
+                "request-1",
+                "inspect then test",
+                Some("1".to_string()),
+                None
+            ),
             Default::default()
         );
     }

--- a/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
+++ b/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
@@ -104,6 +104,17 @@ struct ReasoningCursor {
     active_item_id: Option<String>,
     progress_seq: Option<String>,
     segment: u64,
+    /// Text of the most recently completed segment, retained while the durable
+    /// row may still serve it stale — i.e. until the runtime's reset-tail write
+    /// (an observed empty tail) proves the buffer was actually cleared. Without
+    /// it, re-observing the unchanged text after a boundary manufactures a
+    /// full replay on a fresh segment (#1040); the Lean contract
+    /// `reset_before_terminal_suppresses_durable_replay` forbids exactly that.
+    completed_preview: String,
+    /// `reasoning_progress_seq` observed when the segment completed: a stale
+    /// re-read carries the same value, a genuine byte-identical rewrite has
+    /// advanced it (`write_reasoning` bumps it on every append).
+    completed_reasoning_seq: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -362,6 +373,8 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
                     &current.request_id,
                     reasoning,
                     response_row.and_then(|row| scalar_marker(Some(row), "progress_seq")),
+                    response_row
+                        .and_then(|row| scalar_marker(Some(row), "reasoning_progress_seq")),
                 );
                 if let Some(item_id) = observation.completed_item_id {
                     projection
@@ -943,6 +956,7 @@ impl ReasoningCursor {
         request_id: &str,
         current: &str,
         progress_seq: Option<String>,
+        reasoning_seq: Option<String>,
     ) -> ReasoningObservation {
         let progress_boundary = self.progress_seq.is_some()
             && progress_seq.is_some()
@@ -954,19 +968,64 @@ impl ReasoningCursor {
             && !self.observed_preview.is_empty())
         .then(|| self.active_item_id(request_id));
         if completed_item_id.is_some() {
-            self.observed_preview.clear();
+            self.completed_preview = std::mem::take(&mut self.observed_preview);
+            self.completed_reasoning_seq = reasoning_seq.clone();
             self.active_item_id = None;
             self.segment = self.segment.saturating_add(1);
         }
 
-        if current.is_empty()
-            || (progress_boundary && current == previous_preview)
-            || current == self.observed_preview
-        {
+        if current.is_empty() {
+            // An observed empty tail proves the runtime's reset-tail write
+            // landed; identical text after this point is a genuine new segment.
+            self.completed_preview.clear();
+            self.completed_reasoning_seq = None;
             return ReasoningObservation {
                 completed_item_id,
                 delta: None,
             };
+        }
+        if (progress_boundary && current == previous_preview) || current == self.observed_preview {
+            return ReasoningObservation {
+                completed_item_id,
+                delta: None,
+            };
+        }
+        if self.observed_preview.is_empty() && !self.completed_preview.is_empty() {
+            if current == self.completed_preview {
+                let seq_advanced = reasoning_seq.is_some()
+                    && self.completed_reasoning_seq.is_some()
+                    && reasoning_seq != self.completed_reasoning_seq;
+                if !seq_advanced {
+                    // Stale re-read of the segment that already completed:
+                    // never reopen it.
+                    return ReasoningObservation {
+                        completed_item_id,
+                        delta: None,
+                    };
+                }
+                self.completed_preview.clear();
+                self.completed_reasoning_seq = None;
+            } else if let Some(suffix) = current.strip_prefix(self.completed_preview.as_str()) {
+                // The tail grew past the completed segment without an observed
+                // reset: only the unseen suffix is new.
+                self.completed_preview.clear();
+                self.completed_reasoning_seq = None;
+                self.observed_preview = current.to_string();
+                let item_id = self
+                    .active_item_id
+                    .get_or_insert_with(|| reasoning_item_id(request_id, self.segment))
+                    .clone();
+                return ReasoningObservation {
+                    completed_item_id,
+                    delta: Some(ReasoningDelta {
+                        item_id,
+                        text: suffix.to_string(),
+                    }),
+                };
+            } else {
+                self.completed_preview.clear();
+                self.completed_reasoning_seq = None;
+            }
         }
 
         let (delta, discontinuity) = if self.observed_preview.is_empty() {
@@ -1008,6 +1067,8 @@ impl ReasoningCursor {
     fn prime(&mut self, item_id: String, text: &str) {
         self.observed_preview = text.to_string();
         self.active_item_id = Some(item_id);
+        self.completed_preview.clear();
+        self.completed_reasoning_seq = None;
     }
 
     fn active_item_id(&self, request_id: &str) -> String {
@@ -1021,6 +1082,8 @@ impl ReasoningCursor {
         self.active_item_id = None;
         self.progress_seq = None;
         self.segment = 0;
+        self.completed_preview.clear();
+        self.completed_reasoning_seq = None;
     }
 }
 
@@ -1384,20 +1447,20 @@ mod tests {
     fn reasoning_cursor_emits_live_append_without_duplication() {
         let mut cursor = ReasoningCursor::default();
         let first = cursor
-            .observe("request-1", "inspect", Some("1".to_string()))
+            .observe("request-1", "inspect", Some("1".to_string()), None)
             .delta
             .expect("first reasoning delta");
         assert_eq!(first.item_id, "gents-reasoning-request-1");
         assert_eq!(first.text, "inspect");
 
         let appended = cursor
-            .observe("request-1", "inspect then test", Some("1".to_string()))
+            .observe("request-1", "inspect then test", Some("1".to_string()), None)
             .delta
             .expect("appended reasoning delta");
         assert_eq!(appended.item_id, first.item_id);
         assert_eq!(appended.text, " then test");
         assert_eq!(
-            cursor.observe("request-1", "inspect then test", Some("1".to_string())),
+            cursor.observe("request-1", "inspect then test", Some("1".to_string()), None),
             Default::default()
         );
     }
@@ -1406,11 +1469,11 @@ mod tests {
     fn reasoning_cursor_recovers_delta_after_bounded_tail_rolls() {
         let mut cursor = ReasoningCursor::default();
         cursor
-            .observe("request-1", "first middle", Some("1".to_string()))
+            .observe("request-1", "first middle", Some("1".to_string()), None)
             .delta
             .expect("first reasoning delta");
         let rolled = cursor
-            .observe("request-1", "middle last", Some("1".to_string()))
+            .observe("request-1", "middle last", Some("1".to_string()), None)
             .delta
             .expect("rolled reasoning delta");
         assert_eq!(rolled.item_id, "gents-reasoning-request-1");
@@ -1422,7 +1485,7 @@ mod tests {
         let mut cursor = ReasoningCursor::default();
         cursor.prime("gents-reasoning-request-1".to_string(), "already visible");
         assert!(cursor
-            .observe("request-1", "already visible", Some("1".to_string()))
+            .observe("request-1", "already visible", Some("1".to_string()), None)
             .delta
             .is_none());
         let delta = cursor
@@ -1430,6 +1493,7 @@ mod tests {
                 "request-1",
                 "already visible plus new",
                 Some("1".to_string()),
+                None,
             )
             .delta
             .expect("new reasoning after resume");
@@ -1459,11 +1523,16 @@ mod tests {
     fn reasoning_cursor_starts_new_item_after_unrecoverable_gap() {
         let mut cursor = ReasoningCursor::default();
         cursor
-            .observe("request-1", "old preview", Some("1".to_string()))
+            .observe("request-1", "old preview", Some("1".to_string()), None)
             .delta
             .expect("first reasoning delta");
         let replacement = cursor
-            .observe("request-1", "entirely new preview", Some("1".to_string()))
+            .observe(
+                "request-1",
+                "entirely new preview",
+                Some("1".to_string()),
+                None,
+            )
             .delta
             .expect("replacement reasoning delta");
         assert_eq!(replacement.item_id, "gents-reasoning-request-1-segment-1");
@@ -1474,11 +1543,11 @@ mod tests {
     fn reasoning_cursor_segments_on_observed_empty_runtime_boundary() {
         let mut cursor = ReasoningCursor::default();
         cursor
-            .observe("request-1", "first turn", Some("1".to_string()))
+            .observe("request-1", "first turn", Some("1".to_string()), None)
             .delta
             .expect("first reasoning delta");
 
-        let boundary = cursor.observe("request-1", "", Some("2".to_string()));
+        let boundary = cursor.observe("request-1", "", Some("2".to_string()), None);
         assert_eq!(
             boundary.completed_item_id.as_deref(),
             Some("gents-reasoning-request-1")
@@ -1486,7 +1555,7 @@ mod tests {
         assert!(boundary.delta.is_none());
 
         let next = cursor
-            .observe("request-1", "second turn", Some("2".to_string()))
+            .observe("request-1", "second turn", Some("2".to_string()), None)
             .delta
             .expect("second reasoning delta");
         assert_eq!(next.item_id, "gents-reasoning-request-1-segment-1");
@@ -1497,7 +1566,7 @@ mod tests {
     fn reasoning_cursor_uses_progress_boundary_when_empty_write_was_missed() {
         let mut cursor = ReasoningCursor::default();
         cursor
-            .observe("request-1", "tail shared", Some("1".to_string()))
+            .observe("request-1", "tail shared", Some("1".to_string()), None)
             .delta
             .expect("first reasoning delta");
 
@@ -1505,6 +1574,7 @@ mod tests {
             "request-1",
             "shared but belongs to the next turn",
             Some("2".to_string()),
+            None,
         );
         assert_eq!(
             next.completed_item_id.as_deref(),
@@ -1513,6 +1583,217 @@ mod tests {
         let delta = next.delta.expect("next-turn reasoning delta");
         assert_eq!(delta.item_id, "gents-reasoning-request-1-segment-1");
         assert_eq!(delta.text, "shared but belongs to the next turn");
+    }
+
+    #[test]
+    fn reasoning_cursor_does_not_reopen_completed_segment_from_stale_tail() {
+        let mut cursor = ReasoningCursor::default();
+        let first = cursor
+            .observe(
+                "request-1",
+                "durable thought",
+                Some("1".to_string()),
+                Some("5".to_string()),
+            )
+            .delta
+            .expect("first reasoning delta");
+        assert_eq!(first.item_id, "gents-reasoning-request-1");
+
+        let boundary = cursor.observe(
+            "request-1",
+            "durable thought",
+            Some("2".to_string()),
+            Some("5".to_string()),
+        );
+        assert_eq!(
+            boundary.completed_item_id.as_deref(),
+            Some("gents-reasoning-request-1")
+        );
+        assert!(boundary.delta.is_none());
+
+        // The reset-tail write has not been observed yet; the row still serves
+        // the completed text. This must never reopen the segment (#1040).
+        assert_eq!(
+            cursor.observe(
+                "request-1",
+                "durable thought",
+                Some("2".to_string()),
+                Some("5".to_string()),
+            ),
+            Default::default()
+        );
+    }
+
+    #[test]
+    fn reasoning_cursor_ignores_stale_tail_across_repeated_progress_boundaries() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe("request-1", "durable thought", Some("1".to_string()), None)
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe("request-1", "durable thought", Some("2".to_string()), None);
+        assert!(boundary.completed_item_id.is_some());
+
+        // A second progress boundary (e.g. a tool-result advance) with the
+        // reset still unobserved must not resurrect the completed text.
+        assert_eq!(
+            cursor.observe("request-1", "durable thought", Some("3".to_string()), None),
+            Default::default()
+        );
+    }
+
+    #[test]
+    fn reasoning_cursor_streams_only_new_suffix_when_stale_tail_grows() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe(
+                "request-1",
+                "durable thought",
+                Some("1".to_string()),
+                Some("5".to_string()),
+            )
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe(
+            "request-1",
+            "durable thought",
+            Some("2".to_string()),
+            Some("5".to_string()),
+        );
+        assert!(boundary.completed_item_id.is_some());
+
+        let grown = cursor
+            .observe(
+                "request-1",
+                "durable thought and more",
+                Some("2".to_string()),
+                Some("6".to_string()),
+            )
+            .delta
+            .expect("suffix delta after growth");
+        assert_eq!(grown.item_id, "gents-reasoning-request-1-segment-1");
+        assert_eq!(grown.text, " and more");
+    }
+
+    #[test]
+    fn reasoning_cursor_streams_identical_segment_after_observed_reset() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe("request-1", "durable thought", Some("1".to_string()), None)
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe("request-1", "durable thought", Some("2".to_string()), None);
+        assert!(boundary.completed_item_id.is_some());
+
+        // Observing the cleared tail proves reset-tail landed; suppression ends.
+        let reset = cursor.observe("request-1", "", Some("2".to_string()), None);
+        assert!(reset.completed_item_id.is_none());
+        assert!(reset.delta.is_none());
+
+        let fresh = cursor
+            .observe("request-1", "durable thought", Some("2".to_string()), None)
+            .delta
+            .expect("identical text after observed reset is a genuine segment");
+        assert_eq!(fresh.item_id, "gents-reasoning-request-1-segment-1");
+        assert_eq!(fresh.text, "durable thought");
+    }
+
+    #[test]
+    fn reasoning_cursor_streams_identical_segment_when_reasoning_seq_advances() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe(
+                "request-1",
+                "durable thought",
+                Some("1".to_string()),
+                Some("5".to_string()),
+            )
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe(
+            "request-1",
+            "durable thought",
+            Some("2".to_string()),
+            Some("5".to_string()),
+        );
+        assert!(boundary.completed_item_id.is_some());
+
+        // write_reasoning bumps reasoning_progress_seq on every append, so an
+        // advanced seq with identical bytes is a genuine rewrite, not a stale read.
+        let rewrite = cursor
+            .observe(
+                "request-1",
+                "durable thought",
+                Some("2".to_string()),
+                Some("7".to_string()),
+            )
+            .delta
+            .expect("identical text with advanced reasoning seq streams fresh");
+        assert_eq!(rewrite.item_id, "gents-reasoning-request-1-segment-1");
+        assert_eq!(rewrite.text, "durable thought");
+    }
+
+    #[test]
+    fn reasoning_cursor_stale_window_divergence_streams_full_new_text() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe("request-1", "durable thought", Some("1".to_string()), None)
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe("request-1", "durable thought", Some("2".to_string()), None);
+        assert!(boundary.completed_item_id.is_some());
+
+        let diverged = cursor.observe(
+            "request-1",
+            "completely different reasoning",
+            Some("2".to_string()),
+            None,
+        );
+        assert!(diverged.completed_item_id.is_none());
+        let delta = diverged.delta.expect("diverged text streams in full");
+        assert_eq!(delta.item_id, "gents-reasoning-request-1-segment-1");
+        assert_eq!(delta.text, "completely different reasoning");
+    }
+
+    #[test]
+    fn reasoning_cursor_reset_clears_completed_segment_memory() {
+        let mut cursor = ReasoningCursor::default();
+        cursor
+            .observe("request-1", "durable thought", Some("1".to_string()), None)
+            .delta
+            .expect("first reasoning delta");
+        let boundary = cursor.observe("request-1", "durable thought", Some("2".to_string()), None);
+        assert!(boundary.completed_item_id.is_some());
+
+        // Steering handoff resets the cursor for a new request/response doc;
+        // the new request's first segment must stream even if byte-identical.
+        cursor.reset();
+        let fresh = cursor
+            .observe("request-1", "durable thought", Some("9".to_string()), None)
+            .delta
+            .expect("post-reset reasoning streams from scratch");
+        assert_eq!(fresh.item_id, "gents-reasoning-request-1");
+        assert_eq!(fresh.text, "durable thought");
+    }
+
+    #[test]
+    fn reasoning_cursor_primed_resume_does_not_replay_after_boundary() {
+        let mut cursor = ReasoningCursor::default();
+        cursor.prime("gents-reasoning-request-1".to_string(), "resumed thought");
+        assert!(cursor
+            .observe("request-1", "resumed thought", Some("1".to_string()), None)
+            .delta
+            .is_none());
+        let boundary = cursor.observe("request-1", "resumed thought", Some("2".to_string()), None);
+        assert_eq!(
+            boundary.completed_item_id.as_deref(),
+            Some("gents-reasoning-request-1")
+        );
+
+        assert_eq!(
+            cursor.observe("request-1", "resumed thought", Some("2".to_string()), None),
+            Default::default()
+        );
     }
 
     #[test]

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -71,6 +71,38 @@ pub(super) fn spawn_server(bin: &Path, home: &Path, port: u16, log: &Path) -> Re
     cmd.spawn().context("spawning demo server")
 }
 
+/// `/healthz` answering only proves the node HTTP server is up; the runtime
+/// (and the schemas the p2p subcommands query, e.g. AgentNetwork before a
+/// pairings join) is ready strictly later. Gate on AgentRuntime reaching
+/// `ready` before driving CLI subcommands at this node (#990 — the pattern
+/// from #935/#926).
+pub(super) async fn wait_runtime_ready(
+    graphql: &str,
+    agent_did: &str,
+    server: &mut Child,
+) -> Result<()> {
+    let query = format!(
+        r#"{{ AgentRuntime(filter: {{ agent_did: {{ _eq: "{}" }} }}, limit: 1) {{ process_state }} }}"#,
+        escape_graphql_string(agent_did)
+    );
+    for _ in 0..240 {
+        if let Ok(resp) = post_graphql(graphql, &query).await {
+            if resp
+                .pointer("/data/AgentRuntime/0/process_state")
+                .and_then(Value::as_str)
+                == Some("ready")
+            {
+                return Ok(());
+            }
+        }
+        if let Ok(Some(status)) = server.try_wait() {
+            bail!("demo server exited before its runtime became ready ({status})");
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("timed out waiting for the demo runtime at {graphql} to become ready")
+}
+
 pub(super) async fn wait_http(url: &str, server: &mut Child) -> Result<()> {
     let client = reqwest::Client::new();
     for _ in 0..300 {
@@ -113,6 +145,7 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
     println!("  starting node B…");
     let mut server_b = spawn_server(&bin, &home_b, port_b, &home_b.join("server.log"))?;
     wait_http(&format!("http://127.0.0.1:{port_b}/healthz"), &mut server_b).await?;
+    wait_runtime_ready(&graphql_b, &did_b, &mut server_b).await?;
 
     let (peer_a, addr_a) = p2p_identity(&bin, &home_a, &graphql_a).await?;
     let (peer_b, addr_b) = p2p_identity(&bin, &home_b, &graphql_b).await?;

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -141,16 +141,32 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
     let backend = fleet.backend.clone();
     let home_b = home_a.join("node-b");
     let work_b = home_b.join("work");
-    let port_b = fleet.base_port + 1;
-    let graphql_b = format!("http://127.0.0.1:{port_b}/api/v0/graphql");
 
     println!("  initializing node B (worker)…");
     let did_b = init_agent(&bin, &home_b, &work_b, &backend, "worker").await?;
     std::fs::create_dir_all(&work_b)?;
 
     println!("  starting node B…");
-    let mut server_b = spawn_server(&bin, &home_b, port_b, &home_b.join("server.log"))?;
-    wait_http(&format!("http://127.0.0.1:{port_b}/healthz"), &mut server_b).await?;
+    // Allocate node B's port at spawn time, not fleet-start time: a reserved
+    // but unbound port sits exposed to the OS ephemeral allocator (poll
+    // sockets take source ports from the same range), and a stolen bind kills
+    // the node's HTTP listener while the process stays alive. Keeping the
+    // window at milliseconds plus one respawn retry removes the class.
+    let mut attempt = 0;
+    let (mut server_b, graphql_b) = loop {
+        attempt += 1;
+        let port_b = allocate_ephemeral_port()?;
+        let graphql_b = format!("http://127.0.0.1:{port_b}/api/v0/graphql");
+        let mut server_b = spawn_server(&bin, &home_b, port_b, &home_b.join("server.log"))?;
+        match wait_http(&format!("http://127.0.0.1:{port_b}/healthz"), &mut server_b).await {
+            Ok(()) => break (server_b, graphql_b),
+            Err(error) if attempt < 3 => {
+                let _ = server_b.start_kill();
+                println!("  node B did not come up ({error}); retrying with a fresh port…");
+            }
+            Err(error) => return Err(error),
+        }
+    };
     wait_runtime_ready(&graphql_b, &did_b, &mut server_b).await?;
 
     let (peer_a, addr_a) = p2p_identity(&bin, &home_a, &graphql_a).await?;
@@ -248,9 +264,25 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
         server: server_b,
     });
     println!(
-        "  ✓ paired. Node B (worker) is live; run `delegate` to enable cross-node delegation."
+        "  ✓ paired. Node B (worker) is live at {}; run `delegate` to enable cross-node delegation.",
+        fleet
+            .node_b
+            .as_ref()
+            .map(|worker| worker.graphql.as_str())
+            .unwrap_or_default()
     );
     Ok(())
+}
+
+fn allocate_ephemeral_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .context("allocating an ephemeral port for node B")?;
+    let port = listener
+        .local_addr()
+        .context("reading allocated node B port")?
+        .port();
+    drop(listener);
+    Ok(port)
 }
 
 /// The fleet always knows each node's admin endpoint, so pass it explicitly:

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -85,7 +85,10 @@ pub(super) async fn wait_runtime_ready(
         r#"{{ AgentRuntime(filter: {{ agent_did: {{ _eq: "{}" }} }}, limit: 1) {{ process_state }} }}"#,
         escape_graphql_string(agent_did)
     );
-    for _ in 0..240 {
+    // 180s: a second node cold-starts a full DefraDB + runtime process, and on
+    // a contended host (parallel test suites, sibling builds) that can take
+    // minutes. Bounded and explicit — on expiry the error names the node.
+    for _ in 0..360 {
         if let Ok(resp) = post_graphql(graphql, &query).await {
             if resp
                 .pointer("/data/AgentRuntime/0/process_state")
@@ -105,7 +108,10 @@ pub(super) async fn wait_runtime_ready(
 
 pub(super) async fn wait_http(url: &str, server: &mut Child) -> Result<()> {
     let client = reqwest::Client::new();
-    for _ in 0..300 {
+    // 120s: /healthz reports 200 only once the runtime row exists, so this is
+    // already a coarse readiness gate; give a cold second node headroom on a
+    // contended host. Bounded — server death is still detected immediately.
+    for _ in 0..600 {
         if client
             .get(url)
             .timeout(Duration::from_millis(500))

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -99,6 +99,7 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
     }
     let bin = fleet.bin.clone();
     let home_a = fleet.home_a.clone();
+    let graphql_a = fleet.graphql_a.clone();
     let backend = fleet.backend.clone();
     let home_b = home_a.join("node-b");
     let work_b = home_b.join("work");
@@ -113,8 +114,8 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
     let mut server_b = spawn_server(&bin, &home_b, port_b, &home_b.join("server.log"))?;
     wait_http(&format!("http://127.0.0.1:{port_b}/healthz"), &mut server_b).await?;
 
-    let (peer_a, addr_a) = p2p_identity(&bin, &home_a).await?;
-    let (peer_b, addr_b) = p2p_identity(&bin, &home_b).await?;
+    let (peer_a, addr_a) = p2p_identity(&bin, &home_a, &graphql_a).await?;
+    let (peer_b, addr_b) = p2p_identity(&bin, &home_b, &graphql_b).await?;
 
     println!("  creating the network and enrolling node B…");
     run_cli_text(
@@ -125,6 +126,8 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
             "create",
             "--home",
             &path_arg(&home_a),
+            "--graphql",
+            &graphql_a,
             "--name",
             "Demo Fleet",
             "--output",
@@ -140,6 +143,8 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
             "grant",
             "--home",
             &path_arg(&home_a),
+            "--graphql",
+            &graphql_a,
             &did_b,
             "--output",
             "json",
@@ -154,6 +159,8 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
             "invite",
             "--home",
             &path_arg(&home_a),
+            "--graphql",
+            &graphql_a,
             "--member-did",
             &did_b,
             "--template",
@@ -173,6 +180,8 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
             "join",
             "--home",
             &path_arg(&home_b),
+            "--graphql",
+            &graphql_b,
             &token,
         ]),
     )
@@ -205,8 +214,24 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
     Ok(())
 }
 
-async fn p2p_identity(bin: &Path, home: &Path) -> Result<(String, String)> {
-    let status = run_cli_json(bin, &cli(&["p2p", "status", "--home", &path_arg(home)])).await?;
+/// The fleet always knows each node's admin endpoint, so pass it explicitly:
+/// `--home`-only invocations resolve the endpoint from the node's persisted
+/// `runtime_state.json`, which the server only writes once its runtime reaches
+/// Ready — later than `/healthz` starts answering — and the fallback is the
+/// hardcoded default port 9191 (#990).
+async fn p2p_identity(bin: &Path, home: &Path, graphql: &str) -> Result<(String, String)> {
+    let status = run_cli_json(
+        bin,
+        &cli(&[
+            "p2p",
+            "status",
+            "--home",
+            &path_arg(home),
+            "--graphql",
+            graphql,
+        ]),
+    )
+    .await?;
     let peer = status
         .get("p2p_peer_id")
         .and_then(Value::as_str)
@@ -355,8 +380,8 @@ pub(super) async fn delegate(fleet: &Fleet) -> Result<()> {
         bail!("not paired — run `pair` first");
     };
     println!("  configuring cross-node delegation…");
-    let (peer_a, addr_a) = p2p_identity(&fleet.bin, &fleet.home_a).await?;
-    let (peer_b, addr_b) = p2p_identity(&fleet.bin, &worker.home).await?;
+    let (peer_a, addr_a) = p2p_identity(&fleet.bin, &fleet.home_a, &fleet.graphql_a).await?;
+    let (peer_b, addr_b) = p2p_identity(&fleet.bin, &worker.home, &worker.graphql).await?;
 
     println!("  switching the data plane to subagent delegation templates…");
     upsert_data_plane(

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -161,7 +161,9 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
         match wait_http(&format!("http://127.0.0.1:{port_b}/healthz"), &mut server_b).await {
             Ok(()) => break (server_b, graphql_b),
             Err(error) if attempt < 3 => {
-                let _ = server_b.start_kill();
+                // kill() waits for exit so the replacement cannot race the old
+                // process's RocksDB lock on the shared node B home.
+                let _ = server_b.kill().await;
                 println!("  node B did not come up ({error}); retrying with a fresh port…");
             }
             Err(error) => return Err(error),

--- a/crates/gents-cli/src/commands/demo/mod.rs
+++ b/crates/gents-cli/src/commands/demo/mod.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use crate::cli::args::DemoArgs;
 
 use backend::{read_backend_args, resolve_backend, write_backend_args, BackendChoice};
-use fleet::{desktop, spawn_server, wait_http, Fleet};
+use fleet::{desktop, spawn_server, wait_http, wait_runtime_ready, Fleet};
 use setup::{init_agent, read_agent_did, resolve_home, seed_demo_skills};
 use shell::{print_welcome, run_shell};
 use util::short;
@@ -53,6 +53,7 @@ pub(crate) async fn demo(args: DemoArgs) -> Result<()> {
     let graphql = format!("http://127.0.0.1:{port}/api/v0/graphql");
     let mut server = spawn_server(&bin, &home, port, &home.join("server.log"))?;
     wait_http(&format!("http://127.0.0.1:{port}/healthz"), &mut server).await?;
+    wait_runtime_ready(&graphql, &agent_did, &mut server).await?;
 
     if first_run {
         seed_demo_skills(&bin, &graphql, &agent_did).await;

--- a/crates/gents-cli/src/commands/demo/shell.rs
+++ b/crates/gents-cli/src/commands/demo/shell.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use crate::commands::chat::submit_chat_turn;
 
 use super::backend::{pick_backend, write_backend_args};
-use super::fleet::{delegate, desktop, pair, spawn_server, wait_http, Fleet};
+use super::fleet::{delegate, desktop, pair, spawn_server, wait_http, wait_runtime_ready, Fleet};
 use super::setup::{init_agent, seed_demo_skills};
 use super::util::{prompt, short, StdinLines};
 use super::NODE_A_NAME;
@@ -146,6 +146,7 @@ async fn reconfigure(fleet: &mut Fleet, reader: &mut StdinLines) -> Result<()> {
         &mut server,
     )
     .await?;
+    wait_runtime_ready(&fleet.graphql_a, &did, &mut server).await?;
     seed_demo_skills(&fleet.bin, &fleet.graphql_a, &did).await;
 
     fleet.server_a = server;

--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -160,7 +160,13 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
     let mut serve = spawn_server_with_env(&home_dir, server_port, &server_args, &[])?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/")).await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let thread_id = start_thread(&mut ws, &home_dir).await?;
@@ -186,7 +192,13 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
     let mut restarted = spawn_server_with_env(&home_dir, server_port, &server_args, &[])?;
     wait_for_port(server_port, &mut restarted)?;
     wait_for_port(shim_port, &mut restarted)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    restarted
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/")).await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     send_client_request(
@@ -207,10 +219,11 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
     assert_eq!(goal.token_budget, Some(12_345));
 
     let foreign_thread_id = format!("foreign-goal-{}", Uuid::new_v4().simple());
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
+    restarted
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{
                 create_Goal(input: {{
                     goal_id: "foreign-goal",
                     session_id: "{}",
@@ -220,11 +233,11 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
                     created_at: "2026-07-16T00:00:00Z"
                 }}) {{ _docID }}
             }}"#,
-            escape_graphql_string(&foreign_thread_id),
-            escape_graphql_string(&agent_did),
-        ),
-    )
-    .await?;
+                escape_graphql_string(&foreign_thread_id),
+                escape_graphql_string(&agent_did),
+            ),
+        ))
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::ThreadGoalGet {
@@ -251,14 +264,15 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
     let foreign_clear: codex::ThreadGoalClearResponse =
         read_typed_response(&mut ws, request_id(123)).await?;
     assert!(!foreign_clear.cleared);
-    let foreign_rows = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{ Goal(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ goal_id }} }}"#,
-            escape_graphql_string(&foreign_thread_id)
-        ),
-    )
-    .await?;
+    let foreign_rows = restarted
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{ Goal(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ goal_id }} }}"#,
+                escape_graphql_string(&foreign_thread_id)
+            ),
+        ))
+        .await?;
     assert_eq!(
         foreign_rows
             .pointer("/data/Goal")
@@ -267,10 +281,11 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
         Some(1)
     );
 
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
+    restarted
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{
                 create_Goal(input: {{
                     goal_id: "duplicate-goal",
                     session_id: "{}",
@@ -280,11 +295,11 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
                     created_at: "2026-07-16T00:00:01Z"
                 }}) {{ _docID }}
             }}"#,
-            escape_graphql_string(&thread_id),
-            escape_graphql_string(&agent_did),
-        ),
-    )
-    .await?;
+                escape_graphql_string(&thread_id),
+                escape_graphql_string(&agent_did),
+            ),
+        ))
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::ThreadGoalClear {
@@ -298,14 +313,15 @@ async fn thread_goal_round_trip_survives_shim_restart() -> Result<()> {
     let cleared: codex::ThreadGoalClearResponse =
         read_typed_response(&mut ws, request_id(124)).await?;
     assert!(cleared.cleared);
-    let cleared_rows = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{ Goal(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ goal_id }} }}"#,
-            escape_graphql_string(&thread_id)
-        ),
-    )
-    .await?;
+    let cleared_rows = restarted
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{ Goal(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ goal_id }} }}"#,
+                escape_graphql_string(&thread_id)
+            ),
+        ))
+        .await?;
     assert_eq!(
         cleared_rows
             .pointer("/data/Goal")
@@ -349,7 +365,13 @@ async fn server_keeps_running_when_codex_shim_port_is_taken() -> Result<()> {
         &[],
     )?;
     wait_for_port(server_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
     assert_eq!(
         readiness
@@ -413,11 +435,21 @@ async fn codex_shim_protocol_turn_streams_gents_response() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
 
     send_client_request(
         &mut ws,
@@ -477,10 +509,11 @@ async fn codex_shim_protocol_turn_streams_gents_response() -> Result<()> {
     Uuid::parse_str(&thread_id)
         .with_context(|| format!("Codex TUI requires UUID thread ids, got {thread_id}"))?;
 
-    let session_response = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{
+    let session_response = serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{
                 AgentSession(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
                     session_id
                     agent_did
@@ -489,10 +522,10 @@ async fn codex_shim_protocol_turn_streams_gents_response() -> Result<()> {
                     started
                 }}
             }}"#,
-            escape_graphql_string(&thread_id),
-        ),
-    )
-    .await?;
+                escape_graphql_string(&thread_id),
+            ),
+        ))
+        .await?;
     let session = first_graphql_row(&session_response, "AgentSession")?;
     assert_eq!(
         session.get("session_id").and_then(Value::as_str),
@@ -1059,7 +1092,13 @@ async fn codex_shim_thread_list_reconstructs_turned_threads_from_durable_data() 
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
     let turned_session_id = Uuid::new_v4().to_string();
     for mutation in [
@@ -1094,27 +1133,32 @@ async fn codex_shim_thread_list_reconstructs_turned_threads_from_durable_data() 
             agent_did = escape_graphql_string(&agent_did),
         ),
     ] {
-        graphql_query(&graphql, &mutation).await?;
+        serve.capturing(graphql_query(&graphql, &mutation)).await?;
     }
 
     let zero_turn_session_id = Uuid::new_v4().to_string();
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{ create_AgentSession(input: {{
+    serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{ create_AgentSession(input: {{
                 session_id: "{s}", agent_name: "{behavior_id}", agent_did: "{agent_did}",
                 behavior_id: "{behavior_id}", started: "2026-01-01T00:00:00Z", status: "active"
             }}) {{ _docID }} }}"#,
-            s = escape_graphql_string(&zero_turn_session_id),
-            behavior_id = escape_graphql_string(&behavior_id),
-            agent_did = escape_graphql_string(&agent_did),
-        ),
-    )
-    .await?;
+                s = escape_graphql_string(&zero_turn_session_id),
+                behavior_id = escape_graphql_string(&behavior_id),
+                agent_did = escape_graphql_string(&agent_did),
+            ),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -1224,11 +1268,21 @@ async fn codex_shim_derives_git_info_and_persists_early_rename() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -1387,13 +1441,20 @@ async fn codex_shim_thread_list_excludes_non_codex_sessions() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
     let foreign_session_id = Uuid::new_v4().to_string();
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
+    serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{
                 create_AgentSession(input: {{
                     session_id: "{session}",
                     agent_name: "{agent_name}",
@@ -1403,17 +1464,18 @@ async fn codex_shim_thread_list_excludes_non_codex_sessions() -> Result<()> {
                     status: "active"
                 }}) {{ _docID }}
             }}"#,
-            session = escape_graphql_string(&foreign_session_id),
-            agent_name = escape_graphql_string(&agent_name),
-            agent_did = escape_graphql_string(&agent_did),
-            behavior_id = escape_graphql_string(&behavior_id),
-        ),
-    )
-    .await?;
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
+                session = escape_graphql_string(&foreign_session_id),
+                agent_name = escape_graphql_string(&agent_name),
+                agent_did = escape_graphql_string(&agent_did),
+                behavior_id = escape_graphql_string(&behavior_id),
+            ),
+        ))
+        .await?;
+    serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{
                 create_AgentRequest(input: {{
                     request_id: "{request}",
                     agent_did: "{agent_did}",
@@ -1424,17 +1486,21 @@ async fn codex_shim_thread_list_excludes_non_codex_sessions() -> Result<()> {
                     created_at: "2026-01-01T00:00:00Z"
                 }}) {{ _docID }}
             }}"#,
-            request = escape_graphql_string(&Uuid::new_v4().to_string()),
-            agent_did = escape_graphql_string(&agent_did),
-            behavior_id = escape_graphql_string(&behavior_id),
-            session = escape_graphql_string(&foreign_session_id),
-        ),
-    )
-    .await?;
+                request = escape_graphql_string(&Uuid::new_v4().to_string()),
+                agent_did = escape_graphql_string(&agent_did),
+                behavior_id = escape_graphql_string(&behavior_id),
+                session = escape_graphql_string(&foreign_session_id),
+            ),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -1548,11 +1614,21 @@ async fn codex_shim_completes_blank_materialized_terminal_message() -> Result<()
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let thread_id = start_thread(&mut ws, &home_dir).await?;
 
@@ -1620,11 +1696,21 @@ async fn codex_shim_thread_fork_and_search_project_gents_sessions() -> Result<()
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let thread_id = start_thread(&mut ws, &home_dir).await?;
 
@@ -1659,20 +1745,21 @@ async fn codex_shim_thread_fork_and_search_project_gents_sessions() -> Result<()
     assert_turn_has_user_text(&forked.thread.turns[0], &prompt);
     assert_turn_has_agent_text(&forked.thread.turns[0], &expected_reply);
 
-    let forked_conversation = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{
+    let forked_conversation = serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{
                 AgentConversation(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
                     session_id
                     forked_from_session_id
                     fork_at_user_turn
                 }}
             }}"#,
-            escape_graphql_string(&forked_id),
-        ),
-    )
-    .await?;
+                escape_graphql_string(&forked_id),
+            ),
+        ))
+        .await?;
     let child = first_graphql_row(&forked_conversation, "AgentConversation")?;
     assert_eq!(
         child.get("forked_from_session_id").and_then(Value::as_str),
@@ -1789,11 +1876,21 @@ async fn codex_shim_fs_routes_are_unsupported() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
 
     for (idx, method, params) in [
@@ -1919,11 +2016,21 @@ async fn codex_shim_host_runtime_routes_cover_low_risk_paths() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
 
     send_raw_client_request(
@@ -2121,11 +2228,21 @@ async fn codex_shim_turn_steer_queues_gents_request_on_active_turn() -> Result<(
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let thread_id = start_thread(&mut ws, &home_dir).await?;
 
@@ -2317,11 +2434,21 @@ async fn codex_shim_interrupt_completes_with_running_background_tool() -> Result
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let thread_id = start_thread(&mut ws, &home_dir).await?;
 
@@ -2467,11 +2594,21 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let parent_thread_id = start_thread(&mut ws, &home_dir).await?;
     let prompt = format!("hold subagent projection {}", Uuid::new_v4().simple());
@@ -2490,8 +2627,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let turn_start: codex::TurnStartResponse =
-        read_typed_response(&mut ws, request_id(230)).await?;
+    let turn_start: codex::TurnStartResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(230)))
+        .await?;
     let started = read_turn_started(&mut ws).await?;
     assert_eq!(started.turn.id, turn_start.turn.id);
     let parent_active = read_thread_status_changed(&mut ws, &parent_thread_id).await?;
@@ -2551,8 +2689,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let subagent_list: codex::ThreadListResponse =
-        read_typed_response(&mut ws, request_id(239)).await?;
+    let subagent_list: codex::ThreadListResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(239)))
+        .await?;
     assert_eq!(subagent_list.data.len(), 1, "{subagent_list:?}");
     assert_eq!(subagent_list.data[0].id, child_thread_id);
     assert!(matches!(
@@ -2571,8 +2710,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let child_read: codex::ThreadReadResponse =
-        read_typed_response(&mut ws, request_id(231)).await?;
+    let child_read: codex::ThreadReadResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(231)))
+        .await?;
     assert_eq!(child_read.thread.id, child_thread_id);
     assert!(matches!(
         child_read.thread.status,
@@ -2602,8 +2742,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let child_resume: codex::ThreadResumeResponse =
-        read_typed_response(&mut ws, request_id(232)).await?;
+    let child_resume: codex::ThreadResumeResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(232)))
+        .await?;
     assert_eq!(child_resume.thread.id, child_thread_id);
     assert_eq!(child_resume.model, child_model_selection);
 
@@ -2620,8 +2761,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let child_resume_without_behavior: codex::ThreadResumeResponse =
-        read_typed_response(&mut ws, request_id(241)).await?;
+    let child_resume_without_behavior: codex::ThreadResumeResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(241)))
+        .await?;
     assert_eq!(child_resume_without_behavior.thread.id, child_thread_id);
     assert_eq!(child_resume_without_behavior.model, root_model_selection);
 
@@ -2717,8 +2859,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let completed_child: codex::ThreadReadResponse =
-        read_typed_response(&mut ws, request_id(240)).await?;
+    let completed_child: codex::ThreadReadResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(240)))
+        .await?;
     assert!(completed_child.thread.turns.iter().any(|turn| {
         turn.items.iter().any(|item| {
             matches!(
@@ -2822,8 +2965,9 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         },
     )
     .await?;
-    let failed_parent: codex::ThreadReadResponse =
-        read_typed_response(&mut ws, request_id(242)).await?;
+    let failed_parent: codex::ThreadReadResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(242)))
+        .await?;
     assert_eq!(
         failed_parent.thread.status,
         codex::ThreadStatus::SystemError
@@ -2885,11 +3029,21 @@ async fn codex_shim_turn_steer_drains_queued_request_before_completing_turn() ->
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     initialize_config_and_thread(&mut ws, &home_dir).await?;
     let thread_id = start_thread(&mut ws, &home_dir).await?;
 
@@ -3692,7 +3846,13 @@ async fn codex_shim_remote_frontend_keeps_client_codex_home_separate() -> Result
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
     let expected_shim_home = home_dir.join(".gents").join("codex-ui");
     let (_stdout, stderr) = serve.captured_output()?;
@@ -3717,9 +3877,13 @@ async fn codex_shim_remote_frontend_keeps_client_codex_home_separate() -> Result
         "server guidance must not depend on or rewrite a user's local Codex home; stderr:\n{stderr}"
     );
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -3996,7 +4160,13 @@ async fn codex_shim_waits_for_a_missing_bound_behavior_instead_of_disabling() ->
         &[],
     )?;
     wait_for_port(server_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
     assert_eq!(
         readiness
@@ -4080,7 +4250,13 @@ async fn codex_shim_model_list_enumerates_backend_models() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let create_extra_backend = format!(
@@ -4111,11 +4287,17 @@ async fn codex_shim_model_list_enumerates_backend_models() -> Result<()> {
         escape_graphql_string(extra_endpoint.endpoint()),
         escape_graphql_string(extra_endpoint.endpoint())
     );
-    graphql_query(&graphql, &create_extra_backend).await?;
+    serve
+        .capturing(graphql_query(&graphql, &create_extra_backend))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
 
     send_client_request(
         &mut ws,
@@ -4233,7 +4415,13 @@ async fn codex_shim_config_read_reflects_doc_mutation() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let switch_behavior = format!(
@@ -4244,11 +4432,17 @@ async fn codex_shim_config_read_reflects_doc_mutation() -> Result<()> {
             ) {{ _docID }}
         }}"#
     );
-    graphql_query(&graphql, &switch_behavior).await?;
+    serve
+        .capturing(graphql_query(&graphql, &switch_behavior))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -4327,7 +4521,13 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let create_alt_backend = format!(
@@ -4346,11 +4546,17 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
         }}"#,
         escape_graphql_string(alt_endpoint.endpoint())
     );
-    graphql_query(&graphql, &create_alt_backend).await?;
+    serve
+        .capturing(graphql_query(&graphql, &create_alt_backend))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -4366,8 +4572,9 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
         },
     )
     .await?;
-    let _initialize: codex::InitializeResponse =
-        read_typed_response(&mut ws, request_id(1)).await?;
+    let _initialize: codex::InitializeResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(1)))
+        .await?;
     send_client_notification(&mut ws, codex::ClientNotification::Initialized).await?;
 
     send_client_request(
@@ -4384,20 +4591,23 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
         },
     )
     .await?;
-    let _write: codex::ConfigWriteResponse = read_typed_response(&mut ws, request_id(2)).await?;
+    let _write: codex::ConfigWriteResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(2)))
+        .await?;
 
-    let resp = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{
+    let resp = serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{
                 AgentBehavior(
                     filter: {{ behavior_id: {{ _eq: "{default_behavior_id}" }} }},
                     limit: 1
                 ) {{ backend_id model_name inference_profile_id }}
             }}"#
-        ),
-    )
-    .await?;
+            ),
+        ))
+        .await?;
     let stored_backend = resp
         .pointer("/data/AgentBehavior/0/backend_id")
         .and_then(|v| v.as_str())
@@ -4464,11 +4674,21 @@ async fn codex_shim_config_value_write_rejects_unknown_model() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -4509,18 +4729,19 @@ async fn codex_shim_config_value_write_rejects_unknown_model() -> Result<()> {
         error.message
     );
 
-    let resp = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{
+    let resp = serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{
                 AgentBehavior(
                     filter: {{ behavior_id: {{ _eq: "{default_behavior_id}" }} }},
                     limit: 1
                 ) {{ backend_id model_name inference_profile_id }}
             }}"#
-        ),
-    )
-    .await?;
+            ),
+        ))
+        .await?;
     let stored_backend = resp
         .pointer("/data/AgentBehavior/0/backend_id")
         .and_then(|v| v.as_str())
@@ -4586,12 +4807,19 @@ async fn codex_shim_does_not_clobber_session_behavior_id() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
+    serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{
                 create_AgentSession(input: {{
                     session_id: "{session_id}",
                     agent_name: "preexisting",
@@ -4599,13 +4827,17 @@ async fn codex_shim_does_not_clobber_session_behavior_id() -> Result<()> {
                     status: "active"
                 }}) {{ _docID }}
             }}"#
-        ),
-    )
-    .await?;
+            ),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -4621,8 +4853,9 @@ async fn codex_shim_does_not_clobber_session_behavior_id() -> Result<()> {
         },
     )
     .await?;
-    let _initialize: codex::InitializeResponse =
-        read_typed_response(&mut ws, request_id(1)).await?;
+    let _initialize: codex::InitializeResponse = serve
+        .capturing(read_typed_response(&mut ws, request_id(1)))
+        .await?;
     send_client_notification(&mut ws, codex::ClientNotification::Initialized).await?;
     send_client_request(
         &mut ws,
@@ -4636,20 +4869,21 @@ async fn codex_shim_does_not_clobber_session_behavior_id() -> Result<()> {
         },
     )
     .await?;
-    let _ = read_jsonrpc(&mut ws).await?;
+    let _ = serve.capturing(read_jsonrpc(&mut ws)).await?;
 
-    let resp = graphql_query(
-        &graphql,
-        &format!(
-            r#"{{
+    let resp = serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"{{
                 AgentSession(
                     filter: {{ session_id: {{ _eq: "{session_id}" }} }},
                     limit: 1
                 ) {{ agent_name behavior_id }}
             }}"#
-        ),
-    )
-    .await?;
+            ),
+        ))
+        .await?;
     let preserved_agent_name = resp
         .pointer("/data/AgentSession/0/agent_name")
         .and_then(|v| v.as_str())
@@ -4706,12 +4940,19 @@ async fn codex_shim_rejects_resume_with_mismatched_behavior() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
 
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
+    serve
+        .capturing(graphql_query(
+            &graphql,
+            &format!(
+                r#"mutation {{
                 create_AgentSession(input: {{
                     session_id: "{session_id}",
                     agent_name: "foreign",
@@ -4719,13 +4960,17 @@ async fn codex_shim_rejects_resume_with_mismatched_behavior() -> Result<()> {
                     status: "active"
                 }}) {{ _docID }}
             }}"#
-        ),
-    )
-    .await?;
+            ),
+        ))
+        .await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -4812,7 +5057,13 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let added = run_cli_json(
@@ -4842,9 +5093,13 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
         Some("research")
     );
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -4966,7 +5221,13 @@ async fn codex_shim_live_skill_add_reaches_model_in_conversation() -> Result<()>
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     let gen0 = wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let catalog_phrase = format!("cite-sources-{}", Uuid::new_v4().simple());
@@ -4994,9 +5255,13 @@ async fn codex_shim_live_skill_add_reaches_model_in_conversation() -> Result<()>
     )?;
     wait_for_runtime_quiescence(&graphql, &agent_did, gen0 + 1, Duration::from_secs(2)).await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -5107,7 +5372,13 @@ async fn codex_shim_explicit_skill_selection_injects_body_into_turn() -> Result<
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     let gen0 = wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let body_phrase = format!("INJECTED-BODY-{}", Uuid::new_v4().simple());
@@ -5135,9 +5406,13 @@ async fn codex_shim_explicit_skill_selection_injects_body_into_turn() -> Result<
     )?;
     wait_for_runtime_quiescence(&graphql, &agent_did, gen0 + 1, Duration::from_secs(2)).await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -5248,7 +5523,13 @@ async fn codex_shim_explicit_selection_respects_effective_set() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let body_phrase = format!("UNSCOPED-BODY-{}", Uuid::new_v4().simple());
@@ -5275,9 +5556,13 @@ async fn codex_shim_explicit_selection_respects_effective_set() -> Result<()> {
         ],
     )?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -5396,7 +5681,13 @@ async fn codex_shim_live_skill_toggle_reaches_model_in_conversation() -> Result<
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_port(shim_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     let gen0 = wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let catalog_phrase = format!("toggle-cite-{}", Uuid::new_v4().simple());
@@ -5425,9 +5716,13 @@ async fn codex_shim_live_skill_toggle_reaches_model_in_conversation() -> Result<
     let gen1 =
         wait_for_runtime_quiescence(&graphql, &agent_did, gen0 + 1, Duration::from_secs(2)).await?;
 
-    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
-        .await
-        .context("connecting to codex-shim websocket")?;
+    let (mut ws, _) = serve
+        .capturing(async {
+            connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+                .await
+                .context("connecting to codex-shim websocket")
+        })
+        .await?;
     send_client_request(
         &mut ws,
         codex::ClientRequest::Initialize {
@@ -5572,7 +5867,13 @@ async fn config_skill_cli_disable_enable_and_rm_round_trip() -> Result<()> {
 
     let mut serve = spawn_server_with_env(&home_dir, server_port, &[], &[])?;
     wait_for_port(server_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     run_cli_json(
@@ -5774,7 +6075,13 @@ async fn config_skill_import_export_roundtrip_hermes() -> Result<()> {
 
     let mut serve = spawn_server_with_env(&home_dir, server_port, &[], &[])?;
     wait_for_port(server_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 
     let imported = run_cli_json(
@@ -5917,7 +6224,13 @@ async fn codex_shim_binds_when_config_apply_supplies_its_behavior() -> Result<()
         &[],
     )?;
     wait_for_port(server_port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    serve
+        .capturing(wait_for_runtime_ready(
+            &graphql,
+            &agent_did,
+            Duration::from_secs(30),
+        ))
+        .await?;
     wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
     wait_for_runtime_quiescence(&graphql, &agent_did, 1, Duration::from_secs(2)).await?;
 

--- a/crates/gents-cli/tests/cli_codex_shim/helpers.rs
+++ b/crates/gents-cli/tests/cli_codex_shim/helpers.rs
@@ -1796,7 +1796,14 @@ pub(super) async fn read_terminal_child_without_reasoning_replay(
             codex::JSONRPCMessage::Response(_) => {}
         }
 
-        if child_status.is_some() && thread_status.is_some() && agent_completed_at_ms.is_some() {
+        // A CollabAgentToolCall update can still carry the child's
+        // intermediate Running status after its thread has gone Idle; keep
+        // reading until the collab projection reports a settled (non-Running)
+        // status instead of asserting the first snapshot observed.
+        let child_settled = child_status
+            .as_ref()
+            .is_some_and(|status| *status != codex::CollabAgentStatus::Running);
+        if child_settled && thread_status.is_some() && agent_completed_at_ms.is_some() {
             return Ok((
                 child_status.take().expect("checked child status"),
                 thread_status.take().expect("checked thread status"),

--- a/crates/gents-cli/tests/cli_demo.rs
+++ b/crates/gents-cli/tests/cli_demo.rs
@@ -3,7 +3,7 @@ use support::*;
 
 use std::fs;
 use std::io::Write;
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use std::sync::Arc;

--- a/crates/gents-cli/tests/cli_demo.rs
+++ b/crates/gents-cli/tests/cli_demo.rs
@@ -64,19 +64,6 @@ fn wait_port_free(port: u16, timeout: Duration) -> bool {
     }
 }
 
-fn allocate_demo_base_port() -> Result<u16> {
-    loop {
-        let port = allocate_port()?;
-        let Some(worker_port) = port.checked_add(1) else {
-            continue;
-        };
-        if let Ok(listener) = TcpListener::bind(("127.0.0.1", worker_port)) {
-            drop(listener);
-            return Ok(port);
-        }
-    }
-}
-
 fn require_success(output: &std::process::Output) -> Result<String> {
     if !output.status.success() {
         bail!(
@@ -431,8 +418,7 @@ async fn demo_pair_delegate_materializes_remote_worker() -> Result<()> {
             ChatAction::Sse(completion_text_sse("demo fallback"))
         })
     })?;
-    let port = allocate_demo_base_port()?;
-    let worker_port = port + 1;
+    let port = allocate_port()?;
 
     let input = format!("pair\ndelegate\nchat\n{parent_prompt}\n/back\ndown\n");
     let output = run_demo(
@@ -450,10 +436,16 @@ async fn demo_pair_delegate_materializes_remote_worker() -> Result<()> {
         &input,
     )?;
     let stdout = require_success(&output)?;
-    assert!(
-        stdout.contains("paired. Node B (worker) is live"),
-        "demo pair did not converge:\n{stdout}"
-    );
+    if !stdout.contains("paired. Node B (worker) is live") {
+        // The demo's server logs live inside the tempdir and vanish with it;
+        // dump both nodes' logs so a pair failure is diagnosable (#1041 pattern).
+        let node_a_log = std::fs::read_to_string(home.join("server.log")).unwrap_or_default();
+        let node_b_log =
+            std::fs::read_to_string(home.join("node-b").join("server.log")).unwrap_or_default();
+        panic!(
+            "demo pair did not converge:\n{stdout}\n--- node A server.log ---\n{node_a_log}\n--- node B server.log ---\n{node_b_log}"
+        );
+    }
     assert!(
         stdout.contains("cross-node delegation enabled"),
         "demo delegate did not configure the fleet:\n{stdout}"
@@ -462,6 +454,19 @@ async fn demo_pair_delegate_materializes_remote_worker() -> Result<()> {
         stdout.contains(&parent_reply),
         "parent did not finish after live background-child inspection:\n{stdout}"
     );
+    // Node B allocates its port at pair time; recover it from the paired
+    // banner so the leak check covers the port actually bound.
+    let worker_port = stdout
+        .lines()
+        .find_map(|line| {
+            line.split_once("(worker) is live at http://127.0.0.1:")?
+                .1
+                .split('/')
+                .next()?
+                .parse::<u16>()
+                .ok()
+        })
+        .expect("paired banner names node B's endpoint");
     assert!(
         wait_port_free(port, Duration::from_secs(15))
             && wait_port_free(worker_port, Duration::from_secs(15)),

--- a/crates/gents-cli/tests/support/process.rs
+++ b/crates/gents-cli/tests/support/process.rs
@@ -51,6 +51,24 @@ impl ServeProcess {
             read_captured_log(self.stderr_log.as_ref())?,
         ))
     }
+
+    /// Run a fallible future and, on failure, append the server's captured
+    /// stdout/stderr to the error — mirroring the `wait_for_port` bail format —
+    /// so mid-test connection failures are diagnosable (#1041).
+    pub async fn capturing<T>(
+        &self,
+        fut: impl std::future::Future<Output = Result<T>>,
+    ) -> Result<T> {
+        match fut.await {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let (stdout, stderr) = self.captured_output().unwrap_or_default();
+                Err(error.context(format!(
+                    "server stdout:\n{stdout}\nserver stderr:\n{stderr}"
+                )))
+            }
+        }
+    }
 }
 
 pub fn cli_bin() -> &'static str {

--- a/crates/gents-cli/tests/support/process.rs
+++ b/crates/gents-cli/tests/support/process.rs
@@ -52,9 +52,11 @@ impl ServeProcess {
         ))
     }
 
-    /// Run a fallible future and, on failure, append the server's captured
-    /// stdout/stderr to the error — mirroring the `wait_for_port` bail format —
-    /// so mid-test connection failures are diagnosable (#1041).
+    /// Run a fallible future and, on failure, attach the server's captured
+    /// stdout/stderr to the error chain (the original failure stays as the
+    /// cause) so mid-test connection failures are diagnosable (#1041). A
+    /// failure to read the capture files is reported in place of the logs
+    /// rather than silently rendering as an empty (silent-looking) server.
     pub async fn capturing<T>(
         &self,
         fut: impl std::future::Future<Output = Result<T>>,
@@ -62,7 +64,9 @@ impl ServeProcess {
         match fut.await {
             Ok(value) => Ok(value),
             Err(error) => {
-                let (stdout, stderr) = self.captured_output().unwrap_or_default();
+                let (stdout, stderr) = self
+                    .captured_output()
+                    .unwrap_or_else(|error| (format!("<capture failed: {error}>"), String::new()));
                 Err(error.context(format!(
                     "server stdout:\n{stdout}\nserver stderr:\n{stderr}"
                 )))

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -30,6 +30,10 @@ fi
 
 if git show-ref --verify --quiet "refs/heads/$branch"; then
     git worktree add "$dest" "$branch"
+elif git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+    # worktree add does not DWIM remote-only branches unless
+    # worktree.guessRemote is set; start the local branch from origin's.
+    git worktree add -b "$branch" "$dest" "origin/$branch"
 else
     git worktree add -b "$branch" "$dest" "$base"
 fi

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Create a git worktree with warm build caches.
+#
+# A bare `git worktree add` starts every cache cold: the new worktree has no
+# `target/` (a full workspace test build recompiles ~40 minutes even with
+# sccache, which cannot cache build scripts, proc-macro expansion, or linking)
+# and no `crates/gents/proofs/.lake` (Mathlib rebuilds for hours). Both are
+# cheaply transferable from the current checkout via APFS clonefile (`cp -c`),
+# which shares blocks copy-on-write instead of duplicating them.
+#
+# Usage: scripts/worktree-bootstrap.sh <branch> [dest-dir] [base-ref]
+#   branch    branch to check out; created from base-ref if it does not exist
+#   dest-dir  defaults to a sibling directory gents-<slug> derived from branch
+#   base-ref  defaults to HEAD; only used when creating the branch
+set -eu
+
+branch="${1:?usage: worktree-bootstrap.sh <branch> [dest-dir] [base-ref]}"
+repo_root="$(git rev-parse --show-toplevel)"
+
+slug="$(printf '%s' "$branch" | sed -E 's#^(fix|feat|feature|docs|perf|chore|agent)/##; s#/#-#g')"
+dest="${2:-"$(dirname "$repo_root")/gents-$slug"}"
+base="${3:-HEAD}"
+
+if [ -e "$dest" ]; then
+    echo "error: destination $dest already exists" >&2
+    exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git worktree add "$dest" "$branch"
+else
+    git worktree add -b "$branch" "$dest" "$base"
+fi
+
+# Copying target/ out from under a live build is only mildly risky (cargo
+# rebuilds anything whose fingerprint doesn't verify), but warn so a slow or
+# odd first build in the new worktree isn't a mystery.
+for pid in $(pgrep -x cargo 2>/dev/null || true); do
+    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')"
+    if [ "$cwd" = "$repo_root" ]; then
+        echo "warning: cargo (pid $pid) is building in $repo_root; cloned artifacts it is mid-writing will just recompile" >&2
+    fi
+done
+
+clone_dir() {
+    src="$1"
+    dst="$2"
+    label="$3"
+    if [ ! -d "$src" ]; then
+        echo "skip: no $label to clone ($src)"
+        return 0
+    fi
+    echo "cloning $label ..."
+    if ! cp -Rc "$src" "$dst" 2>/dev/null; then
+        rm -rf "$dst"
+        echo "clonefile unavailable (cross-volume?); plain copy of $label ..." >&2
+        cp -R "$src" "$dst"
+    fi
+}
+
+clone_dir "$repo_root/target" "$dest/target" "cargo target/"
+# Stale incremental state is worthless across worktrees (the workspace builds
+# with incremental=false) and just wastes space in the clone.
+rm -rf "$dest/target/debug/incremental" "$dest/target/release/incremental"
+
+# Lean caches are only valid against an identical dependency manifest.
+proofs="crates/gents/proofs"
+if cmp -s "$repo_root/$proofs/lake-manifest.json" "$dest/$proofs/lake-manifest.json" 2>/dev/null; then
+    clone_dir "$repo_root/$proofs/.lake" "$dest/$proofs/.lake" "Lean proofs .lake/"
+else
+    echo "skip: lake-manifest.json differs (or missing); not cloning .lake — lake build will repopulate"
+fi
+
+echo
+echo "worktree ready: $dest (branch $branch)"
+df -h "$dest" | tail -1 | awk '{print "disk: " $4 " free (" $5 " used)"}'

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -10,16 +10,18 @@
 #
 # Usage: scripts/worktree-bootstrap.sh <branch> [dest-dir] [base-ref]
 #   branch    branch to check out; created from base-ref if it does not exist
-#   dest-dir  defaults to a sibling directory gents-<slug> derived from branch
-#   base-ref  defaults to HEAD; only used when creating the branch
+#   dest-dir  defaults to $WORKTREE_DIR, then a sibling gents-<slug> directory
+#   base-ref  defaults to $WORKTREE_BASE, then HEAD; used when creating the branch
+# The env-var forms exist so `make worktree` can pass optional values without
+# positional-argument collapse (an empty positional would shift later ones).
 set -eu
 
 branch="${1:?usage: worktree-bootstrap.sh <branch> [dest-dir] [base-ref]}"
 repo_root="$(git rev-parse --show-toplevel)"
 
 slug="$(printf '%s' "$branch" | sed -E 's#^(fix|feat|feature|docs|perf|chore|agent)/##; s#/#-#g')"
-dest="${2:-"$(dirname "$repo_root")/gents-$slug"}"
-base="${3:-HEAD}"
+dest="${2:-${WORKTREE_DIR:-"$(dirname "$repo_root")/gents-$slug"}}"
+base="${3:-${WORKTREE_BASE:-HEAD}}"
 
 if [ -e "$dest" ]; then
     echo "error: destination $dest already exists" >&2


### PR DESCRIPTION
# Kill the CLI-suite flake class: full-workspace parallel-run contention

Three flaky CLI integration tests shared one class — they only failed under full-suite parallel load, when server startup is slow enough that gaps the tests never see in isolation open up. Each got a root-cause fix in product code; no test bodies changed, no timing slack added. Plus one deterministic gate breakage found and fixed along the way, and a dev-workflow improvement.

## #990 — `demo_pair_delegate_materializes_remote_worker` (candidate (a): real endpoint-resolution bug)

The demo pair/delegate flow shelled out to `p2p status` / `network create|grant` / `pairings invite|join` with only `--home`. Those subcommands resolve the admin endpoint via `resolve_graphql_endpoint`: explicit `--graphql` → the node's persisted `runtime_state.json` → **hardcoded default port 9191**. The server writes `runtime_state.json` only after its runtime reaches Ready (`serve.rs`), but `/healthz` — the only thing `pair()` gates on — is served by the DefraDB node HTTP server from node build time. Under parallel-suite load that window stretches to seconds, `p2p status --home <node>` finds no state file, probes `http://127.0.0.1:9191/api/v0/p2p/info`, and dies with connection refused. Everything downstream (`delegate failed: not paired`, `spawn_subagent tool_not_allowed`) was cascade.

**Fix** (`commands/demo/fleet.rs`): the fleet constructs both endpoints itself — pass `--graphql` explicitly on every CLI invocation in `pair()`/`delegate()`. `pairings invite` builds its token from the live HTTP API (`/node/identity`, `/p2p/shareable-address`), so no `runtime_state.json` dependency remains anywhere in the pair path. Both node A and node B were exposed (node A is also only healthz-gated before the shell accepts `pair`); both are covered.

## #933 — `cli_codex_shim` `thread/start` raw transaction conflict

`codex_shim/store.rs::query_node_json` executed reads **and auto-committed upserts** (`thread/start`'s `create_codex_thread`/`ensure_agent_session`, early rename's `upsert_AgentConversation`) via bare `EmbeddedNode::execute` — no conflict retry. Right after `AgentRuntime.process_state=ready` the runtime's startup reconciliation writes are still in flight; an auto-commit that loses that race surfaces `commit error: … transaction conflict. Please retry` raw to the Codex client. This is the same defect class already fixed on adjacent paths: startup config writes (#935/#926) and the shim's own turn-submission path (`create_agent_request_with_retry`) both have bounded retries.

**Fix**: route `query_node_json` through the centralized bounded conflict retry (`gents::retry::execute_graphql_with_conflict_retry`, #440 — 3 retries, 100 ms doubling backoff), and give `execute_committed` the same bounded retry around its begin/execute/commit cycle. Retrying is safe: a conflicted transaction aborted without committing. Error strings unchanged; exhaustion still returns the raw error. This is a production fix, not test hygiene — a user connecting Codex right after server start hit the same raw conflict.

## #989 — `codex_shim_derives_git_info_and_persists_early_rename` (same class; honest status: not individually reproduced)

The original panic was truncated (`tail -6`), so there is no captured message to match. But every operation on that test's failing surface — `thread/start` ×2, `thread/name/set` (an `upsert_AgentConversation`), `thread/read` — flows through the exact unretried path fixed for #933, and the test's error-reporting shape (`read_typed_response` bail) matches #933's captured failure. The fix covers that whole class. Linked rather than closed; leaving an honest status comment on the issue — if it recurs post-merge it is a different defect and deserves a fresh capture.

## Also: deterministic gate breakage from #1011 (found while reproducing)

`cargo test -p gents-cli` standalone has been red since yesterday: #1011 (via #1024, "keep non-production storage backends test-only") moved the `redb` feature to `gents`' dev-deps, and the codex-shim background unit test (`background.rs`) was the one `EmbeddedNode` construction site still relying on the upstream default backend — which is `Redb`, now compiled out in a standalone `-p gents-cli` graph. Every other site pins RocksDb; this one now does too. PR CI never sees this (full CLI suites run only on main pushes), which is how it landed silently.

## Dev workflow: `make worktree`

Cold worktrees cost ~40 min of recompilation (sccache can't cache build scripts, proc-macro expansion, or linking) plus hours of Mathlib. `make worktree BRANCH=<branch>` bootstraps a sibling worktree with `target/` and `proofs/.lake` cloned from the current checkout via APFS clonefile (~8 s, copy-on-write; `.lake` copy gated on a `lake-manifest.json` match). Documented in CLAUDE.md as the default.

## Verification (final, at merge head — `8b3ec81d` is `d0f364ac` + a formatting-only commit)

Full sweep at `d0f364ac`: **40/44 green**, and every failure is the single filed, pre-existing #1041 port-theft class, each self-diagnosed by this PR's capture fix:

| Gate | Result |
|---|---|
| `cli_codex_shim` ×20 | 17/20 — all 3 failures: shim port stolen pre-bind (captured: "Address already in use"), #1041 |
| `cli_demo` ×20 | 19/20 — 1 failure: node A port theft (captured), #1041 |
| **`demo_pair_delegate_materializes_remote_worker` (#990)** | **20/20** (+15/15 in the pre-commit loop) |
| **`codex_shim_interrupt_completes_with_running_background_tool` (#933)** | **19/20, zero transaction conflicts** (1 loss = captured port theft) |
| **`codex_shim_derives_git_info_and_persists_early_rename` (#989)** | **20/20** |
| `cargo test -p gents-cli` (full parallel) ×2 | 2/2 |
| `cargo test -p gents` | green |
| `cargo check --workspace --all-targets` | green |

Also: matched-load A/B (30×/30×, earlier head): branch 30/30 vs base 28/30. Review round: 5 independent reviewers + adversarial verify; all confirmed findings fixed on this branch (see review comment and `672ded8c`/`1f635ae8`/`d0f364ac`).

The residual port-theft class (test-suite ports pre-allocated at test start, stolen by the OS ephemeral allocator before bind; defra-node's HTTP task then dies silently while the process lives) is pre-existing on main (2/30 in the base A/B), fully diagnosed with captures on #1041, and needs the respawn-retry pattern across the spawn helpers plus a product-side startup self-probe — follow-up scope.

## Follow-ups (now fixed in this PR where possible)

- #1040 — duplicate reasoning replay after reset-tail: **fixed here** (`83b86c51`). Contracts check confirmed the Lean model already forbids the duplicate — pure implementation alignment. Red-first repro proven against base; 8 new cursor unit tests.
- #1041 — mid-test server death: **diagnosis capture added here** (`c00255fb`, `ServeProcess::capturing()` + 84 wrapped call sites). Issue stays open for the root-cause fix; structural candidates documented on the issue.

Closes #990
Closes #933
Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)




