### PR TITLE
fix(personas): ceiling-filter workspace roots at catalog + admission (#1051)

### DIFF
--- a/crates/gents/src/agent/directory_projection.rs
+++ b/crates/gents/src/agent/directory_projection.rs
@@ -363,9 +363,10 @@ pub async fn reconcile_directory_tick(
 pub async fn run_directory_projection(
     node: Arc<EmbeddedNode>,
     source_did: String,
+    ceiling_root: Option<std::path::PathBuf>,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let store = GraphqlDirectoryStore::new(node.clone());
+    let store = GraphqlDirectoryStore::new(node.clone(), ceiling_root);
     let mut subscription = node.subscribe(&[EventName::Update]);
     let mut interval =
         tokio::time::interval(crate::agent::p2p_reconcile::intervals::sweep_interval());
@@ -418,11 +419,14 @@ async fn sweep_directory(store: &GraphqlDirectoryStore, source_did: &str) {
 // tie-in) — this is the only reason it needs to be more than module-private.
 pub(crate) struct GraphqlDirectoryStore {
     node: Arc<EmbeddedNode>,
+    /// Operator tool-root ceiling (`--tool-root`); see
+    /// [`filter_roots_to_ceiling`].
+    ceiling_root: Option<std::path::PathBuf>,
 }
 
 impl GraphqlDirectoryStore {
-    pub(crate) fn new(node: Arc<EmbeddedNode>) -> Self {
-        Self { node }
+    pub(crate) fn new(node: Arc<EmbeddedNode>, ceiling_root: Option<std::path::PathBuf>) -> Self {
+        Self { node, ceiling_root }
     }
 }
 
@@ -494,7 +498,7 @@ impl DirectoryStore for GraphqlDirectoryStore {
             behaviors: parse_behaviors(&response)?,
             runtimes: parse_runtime_states(&response)?,
             selections: parse_tool_selections(&response)?,
-            options: parse_catalog_options(&response)?,
+            options: parse_catalog_options(&response, self.ceiling_root.as_deref())?,
         })
     }
 
@@ -921,7 +925,38 @@ fn render_profile_params_json(
     format!("{{{}}}", fields.join(","))
 }
 
-fn parse_catalog_options(response: &QueryResponse) -> Result<CatalogOptions> {
+/// Keep only workspace roots inside the operator tool-root ceiling
+/// (`gents server --tool-root`). The serve-time guard in
+/// `tool_surface::build` refuses any behavior whose file tool root escapes
+/// the ceiling, so publishing such a root in the catalog — or admitting it
+/// into a persona — mints admitted-yet-unusable config (#1051). Resolution
+/// mirrors the guard exactly (`resolve_configured_tool_root` +
+/// `starts_with`); a root (or ceiling) that fails to resolve is dropped,
+/// fail-closed: never offer what the guard may refuse.
+pub(crate) fn filter_roots_to_ceiling(
+    roots: Vec<String>,
+    ceiling_root: Option<&std::path::Path>,
+) -> Vec<String> {
+    let Some(ceiling) = ceiling_root else {
+        return roots;
+    };
+    let Ok(ceiling) = crate::tool_surface::resolve_configured_tool_root(ceiling) else {
+        return Vec::new();
+    };
+    roots
+        .into_iter()
+        .filter(|root| {
+            crate::tool_surface::resolve_configured_tool_root(std::path::Path::new(root))
+                .map(|resolved| resolved.starts_with(&ceiling))
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
+fn parse_catalog_options(
+    response: &QueryResponse,
+    ceiling_root: Option<&std::path::Path>,
+) -> Result<CatalogOptions> {
     // Backend rows always carry `enabled` (backend_registry treats it as
     // required on decode), so the conservative null-means-disabled default
     // here is a dead branch — deliberately stricter than `parse_behaviors`'
@@ -943,11 +978,14 @@ fn parse_catalog_options(response: &QueryResponse) -> Result<CatalogOptions> {
     available_models.sort();
     available_models.dedup();
 
-    let mut allowed_roots: Vec<String> = rows::<WorkspaceRootRow>(response, "WorkspaceRoot")?
-        .into_iter()
-        .filter(|row| row.enabled.unwrap_or(false))
-        .filter_map(|row| row.root_path)
-        .collect();
+    let mut allowed_roots: Vec<String> = filter_roots_to_ceiling(
+        rows::<WorkspaceRootRow>(response, "WorkspaceRoot")?
+            .into_iter()
+            .filter(|row| row.enabled.unwrap_or(false))
+            .filter_map(|row| row.root_path)
+            .collect(),
+        ceiling_root,
+    );
     allowed_roots.sort();
 
     // Sort pairs first, then split (mirrors how `behaviors`/`behavior_ids`
@@ -1132,6 +1170,33 @@ struct DirectoryRow {
 
 #[cfg(test)]
 mod tests {
+    use super::filter_roots_to_ceiling;
+
+    #[test]
+    fn ceiling_filter_matrix() {
+        let roots = vec![
+            "/ceil/ws/app".to_string(),
+            "/ceil/ws".to_string(),
+            "/ceil/wsx/app".to_string(),
+            "/outside/app".to_string(),
+        ];
+
+        // No ceiling: untouched.
+        assert_eq!(
+            filter_roots_to_ceiling(roots.clone(), None),
+            roots,
+            "no ceiling must publish every enabled root"
+        );
+
+        // Component-wise containment: "/ceil/wsx" is NOT within "/ceil/ws"
+        // (the sibling-prefix trap a string prefix check would fall into).
+        assert_eq!(
+            filter_roots_to_ceiling(roots, Some(std::path::Path::new("/ceil/ws"))),
+            vec!["/ceil/ws/app".to_string(), "/ceil/ws".to_string()],
+            "only roots within the ceiling (incl. the ceiling itself) survive"
+        );
+    }
+
     use super::*;
 
     fn entry(agent_did: &str, last_seen: &str) -> DirectoryEntry {
@@ -1442,7 +1507,7 @@ mod tests {
         let response = node.execute(&seed).await;
         ensure_no_errors(&response, "seed runtime-format updated_at")?;
 
-        let store = GraphqlDirectoryStore::new(node.clone());
+        let store = GraphqlDirectoryStore::new(node.clone(), None);
         let first = reconcile_directory_tick(&store, "did:key:home").await?;
         assert_eq!(first.upserted, BTreeSet::from(["did:key:real".to_string()]));
 
@@ -1578,7 +1643,7 @@ mod tests {
         let response = node.execute(seed).await;
         ensure_no_errors(&response, "seed directory projection principals")?;
 
-        let store = GraphqlDirectoryStore::new(node.clone());
+        let store = GraphqlDirectoryStore::new(node.clone(), None);
         let outcome = reconcile_directory_tick(&store, "did:key:home").await?;
         assert_eq!(
             outcome.upserted,
@@ -1757,7 +1822,7 @@ mod source_partition_regression_tests {
             "seed same-DID source partitions",
         )?;
 
-        let store = GraphqlDirectoryStore::new(node.clone());
+        let store = GraphqlDirectoryStore::new(node.clone(), None);
         let first = reconcile_directory_tick(&store, local_source).await?;
         assert_eq!(first.upserted, BTreeSet::from([agent_did.to_string()]));
         assert_eq!(

--- a/crates/gents/src/agent/p2p_reconcile/persona_requests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/persona_requests.rs
@@ -160,9 +160,10 @@ async fn process_one_request(
 
 pub async fn run_persona_request_reconciler(
     node: Arc<EmbeddedNode>,
+    ceiling_root: Option<std::path::PathBuf>,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let store = GraphqlPersonaRequestStore::new(node.clone());
+    let store = GraphqlPersonaRequestStore::with_ceiling(node.clone(), ceiling_root);
     let mut subscription = node.subscribe(&[EventName::Update]);
     let mut interval = tokio::time::interval(super::intervals::sweep_interval());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -210,11 +211,25 @@ async fn sweep_persona_requests(store: &GraphqlPersonaRequestStore, node: &Arc<E
 
 pub struct GraphqlPersonaRequestStore {
     node: Arc<EmbeddedNode>,
+    /// Operator tool-root ceiling (`--tool-root`); see
+    /// `directory_projection::filter_roots_to_ceiling`. `None` when the
+    /// caller has no ceiling in scope (e.g. the self-config tool's read-only
+    /// `list`): admission always runs against the reconciler's own
+    /// ceiling-aware store, so a `None` here can never admit an unusable
+    /// root.
+    ceiling_root: Option<std::path::PathBuf>,
 }
 
 impl GraphqlPersonaRequestStore {
     pub fn new(node: Arc<EmbeddedNode>) -> Self {
-        Self { node }
+        Self {
+            node,
+            ceiling_root: None,
+        }
+    }
+
+    pub fn with_ceiling(node: Arc<EmbeddedNode>, ceiling_root: Option<std::path::PathBuf>) -> Self {
+        Self { node, ceiling_root }
     }
 }
 
@@ -252,7 +267,7 @@ impl PersonaRequestStore for GraphqlPersonaRequestStore {
     }
 
     async fn load_catalog_view(&self, agent_did: &str) -> Result<PersonaCatalogView> {
-        load_catalog_view_from_node(&self.node, agent_did).await
+        load_catalog_view_from_node(&self.node, agent_did, self.ceiling_root.as_deref()).await
     }
 
     async fn mark_applied(&self, request_key: &str, behavior_id: &str) -> Result<()> {
@@ -286,6 +301,7 @@ impl PersonaRequestStore for GraphqlPersonaRequestStore {
 async fn load_catalog_view_from_node(
     node: &Arc<EmbeddedNode>,
     agent_did: &str,
+    ceiling_root: Option<&std::path::Path>,
 ) -> Result<PersonaCatalogView> {
     let escaped_agent_did = escape_graphql_string(agent_did);
     let query = format!(
@@ -340,10 +356,20 @@ async fn load_catalog_view_from_node(
             })
             .collect();
 
-    let allowed_roots: BTreeSet<String> = rows::<WorkspaceRootRow>(&response, "WorkspaceRoot")?
+    // Ceiling-filtered through the same predicate the directory catalog
+    // publishes with, so admission can never admit a root the serve-time
+    // guard would refuse (#1051): the `root ∈ allowed_roots` conjunct
+    // enforces the operator ceiling for free.
+    let allowed_roots: BTreeSet<String> =
+        crate::agent::directory_projection::filter_roots_to_ceiling(
+            rows::<WorkspaceRootRow>(&response, "WorkspaceRoot")?
+                .into_iter()
+                .filter(|row| row.enabled.unwrap_or(false))
+                .filter_map(|row| row.root_path)
+                .collect(),
+            ceiling_root,
+        )
         .into_iter()
-        .filter(|row| row.enabled.unwrap_or(false))
-        .filter_map(|row| row.root_path)
         .collect();
 
     let available_profile_ids: BTreeSet<String> =
@@ -955,7 +981,7 @@ mod tests {
         // materialized persona.
         use crate::agent::directory_projection::DirectoryStore as _;
         let directory_store =
-            crate::agent::directory_projection::GraphqlDirectoryStore::new(node.clone());
+            crate::agent::directory_projection::GraphqlDirectoryStore::new(node.clone(), None);
         let directory_source_did = "did:key:home";
         let directory_outcome = crate::agent::directory_projection::reconcile_directory_tick(
             &directory_store,
@@ -973,6 +999,89 @@ mod tests {
         assert!(entry.behaviors.contains(&"Research Assistant".to_string()));
         assert!(entry.behavior_ids.contains(&behavior_id.to_string()));
 
+        Ok(())
+    }
+
+    /// #1051: the reconciler's catalog view is ceiling-filtered, so the
+    /// `root ∈ allowed_roots` conjunct rejects a root the serve-time
+    /// operator-ceiling guard would refuse — a persona can no longer be
+    /// admitted-yet-unusable.
+    #[tokio::test]
+    async fn ceiling_filtered_view_rejects_out_of_ceiling_root() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let node = build_node(&tempdir).await;
+
+        let seed = r#"mutation {
+            create_AgentPrincipal(input: {
+                agent_did: "did:key:ceiling-agent",
+                display_name: "Ceiling Agent",
+                enabled: true,
+                created_at: "2026-08-06T00:00:00Z"
+            }) { _docID }
+            create_InferenceBackend(input: {
+                backend_id: "openai",
+                name: "OpenAI",
+                enabled: true,
+                models: ["gpt-5"]
+            }) { _docID }
+            create_InferenceProfile(input: {
+                profile_id: "profile-1",
+                display_name: "Fast"
+            }) { _docID }
+            create_WorkspaceRoot(input: {
+                root_path: "/ceil/ws/inside",
+                display_name: "inside",
+                enabled: true
+            }) { _docID }
+            create_WorkspaceRoot(input: {
+                root_path: "/outside/app",
+                display_name: "outside",
+                enabled: true
+            }) { _docID }
+        }"#;
+        ensure_no_errors(&node.execute(seed).await, "seed ceiling fixtures")?;
+
+        let store = GraphqlPersonaRequestStore::with_ceiling(
+            node.clone(),
+            Some(std::path::PathBuf::from("/ceil/ws")),
+        );
+        let catalog = store.load_catalog_view("did:key:ceiling-agent").await?;
+        assert!(
+            catalog.allowed_roots.contains("/ceil/ws/inside"),
+            "in-ceiling root must stay published"
+        );
+        assert!(
+            !catalog.allowed_roots.contains("/outside/app"),
+            "out-of-ceiling root must never enter the admission set"
+        );
+
+        let doc = PersonaRequestDoc {
+            request_key: "pcr-ceiling".to_string(),
+            requester_did: "did:key:phone".to_string(),
+            agent_did: "did:key:ceiling-agent".to_string(),
+            op_raw: "create".to_string(),
+            op: Some(PersonaOp::Create { clone_from: None }),
+            behavior_id: None,
+            persona_name: Some("Escapee".to_string()),
+            backend_model: Some("openai|gpt-5".to_string()),
+            root: Some("/outside/app".to_string()),
+            preset: Some("readonly".to_string()),
+            profile_id: Some("profile-1".to_string()),
+            created_at: None,
+            status: Some("pending".to_string()),
+            status_detail: None,
+            applied_behavior_id: None,
+            processed_at: None,
+        };
+        match crate::agent::persona_ops::decide_persona_request(&doc, &catalog) {
+            crate::agent::persona_ops::PersonaVerdict::Reject(detail) => {
+                assert!(
+                    detail.contains("/outside/app"),
+                    "rejection must name the offending root: {detail}"
+                );
+            }
+            verdict => panic!("out-of-ceiling root must be rejected, got {verdict:?}"),
+        }
         Ok(())
     }
 }

--- a/crates/gents/src/agent/runtime/startup.rs
+++ b/crates/gents/src/agent/runtime/startup.rs
@@ -456,11 +456,16 @@ pub(in crate::agent) async fn run_agent(
     });
 
     let persona_request_node = agent.node.clone();
+    let persona_request_ceiling = agent
+        .document_runtime_context()
+        .and_then(|context| context.tool_ceiling.root())
+        .map(std::path::Path::to_path_buf);
     let persona_request_cancel = cancel.child_token();
     background_tasks.spawn(async move {
         BackgroundTaskResult::PersonaRequestReconcile(
             crate::agent::p2p_reconcile::run_persona_request_reconciler(
                 persona_request_node,
+                persona_request_ceiling,
                 persona_request_cancel,
             )
             .await,
@@ -483,12 +488,17 @@ pub(in crate::agent) async fn run_agent(
 
     let directory_node = agent.node.clone();
     let directory_source_did = agent.agent_did().to_string();
+    let directory_ceiling = agent
+        .document_runtime_context()
+        .and_then(|context| context.tool_ceiling.root())
+        .map(std::path::Path::to_path_buf);
     let directory_cancel = cancel.child_token();
     background_tasks.spawn(async move {
         BackgroundTaskResult::DirectoryProjection(
             crate::agent::directory_projection::run_directory_projection(
                 directory_node,
                 directory_source_did,
+                directory_ceiling,
                 directory_cancel,
             )
             .await,

--- a/crates/gents/src/tool_surface/build.rs
+++ b/crates/gents/src/tool_surface/build.rs
@@ -266,7 +266,7 @@ pub(super) fn resolve_effective_tool_root(
     }
 }
 
-pub(super) fn resolve_configured_tool_root(path: &Path) -> Result<PathBuf> {
+pub(crate) fn resolve_configured_tool_root(path: &Path) -> Result<PathBuf> {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {

--- a/crates/gents/src/tool_surface/mod.rs
+++ b/crates/gents/src/tool_surface/mod.rs
@@ -7,6 +7,7 @@ mod runtime_context;
 mod selection;
 
 pub use behavior_config::BehaviorToolConfig;
+pub(crate) use build::resolve_configured_tool_root;
 pub use explain::{ToolSurfaceExplanation, ToolSurfaceWarning};
 pub use modes::{BashMode, FileToolMode, ToolCeiling};
 pub use policy::{


### PR DESCRIPTION
Closes the admitted-yet-unusable seam from #1051: a persona could pick a workspace root the catalog published and admission accepted, then fail at serve time with `escapes operator tool root` because `--tool-root` is a separate confinement mechanism the persona pipeline never consulted.

## Fix
One shared predicate — `directory_projection::filter_roots_to_ceiling` — mirroring the serve-time guard's exact semantics (`resolve_configured_tool_root` + component-wise `starts_with`, fail-closed on unresolvable paths), applied at both loaders:
- The directory projection's `allowed_roots` publication: clients are never offered a root the runtime would refuse.
- The persona reconciler's `PersonaCatalogView`: the existing `root ∈ allowed_roots` admission conjunct now enforces the ceiling for free, rejecting with the standard named-value `status_detail`.

Ceiling threads from `DocumentResolveContext.tool_ceiling.root()` at both background-task spawn sites; no ceiling (`None`) behaves exactly as before. No schema changes, no Lean changes (the conjunct set is unchanged — only the set it validates against is now consistent with the runtime).

Deliberately out of scope (noted in #1051): the CLI set-time warning (needs cross-process ceiling knowledge — likely wants the effective ceiling published on the runtime row) and deriving the ceiling from registered roots.

## Tests
Filter matrix incl. the `/ceil/ws` vs `/ceil/wsx` sibling-prefix trap (component-wise containment); embedded-node test: ceiling-aware store excludes the out-of-ceiling root from the view and admission rejects a create naming it. Full suite 1681 passed / 0 non-environmental failures; workspace all-targets check clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Arv3YzUJH1oSvYL21kekca