### PR TITLE
test(cli): align p2p template fences with mobile sync collections

### DIFF
--- a/crates/gents-cli/src/commands/p2p/templates.rs
+++ b/crates/gents-cli/src/commands/p2p/templates.rs
@@ -172,7 +172,10 @@ mod tests {
         let row = rows.iter().find(|r| r.id == "conversation").unwrap();
         assert_eq!(row.delivery, "push");
         assert_eq!(row.scope, "per-collection");
-        assert_eq!(row.collections.split(',').count(), 9);
+        let collections = row.collections.split(',').collect::<Vec<_>>();
+        assert_eq!(collections.len(), 15);
+        assert!(collections.contains(&"AgentRequest"));
+        assert!(collections.contains(&"InferenceBackend"));
     }
 
     #[test]
@@ -182,10 +185,11 @@ mod tests {
         assert_eq!(row.delivery, "push");
         assert_eq!(row.scope, "per-collection");
         let collections = row.collections.split(',').collect::<Vec<_>>();
-        assert_eq!(collections.len(), 11);
+        assert_eq!(collections.len(), 17);
         assert!(collections.contains(&"BearerPairingReady"));
         assert!(collections.contains(&"AgentDirectoryEntry"));
         assert!(collections.contains(&"PersonaConfigRequest"));
+        assert!(collections.contains(&"Skill"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Main has been red since fe50352d (#1039): `rust-and-cli (cli)` fails on
`conversation_row_is_push_per_collection` and
`machine_row_adds_directory_to_complete_conversation_projection`.

4c4ec1f1 added six config control-plane collections to the conversation and
machine templates and updated the runtime catalog tests, but missed the CLI
projection fences in `commands/p2p/templates.rs`, which still asserted the
old counts (9/11 vs the new 15/17).

This updates the CLI fences to the new catalog shape and asserts a
representative added collection in each (`InferenceBackend`, `Skill`).

## Testing

- `cargo test -q -p gents-cli --lib p2p::templates` — 8 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)