### PR TITLE
fix(runtime): harden Terminal-Bench compaction recovery

### DIFF
--- a/crates/gents/src/agent/loop_stream.rs
+++ b/crates/gents/src/agent/loop_stream.rs
@@ -101,10 +101,26 @@ impl StructuredOutputConfig {
             validate: Arc::new(|raw| {
                 serde_json::from_str::<T>(raw)
                     .map(|_| ())
-                    .map_err(|error| error.to_string())
+                    .map_err(|error| {
+                        format!(
+                            "{error}; raw_output_preview={}; finish_metadata=unavailable_at_rig_streaming_boundary",
+                            bounded_structured_output_preview(raw)
+                        )
+                    })
             }),
         }
     }
+}
+
+fn bounded_structured_output_preview(raw: &str) -> String {
+    const MAX_PREVIEW_BYTES: usize = 192;
+    let mut cut = raw.len().min(MAX_PREVIEW_BYTES);
+    while !raw.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let suffix = if cut < raw.len() { "…" } else { "" };
+    serde_json::to_string(&format!("{}{suffix}", &raw[..cut]))
+        .unwrap_or_else(|_| "\"<unavailable>\"".to_string())
 }
 
 #[derive(Debug)]
@@ -694,7 +710,9 @@ where
                     MidStreamDirective::Fail { reason } => {
                         Err(StreamingError::Completion(
                             CompletionError::ProviderError(format!(
-                                "completion produced no visible output: {reason}"
+                                "completion produced no visible output: {reason}; \
+                                 raw_output_preview=\"\"; \
+                                 finish_metadata=unavailable_at_rig_streaming_boundary"
                             )),
                         ))?;
                         unreachable!("Err(..)? above ends the stream");

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -11,8 +11,8 @@ mod tests;
 
 use history::{extract_file_activity, pretruncate_tool_results, split_messages_for_summary};
 use summary::{
-    bounded_error_diagnostic, compaction_prompt, compaction_request_prompt, format_summary,
-    ContinuationCheckpoint,
+    bounded_error_diagnostic, compaction_json_fallback_prompt, compaction_prompt,
+    compaction_request_prompt, format_summary, parse_fallback_checkpoint, ContinuationCheckpoint,
 };
 
 #[derive(Debug, Clone)]
@@ -216,21 +216,72 @@ impl<M: CompletionModel + 'static> Compactor for DefraCompactor<M> {
             (Some(from_options), Some(from_config)) => Some(from_options.min(from_config)),
             (from_options, from_config) => from_options.or(from_config),
         };
-        let checkpoint: ContinuationCheckpoint = crate::agent::loop_stream::run_loop_to_typed(
+        let guided_result = crate::agent::loop_stream::run_loop_to_typed(
             (*self.model).clone(),
             None,
             crate::llm::message::Message::user(compaction_request_prompt()),
             prepared_history.clone(),
             std::sync::Arc::new(Vec::new()),
-            summary_config,
+            summary_config.clone(),
         )
-        .await
-        .map_err(|error| {
-            anyhow::anyhow!(
-                "compaction summary inference failed: {}",
-                bounded_error_diagnostic(&format!("{error}"))
-            )
-        })?;
+        .await;
+        let checkpoint: ContinuationCheckpoint = match guided_result {
+            Ok(checkpoint) => checkpoint,
+            Err(guided_error)
+                if is_guided_output_failure(&guided_error)
+                    && !deadline_elapsed(summary_config.deadline) =>
+            {
+                tracing::warn!(
+                    error = %bounded_error_diagnostic(&format!("{guided_error:#}")),
+                    "guided compaction output exhausted recovery; trying one strict non-guided JSON fallback"
+                );
+                let mut fallback_config = summary_config;
+                fallback_config.structured_output = None;
+                fallback_config.retry_policy =
+                    crate::agent::completion_retry::CompletionRetryPolicy::no_retry();
+                fallback_config.preamble = Some(format!(
+                    "{}\n\n{}",
+                    compaction_prompt(),
+                    compaction_json_fallback_prompt()
+                ));
+                let raw = crate::agent::loop_stream::run_loop_to_text(
+                    (*self.model).clone(),
+                    None,
+                    crate::llm::message::Message::user(compaction_request_prompt()),
+                    prepared_history,
+                    std::sync::Arc::new(Vec::new()),
+                    fallback_config,
+                )
+                .await
+                .map_err(|fallback_error| {
+                    anyhow::anyhow!(
+                        "compaction_provider_failure: guided structured output failed: {}; \
+                         non-guided JSON fallback failed: {}",
+                        bounded_error_diagnostic(&format!("{guided_error:#}")),
+                        bounded_error_diagnostic(&format!("{fallback_error:#}"))
+                    )
+                })?;
+                parse_fallback_checkpoint(&raw).map_err(|fallback_error| {
+                    anyhow::anyhow!(
+                        "compaction_provider_failure: guided structured output failed: {}; \
+                         non-guided JSON fallback failed: {}",
+                        bounded_error_diagnostic(&format!("{guided_error:#}")),
+                        bounded_error_diagnostic(&fallback_error)
+                    )
+                })?
+            }
+            Err(error) => {
+                let deadline_context = if deadline_elapsed(summary_config.deadline) {
+                    "compaction deadline elapsed after "
+                } else {
+                    ""
+                };
+                return Err(anyhow::anyhow!(
+                    "compaction_provider_failure: {deadline_context}{}",
+                    bounded_error_diagnostic(&format!("{error:#}"))
+                ));
+            }
+        };
 
         // Structural extraction is the sole source of file activity (#1017):
         // the model no longer returns lists, so it can neither balloon the
@@ -264,6 +315,16 @@ impl<M: CompletionModel + 'static> Compactor for DefraCompactor<M> {
             compaction_count: 1,
         })
     }
+}
+
+fn is_guided_output_failure(error: &anyhow::Error) -> bool {
+    let diagnostic = format!("{error:#}");
+    diagnostic.contains("structured-output validation failed")
+        || diagnostic.contains("completion produced no visible output")
+}
+
+fn deadline_elapsed(deadline: Option<chrono::DateTime<chrono::Utc>>) -> bool {
+    deadline.is_some_and(|deadline| chrono::Utc::now() >= deadline)
 }
 
 pub fn estimate_tokens(text: &str) -> usize {

--- a/crates/gents/src/compaction/summary.rs
+++ b/crates/gents/src/compaction/summary.rs
@@ -44,6 +44,49 @@ pub(super) fn compaction_request_prompt() -> &'static str {
     "Produce the required structured continuation checkpoint now."
 }
 
+pub(super) fn compaction_json_fallback_prompt() -> &'static str {
+    "Guided structured decoding was unavailable. Return exactly one JSON object and no Markdown. \
+Use these keys: goal (string), constraints_and_preferences, completed_work, in_progress, \
+blockers, current_work, key_decisions, errors_and_fixes, verification, uncertainties, \
+next_actions, and critical_context (arrays of strings). Include every key. Preserve unfinished \
+work in next_actions in execution order; the first item must be the immediate continuation."
+}
+
+pub(super) fn parse_fallback_checkpoint(raw: &str) -> Result<ContinuationCheckpoint, String> {
+    let checkpoint: ContinuationCheckpoint = serde_json::from_str(raw).map_err(|error| {
+        format!(
+            "strict JSON validation failed: {error}; raw_output_preview={}",
+            bounded_raw_output_preview(raw)
+        )
+    })?;
+    if checkpoint.goal.trim().is_empty() {
+        return Err(format!(
+            "checkpoint goal is empty; raw_output_preview={}",
+            bounded_raw_output_preview(raw)
+        ));
+    }
+    if checkpoint
+        .next_actions
+        .iter()
+        .all(|action| action.trim().is_empty())
+    {
+        return Err(format!(
+            "checkpoint has no pending next action; raw_output_preview={}",
+            bounded_raw_output_preview(raw)
+        ));
+    }
+    Ok(checkpoint)
+}
+
+fn bounded_raw_output_preview(raw: &str) -> String {
+    const RAW_OUTPUT_PREVIEW_MAX_BYTES: usize = 192;
+    let cut = floor_char_boundary(raw, raw.len().min(RAW_OUTPUT_PREVIEW_MAX_BYTES));
+    let preview = &raw[..cut];
+    let suffix = if cut < raw.len() { "…" } else { "" };
+    serde_json::to_string(&format!("{preview}{suffix}"))
+        .unwrap_or_else(|_| "\"<unavailable>\"".to_string())
+}
+
 /// Byte bound for one rendered list item. Structural paths are copied verbatim
 /// from tool arguments; an item-count cap alone cannot bound bytes (#1017).
 const SUMMARY_ITEM_MAX_BYTES: usize = 512;

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -955,7 +955,8 @@ fn scheduled_origin_config() -> crate::agent::loop_stream::LoopConfig {
 
 fn valid_summary_json() -> String {
     serde_json::json!({
-        "goal": "Continue the task from the compacted turns."
+        "goal": "Continue the task from the compacted turns.",
+        "next_actions": ["Run the pending verification command."]
     })
     .to_string()
 }
@@ -1203,17 +1204,19 @@ async fn schema_invalid_structured_summary_is_retracted_and_resampled() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn repeated_malformed_structured_summaries_exhaust_the_internal_budget() {
+async fn repeated_malformed_structured_summaries_use_strict_non_guided_fallback() {
     let model = ScriptedSummaryModel::new(vec![
         ScriptedSummaryModel::malformed_summary_turn(),
         ScriptedSummaryModel::malformed_summary_turn(),
         ScriptedSummaryModel::malformed_summary_turn(),
         ScriptedSummaryModel::malformed_summary_turn(),
+        ScriptedSummaryModel::summary_turn(),
     ]);
     let calls = model.calls.clone();
+    let requests = model.requests.clone();
     let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
 
-    let error = compactor
+    let result = compactor
         .compact(
             summary_worthy_messages(),
             500,
@@ -1225,18 +1228,27 @@ async fn repeated_malformed_structured_summaries_exhaust_the_internal_budget() {
             },
         )
         .await
-        .expect_err("persistently malformed output must exhaust bounded recovery");
+        .expect("a strict non-guided JSON fallback should recover after guided decoding fails");
 
     assert!(
-        error
-            .to_string()
-            .contains("structured-output validation failed"),
-        "terminal error must identify the typed-output contract: {error}"
+        result
+            .summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("Run the pending verification command.")),
+        "the fallback must preserve the pending next action"
     );
     assert_eq!(
         calls.load(std::sync::atomic::Ordering::SeqCst),
-        4,
-        "typed-output retracts consume exactly 1 initial call + 3 retries"
+        5,
+        "guided output consumes 1 initial call + 3 retries, then one fallback"
+    );
+    let requests = requests.lock().unwrap();
+    assert!(requests[..4]
+        .iter()
+        .all(|request| request.output_schema.is_some()));
+    assert!(
+        requests[4].output_schema.is_none(),
+        "the final escape hatch must bypass the failing guided decoder"
     );
 }
 
@@ -1278,15 +1290,53 @@ async fn expired_deadline_stops_malformed_structured_output_recovery_at_one_prov
 }
 
 #[tokio::test(start_paused = true)]
-async fn repeated_empty_compaction_completions_fail_after_the_internal_budget() {
-    // #1016: recovery is bounded. A provider that never produces visible
-    // output exhausts the fixed internal ladder deterministically — 1 initial
-    // call + 3 immediate retries — and then fails.
+async fn repeated_empty_compaction_completions_use_non_guided_fallback() {
+    // Guided recovery remains bounded at 1 initial call + 3 immediate retries.
+    // The fifth and final call drops the schema transport that exercises the
+    // provider's guided decoder, but still requires strict local JSON.
     let model = ScriptedSummaryModel::new(vec![
         ScriptedSummaryModel::empty_turn(),
         ScriptedSummaryModel::empty_turn(),
         ScriptedSummaryModel::empty_turn(),
         ScriptedSummaryModel::empty_turn(),
+        ScriptedSummaryModel::summary_turn(),
+    ]);
+    let calls = model.calls.clone();
+    let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
+
+    let result = compactor
+        .compact(
+            summary_worthy_messages(),
+            500,
+            &CompactionOptions {
+                threshold: 0.50,
+                keep_recent_tokens: 50,
+                strategy: CompactionStrategy::Summarize,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("a visible strict JSON fallback should recover after empty guided turns");
+
+    assert!(
+        result.summary.is_some(),
+        "the strict fallback checkpoint must be used"
+    );
+    assert_eq!(
+        calls.load(std::sync::atomic::Ordering::SeqCst),
+        5,
+        "empty guided turns consume the internal ladder plus one fallback"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn invalid_non_guided_fallback_is_a_distinct_bounded_provider_failure() {
+    let model = ScriptedSummaryModel::new(vec![
+        ScriptedSummaryModel::malformed_summary_turn(),
+        ScriptedSummaryModel::malformed_summary_turn(),
+        ScriptedSummaryModel::malformed_summary_turn(),
+        ScriptedSummaryModel::malformed_summary_turn(),
+        ScriptedSummaryModel::malformed_summary_turn(),
     ]);
     let calls = model.calls.clone();
     let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
@@ -1303,17 +1353,24 @@ async fn repeated_empty_compaction_completions_fail_after_the_internal_budget() 
             },
         )
         .await
-        .expect_err("persistently empty output must fail once the internal budget is spent");
+        .expect_err("invalid guided and fallback output must never become a checkpoint");
 
+    let diagnostic = error.to_string();
+    assert!(diagnostic.starts_with("compaction_provider_failure:"));
+    assert!(diagnostic.contains("non-guided JSON fallback failed"));
+    assert!(diagnostic.contains("raw_output_preview"));
     assert!(
-        error.to_string().contains("no visible output"),
-        "the failure must name the empty-output condition: {error}"
+        diagnostic.len() < 800,
+        "diagnostic must remain bounded: {diagnostic}"
     );
-    assert_eq!(
-        calls.load(std::sync::atomic::Ordering::SeqCst),
-        4,
-        "empty-output retracts consume exactly the internal ladder: 1 initial + 3 retries"
-    );
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 5);
+}
+
+#[test]
+fn non_guided_fallback_rejects_a_vague_checkpoint_without_pending_actions() {
+    let error = super::summary::parse_fallback_checkpoint(r#"{"goal":"Keep going."}"#)
+        .expect_err("a fallback may not silently discard pending work");
+    assert!(error.contains("no pending next action"));
 }
 
 #[test]

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -1214,7 +1214,15 @@ async fn repeated_malformed_structured_summaries_use_strict_non_guided_fallback(
     ]);
     let calls = model.calls.clone();
     let requests = model.requests.clone();
-    let compactor = DefraCompactor::new(std::sync::Arc::new(model), scheduled_origin_config());
+    let inherited_reasoning = serde_json::json!({
+        "chat_template_kwargs": {
+            "enable_thinking": true,
+            "reasoning_effort": "max"
+        }
+    });
+    let mut config = scheduled_origin_config();
+    config.additional_params = Some(inherited_reasoning.clone());
+    let compactor = DefraCompactor::new(std::sync::Arc::new(model), config);
 
     let result = compactor
         .compact(
@@ -1249,6 +1257,12 @@ async fn repeated_malformed_structured_summaries_use_strict_non_guided_fallback(
     assert!(
         requests[4].output_schema.is_none(),
         "the final escape hatch must bypass the failing guided decoder"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.additional_params.as_ref() == Some(&inherited_reasoning)),
+        "guided compaction and its fallback must inherit the parent reasoning profile"
     );
 }
 

--- a/crates/gents/src/config.rs
+++ b/crates/gents/src/config.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_STREAM_BATCH_MS: u64 = 1_000;
 pub const DEFAULT_COMPACTION_THRESHOLD: f64 = 0.75;
 /// Output budget for the internal compaction summary completion — independent
 /// of the user turn's `max_output_tokens` (#1017).
-pub const DEFAULT_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS: usize = 4_096;
+pub const DEFAULT_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS: usize = 32_768;
 pub const MAX_COMPACTION_SUMMARY_MAX_OUTPUT_TOKENS: usize = 32_768;
 /// Most file paths rendered per list in the formatted compaction summary.
 pub const DEFAULT_COMPACTION_SUMMARY_FILE_LIST_MAX: usize = 100;

--- a/crates/gents/src/managed_exec/output.rs
+++ b/crates/gents/src/managed_exec/output.rs
@@ -12,7 +12,11 @@ pub(crate) enum ManagedExecOutcome {
         code: Option<i32>,
         stdout: Vec<u8>,
         stderr: Vec<u8>,
+        /// True when the byte cap, a read failure, or the post-exit drain
+        /// deadline prevented observing the complete stream.
         stdout_truncated: bool,
+        /// True when the byte cap, a read failure, or the post-exit drain
+        /// deadline prevented observing the complete stream.
         stderr_truncated: bool,
     },
     TimedOut {

--- a/crates/gents/src/managed_exec/process.rs
+++ b/crates/gents/src/managed_exec/process.rs
@@ -19,7 +19,7 @@ mod job_object;
 mod process_group;
 mod registry;
 
-use capture::{join_capture, join_capture_with_timeout, read_optional_capped};
+use capture::{join_capture_with_timeout, spawn_optional_capped};
 #[cfg(windows)]
 use job_object::{terminate_job, ManagedChildJob};
 #[cfg(unix)]
@@ -28,7 +28,7 @@ use registry::ActiveExecGuard;
 
 pub(crate) use registry::active_executor_snapshots;
 
-const CAPTURE_DRAIN_AFTER_FAILED_REAP: Duration = Duration::from_millis(50);
+const CAPTURE_DRAIN_AFTER_CHILD_EXIT: Duration = Duration::from_millis(100);
 
 #[derive(Debug)]
 pub(crate) struct ManagedExecRequest {
@@ -103,22 +103,22 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     let stdout = child.inner.stdout.take();
     let stderr = child.inner.stderr.take();
     let max_output_bytes = request.max_output_bytes;
-    let stdout_task = tokio::spawn(read_optional_capped(
+    let stdout_task = spawn_optional_capped(
         stdout,
         max_output_bytes,
         request
             .live_output
             .clone()
             .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stdout)),
-    ));
-    let stderr_task = tokio::spawn(read_optional_capped(
+    );
+    let stderr_task = spawn_optional_capped(
         stderr,
         max_output_bytes,
         request
             .live_output
             .clone()
             .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stderr)),
-    ));
+    );
 
     let child_pgid = child.pgid();
     let mut wait = Box::pin(child.inner.wait());
@@ -134,8 +134,10 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
                 Ok(status) => {
                     drop(wait);
                     child.mark_finished(true);
-                    let stdout = join_capture(stdout_task).await;
-                    let stderr = join_capture(stderr_task).await;
+                    let (stdout, stderr) = tokio::join!(
+                        join_capture_with_timeout(stdout_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                        join_capture_with_timeout(stderr_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                    );
                     return ManagedExecOutcome::Exited {
                         code: status.code(),
                         stdout: stdout.bytes,
@@ -147,6 +149,10 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
                 Err(error) => {
                     drop(wait);
                     child.mark_finished(true);
+                    let _ = tokio::join!(
+                        join_capture_with_timeout(stdout_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                        join_capture_with_timeout(stderr_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                    );
                     return ManagedExecOutcome::SpawnFailed {
                         error: format!("waiting for managed exec failed: {error}"),
                     };
@@ -158,9 +164,10 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     let kill = terminate_process_group(child_pgid, &mut wait).await;
     drop(wait);
     child.mark_finished(kill.reaped);
-    let capture_timeout = (!kill.reaped).then_some(CAPTURE_DRAIN_AFTER_FAILED_REAP);
-    let stdout = join_capture_with_timeout(stdout_task, capture_timeout).await;
-    let stderr = join_capture_with_timeout(stderr_task, capture_timeout).await;
+    let (stdout, stderr) = tokio::join!(
+        join_capture_with_timeout(stdout_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+        join_capture_with_timeout(stderr_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+    );
 
     match outcome_kind {
         OutcomeKind::TimedOut => ManagedExecOutcome::TimedOut {
@@ -229,22 +236,22 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     let stdout = child.inner.stdout.take();
     let stderr = child.inner.stderr.take();
     let max_output_bytes = request.max_output_bytes;
-    let stdout_task = tokio::spawn(read_optional_capped(
+    let stdout_task = spawn_optional_capped(
         stdout,
         max_output_bytes,
         request
             .live_output
             .clone()
             .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stdout)),
-    ));
-    let stderr_task = tokio::spawn(read_optional_capped(
+    );
+    let stderr_task = spawn_optional_capped(
         stderr,
         max_output_bytes,
         request
             .live_output
             .clone()
             .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stderr)),
-    ));
+    );
 
     let job = child.job();
     let mut wait = Box::pin(child.inner.wait());
@@ -260,8 +267,10 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
                 Ok(status) => {
                     drop(wait);
                     child.mark_finished(true);
-                    let stdout = join_capture(stdout_task).await;
-                    let stderr = join_capture(stderr_task).await;
+                    let (stdout, stderr) = tokio::join!(
+                        join_capture_with_timeout(stdout_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                        join_capture_with_timeout(stderr_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                    );
                     return ManagedExecOutcome::Exited {
                         code: status.code(),
                         stdout: stdout.bytes,
@@ -273,6 +282,10 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
                 Err(error) => {
                     drop(wait);
                     child.mark_finished(true);
+                    let _ = tokio::join!(
+                        join_capture_with_timeout(stdout_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                        join_capture_with_timeout(stderr_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+                    );
                     return ManagedExecOutcome::SpawnFailed {
                         error: format!("waiting for managed exec failed: {error}"),
                     };
@@ -284,9 +297,10 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     let kill = terminate_job(job, &mut wait).await;
     drop(wait);
     child.mark_finished(kill.reaped);
-    let capture_timeout = (!kill.reaped).then_some(CAPTURE_DRAIN_AFTER_FAILED_REAP);
-    let stdout = join_capture_with_timeout(stdout_task, capture_timeout).await;
-    let stderr = join_capture_with_timeout(stderr_task, capture_timeout).await;
+    let (stdout, stderr) = tokio::join!(
+        join_capture_with_timeout(stdout_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+        join_capture_with_timeout(stderr_task, CAPTURE_DRAIN_AFTER_CHILD_EXIT),
+    );
 
     match outcome_kind {
         OutcomeKind::TimedOut => ManagedExecOutcome::TimedOut {

--- a/crates/gents/src/managed_exec/process/capture.rs
+++ b/crates/gents/src/managed_exec/process/capture.rs
@@ -1,92 +1,104 @@
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::background_tools::{LiveOutputStream, LiveToolOutputWriter};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct OutputCapture {
     pub(super) bytes: Vec<u8>,
     pub(super) truncated: bool,
 }
 
-pub(super) async fn read_optional_capped<R>(
+pub(super) struct CaptureTask {
+    handle: tokio::task::JoinHandle<()>,
+    output: Arc<Mutex<OutputCapture>>,
+}
+
+pub(super) fn spawn_optional_capped<R>(
     reader: Option<R>,
     max_bytes: usize,
     live_output: Option<(LiveToolOutputWriter, LiveOutputStream)>,
-) -> OutputCapture
+) -> CaptureTask
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead + Unpin + Send + 'static,
 {
-    let Some(reader) = reader else {
-        return OutputCapture {
-            bytes: Vec::new(),
-            truncated: false,
+    let output = Arc::new(Mutex::new(OutputCapture {
+        bytes: Vec::new(),
+        truncated: false,
+    }));
+    let task_output = Arc::clone(&output);
+    let handle = tokio::spawn(async move {
+        let Some(reader) = reader else {
+            return;
         };
-    };
-    read_capped(reader, max_bytes, live_output).await
+        read_capped(reader, max_bytes, live_output, task_output).await;
+    });
+    CaptureTask { handle, output }
 }
 
 async fn read_capped<R>(
     mut reader: R,
     max_bytes: usize,
     live_output: Option<(LiveToolOutputWriter, LiveOutputStream)>,
-) -> OutputCapture
-where
+    output: Arc<Mutex<OutputCapture>>,
+) where
     R: AsyncRead + Unpin,
 {
-    let mut bytes = Vec::new();
-    let mut truncated = false;
     let mut buf = [0u8; 8192];
     loop {
         let read = match reader.read(&mut buf).await {
             Ok(0) => break,
             Ok(read) => read,
-            Err(_) => break,
+            Err(_) => {
+                lock_output(&output).truncated = true;
+                break;
+            }
         };
+        {
+            let mut output = lock_output(&output);
+            let remaining = max_bytes.saturating_sub(output.bytes.len());
+            if remaining == 0 {
+                output.truncated = true;
+            } else {
+                let take = remaining.min(read);
+                output.bytes.extend_from_slice(&buf[..take]);
+                if take < read {
+                    output.truncated = true;
+                }
+            }
+        }
         if let Some((writer, stream)) = &live_output {
             writer.append(*stream, &buf[..read]).await;
         }
-        let remaining = max_bytes.saturating_sub(bytes.len());
-        if remaining == 0 {
-            truncated = true;
-            continue;
-        }
-        let take = remaining.min(read);
-        bytes.extend_from_slice(&buf[..take]);
-        if take < read {
-            truncated = true;
-        }
     }
-    OutputCapture { bytes, truncated }
 }
 
-pub(super) async fn join_capture(task: tokio::task::JoinHandle<OutputCapture>) -> OutputCapture {
-    task.await.unwrap_or(OutputCapture {
-        bytes: Vec::new(),
-        truncated: true,
-    })
+fn lock_output(output: &Mutex<OutputCapture>) -> std::sync::MutexGuard<'_, OutputCapture> {
+    output
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 pub(super) async fn join_capture_with_timeout(
-    mut task: tokio::task::JoinHandle<OutputCapture>,
-    timeout: Option<Duration>,
+    mut task: CaptureTask,
+    timeout: Duration,
 ) -> OutputCapture {
-    let Some(timeout) = timeout else {
-        return join_capture(task).await;
-    };
-
     tokio::select! {
-        result = &mut task => result.unwrap_or(OutputCapture {
-            bytes: Vec::new(),
-            truncated: true,
-        }),
-        _ = tokio::time::sleep(timeout) => {
-            task.abort();
-            OutputCapture {
-                bytes: Vec::new(),
-                truncated: true,
+        result = &mut task.handle => {
+            let mut output = lock_output(&task.output).clone();
+            if result.is_err() {
+                output.truncated = true;
             }
+            output
+        },
+        _ = tokio::time::sleep(timeout) => {
+            task.handle.abort();
+            let _ = task.handle.await;
+            let mut output = lock_output(&task.output).clone();
+            output.truncated = true;
+            output
         }
     }
 }

--- a/crates/gents/src/managed_exec/tests.rs
+++ b/crates/gents/src/managed_exec/tests.rs
@@ -363,3 +363,84 @@ async fn managed_exec_caps_stdout() {
         other => panic!("expected exited outcome, got {other:?}"),
     }
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn managed_exec_bounds_stdout_drain_after_direct_child_exit() {
+    assert_bounded_capture_drain("stdout").await;
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn managed_exec_bounds_stderr_drain_after_direct_child_exit() {
+    assert_bounded_capture_drain("stderr").await;
+}
+
+#[cfg(unix)]
+async fn assert_bounded_capture_drain(retained_stream: &str) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let pid_file = temp
+        .path()
+        .join(format!("{retained_stream}-descendant.pid"));
+    let script = match retained_stream {
+        "stdout" => format!(
+            "printf stdout-before; printf stderr-before >&2; sleep 30 2>/dev/null & echo $! > '{}'; exit 7",
+            pid_file.display()
+        ),
+        "stderr" => format!(
+            "printf stdout-before; printf stderr-before >&2; sleep 30 >/dev/null & echo $! > '{}'; exit 7",
+            pid_file.display()
+        ),
+        other => panic!("unexpected retained stream {other}"),
+    };
+    let tool_name = format!("retained-{retained_stream}-pipe");
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(1),
+        run_managed_exec(ManagedExecRequest {
+            argv: vec!["/bin/sh".to_string(), "-c".to_string(), script],
+            cwd: temp.path().to_path_buf(),
+            deadline_at: Some(Utc::now() + chrono::Duration::seconds(10)),
+            cancellation_token: CancellationToken::new(),
+            max_output_bytes: 1024,
+            stdin: Vec::new(),
+            environment: None,
+            tool_name: Some(tool_name.clone()),
+            live_output: None,
+        }),
+    )
+    .await
+    .expect("managed exec must not wait indefinitely for descendant-held pipes");
+
+    let descendant_pid = std::fs::read_to_string(&pid_file)
+        .expect("descendant pid file")
+        .trim()
+        .parse::<i32>()
+        .expect("descendant pid");
+    unsafe {
+        libc::kill(descendant_pid, libc::SIGKILL);
+    }
+
+    match outcome {
+        ManagedExecOutcome::Exited {
+            code,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+        } => {
+            assert_eq!(code, Some(7), "direct child status remains authoritative");
+            assert_eq!(stdout, b"stdout-before");
+            assert_eq!(stderr, b"stderr-before");
+            assert_eq!(stdout_truncated, retained_stream == "stdout");
+            assert_eq!(stderr_truncated, retained_stream == "stderr");
+        }
+        other => panic!("expected exited outcome, got {other:?}"),
+    }
+    assert!(
+        crate::active_native_executors()
+            .into_iter()
+            .all(|snapshot| snapshot.tool_name.as_deref() != Some(&tool_name)),
+        "direct-child exit must promptly clear the active executor"
+    );
+}

--- a/crates/gents/src/toolset/shared/command.rs
+++ b/crates/gents/src/toolset/shared/command.rs
@@ -200,21 +200,49 @@ pub(crate) async fn run_command(
     })
     .await;
     let duration_ms = elapsed_ms(started);
-    let (exit_code, timed_out, stdout_bytes, stderr_bytes) = match outcome {
+    let (
+        exit_code,
+        timed_out,
+        stdout_bytes,
+        stderr_bytes,
+        stdout_capture_incomplete,
+        stderr_capture_incomplete,
+    ) = match outcome {
         ManagedExecOutcome::Exited {
             code,
             stdout,
             stderr,
+            stdout_truncated,
+            stderr_truncated,
+        } => (
+            code,
+            false,
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
+        ),
+        ManagedExecOutcome::TimedOut {
+            stdout,
+            stderr,
+            stdout_truncated,
+            stderr_truncated,
             ..
-        } => (code, false, stdout, stderr),
-        ManagedExecOutcome::TimedOut { stdout, stderr, .. } => {
+        } => {
             if request_deadline.is_some_and(|deadline| chrono::Utc::now() >= deadline) {
                 // Never model-facing: the dispatcher's envelope shares this
                 // deadline and its `biased` select resolves the call to
                 // `ToolOutcome::TimedOut` before this text can thread.
                 return Ok("command was stopped at the request deadline".to_string());
             }
-            (None, true, stdout, stderr)
+            (
+                None,
+                true,
+                stdout,
+                stderr,
+                stdout_truncated,
+                stderr_truncated,
+            )
         }
         // Never model-facing: the envelope's (fired) cancellation branch is
         // polled first and resolves the call to `ToolOutcome::Cancelled`.
@@ -248,6 +276,8 @@ pub(crate) async fn run_command(
         execution_mode: policy.mode,
         network_mode: policy.network_mode,
         sandbox,
+        stdout_capture_incomplete,
+        stderr_capture_incomplete,
         stdout_truncation: stdout.metadata,
         stderr_truncation: stderr.metadata,
     };
@@ -966,6 +996,8 @@ struct CommandMetadata {
     execution_mode: CommandExecutionMode,
     network_mode: CommandNetworkMode,
     sandbox: &'static str,
+    stdout_capture_incomplete: bool,
+    stderr_capture_incomplete: bool,
     stdout_truncation: StreamTruncationMetadata,
     stderr_truncation: StreamTruncationMetadata,
 }

--- a/crates/gents/src/toolset/tests.rs
+++ b/crates/gents/src/toolset/tests.rs
@@ -1623,10 +1623,42 @@ async fn unrestricted_bash_runs_shell_command_strings() {
     assert_eq!(meta["ok"], true);
     assert_eq!(meta["exit_code"], 0);
     assert_eq!(meta["timed_out"], false);
+    assert_eq!(meta["stdout_capture_incomplete"], false);
+    assert_eq!(meta["stderr_capture_incomplete"], false);
     assert_eq!(meta["argv"][0], "/bin/sh");
     assert_eq!(meta["stdout_truncation"]["total_bytes"], 2);
     assert_eq!(meta["stderr_truncation"]["total_bytes"], 3);
     assert!(output.contains("stdout:\nOK"));
+    assert!(output.contains("stderr:\nERR"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unrestricted_bash_reports_descendant_bounded_capture() {
+    let root = temp_root("gents-unrestricted-capture-drain");
+    let tool = UnrestrictedBashTool::new(
+        ToolContext::new(root, false).unwrap(),
+        Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+    );
+
+    let output = crate::llm::tool::Tool::call(
+        &tool,
+        BashArgs {
+            command: "printf ERR >&2; sleep 2 >/dev/null & exit 0".to_string(),
+            args: Vec::new(),
+            cwd: None,
+            timeout_secs: Some(DEFAULT_COMMAND_TIMEOUT_SECS),
+            raw_json: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let meta = compact_exec_meta(&output);
+    assert_eq!(meta["ok"], true);
+    assert_eq!(meta["exit_code"], 0);
+    assert_eq!(meta["stdout_capture_incomplete"], false);
+    assert_eq!(meta["stderr_capture_incomplete"], true);
     assert!(output.contains("stderr:\nERR"));
 }
 

--- a/scripts/harbor/README.md
+++ b/scripts/harbor/README.md
@@ -105,7 +105,9 @@ runner attempts a bounded status query, partial response, timeline and ATIF
 projection, captures a server-log tail and process tree, inventories the local
 store, and archives the home only when it fits the configured size ceiling.
 GraphQL failure is retained explicitly rather than replacing the server-loss
-cause with a connection error.
+cause with a connection error. Compaction failures that exhaust both guided
+decoding and the strict non-guided JSON fallback are classified separately as
+`compaction_provider_error` in `gents-outcome.json`.
 
 For task images that need the glibc compatibility loader, the adapter installs
 an explicit `gents-fs-runner` shim and verifies it during setup. This keeps the

--- a/scripts/harbor/README.md
+++ b/scripts/harbor/README.md
@@ -97,6 +97,16 @@ also checks the inference service every 15 seconds and stops Harbor after three
 consecutive failures; both values can be changed with
 `HARBOR_HEALTHCHECK_INTERVAL_SECS` and `HARBOR_HEALTHCHECK_FAILURE_LIMIT`.
 
+Within each trial, `run_gents.sh` supervises the Gents server and response
+waiter as one lifecycle. If the server exits during an active request, the
+waiter is cancelled and the runner reports whether `wait(2)` observed an exit
+code or a terminating signal. Before cleanup removes the UUID-scoped home, the
+runner attempts a bounded status query, partial response, timeline and ATIF
+projection, captures a server-log tail and process tree, inventories the local
+store, and archives the home only when it fits the configured size ceiling.
+GraphQL failure is retained explicitly rather than replacing the server-loss
+cause with a connection error.
+
 For task images that need the glibc compatibility loader, the adapter installs
 an explicit `gents-fs-runner` shim and verifies it during setup. This keeps the
 native filesystem tools available even though Linux reports the explicit glibc
@@ -130,6 +140,9 @@ Useful overrides:
 | `GENTS_REQUEST_TIMEOUT_SECS` | `86400` | Durable request and Harbor exec timeout |
 | `GENTS_COMMAND_TIMEOUT_SECS` | `600` | Foreground command timeout applied when the model omits `timeout_secs` |
 | `GENTS_COMMAND_TIMEOUT_MAX_SECS` | `3600` | Foreground cap for explicit `timeout_secs` requests; kept far below `GENTS_REQUEST_TIMEOUT_SECS` so a pathological command returns control to the model (#1018) |
+| `GENTS_DIAGNOSTIC_TIMEOUT_SECS` | `10` | Per-command ceiling while capturing failure diagnostics |
+| `GENTS_DIAGNOSTIC_HOME_MAX_BYTES` | `67108864` | Maximum runtime-home size eligible for the diagnostic archive; larger homes retain an inventory and an archive-skipped note |
+| `GENTS_SUPERVISION_POLL_SECS` | `1` | Poll interval for the server/response-waiter lifecycle supervisor |
 | `GENTS_TOOL_ROOT` | `/app` | Filesystem and shell tool root |
 
 Each trial retains:
@@ -138,3 +151,8 @@ Each trial retains:
 - `request.json`, `request.stdout.json`, and `response.json` — request and response
 - `gents-init.json`, `gents-profile.json`, `gents-status.json`, and
   `gents-server.log` — runtime evidence
+- On runner failure, `gents-diagnostic.json`, `gents-server-exit.json` when the
+  server was reaped, `gents-server-tail.txt`, `process-tree.txt`, final status
+  or `graphql-unavailable.txt`, partial response/timeline/ATIF output, and
+  `gents-home-inventory.txt`. `gents-home.tar.gz` is also retained when the
+  home fits `GENTS_DIAGNOSTIC_HOME_MAX_BYTES`.

--- a/scripts/harbor/gents_agent.py
+++ b/scripts/harbor/gents_agent.py
@@ -409,6 +409,8 @@ install -m 0755 "$binary" {shlex.quote(self._REMOTE_BINARY)}
         failure_origin = None
         if diagnostic.get("reason") == "server_lost_during_request":
             failure_origin = "gents_server"
+        elif outcome.get("outcome") == "compaction_provider_error":
+            failure_origin = "compaction_provider"
 
         context.metadata = {
             **(context.metadata or {}),

--- a/scripts/harbor/gents_agent.py
+++ b/scripts/harbor/gents_agent.py
@@ -333,6 +333,14 @@ install -m 0755 "$binary" {shlex.quote(self._REMOTE_BINARY)}
             env=run_env,
             timeout_sec=request_timeout + 180,
         )
+        runner_error: BaseException | None = None
+        try:
+            # Classify the runner while GENTS_HOME still exists. The runner's
+            # failure trap projects partial traces and captures its bounded
+            # diagnostic bundle before returning a nonzero status.
+            self._require_success(self._REMOTE_RUNNER, result)
+        except BaseException as error:
+            runner_error = error
         cleanup_files = [
             self._REMOTE_BINARY,
             self._REMOTE_REAL_BINARY,
@@ -361,7 +369,8 @@ install -m 0755 "$binary" {shlex.quote(self._REMOTE_BINARY)}
                 "Failed to remove temporary Gents runtime artifacts: %s",
                 (cleanup_result.stderr or cleanup_result.stdout or "").strip(),
             )
-        self._require_success(self._REMOTE_RUNNER, result)
+        if runner_error is not None:
+            raise runner_error
 
         context.metadata = {
             **(context.metadata or {}),
@@ -381,18 +390,25 @@ install -m 0755 "$binary" {shlex.quote(self._REMOTE_BINARY)}
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         trajectory_path = self.logs_dir / "trajectory.json"
+        trajectory: dict[str, Any] = {}
         if not trajectory_path.is_file():
             self.logger.warning("Gents did not emit %s", trajectory_path)
-            return
-        try:
-            trajectory = json.loads(trajectory_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            self.logger.exception("Failed to read Gents ATIF trajectory")
-            return
+        else:
+            try:
+                parsed_trajectory = json.loads(trajectory_path.read_text())
+                if isinstance(parsed_trajectory, dict):
+                    trajectory = parsed_trajectory
+            except (OSError, json.JSONDecodeError):
+                self.logger.exception("Failed to read Gents ATIF trajectory")
 
         request = self._read_json_object(self.logs_dir / "request.json")
         outcome = self._read_json_object(self.logs_dir / "gents-outcome.json")
         response = self._read_json_object(self.logs_dir / "response.json")
+        diagnostic = self._read_json_object(self.logs_dir / "gents-diagnostic.json")
+        server_exit = self._read_json_object(self.logs_dir / "gents-server-exit.json")
+        failure_origin = None
+        if diagnostic.get("reason") == "server_lost_during_request":
+            failure_origin = "gents_server"
 
         context.metadata = {
             **(context.metadata or {}),
@@ -410,6 +426,10 @@ install -m 0755 "$binary" {shlex.quote(self._REMOTE_BINARY)}
                 "outcome": outcome.get("outcome"),
                 "budget_exhausted": outcome.get("outcome") == "max_turns_exhausted",
                 "terminal_error": response.get("error_message"),
+                "failure_origin": failure_origin,
+                "diagnostic_reason": diagnostic.get("reason"),
+                "diagnostic_graphql_available": diagnostic.get("graphql_available"),
+                "server_exit": server_exit or None,
             },
         }
 

--- a/scripts/harbor/run_gents.sh
+++ b/scripts/harbor/run_gents.sh
@@ -12,6 +12,15 @@ set -eu
 # key-plus-prefix is safe against model content: JSON escapes quotes inside
 # string values, so this byte sequence can only introduce the real field.
 _MAX_TURN_ERROR_PREFIX='"error_message": "agent stream failed: PromptError: MaxTurnError: '
+_COMPACTION_PROVIDER_ERROR='compaction_provider_failure:'
+
+response_error_has() {
+  response_file=$1
+  expected=$2
+  sed -n '/^[[:space:]]*"error_message":/p' "${response_file}" |
+    head -1 |
+    grep -qF "${expected}"
+}
 
 classify_response() {
   response_file=$1
@@ -23,6 +32,8 @@ classify_response() {
     error)
       if grep -qF "${_MAX_TURN_ERROR_PREFIX}" "${response_file}"; then
         printf 'max_turns_exhausted\n'
+      elif response_error_has "${response_file}" "${_COMPACTION_PROVIDER_ERROR}"; then
+        printf 'compaction_provider_error\n'
       else
         printf 'agent_error\n'
       fi
@@ -94,11 +105,27 @@ EOF
   "error_message": "compaction failed: summary request rejected by provider"
 }
 EOF
+  cat >"${self_test_dir}/compaction-provider-error.json" <<'EOF'
+{
+  "request_id": "req-12",
+  "status": "error",
+  "content": null,
+  "error_message": "agent stream failed: CompletionError: ProviderError: per-turn provider-input compaction failed: compaction_provider_failure: guided and fallback output failed"
+}
+EOF
   cat >"${self_test_dir}/content-mentions-max-turn.json" <<'EOF'
 {
   "request_id": "req-6",
   "status": "error",
   "content": "I hit MaxTurnError: in a log I was reading",
+  "error_message": "agent stream failed: CompletionError: ProviderError: connection reset"
+}
+EOF
+  cat >"${self_test_dir}/content-mentions-compaction-provider.json" <<'EOF'
+{
+  "request_id": "req-13",
+  "status": "error",
+  "content": "A log contained compaction_provider_failure: but it was not this request failure.",
   "error_message": "agent stream failed: CompletionError: ProviderError: connection reset"
 }
 EOF
@@ -167,7 +194,9 @@ EOF
   expect_outcome max-turns max_turns_exhausted
   expect_outcome provider-error agent_error
   expect_outcome compaction-error agent_error
+  expect_outcome compaction-provider-error compaction_provider_error
   expect_outcome content-mentions-max-turn agent_error
+  expect_outcome content-mentions-compaction-provider agent_error
   expect_outcome unexpected-status unexpected:interrupted
   expect_outcome missing-status unexpected:missing
   expect_outcome envelope-max-turns max_turns_exhausted
@@ -626,6 +655,11 @@ case "${outcome}" in
     sed -n '/^[[:space:]]*"error_message":/p' "${response_log}" >&2 || true
     printf 'gents request %s reached the %s-turn limit; trajectory=%s\n' \
       "${request_id}" "${GENTS_MAX_TURNS}" "${trajectory_path}"
+    ;;
+  compaction_provider_error)
+    echo "Gents request ${request_id} terminated because both guided and strict fallback compaction failed" >&2
+    sed -n '/^[[:space:]]*"error_message":/p' "${response_log}" >&2 || true
+    exit 1
     ;;
   agent_error)
     echo "Gents request ${request_id} terminated with an error response" >&2

--- a/scripts/harbor/run_gents.sh
+++ b/scripts/harbor/run_gents.sh
@@ -205,8 +205,23 @@ fi
 : "${GENTS_COMMAND_TIMEOUT_SECS:=600}"
 : "${GENTS_COMMAND_TIMEOUT_MAX_SECS:=3600}"
 : "${GENTS_SERVER_STARTUP_TIMEOUT_SECS:=300}"
+: "${GENTS_DIAGNOSTIC_TIMEOUT_SECS:=10}"
+: "${GENTS_DIAGNOSTIC_HOME_MAX_BYTES:=67108864}"
+: "${GENTS_SUPERVISION_POLL_SECS:=1}"
+: "${GENTS_LOGS_DIR:=/logs/agent}"
 
-logs_dir=/logs/agent
+for numeric_value in \
+  "${GENTS_DIAGNOSTIC_TIMEOUT_SECS}" \
+  "${GENTS_DIAGNOSTIC_HOME_MAX_BYTES}"; do
+  case "${numeric_value}" in
+    ''|*[!0-9]*|0)
+      echo "diagnostic bounds must be positive integers" >&2
+      exit 2
+      ;;
+  esac
+done
+
+logs_dir=${GENTS_LOGS_DIR}
 server_log="${logs_dir}/gents-server.log"
 init_log="${logs_dir}/gents-init.json"
 request_log="${logs_dir}/request.json"
@@ -216,7 +231,20 @@ trajectory_path="${logs_dir}/trajectory.json"
 outcome_log="${logs_dir}/gents-outcome.json"
 status_log="${logs_dir}/gents-status.json"
 profile_log="${logs_dir}/gents-profile.json"
+diagnostic_log="${logs_dir}/gents-diagnostic.json"
+server_exit_log="${logs_dir}/gents-server-exit.json"
+server_tail_log="${logs_dir}/gents-server-tail.txt"
+process_tree_log="${logs_dir}/process-tree.txt"
+final_status_log="${logs_dir}/gents-status-final.json"
+graphql_unavailable_log="${logs_dir}/graphql-unavailable.txt"
+timeline_log="${logs_dir}/partial-timeline.json"
+partial_response_log="${logs_dir}/response-partial.json"
+home_inventory_log="${logs_dir}/gents-home-inventory.txt"
+home_archive="${logs_dir}/gents-home.tar.gz"
 request_id=""
+server_pid=""
+waiter_pid=""
+diagnostics_captured=0
 
 mkdir -p "${logs_dir}"
 test -x "${GENTS_BINARY}"
@@ -272,6 +300,144 @@ start_server() {
     --command-timeout-max-secs "${GENTS_COMMAND_TIMEOUT_MAX_SECS}" \
     >>"${server_log}" 2>&1 &
   server_pid=$!
+}
+
+process_is_running() {
+  process_pid=$1
+  kill -0 "${process_pid}" >/dev/null 2>&1 || return 1
+  process_state=$(ps -o stat= -p "${process_pid}" 2>/dev/null || true)
+  case "${process_state}" in
+    Z*|*' Z'*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+run_bounded() {
+  bounded_output=$1
+  bounded_timeout=$2
+  shift 2
+  "$@" >"${bounded_output}" 2>&1 &
+  bounded_pid=$!
+  bounded_elapsed=0
+  while process_is_running "${bounded_pid}"; do
+    if [ "${bounded_elapsed}" -ge "${bounded_timeout}" ]; then
+      kill "${bounded_pid}" >/dev/null 2>&1 || true
+      sleep 1
+      kill -KILL "${bounded_pid}" >/dev/null 2>&1 || true
+      wait "${bounded_pid}" >/dev/null 2>&1 || true
+      printf '\ndiagnostic command exceeded %ss and was terminated\n' "${bounded_timeout}" >>"${bounded_output}"
+      return 124
+    fi
+    sleep 1
+    bounded_elapsed=$((bounded_elapsed + 1))
+  done
+  bounded_status=0
+  wait "${bounded_pid}" || bounded_status=$?
+  return "${bounded_status}"
+}
+
+stop_waiter() {
+  if [ -z "${waiter_pid}" ]; then
+    return
+  fi
+  if process_is_running "${waiter_pid}"; then
+    kill "${waiter_pid}" >/dev/null 2>&1 || true
+    waiter_stop_attempt=0
+    while process_is_running "${waiter_pid}" && [ "${waiter_stop_attempt}" -lt 20 ]; do
+      sleep 0.1
+      waiter_stop_attempt=$((waiter_stop_attempt + 1))
+    done
+    if process_is_running "${waiter_pid}"; then
+      kill -KILL "${waiter_pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+  wait "${waiter_pid}" >/dev/null 2>&1 || true
+  waiter_pid=""
+}
+
+record_server_exit() {
+  server_wait_status=0
+  wait "${server_pid}" || server_wait_status=$?
+  if [ "${server_wait_status}" -gt 128 ]; then
+    server_signal=$((server_wait_status - 128))
+    printf '{\n  "status": "signal",\n  "signal": %s,\n  "wait_status": %s\n}\n' \
+      "${server_signal}" "${server_wait_status}" >"${server_exit_log}"
+    server_exit_description="signal ${server_signal}"
+  else
+    printf '{\n  "status": "exit",\n  "exit_code": %s,\n  "wait_status": %s\n}\n' \
+      "${server_wait_status}" "${server_wait_status}" >"${server_exit_log}"
+    server_exit_description="exit code ${server_wait_status}"
+  fi
+  if [ -n "${request_id}" ]; then
+    printf '{\n  "outcome": "runtime_server_lost",\n  "response_status": "unavailable",\n  "max_turns": %s,\n  "request_id": "%s"\n}\n' \
+      "${GENTS_MAX_TURNS}" "${request_id}" >"${outcome_log}"
+  fi
+  server_pid=""
+}
+
+capture_diagnostics() {
+  diagnostic_reason=$1
+  if [ "${diagnostics_captured}" = "1" ]; then
+    return
+  fi
+  diagnostics_captured=1
+
+  tail -200 "${server_log}" >"${server_tail_log}" 2>&1 || true
+  ps -ef >"${process_tree_log}" 2>&1 || printf 'process-tree snapshot unavailable\n' >"${process_tree_log}"
+
+  graphql_available=false
+  if run_bounded "${final_status_log}" "${GENTS_DIAGNOSTIC_TIMEOUT_SECS}" \
+    "${GENTS_BINARY}" status --home "${GENTS_HOME}"; then
+    graphql_available=true
+    rm -f "${graphql_unavailable_log}"
+  else
+    printf 'GraphQL unavailable while capturing diagnostics; see %s\n' "${final_status_log}" \
+      >"${graphql_unavailable_log}"
+  fi
+
+  if [ -n "${request_id}" ]; then
+    if run_bounded "${partial_response_log}" "${GENTS_DIAGNOSTIC_TIMEOUT_SECS}" \
+      "${GENTS_BINARY}" response show --home "${GENTS_HOME}" --request-id "${request_id}"; then
+      if [ ! -s "${response_log}" ]; then
+        cp "${partial_response_log}" "${response_log}"
+      fi
+    fi
+    run_bounded "${timeline_log}" "${GENTS_DIAGNOSTIC_TIMEOUT_SECS}" \
+      "${GENTS_BINARY}" trace timeline --home "${GENTS_HOME}" --request-id "${request_id}" || true
+    if [ ! -s "${trajectory_path}" ]; then
+      run_bounded "${logs_dir}/partial-atif-export.log" "${GENTS_DIAGNOSTIC_TIMEOUT_SECS}" \
+        "${GENTS_BINARY}" trace project \
+        --home "${GENTS_HOME}" \
+        --request-id "${request_id}" \
+        --projection atif \
+        --format native-json \
+        --output-file "${trajectory_path}" || true
+    fi
+  fi
+
+  if [ -d "${GENTS_HOME}" ]; then
+    find "${GENTS_HOME}" -type f -exec ls -ln {} \; 2>&1 |
+      sed -n '1,2000p' >"${home_inventory_log}" || true
+    home_kib=$(du -sk "${GENTS_HOME}" 2>/dev/null | sed -n 's/^[[:space:]]*\([0-9][0-9]*\).*/\1/p' || true)
+    case "${home_kib}" in
+      ''|*[!0-9]*) home_kib=0 ;;
+    esac
+    home_archive_limit_kib=$(((GENTS_DIAGNOSTIC_HOME_MAX_BYTES + 1023) / 1024))
+    if [ "${home_kib}" -le "${home_archive_limit_kib}" ]; then
+      home_parent=$(dirname "${GENTS_HOME}")
+      home_name=$(basename "${GENTS_HOME}")
+      run_bounded "${logs_dir}/gents-home-archive.log" "${GENTS_DIAGNOSTIC_TIMEOUT_SECS}" \
+        tar -czf "${home_archive}" -C "${home_parent}" "${home_name}" || true
+    else
+      printf 'GENTS_HOME is %s KiB; archive limit is %s bytes\n' \
+        "${home_kib}" "${GENTS_DIAGNOSTIC_HOME_MAX_BYTES}" \
+        >"${logs_dir}/gents-home-archive-skipped.txt"
+    fi
+  fi
+
+  printf '{\n  "reason": "%s",\n  "request_id": "%s",\n  "graphql_available": %s,\n  "home_archive_limit_bytes": %s\n}\n' \
+    "${diagnostic_reason}" "${request_id}" "${graphql_available}" \
+    "${GENTS_DIAGNOSTIC_HOME_MAX_BYTES}" >"${diagnostic_log}"
 }
 
 wait_for_server_ready() {
@@ -345,18 +511,16 @@ start_server
 cleanup() {
   exit_code=$?
   trap - EXIT INT TERM
-  if [ -n "${request_id}" ] && [ ! -s "${trajectory_path}" ] && \
-    kill -0 "${server_pid}" >/dev/null 2>&1; then
-    "${GENTS_BINARY}" trace project \
-      --home "${GENTS_HOME}" \
-      --request-id "${request_id}" \
-      --projection atif \
-      --format native-json \
-      --output-file "${trajectory_path}" \
-      >/dev/null 2>&1 || true
+  stop_waiter
+  if [ "${exit_code}" -ne 0 ] && [ "${diagnostics_captured}" != "1" ]; then
+    capture_diagnostics "runner_exit"
+  elif [ -n "${request_id}" ] && [ ! -s "${trajectory_path}" ]; then
+    capture_diagnostics "partial_trace"
   fi
-  kill "${server_pid}" >/dev/null 2>&1 || true
-  wait "${server_pid}" >/dev/null 2>&1 || true
+  if [ -n "${server_pid}" ]; then
+    kill "${server_pid}" >/dev/null 2>&1 || true
+    wait "${server_pid}" >/dev/null 2>&1 || true
+  fi
   exit "${exit_code}"
 }
 trap cleanup EXIT
@@ -403,7 +567,33 @@ fi
   --request-id "${request_id}" \
   --timeout-secs "${GENTS_REQUEST_TIMEOUT_SECS}" \
   --poll-secs 1 \
-  >"${response_log}"
+  >"${response_log}" 2>"${logs_dir}/response-wait.stderr.log" &
+waiter_pid=$!
+
+while process_is_running "${waiter_pid}"; do
+  if ! process_is_running "${server_pid}"; then
+    record_server_exit
+    stop_waiter
+    capture_diagnostics "server_lost_during_request"
+    echo "Gents server exited during active request (${server_exit_description}); waiter cancelled; diagnostics=${diagnostic_log}" >&2
+    exit 70
+  fi
+  sleep "${GENTS_SUPERVISION_POLL_SECS}"
+done
+
+waiter_status=0
+wait "${waiter_pid}" || waiter_status=$?
+waiter_pid=""
+if ! process_is_running "${server_pid}"; then
+  record_server_exit
+  capture_diagnostics "server_lost_during_request"
+  echo "Gents server exited during active request (${server_exit_description}); diagnostics=${diagnostic_log}" >&2
+  exit 70
+fi
+if [ "${waiter_status}" -ne 0 ]; then
+  echo "Gents response waiter exited with status ${waiter_status}" >&2
+  exit "${waiter_status}"
+fi
 
 "${GENTS_BINARY}" trace project \
   --home "${GENTS_HOME}" \

--- a/scripts/harbor/test_gents_agent.py
+++ b/scripts/harbor/test_gents_agent.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -129,6 +131,154 @@ class PopulateContextPostRunTest(unittest.TestCase):
         self.assertIsNone(gents.get("outcome"))
         self.assertIs(gents.get("budget_exhausted"), False)
         self.assertEqual(gents.get("terminal_error"), _MAX_TURN_ERROR)
+
+    def test_server_loss_metadata_survives_without_atif(self) -> None:
+        gents = self._run(
+            {
+                "request.json": {"request_id": "req-lost"},
+                "gents-outcome.json": {"outcome": "runtime_server_lost"},
+                "gents-diagnostic.json": {
+                    "reason": "server_lost_during_request",
+                    "graphql_available": False,
+                },
+                "gents-server-exit.json": {
+                    "status": "signal",
+                    "signal": 9,
+                    "wait_status": 137,
+                },
+            }
+        )
+        self.assertEqual(gents.get("request_id"), "req-lost")
+        self.assertEqual(gents.get("failure_origin"), "gents_server")
+        self.assertIs(gents.get("diagnostic_graphql_available"), False)
+        self.assertEqual((gents.get("server_exit") or {}).get("signal"), 9)
+
+
+class RunnerSupervisionTest(unittest.TestCase):
+    def test_server_signal_cancels_waiter_and_preserves_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            logs = root / "logs"
+            home = root / "home"
+            instruction = root / "instruction.md"
+            fake_gents = root / "gents"
+            instruction.write_text("finish the task")
+            fake_gents.write_text(_FAKE_GENTS)
+            fake_gents.chmod(0o755)
+
+            env = {
+                **os.environ,
+                "GENTS_BINARY": str(fake_gents),
+                "GENTS_HOME": str(home),
+                "GENTS_INSTRUCTION_FILE": str(instruction),
+                "GENTS_INFERENCE_URL": "http://127.0.0.1:8000/v1",
+                "GENTS_MODEL": "fake-model",
+                "GENTS_TOOL_ROOT": str(root),
+                "GENTS_LOGS_DIR": str(logs),
+                "GENTS_SERVER_STARTUP_TIMEOUT_SECS": "5",
+                "GENTS_DIAGNOSTIC_TIMEOUT_SECS": "2",
+                "GENTS_SUPERVISION_POLL_SECS": "0.05",
+            }
+            result = subprocess.run(
+                ["sh", str(_REPO_ROOT / "scripts/harbor/run_gents.sh")],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 70, result.stderr)
+            self.assertIn(
+                "Gents server exited during active request (signal 15)", result.stderr
+            )
+            self.assertTrue((home / "waiter-cancelled").is_file())
+            self.assertEqual(
+                json.loads((logs / "gents-server-exit.json").read_text())["signal"],
+                15,
+            )
+            diagnostic = json.loads((logs / "gents-diagnostic.json").read_text())
+            self.assertEqual(diagnostic["reason"], "server_lost_during_request")
+            self.assertIs(diagnostic["graphql_available"], False)
+            self.assertTrue((logs / "graphql-unavailable.txt").is_file())
+            self.assertGreater((logs / "gents-server-tail.txt").stat().st_size, 0)
+            self.assertGreater((logs / "process-tree.txt").stat().st_size, 0)
+            self.assertGreater((logs / "gents-home-inventory.txt").stat().st_size, 0)
+            self.assertGreater((logs / "gents-home.tar.gz").stat().st_size, 0)
+            self.assertGreater((logs / "partial-timeline.json").stat().st_size, 0)
+            trajectory = json.loads((logs / "trajectory.json").read_text())
+            self.assertEqual(trajectory["trajectory_id"], "partial-trajectory")
+
+
+_FAKE_GENTS = r'''#!/usr/bin/env python3
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+args = sys.argv[1:]
+
+def option(name, default=None):
+    if name not in args:
+        return default
+    return args[args.index(name) + 1]
+
+home = Path(option("--home", os.environ.get("GENTS_HOME", "/tmp/fake-gents")))
+home.mkdir(parents=True, exist_ok=True)
+(home / "store-evidence.db").touch()
+
+if args[:1] == ["init"]:
+    print(json.dumps({"inference_profile_id": "profile-1"}, indent=2))
+elif args[:1] == ["server"]:
+    count_file = home / "server-count"
+    count = int(count_file.read_text()) + 1 if count_file.exists() else 1
+    count_file.write_text(str(count))
+    print(f"fake server start {count}", flush=True)
+    if count == 1:
+        while True:
+            time.sleep(1)
+    while not (home / "waiter-started").exists():
+        time.sleep(0.01)
+    time.sleep(0.05)
+    (home / "server-lost").write_text("signal 15")
+    os.kill(os.getpid(), signal.SIGTERM)
+elif args[:3] == ["config", "profile", "set"]:
+    print("{}")
+elif args[:1] == ["status"]:
+    if (home / "server-lost").exists():
+        print("GraphQL connection refused", file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps({"process_state": "ready", "behavior_readiness": "ready"}, indent=2))
+elif args[:2] == ["request", "submit"]:
+    request = {"request_id": "request-1"}
+    Path(option("--output-file")).write_text(json.dumps(request, indent=2))
+    print(json.dumps(request, indent=2))
+elif args[:2] == ["response", "wait"]:
+    (home / "waiter-started").touch()
+    def cancelled(_signum, _frame):
+        (home / "waiter-cancelled").touch()
+        sys.exit(143)
+    signal.signal(signal.SIGTERM, cancelled)
+    while True:
+        time.sleep(1)
+elif args[:2] == ["response", "show"]:
+    print("GraphQL connection refused", file=sys.stderr)
+    sys.exit(1)
+elif args[:2] == ["trace", "timeline"]:
+    print(json.dumps({"request_id": "request-1", "events": [{"kind": "partial"}]}))
+elif args[:2] == ["trace", "project"]:
+    trajectory = {
+        "trajectory_id": "partial-trajectory",
+        "session_id": "partial-session",
+        "steps": [{"step_id": "partial-step"}],
+    }
+    Path(option("--output-file")).write_text(json.dumps(trajectory))
+else:
+    print(f"unsupported fake gents invocation: {args}", file=sys.stderr)
+    sys.exit(2)
+'''
 
 
 if __name__ == "__main__":

--- a/scripts/harbor/test_gents_agent.py
+++ b/scripts/harbor/test_gents_agent.py
@@ -153,6 +153,20 @@ class PopulateContextPostRunTest(unittest.TestCase):
         self.assertIs(gents.get("diagnostic_graphql_available"), False)
         self.assertEqual((gents.get("server_exit") or {}).get("signal"), 9)
 
+    def test_compaction_provider_failure_has_distinct_origin(self) -> None:
+        gents = self._run(
+            {
+                "request.json": {"request_id": "req-compaction"},
+                "gents-outcome.json": {"outcome": "compaction_provider_error"},
+                "response.json": {
+                    "status": "error",
+                    "error_message": "compaction_provider_failure: guided and fallback output failed",
+                },
+            }
+        )
+        self.assertEqual(gents.get("outcome"), "compaction_provider_error")
+        self.assertEqual(gents.get("failure_origin"), "compaction_provider")
+
 
 class RunnerSupervisionTest(unittest.TestCase):
     def test_server_signal_cancels_waiter_and_preserves_diagnostics(self) -> None:


### PR DESCRIPTION
## What changed

- bound managed foreground-process capture draining so a noisy command cannot wedge Terminal-Bench execution after exit
- retain useful request and server diagnostics when the Harbor agent loses its server process
- recover from repeated guided structured-output failures with one strict non-guided JSON fallback
- raise the independent compaction summary output budget from 4,096 to the existing validated 32,768-token ceiling
- preserve the parent reasoning profile for guided compaction and its fallback, with explicit regression coverage

## Why

The targeted Terminal-Bench 2.1 regression exposed both harness hangs and a dominant compaction failure mode on DeepSeek V4 Flash. In the prior six-task run, four trials terminated as compaction-provider infrastructure errors. The model was inheriting max reasoning while the internal summary completion had only 4,096 output tokens, producing EOF-truncated JSON or no usable visible output.

The runtime changes keep compaction bounded and diagnostic while giving the inherited reasoning profile enough output room to produce its structured continuation checkpoint.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- focused guided/fallback and independent-output-budget compaction tests
- `CARGO_INCREMENTAL=0 cargo test -p gents compaction::tests` (63 passed, 1 ignored)
- `CARGO_INCREMENTAL=0 cargo test -p gents`
- `CARGO_INCREMENTAL=0 cargo check --workspace --all-targets`
- exact Linux/amd64 release build at `fa899256` on studio-2

## Benchmark status

A fresh six-task, c=6 targeted regression is currently running on studio-2 against workstation-1 DSV4F as `gents-d4f-fa899256-compaction32k-targeted-c6-v2`. All six tasks have entered inference. This PR stays draft until the targeted compaction-heavy run is evaluated.

Tracks #1031 and #1032. Related configurability follow-up: #719.
