### PR TITLE
Capture consumers: rendered-request fact records readable once, centrally (#1066)

### DIFF
--- a/apps/gents-desktop/tests/request-trace.test.tsx
+++ b/apps/gents-desktop/tests/request-trace.test.tsx
@@ -28,6 +28,16 @@ describe("request trace panel", () => {
             content: "hi",
             timestamp: "2026-06-03T14:05:00Z",
           },
+          {
+            kind: "rendered_request",
+            capture_key: "rendered:v1:abc",
+            capture_scope: "inference.1",
+            turn_index: 0,
+            attempt: 1,
+            model_name: "gpt-5",
+            provenance_status: "captured_only",
+            created_at: "2026-06-03T14:05:01Z",
+          },
           { kind: "tool_call", tool_name: "gents_exec", lifecycle_state: "Completed" },
           { kind: "response", status: "materialized" },
         ],
@@ -36,6 +46,9 @@ describe("request trace panel", () => {
     render(<RequestTracePanel agentDid="did:a" rootRequestId="req-1" />);
 
     await waitFor(() => expect(screen.getByText("user: hi")).toBeInTheDocument());
+    expect(
+      screen.getByText("captured inference.1 — turn 0 attempt 1 — gpt-5 — captured_only"),
+    ).toBeInTheDocument();
     expect(screen.getByText("gents_exec — Completed")).toBeInTheDocument();
     expect(screen.getByText("materialized")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy JSON" })).toBeInTheDocument();
@@ -76,5 +89,20 @@ describe("request trace panel", () => {
       eventTimestamp({ kind: "tool_call", started_at: "2026-01-01T00:00:00Z" }),
     ).toBe("2026-01-01T00:00:00Z");
     expect(eventTimestamp({ kind: "response" })).toBeNull();
+    expect(
+      eventSummary({
+        kind: "rendered_request",
+        capture_scope: "compaction.2",
+        turn_index: 1,
+        attempt: 0,
+        provenance_status: "unsupported_manifest",
+      }),
+    ).toBe("captured compaction.2 — turn 1 attempt 0 — unsupported_manifest");
+    expect(
+      eventTimestamp({
+        kind: "rendered_request",
+        created_at: "2026-08-07T12:00:02Z",
+      }),
+    ).toBe("2026-08-07T12:00:02Z");
   });
 });

--- a/apps/gents-desktop/tests/request-trace.test.tsx
+++ b/apps/gents-desktop/tests/request-trace.test.tsx
@@ -47,7 +47,9 @@ describe("request trace panel", () => {
 
     await waitFor(() => expect(screen.getByText("user: hi")).toBeInTheDocument());
     expect(
-      screen.getByText("captured inference.1 — turn 0 attempt 1 — gpt-5 — captured_only"),
+      screen.getByText(
+        "captured inference.1 — turn 0 attempt 1 — gpt-5 — captured_only",
+      ),
     ).toBeInTheDocument();
     expect(screen.getByText("gents_exec — Completed")).toBeInTheDocument();
     expect(screen.getByText("materialized")).toBeInTheDocument();

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -1094,6 +1094,49 @@ pub(crate) enum TraceCommand {
         about = "Print the JSON Schema for an adapter projection output"
     )]
     ProjectSchema(TraceProjectSchemaArgs),
+    #[command(
+        name = "capture",
+        about = "Fetch rendered-request capture metadata, with the request_json field-commit CID"
+    )]
+    Capture(TraceCaptureArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct TraceCaptureArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.gents")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint to read instead of local home state")]
+    pub(crate) graphql: Option<String>,
+    #[arg(
+        long = "capture-key",
+        conflicts_with = "request_id",
+        help = "Fetch one capture by its unique capture_key"
+    )]
+    pub(crate) capture_key: Option<String>,
+    #[arg(long = "request-id", help = "Fetch the captures of one request")]
+    pub(crate) request_id: Option<String>,
+    #[arg(
+        long,
+        requires = "request_id",
+        help = "Narrow to one capture scope, e.g. inference.1 or compaction.2"
+    )]
+    pub(crate) scope: Option<String>,
+    #[arg(long, requires = "request_id", help = "Narrow to one turn_index")]
+    pub(crate) turn: Option<i64>,
+    #[arg(long, requires = "request_id", help = "Narrow to one attempt")]
+    pub(crate) attempt: Option<i64>,
+    #[arg(
+        long,
+        help = "List every match as metadata instead of requiring exactly one"
+    )]
+    pub(crate) list: bool,
+    #[arg(
+        long = "include-body",
+        help = "Include request_json and the raw provenance manifest — the captured provider request body — in the output"
+    )]
+    pub(crate) include_body: bool,
+    #[arg(long = "output-file", help = "Write JSON to a file instead of stdout")]
+    pub(crate) output_file: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]

--- a/crates/gents-cli/src/commands/trace.rs
+++ b/crates/gents-cli/src/commands/trace.rs
@@ -745,11 +745,14 @@ async fn apply_projection_acp_read_filter(
         tool_calls: filtered_tool_calls,
         inference_calls: filtered_inference_calls,
         responses: filtered_responses,
-        // Fail closed: `RenderedRequest` has no ACP policy yet
-        // (defradb.rs#1318), so under an *active* ACP read scope there is no
-        // per-row decision to make — captures are dropped from the filtered
-        // timeline entirely rather than passed through unjudged.
-        rendered_requests: Vec::new(),
+        // Passed through unfiltered: ACP enforcement is DefraDB's, not this
+        // filter's. Reads executed under a requester identity return only the
+        // rows that identity may see, and an unpoliced collection is public by
+        // DefraDB's own rules. When `RenderedRequest` gains its `@policy`,
+        // rows are excluded at the database read — with nothing to change
+        // here. (This per-row decider exists only for the actor-on-behalf
+        // GraphQL path the seven families above already use.)
+        rendered_requests: rows.rendered_requests,
     })
 }
 

--- a/crates/gents-cli/src/commands/trace.rs
+++ b/crates/gents-cli/src/commands/trace.rs
@@ -31,8 +31,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::cli::args::{
-    TraceCommand, TraceExportArgs, TraceProjectArgs, TraceProjectSchemaArgs, TraceProjectionArg,
-    TraceProjectionFormatArg, TraceProjectionRedactionArg, TraceTimelineArgs,
+    TraceCaptureArgs, TraceCommand, TraceExportArgs, TraceProjectArgs, TraceProjectSchemaArgs,
+    TraceProjectionArg, TraceProjectionFormatArg, TraceProjectionRedactionArg, TraceTimelineArgs,
 };
 use crate::config_writes::ConfigAccess;
 use crate::{
@@ -46,7 +46,187 @@ pub(crate) async fn dispatch(command: TraceCommand) -> Result<()> {
         TraceCommand::Timeline(args) => trace_timeline(args).await,
         TraceCommand::Project(args) => trace_project(args).await,
         TraceCommand::ProjectSchema(args) => trace_project_schema(args),
+        TraceCommand::Capture(args) => trace_capture(args).await,
     }
+}
+
+/// Fetch rendered-request capture metadata — and, for exactly one match, its
+/// `request_json` field-commit CID. This is the one deliberate body read in
+/// the system: `--include-body` selects `request_json` and the raw provenance
+/// manifest; without it neither is even queried, and the default output is the
+/// same metadata surface the timeline exposes.
+async fn trace_capture(args: TraceCaptureArgs) -> Result<()> {
+    let (access, _home_dir) =
+        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
+
+    let mut clauses = Vec::new();
+    if let Some(capture_key) = args.capture_key.as_deref() {
+        clauses.push(format!(
+            r#"capture_key: {{ _eq: "{}" }}"#,
+            escape_graphql_string(capture_key)
+        ));
+    }
+    if let Some(request_id) = args.request_id.as_deref() {
+        clauses.push(format!(
+            r#"request_id: {{ _eq: "{}" }}"#,
+            escape_graphql_string(request_id)
+        ));
+    }
+    if clauses.is_empty() {
+        anyhow::bail!("pass --capture-key or --request-id");
+    }
+    if let Some(scope) = args.scope.as_deref() {
+        clauses.push(format!(
+            r#"capture_scope: {{ _eq: "{}" }}"#,
+            escape_graphql_string(scope)
+        ));
+    }
+    if let Some(turn) = args.turn {
+        clauses.push(format!("turn_index: {{ _eq: {turn} }}"));
+    }
+    if let Some(attempt) = args.attempt {
+        clauses.push(format!("attempt: {{ _eq: {attempt} }}"));
+    }
+
+    let body_fields = if args.include_body {
+        "\n                request_json"
+    } else {
+        ""
+    };
+    let query = format!(
+        r#"{{
+            RenderedRequest(
+                filter: {{ {filter} }},
+                order: {{ created_at: ASC }}
+            ) {{
+                _docID
+                capture_key
+                request_doc_id
+                request_id
+                session_id
+                capture_scope
+                turn_index
+                attempt
+                capture_version
+                model_name
+                source
+                prompt_hash
+                tools_hash
+                provenance_json
+                created_at{body_fields}
+            }}
+        }}"#,
+        filter = clauses.join(", "),
+    );
+    let raw_rows =
+        graphql_rows_or_empty_if_collection_missing(&access, "RenderedRequest", &query).await?;
+
+    let mut entries = raw_rows
+        .into_iter()
+        .map(|raw| {
+            let row: gents::run_timeline::TimelineRenderedRequestRow =
+                serde_json::from_value(raw.clone()).context("decoding RenderedRequest row")?;
+            Ok((row, raw))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if entries.is_empty() {
+        anyhow::bail!("no capture rows matched");
+    }
+    // Identity order: parsed numeric order key first, unparseable rows last by
+    // capture key — deterministic either way, never a lexical seq sort.
+    entries.sort_by(|(left, _), (right, _)| {
+        let left_key = capture_order_padded(left);
+        let right_key = capture_order_padded(right);
+        left_key
+            .cmp(&right_key)
+            .then_with(|| left.capture_key.cmp(&right.capture_key))
+    });
+
+    if args.list {
+        let captures = entries
+            .iter()
+            .map(|(row, raw)| capture_metadata_value(row, raw, args.include_body))
+            .collect::<Vec<_>>();
+        let value = json!({ "captures": captures });
+        return write_or_print(args.output_file.as_deref(), &value);
+    }
+
+    if entries.len() > 1 {
+        let keys = entries
+            .iter()
+            .map(|(row, _)| {
+                format!(
+                    "  {} ({} turn {} attempt {})",
+                    row.capture_key,
+                    row.capture_scope.as_deref().unwrap_or("?"),
+                    row.turn_index.map_or("?".to_string(), |t| t.to_string()),
+                    row.attempt.map_or("?".to_string(), |a| a.to_string()),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "{count} capture rows matched; narrow with --scope/--turn/--attempt or pass --list:\n{keys}",
+            count = entries.len(),
+        );
+    }
+
+    let (row, raw) = &entries[0];
+    let mut value = capture_metadata_value(row, raw, args.include_body);
+    let commit = match row.doc_id.as_deref() {
+        Some(doc_id) => gents::rendered_request::commits::request_json_commit(&access, doc_id)
+            .await?
+            .map(|commit| json!({ "cid": commit.cid, "height": commit.height })),
+        None => None,
+    };
+    value["request_json_commit"] = commit.unwrap_or_else(|| json!("unavailable"));
+    write_or_print(args.output_file.as_deref(), &value)
+}
+
+/// The metadata object for one capture row: the timeline's event derivation
+/// plus the document id, with the body fields attached only on request.
+fn capture_metadata_value(
+    row: &gents::run_timeline::TimelineRenderedRequestRow,
+    raw: &Value,
+    include_body: bool,
+) -> Value {
+    let event = gents::run_timeline::rendered_request_event(row);
+    let mut value = serde_json::to_value(&event).unwrap_or_else(|_| json!({}));
+    value["doc_id"] = json!(row.doc_id);
+    if include_body {
+        value["request_json"] = raw.get("request_json").cloned().unwrap_or(Value::Null);
+        value["provenance_json"] = json!(row.provenance_json);
+    }
+    value
+}
+
+fn capture_order_padded(row: &gents::run_timeline::TimelineRenderedRequestRow) -> String {
+    use gents_protocol::rendered_request::{CaptureOrderKey, CaptureScope};
+
+    let scope = row
+        .capture_scope
+        .as_deref()
+        .and_then(|scope| scope.parse::<CaptureScope>().ok());
+    match (scope, row.turn_index, row.attempt) {
+        (Some(scope), Some(turn_index), Some(attempt)) => CaptureOrderKey {
+            scope,
+            turn_index,
+            attempt,
+        }
+        .padded(),
+        // '~' sorts after every padded key's alphabet, pushing unparseable
+        // rows to the end.
+        _ => format!("~{}", row.capture_key),
+    }
+}
+
+fn write_or_print(output_file: Option<&std::path::Path>, value: &Value) -> Result<()> {
+    if let Some(path) = output_file {
+        write_json_output_file(path, value)?;
+    } else {
+        print_json(value)?;
+    }
+    Ok(())
 }
 
 async fn trace_timeline(args: TraceTimelineArgs) -> Result<()> {
@@ -565,6 +745,11 @@ async fn apply_projection_acp_read_filter(
         tool_calls: filtered_tool_calls,
         inference_calls: filtered_inference_calls,
         responses: filtered_responses,
+        // Fail closed: `RenderedRequest` has no ACP policy yet
+        // (defradb.rs#1318), so under an *active* ACP read scope there is no
+        // per-row decision to make — captures are dropped from the filtered
+        // timeline entirely rather than passed through unjudged.
+        rendered_requests: Vec::new(),
     })
 }
 
@@ -763,6 +948,10 @@ fn should_keep_scoped_timeline_event(
                     })
         }
         RunTimelineEvent::InferenceCall(call) => allowed_request_ids.contains(&call.request_id),
+        RunTimelineEvent::RenderedRequest(rendered) => rendered
+            .request_id
+            .as_deref()
+            .is_some_and(|request_id| allowed_request_ids.contains(request_id)),
         RunTimelineEvent::Message(message) => scoped_request_id_allowed(
             message.request_id.as_deref(),
             Some(message.session_id.as_str()),
@@ -2153,6 +2342,7 @@ mod tests {
                     ..TimelineInferenceCallRow::default()
                 },
             ],
+            rendered_requests: Vec::new(),
         }
     }
 

--- a/crates/gents-cli/tests/cli_trace_export.rs
+++ b/crates/gents-cli/tests/cli_trace_export.rs
@@ -1756,6 +1756,8 @@ async fn projection_graphql_mock(
         json!({ "data": { "AgentConversation": [projection_mock_conversation()] } })
     } else if query.contains("InferenceCall(") {
         json!({ "data": { "InferenceCall": [] } })
+    } else if query.contains("RenderedRequest(") {
+        json!({ "data": { "RenderedRequest": [] } })
     } else {
         json!({
             "errors": [{

--- a/crates/gents-cli/tests/cli_trace_export.rs
+++ b/crates/gents-cli/tests/cli_trace_export.rs
@@ -457,6 +457,235 @@ async fn trace_timeline_reconstructs_request_events_from_persisted_rows() -> Res
     Ok(())
 }
 
+/// Seed one request with two rendered-request captures (turn 0 attempts 0 and
+/// 1) carrying v3 provenance manifests with the admission join.
+async fn seed_rendered_request_rows(node: &EmbeddedNode) -> Result<()> {
+    exec(
+        node,
+        r#"mutation {
+            create_AgentRequest(input: {
+                request_id: "req-cap",
+                agent_did: "did:test:amy",
+                behavior_id: "amy",
+                session_id: "session-cap",
+                content: "capture me",
+                metadata: "",
+                status: "completed",
+                lifecycle_state: "complete",
+                backend_id: "studios-cluster",
+                failure_reason: "",
+                created_at: "2026-08-07T12:00:00Z",
+                retry_count: 0
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    for (suffix, attempt, call_id, call_seq, created_at) in [
+        ("a0", 0, "call-cap-1", 1, "2026-08-07T12:00:02Z"),
+        ("a1", 1, "call-cap-2", 2, "2026-08-07T12:00:04Z"),
+    ] {
+        let provenance = json!({
+            "manifest_version": 3,
+            "status": "captured_only",
+            "status_reason": "seeded",
+            "capture_seam": "transport_body",
+            "capture_scope": "inference.1",
+            "admission": { "call_id": call_id, "call_seq": call_seq },
+            "assembly_trace": {
+                "trace_version": 2,
+                "build_path": "budgeted",
+                "effective_message_count": 0,
+                "assistant_message_ids": [],
+                "threaded_tool_results": []
+            }
+        })
+        .to_string();
+        let request_json = json!({
+            "model": "test-model",
+            "messages": [{ "role": "user", "content": "capture me" }]
+        })
+        .to_string();
+        exec(
+            node,
+            &format!(
+                r#"mutation {{
+                    create_RenderedRequest(input: {{
+                        capture_key: "rendered:v1:seeded-{suffix}",
+                        request_doc_id: "doc-req-cap",
+                        request_id: "req-cap",
+                        session_id: "session-cap",
+                        agent_did: "did:test:amy",
+                        requester_did: "",
+                        behavior_id: "amy",
+                        capture_scope: "inference.1",
+                        turn_index: 0,
+                        attempt: {attempt},
+                        capture_version: 1,
+                        model_name: "test-model",
+                        source: "openai_chat_completions",
+                        request_json: "{request_json}",
+                        prompt_hash: "aa",
+                        tools_hash: "bb",
+                        provenance_json: "{provenance}",
+                        created_at: "{created_at}"
+                    }}) {{ _docID }}
+                }}"#,
+                request_json = gents::graphql::escape_graphql_string(&request_json),
+                provenance = gents::graphql::escape_graphql_string(&provenance),
+            ),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn trace_capture_fetches_metadata_with_field_commit_cid() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let agent_home = tempdir.path().join("agent-home");
+    let data_dir = agent_home.join("data");
+
+    {
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .context("opening embedded node")?;
+        ensure_runtime_schemas(&node).await?;
+        seed_rendered_request_rows(&node).await?;
+    }
+    let home = agent_home.to_str().context("agent home utf8")?;
+
+    // --list: both captures, in numeric identity order, metadata only.
+    let output = run_cli_text(
+        tempdir.path(),
+        &[
+            "trace", "capture", "--home", home, "--request-id", "req-cap", "--list",
+        ],
+    )?;
+    let listing = serde_json::from_str::<Value>(&output).context("parsing capture list")?;
+    let captures = listing
+        .get("captures")
+        .and_then(Value::as_array)
+        .context("captures array")?;
+    assert_eq!(captures.len(), 2, "{listing:#}");
+    assert_eq!(
+        captures[0].get("attempt").and_then(Value::as_i64),
+        Some(0),
+        "identity order: attempt 0 first"
+    );
+    assert!(
+        captures.iter().all(|capture| capture.get("request_json").is_none()),
+        "list output must not carry bodies: {listing:#}"
+    );
+    assert_eq!(
+        captures[0].get("call_seq").and_then(Value::as_i64),
+        Some(1),
+        "admission join surfaces: {listing:#}"
+    );
+
+    // Exactly one match: metadata plus the request_json field-commit CID.
+    let output = run_cli_text(
+        tempdir.path(),
+        &[
+            "trace",
+            "capture",
+            "--home",
+            home,
+            "--request-id",
+            "req-cap",
+            "--scope",
+            "inference.1",
+            "--turn",
+            "0",
+            "--attempt",
+            "0",
+        ],
+    )?;
+    let capture = serde_json::from_str::<Value>(&output).context("parsing single capture")?;
+    assert_eq!(
+        capture.get("capture_key").and_then(Value::as_str),
+        Some("rendered:v1:seeded-a0")
+    );
+    assert_eq!(
+        capture.get("provenance_status").and_then(Value::as_str),
+        Some("captured_only")
+    );
+    let cid = capture
+        .pointer("/request_json_commit/cid")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected field-commit cid: {capture:#}"));
+    assert!(!cid.is_empty());
+    assert!(
+        capture.get("request_json").is_none(),
+        "default output must not carry the body: {capture:#}"
+    );
+
+    // --include-body is the one deliberate body read.
+    let output = run_cli_text(
+        tempdir.path(),
+        &[
+            "trace",
+            "capture",
+            "--home",
+            home,
+            "--capture-key",
+            "rendered:v1:seeded-a1",
+            "--include-body",
+        ],
+    )?;
+    let capture = serde_json::from_str::<Value>(&output).context("parsing bodied capture")?;
+    let body = capture
+        .get("request_json")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected request_json with --include-body: {capture:#}"));
+    assert!(body.contains("capture me"));
+    assert!(capture.get("provenance_json").is_some());
+
+    // Ambiguity without --list fails with a narrowing hint.
+    let stderr = run_cli_failure_stderr(
+        tempdir.path(),
+        &["trace", "capture", "--home", home, "--request-id", "req-cap"],
+    )?;
+    assert!(
+        stderr.contains("narrow with --scope/--turn/--attempt"),
+        "{stderr}"
+    );
+
+    // The run timeline surfaces the same captures as events.
+    let output = run_cli_text(
+        tempdir.path(),
+        &[
+            "trace", "timeline", "--home", home, "--request-id", "req-cap",
+        ],
+    )?;
+    let timeline = serde_json::from_str::<Value>(&output).context("parsing timeline")?;
+    let rendered_events = timeline
+        .get("events")
+        .and_then(Value::as_array)
+        .context("timeline events")?
+        .iter()
+        .filter(|event| event.get("kind").and_then(Value::as_str) == Some("rendered_request"))
+        .collect::<Vec<_>>();
+    assert_eq!(rendered_events.len(), 2, "{timeline:#}");
+    assert_eq!(
+        rendered_events[0]
+            .get("provenance_status")
+            .and_then(Value::as_str),
+        Some("captured_only")
+    );
+    assert!(
+        rendered_events
+            .iter()
+            .all(|event| event.get("request_json").is_none()
+                && event.get("provenance_json").is_none()),
+        "timeline events must stay metadata-only: {timeline:#}"
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn trace_project_exports_first_adapter_shapes_from_persisted_rows() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;

--- a/crates/gents-cli/tests/cli_trace_export.rs
+++ b/crates/gents-cli/tests/cli_trace_export.rs
@@ -561,7 +561,13 @@ async fn trace_capture_fetches_metadata_with_field_commit_cid() -> Result<()> {
     let output = run_cli_text(
         tempdir.path(),
         &[
-            "trace", "capture", "--home", home, "--request-id", "req-cap", "--list",
+            "trace",
+            "capture",
+            "--home",
+            home,
+            "--request-id",
+            "req-cap",
+            "--list",
         ],
     )?;
     let listing = serde_json::from_str::<Value>(&output).context("parsing capture list")?;
@@ -576,7 +582,9 @@ async fn trace_capture_fetches_metadata_with_field_commit_cid() -> Result<()> {
         "identity order: attempt 0 first"
     );
     assert!(
-        captures.iter().all(|capture| capture.get("request_json").is_none()),
+        captures
+            .iter()
+            .all(|capture| capture.get("request_json").is_none()),
         "list output must not carry bodies: {listing:#}"
     );
     assert_eq!(
@@ -646,7 +654,14 @@ async fn trace_capture_fetches_metadata_with_field_commit_cid() -> Result<()> {
     // Ambiguity without --list fails with a narrowing hint.
     let stderr = run_cli_failure_stderr(
         tempdir.path(),
-        &["trace", "capture", "--home", home, "--request-id", "req-cap"],
+        &[
+            "trace",
+            "capture",
+            "--home",
+            home,
+            "--request-id",
+            "req-cap",
+        ],
     )?;
     assert!(
         stderr.contains("narrow with --scope/--turn/--attempt"),
@@ -657,7 +672,12 @@ async fn trace_capture_fetches_metadata_with_field_commit_cid() -> Result<()> {
     let output = run_cli_text(
         tempdir.path(),
         &[
-            "trace", "timeline", "--home", home, "--request-id", "req-cap",
+            "trace",
+            "timeline",
+            "--home",
+            home,
+            "--request-id",
+            "req-cap",
         ],
     )?;
     let timeline = serde_json::from_str::<Value>(&output).context("parsing timeline")?;

--- a/crates/gents-protocol/src/lib.rs
+++ b/crates/gents-protocol/src/lib.rs
@@ -4,6 +4,7 @@ pub mod graphql;
 pub mod message;
 pub mod network_token;
 pub mod pairing_token;
+pub mod rendered_request;
 pub mod row;
 pub mod schemas;
 pub mod timeline;

--- a/crates/gents-protocol/src/rendered_request.rs
+++ b/crates/gents-protocol/src/rendered_request.rs
@@ -1,0 +1,984 @@
+//! Shared vocabulary for `RenderedRequest` capture rows (#840, #1066).
+//!
+//! The producer lives in `gents::rendered_request` — it builds the capture DTO
+//! at the transport seam and persists the 18-column row. Every *consumer* (the
+//! run timeline, adapter projections, the CLI, a future reconstructor) reads
+//! through the types here, so the sharp parts of the format — the
+//! `"{kind}.{seq}"` capture scope, the `(scope, turn, attempt)` ordering, and
+//! the versioned provenance manifest — are implemented exactly once, next to
+//! the vocabulary that defines them. `gents` re-exports everything in this
+//! module at its original paths, so the producer and the readers cannot drift.
+//!
+//! Serialized shapes here are load-bearing: `provenance_json` columns already
+//! persisted by #1059 deserialize through these exact serde attributes.
+
+use serde::{Deserialize, Serialize};
+
+use crate::message::{Message, ToolResultContent, UserContent};
+
+/// Capture format version stamped onto every row. Bump when the *set of
+/// columns* a reader must understand changes.
+pub const CAPTURE_VERSION: u32 = 1;
+
+/// Provenance manifest version. Bump when `ProvenanceManifest`'s serialized
+/// shape changes. A reader that does not know this number must report
+/// `UnsupportedManifest` rather than guessing.
+///
+/// v2 (#1059): status, seam, scope, endpoint, assembly trace.
+/// v3 (#1066): optional `admission` join to the persisted `InferenceCall`.
+pub const PROVENANCE_MANIFEST_VERSION: u32 = 3;
+
+/// Assembly-trace version. Bump when `AssemblyTrace`'s serialized shape
+/// changes. Versioned independently of the manifest so a manifest that later
+/// gains pinned config CIDs does not have to re-version the trace.
+pub const ASSEMBLY_TRACE_VERSION: u32 = 2;
+
+/// Request paths whose body is a completion request, and the wire shape each
+/// one implies. The capturing transport only claims a pending capture for one
+/// of these, so a `/models` listing or a token-refresh call issued while a
+/// capture is armed passes through untouched instead of consuming — and
+/// mis-describing — the turn's fact.
+const COMPLETION_REQUEST_PATHS: &[(&str, RenderedRequestSource)] = &[
+    ("/responses", RenderedRequestSource::OpenAiResponses),
+    (
+        "/chat/completions",
+        RenderedRequestSource::OpenAiChatCompletions,
+    ),
+];
+
+/// The provider wire shape a captured body was actually sent on.
+///
+/// Derived from the request path the transport posted to, never from behavior
+/// configuration: configuration says what the runtime *intended*, and this
+/// column has to say what the provider *received*. The two can disagree — a
+/// backend document can be edited between reconcile and send.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RenderedRequestSource {
+    #[serde(rename = "openai_responses")]
+    OpenAiResponses,
+    #[serde(rename = "openai_chat_completions")]
+    OpenAiChatCompletions,
+}
+
+impl RenderedRequestSource {
+    /// Classify by the completion request path. `None` means "not a completion
+    /// request", which is the transport's signal to forward without capturing.
+    pub fn for_request_path(path: &str) -> Option<Self> {
+        COMPLETION_REQUEST_PATHS
+            .iter()
+            .find(|(suffix, _)| path.ends_with(suffix))
+            .map(|(_, source)| *source)
+    }
+
+    /// The body field carrying the provider message list on this wire shape.
+    pub fn messages_field(self) -> &'static str {
+        match self {
+            Self::OpenAiResponses => "input",
+            Self::OpenAiChatCompletions => "messages",
+        }
+    }
+}
+
+/// Which completion loop inside a request is issuing provider calls.
+///
+/// Declaration order is the ordering `CaptureOrderKey` sorts kinds by; it is a
+/// stable identity order, not a temporal one (temporal interleaving across
+/// loops comes from `created_at` and the admission join).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CaptureScopeKind {
+    /// The request's own owned completion loop (`agent/loop_stream.rs`).
+    Inference,
+    /// The guided per-turn compaction summarizer. Its output is the ephemeral
+    /// continuation checkpoint injected straight into provider history and
+    /// never written as an `AgentCompactionEntry`, which is the single fact
+    /// this whole design exists to make explainable.
+    Compaction,
+    /// The strict-JSON compaction fallback, taken when guided structured output
+    /// exhausts its recovery.
+    CompactionFallback,
+    /// Conversation title generation.
+    Title,
+    /// The one-shot runner (`oneshot::run_openai_oneshot_with_tools`).
+    OneShot,
+}
+
+impl CaptureScopeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Inference => "inference",
+            Self::Compaction => "compaction",
+            Self::CompactionFallback => "compaction_fallback",
+            Self::Title => "title",
+            Self::OneShot => "oneshot",
+        }
+    }
+
+    /// The inverse of `as_str`. `None` for anything the producer never writes.
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "inference" => Some(Self::Inference),
+            "compaction" => Some(Self::Compaction),
+            "compaction_fallback" => Some(Self::CompactionFallback),
+            "title" => Some(Self::Title),
+            "oneshot" => Some(Self::OneShot),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CaptureScopeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A parsed `capture_scope` column: which loop, and which allocation of that
+/// loop within the request. The producer writes `"{kind}.{seq}"` with `seq`
+/// starting at 1 per kind (`gents::rendered_request::scope`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CaptureScope {
+    pub kind: CaptureScopeKind,
+    pub seq: u64,
+}
+
+/// Why a `capture_scope` string failed to parse. Malformed scope is an error a
+/// consumer must surface, never a default: defaulting would silently merge the
+/// row into some other loop's ordering.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CaptureScopeParseError {
+    Empty,
+    /// No `.` separator, or an empty kind/seq component.
+    MissingSeparator(String),
+    UnknownKind(String),
+    InvalidSeq(String),
+}
+
+impl std::fmt::Display for CaptureScopeParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "capture scope is empty"),
+            Self::MissingSeparator(scope) => {
+                write!(f, "capture scope {scope:?} is not \"{{kind}}.{{seq}}\"")
+            }
+            Self::UnknownKind(kind) => write!(f, "unknown capture scope kind {kind:?}"),
+            Self::InvalidSeq(seq) => write!(f, "capture scope seq {seq:?} is not a u64"),
+        }
+    }
+}
+
+impl std::error::Error for CaptureScopeParseError {}
+
+impl std::str::FromStr for CaptureScope {
+    type Err = CaptureScopeParseError;
+
+    fn from_str(label: &str) -> Result<Self, Self::Err> {
+        if label.is_empty() {
+            return Err(CaptureScopeParseError::Empty);
+        }
+        // Split on the LAST '.': kind labels contain '_' but never '.', and a
+        // future kind must not silently re-shape existing labels.
+        let (kind, seq) = label
+            .rsplit_once('.')
+            .filter(|(kind, seq)| !kind.is_empty() && !seq.is_empty())
+            .ok_or_else(|| CaptureScopeParseError::MissingSeparator(label.to_string()))?;
+        let kind = CaptureScopeKind::from_label(kind)
+            .ok_or_else(|| CaptureScopeParseError::UnknownKind(kind.to_string()))?;
+        if !seq.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(CaptureScopeParseError::InvalidSeq(seq.to_string()));
+        }
+        let seq = seq
+            .parse::<u64>()
+            .map_err(|_| CaptureScopeParseError::InvalidSeq(seq.to_string()))?;
+        Ok(Self { kind, seq })
+    }
+}
+
+impl std::fmt::Display for CaptureScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.kind, self.seq)
+    }
+}
+
+/// The stable identity ordering of capture rows within one request:
+/// `(kind, seq, turn_index, attempt)`, with `seq` compared numerically — a
+/// lexical sort of the raw `capture_scope` column would put `inference.10`
+/// before `inference.2`.
+///
+/// This orders rows *within* and *across* loops deterministically; it is not a
+/// temporal order across loops (the summarizer's calls interleave with the
+/// inference loop's in wall-clock time). Temporal placement comes from
+/// `created_at` and the provenance admission join.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CaptureOrderKey {
+    pub scope: CaptureScope,
+    pub turn_index: i64,
+    pub attempt: i64,
+}
+
+impl CaptureOrderKey {
+    /// A zero-padded rendering whose lexical order equals `Ord`. For sort-key
+    /// slots that only carry strings (timeline tiebreaks).
+    ///
+    /// The leading numeric rank is load-bearing: the kind *labels* sort
+    /// lexically as `compaction < inference`, which contradicts declaration
+    /// order — the conformance case `kind_rank_dominates_seq` is the fence
+    /// that caught exactly that.
+    pub fn padded(&self) -> String {
+        format!(
+            "{:02}.{}.{:010}.{:06}.{:06}",
+            self.scope.kind as u8,
+            self.scope.kind,
+            self.scope.seq,
+            self.turn_index,
+            self.attempt
+        )
+    }
+}
+
+/// Why a row could not produce a [`CaptureOrderKey`]. `turn_index` and
+/// `attempt` are core facts; a row missing them cannot be ordered, and
+/// defaulting them to zero would silently collide with a real first-turn row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CaptureOrderKeyError {
+    MissingScope,
+    Scope(CaptureScopeParseError),
+    MissingTurnIndex,
+    MissingAttempt,
+}
+
+impl std::fmt::Display for CaptureOrderKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingScope => write!(f, "row has no capture_scope"),
+            Self::Scope(err) => write!(f, "{err}"),
+            Self::MissingTurnIndex => write!(f, "row has no turn_index"),
+            Self::MissingAttempt => write!(f, "row has no attempt"),
+        }
+    }
+}
+
+impl std::error::Error for CaptureOrderKeyError {}
+
+impl From<CaptureScopeParseError> for CaptureOrderKeyError {
+    fn from(err: CaptureScopeParseError) -> Self {
+        Self::Scope(err)
+    }
+}
+
+/// Provenance manifest versions this reader understands. A version outside the
+/// range is reported as [`ParsedProvenance::Unsupported`], never guessed at.
+/// v2 rows (written by #1059 runtimes) stay readable forever; their optional
+/// v3 fields deserialize as absent.
+pub const SUPPORTED_PROVENANCE_MANIFEST_VERSIONS: std::ops::RangeInclusive<u32> = 2..=3;
+
+/// Outcome of reading a `provenance_json` column.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ParsedProvenance {
+    Manifest(ProvenanceManifest),
+    /// The row was written by a runtime this reader does not understand. The
+    /// row is still real and still listed; only its provenance is opaque.
+    Unsupported { manifest_version: u32 },
+}
+
+/// Why a `provenance_json` column failed to read. Distinct from
+/// [`ParsedProvenance::Unsupported`]: these are malformed columns, not
+/// unknown-but-well-formed versions.
+#[derive(Debug)]
+pub enum ProvenanceParseError {
+    Empty,
+    InvalidJson(serde_json::Error),
+    /// JSON object with no numeric `manifest_version` — pre-versioned or
+    /// corrupt; either way unreadable by contract.
+    MissingVersion,
+    /// Version in range but the body did not match that version's shape.
+    InvalidManifest(serde_json::Error),
+}
+
+impl std::fmt::Display for ProvenanceParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "provenance_json is empty"),
+            Self::InvalidJson(err) => write!(f, "provenance_json is not JSON: {err}"),
+            Self::MissingVersion => {
+                write!(f, "provenance_json carries no numeric manifest_version")
+            }
+            Self::InvalidManifest(err) => {
+                write!(f, "provenance_json does not match its declared version: {err}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProvenanceParseError {}
+
+impl ProvenanceManifest {
+    /// Read a `provenance_json` column, gating on `manifest_version` before
+    /// committing to a shape.
+    pub fn parse(provenance_json: &str) -> Result<ParsedProvenance, ProvenanceParseError> {
+        if provenance_json.trim().is_empty() {
+            return Err(ProvenanceParseError::Empty);
+        }
+        let value: serde_json::Value =
+            serde_json::from_str(provenance_json).map_err(ProvenanceParseError::InvalidJson)?;
+        let manifest_version = value
+            .get("manifest_version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|version| u32::try_from(version).ok())
+            .ok_or(ProvenanceParseError::MissingVersion)?;
+        if !SUPPORTED_PROVENANCE_MANIFEST_VERSIONS.contains(&manifest_version) {
+            return Ok(ParsedProvenance::Unsupported { manifest_version });
+        }
+        serde_json::from_value(value)
+            .map(ParsedProvenance::Manifest)
+            .map_err(ProvenanceParseError::InvalidManifest)
+    }
+}
+
+/// Which of the owned loop's two request builders produced the captured
+/// `CompletionRequest`.
+///
+/// This is one of the four unrecoverable inputs. `build_budgeted_request`
+/// applies `clamp_request_output_budget` before returning
+/// (`agent/loop_stream.rs`), but the completion-retry `Repair` directive calls
+/// `build_request` directly (`agent/loop_stream.rs:353,447`) and never clamps.
+/// A repaired attempt therefore carries the raw configured `max_tokens` while
+/// the original attempt for the same turn carries the clamped one. Without this
+/// discriminator a reconstructor cannot tell which of the two it should
+/// reproduce, and both are legal.
+///
+/// The clamp *value* is deliberately not stored: it is a pure function of the
+/// assembled request plus durable config, and `completion_request_input_estimate`
+/// does not read `max_tokens`, so a single reconstruction pass reproduces it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssemblyBuildPath {
+    /// `build_budgeted_request`: ordinary assembly, output clamp applied, and
+    /// per-turn compaction when the request exceeded the input budget.
+    Budgeted,
+    /// `build_request` invoked directly by a completion-retry repair. No output
+    /// clamp is applied on this path.
+    Repair,
+}
+
+impl AssemblyBuildPath {
+    /// Whether the loop applied `clamp_request_output_budget` on this path.
+    pub fn applies_output_clamp(self) -> bool {
+        matches!(self, Self::Budgeted)
+    }
+}
+
+/// A provider-assigned assistant message id, positioned in the effective
+/// message list.
+///
+/// One of the four unrecoverable inputs. `close_streaming_turn` stamps the
+/// provider's `MessageId` event onto the threaded assistant message
+/// (`agent/loop_stream.rs:802-806`) because OpenAI Responses and ChatGPT Codex
+/// follow-up requests reference prior `msg_` ids. The persistence path builds
+/// its assistant message with `id: None`
+/// (`agent/stream_processor.rs:305`), so the id exists in the provider request
+/// and nowhere in the durable transcript.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssistantMessageId {
+    /// Index into `AssemblyTrace::effective_messages`.
+    pub message_index: usize,
+    pub message_id: String,
+}
+
+/// The exact tool-result content threaded back into provider history for one
+/// tool call.
+///
+/// One of the four unrecoverable inputs. The loop threads
+/// `truncate_text(outcome.model_facing_text(), tool_result_truncation_mode(name),
+/// &TruncationLimits::default())` (`agent/loop_stream.rs:655-658`). Persistence
+/// re-derives its text from the stored `AgentToolCall.result` with
+/// `TruncationMode::Head`, the hook's own `truncation_limits`, and
+/// `model_observation_for_tool_result`
+/// (`hook/persistence/message_spawn.rs:296-324`). Those are different functions
+/// over different inputs, so replaying from the transcript does not reproduce
+/// the bytes the model actually saw.
+///
+/// `content` is the full threaded `Vec<ToolResultContent>`, not a flattened
+/// string: `ToolResultContent::from_tool_output` can split a JSON payload into
+/// several parts, and that split is part of what the provider received.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ThreadedToolResult {
+    /// Index into `AssemblyTrace::effective_messages`.
+    pub message_index: usize,
+    /// `ToolResult.id` — rig's locally minted tool-call id.
+    pub tool_call_id: String,
+    /// `ToolResult.call_id` — the provider-side call id when one exists.
+    pub call_id: Option<String>,
+    pub content: Vec<ToolResultContent>,
+}
+
+/// The genuinely unrecoverable inputs to one rendered provider request.
+///
+/// Everything else that shapes a request is either durable (transcript rows,
+/// behavior/profile/backend/skill documents) or a pure function of durable data.
+/// These four are not:
+///
+/// 1. `assistant_message_ids` — provider-assigned, persisted as `None`.
+/// 2. `threaded_tool_results` — the loop and the persistence path derive
+///    different text from different sources.
+/// 3. `effective_messages` — when a rendered request-context message or
+///    per-turn compaction adds ephemeral content. Compaction is a *sticky*
+///    mutation
+///    (`*history = compacted; *new_messages = vec![compacted_prompt]`,
+///    `agent/loop_stream.rs:1350-1351`), so one turn's model-generated summary
+///    governs every later turn of the same request, and that summary is never
+///    written as an `AgentCompactionEntry`. Re-running the summarizer does not
+///    produce the same words.
+/// 4. `build_path` — see `AssemblyBuildPath`.
+///
+/// `assistant_message_ids` and `threaded_tool_results` are projections of the
+/// effective message list, derived by the same constructor so they cannot drift
+/// from it.
+/// They are carried explicitly because a reconstructor rebuilds its message
+/// list from `AgentMessage` rows and needs these as an *overlay* keyed by
+/// position and call id; `effective_messages` is the oracle it checks itself
+/// against. `effective_messages` is present only when that list contains a
+/// rendered request-context message, a model-generated per-turn compaction
+/// summary, or the result of a repair rewrite. Otherwise the durable transcript
+/// plus these overlays reconstructs it exactly.
+///
+/// ## Size
+///
+/// Ordinary turns do not retain the full native message list next to the
+/// provider-wire copy in `request_json`; that list is reconstructible from
+/// durable rows plus the overlays. Once request-context rendering, per-turn
+/// compaction, or a repair introduces content no durable row reproduces, the
+/// full native list becomes the oracle and is retained on that and every later
+/// turn of the request. Compacted lists are bounded by the context window
+/// rather than growing with the unabridged session.
+///
+/// `threaded_tool_results` is carried on **every** turn, compact path included,
+/// because rig joins multi-part tool-result content with `"\n"` on the Chat
+/// Completions wire — the native `Vec<ToolResultContent>` split is genuinely
+/// unrecoverable from `request_json`. So a tool-heavy turn does duplicate its
+/// tool-result payloads; only the surrounding message list is elided.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AssemblyTrace {
+    pub trace_version: u32,
+    pub build_path: AssemblyBuildPath,
+    /// Number of native messages passed to assembly. This validates positional
+    /// overlays even when the reconstructible common-path list is omitted.
+    pub effective_message_count: usize,
+    /// The full effective provider message list at capture time, retained only
+    /// after request-context rendering or per-turn compaction introduces
+    /// ephemeral content. Native `Message`s, not provider wire shapes: this is
+    /// the *input* to assembly, whereas `request_json` is its output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_messages: Option<Vec<Message>>,
+    pub assistant_message_ids: Vec<AssistantMessageId>,
+    pub threaded_tool_results: Vec<ThreadedToolResult>,
+}
+
+impl AssemblyTrace {
+    /// The only constructor that keeps the overlays consistent with
+    /// `effective_messages`. Build traces with this, never with a struct
+    /// literal.
+    pub fn from_effective_messages(
+        build_path: AssemblyBuildPath,
+        effective_messages: Vec<Message>,
+    ) -> Self {
+        Self::from_messages(build_path, effective_messages, true)
+    }
+
+    /// Build the compact common-path trace when the native list can be rebuilt
+    /// from durable transcript/configuration documents plus the overlays.
+    pub fn from_reconstructible_messages(
+        build_path: AssemblyBuildPath,
+        effective_messages: Vec<Message>,
+    ) -> Self {
+        Self::from_messages(build_path, effective_messages, false)
+    }
+
+    fn from_messages(
+        build_path: AssemblyBuildPath,
+        effective_messages: Vec<Message>,
+        retain_effective_messages: bool,
+    ) -> Self {
+        let mut assistant_message_ids = Vec::new();
+        let mut threaded_tool_results = Vec::new();
+
+        for (message_index, message) in effective_messages.iter().enumerate() {
+            match message {
+                Message::Assistant {
+                    id: Some(message_id),
+                    ..
+                } => assistant_message_ids.push(AssistantMessageId {
+                    message_index,
+                    message_id: message_id.clone(),
+                }),
+                Message::User { content } => {
+                    for item in content {
+                        if let UserContent::ToolResult(result) = item {
+                            threaded_tool_results.push(ThreadedToolResult {
+                                message_index,
+                                tool_call_id: result.id.clone(),
+                                call_id: result.call_id.clone(),
+                                content: result.content.clone(),
+                            });
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let effective_message_count = effective_messages.len();
+        Self {
+            trace_version: ASSEMBLY_TRACE_VERSION,
+            build_path,
+            effective_message_count,
+            effective_messages: retain_effective_messages.then_some(effective_messages),
+            assistant_message_ids,
+            threaded_tool_results,
+        }
+    }
+}
+
+/// How much this capture claims about reconstructibility.
+///
+/// Explicit, never inferred from an absent field. A manifest that simply omits
+/// pinned CIDs must not read as "nothing needed pinning".
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProvenanceStatus {
+    /// The rendered request is durable and exact, but no durable source
+    /// versions are pinned alongside it, so a reconstruction cannot be
+    /// verified against it. This is the only status version 1 emits.
+    CapturedOnly,
+}
+
+/// Where in the send path the captured bytes were read.
+///
+/// Recorded positively so a reader never has to infer it. A row that says
+/// `TransportBody` is claiming the stronger thing: these are the bytes the HTTP
+/// client forwarded, after every provider-specific rewrite.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureSeam {
+    /// The last `HttpClientExt` before the network client. The only seam
+    /// version 1 emits.
+    TransportBody,
+}
+
+/// The admission identity of the provider call this capture preceded: the
+/// `call_id`/`call_seq` the admission registry minted for exactly that call.
+///
+/// This makes the capture↔`InferenceCall` correspondence a stored key instead
+/// of an ordinal guess — an admission rejection consumes no `call_seq`, so
+/// counting rows on either side desynchronises; this join does not. Absent for
+/// one-shot runs (no admission scope exists) and on v2 rows.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdmissionJoin {
+    pub call_id: String,
+    pub call_seq: i64,
+}
+
+/// Versioned provenance travelling in the `provenance_json` column.
+///
+/// Version 1 carries the assembly trace, the seam the bytes came from, the
+/// capture scope, and an honest `CapturedOnly` status. Pinned
+/// config/transcript CIDs are a later version; when they arrive, a version-1
+/// row must still be readable and must still report `CapturedOnly`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ProvenanceManifest {
+    pub manifest_version: u32,
+    pub status: ProvenanceStatus,
+    /// Why this row is not `Verified`, in words, so a projection can say so
+    /// without the reader reverse-engineering it from missing fields.
+    pub status_reason: String,
+    pub capture_seam: CaptureSeam,
+    /// Mirrors the `capture_scope` column. Duplicated here so a manifest read
+    /// in isolation still identifies which completion loop it describes.
+    pub capture_scope: String,
+    /// Scheme and authority the body was actually posted to, observed at the
+    /// seam. `None` only when the URI carried no authority.
+    ///
+    /// This is the one routing fact that is otherwise lost in time. `model_name`
+    /// alone cannot distinguish OpenAI from OpenRouter from a local vLLM from
+    /// Grok, and for daemon requests the answer is recoverable only by joining
+    /// to `InferenceCall.backend_id` — a join that does not exist for one-shot
+    /// runs, which never enter an admission scope. Configuration says where the
+    /// bytes were meant to go; this says where they went.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_endpoint: Option<String>,
+    /// The admitted call this capture preceded. Present exactly when an
+    /// admission scope was live at the seam; a one-shot capture legitimately
+    /// carries none, and its absence there is a documented fact, not an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission: Option<AdmissionJoin>,
+    pub assembly_trace: AssemblyTrace,
+}
+
+impl ProvenanceManifest {
+    const CAPTURED_ONLY_REASON: &'static str =
+        "this provenance manifest pins no config or transcript versions, so a \
+         reconstruction cannot be verified against this capture";
+
+    pub fn captured_only(
+        capture_scope: String,
+        provider_endpoint: Option<String>,
+        admission: Option<AdmissionJoin>,
+        assembly_trace: AssemblyTrace,
+    ) -> Self {
+        Self {
+            manifest_version: PROVENANCE_MANIFEST_VERSION,
+            status: ProvenanceStatus::CapturedOnly,
+            status_reason: Self::CAPTURED_ONLY_REASON.to_string(),
+            capture_seam: CaptureSeam::TransportBody,
+            capture_scope,
+            provider_endpoint,
+            admission,
+            assembly_trace,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::message::{AssistantContent, Text, ToolCall, ToolFunction};
+
+    fn tool_result_message(id: &str, call_id: Option<&str>, text: &str) -> Message {
+        Message::User {
+            content: vec![match call_id {
+                Some(call_id) => UserContent::tool_result_with_call_id(
+                    id,
+                    call_id.to_string(),
+                    vec![ToolResultContent::text(text)],
+                ),
+                None => UserContent::tool_result(id, vec![ToolResultContent::text(text)]),
+            }],
+        }
+    }
+
+    fn assistant_with_tool_call(id: Option<&str>, tool_call_id: &str) -> Message {
+        Message::Assistant {
+            id: id.map(str::to_string),
+            content: vec![AssistantContent::ToolCall(ToolCall::new(
+                tool_call_id.to_string(),
+                ToolFunction {
+                    name: "read_file".to_string(),
+                    arguments: json!({"path": "a.txt"}),
+                },
+            ))],
+        }
+    }
+
+    /// The wire shape is read off the path the transport posted to, so the
+    /// column reports what was sent rather than what was configured.
+    #[test]
+    fn rendered_source_follows_the_request_path() {
+        assert_eq!(
+            RenderedRequestSource::for_request_path("/v1/responses"),
+            Some(RenderedRequestSource::OpenAiResponses)
+        );
+        assert_eq!(
+            RenderedRequestSource::for_request_path("/backend-api/codex/responses"),
+            Some(RenderedRequestSource::OpenAiResponses)
+        );
+        assert_eq!(
+            RenderedRequestSource::for_request_path("/v1/chat/completions"),
+            Some(RenderedRequestSource::OpenAiChatCompletions)
+        );
+        assert_eq!(RenderedRequestSource::for_request_path("/v1/models"), None);
+        assert_eq!(RenderedRequestSource::for_request_path("/key"), None);
+    }
+
+    /// Every suffix the capture path claims must classify to the wire shape the
+    /// table names, and the table must stay the only definition of "completion
+    /// request".
+    #[test]
+    fn completion_path_suffixes_all_classify() {
+        for (suffix, source) in COMPLETION_REQUEST_PATHS {
+            assert_eq!(
+                RenderedRequestSource::for_request_path(suffix),
+                Some(*source),
+                "{suffix} must classify as a completion path"
+            );
+        }
+    }
+
+    #[test]
+    fn assembly_trace_records_assistant_message_ids_by_position() {
+        let trace = AssemblyTrace::from_effective_messages(
+            AssemblyBuildPath::Budgeted,
+            vec![
+                Message::user("hi"),
+                assistant_with_tool_call(Some("msg_abc"), "call-1"),
+                tool_result_message("call-1", Some("fc_1"), "ok"),
+                // An assistant turn the provider gave no id for.
+                Message::assistant("done"),
+            ],
+        );
+
+        assert_eq!(
+            trace.assistant_message_ids,
+            vec![AssistantMessageId {
+                message_index: 1,
+                message_id: "msg_abc".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn assembly_trace_records_threaded_tool_results_by_call_identity() {
+        let trace = AssemblyTrace::from_effective_messages(
+            AssemblyBuildPath::Budgeted,
+            vec![
+                assistant_with_tool_call(Some("msg_abc"), "call-1"),
+                tool_result_message("call-1", Some("fc_1"), "threaded bytes"),
+                tool_result_message("call-2", None, "no provider call id"),
+            ],
+        );
+
+        assert_eq!(
+            trace.threaded_tool_results,
+            vec![
+                ThreadedToolResult {
+                    message_index: 1,
+                    tool_call_id: "call-1".to_string(),
+                    call_id: Some("fc_1".to_string()),
+                    content: vec![ToolResultContent::Text(Text {
+                        text: "threaded bytes".to_string()
+                    })],
+                },
+                ThreadedToolResult {
+                    message_index: 2,
+                    tool_call_id: "call-2".to_string(),
+                    call_id: None,
+                    content: vec![ToolResultContent::Text(Text {
+                        text: "no provider call id".to_string()
+                    })],
+                },
+            ]
+        );
+    }
+
+    /// The overlays index into `effective_messages`; a projection that reads
+    /// them has to land back on the message it came from.
+    #[test]
+    fn assembly_trace_overlay_indexes_address_the_effective_messages() {
+        let messages = vec![
+            Message::user("hi"),
+            assistant_with_tool_call(Some("msg_abc"), "call-1"),
+            tool_result_message("call-1", Some("fc_1"), "threaded bytes"),
+        ];
+        let trace =
+            AssemblyTrace::from_effective_messages(AssemblyBuildPath::Budgeted, messages.clone());
+
+        let effective_messages = trace
+            .effective_messages
+            .as_ref()
+            .expect("explicit oracle trace");
+        assert_eq!(effective_messages, &messages);
+        for overlay in &trace.assistant_message_ids {
+            assert!(matches!(
+                &effective_messages[overlay.message_index],
+                Message::Assistant { id: Some(id), .. } if *id == overlay.message_id
+            ));
+        }
+        for overlay in &trace.threaded_tool_results {
+            assert!(matches!(
+                &effective_messages[overlay.message_index],
+                Message::User { .. }
+            ));
+        }
+    }
+
+    /// Per-turn compaction rewrites `history` and `new_messages` in place, so
+    /// the trace has to describe the *post*-compaction list. Nothing else
+    /// records it: the summary is model-generated and never becomes an
+    /// `AgentCompactionEntry`.
+    #[test]
+    fn assembly_trace_carries_the_post_compaction_message_list() {
+        let compacted = vec![
+            Message::system("<system-reminder>continuation checkpoint</system-reminder>"),
+            Message::user("continue"),
+        ];
+        let trace =
+            AssemblyTrace::from_effective_messages(AssemblyBuildPath::Budgeted, compacted.clone());
+
+        assert_eq!(trace.effective_messages, Some(compacted));
+        assert_eq!(trace.trace_version, ASSEMBLY_TRACE_VERSION);
+    }
+
+    #[test]
+    fn capture_scope_round_trips_and_rejects_garbage() {
+        for label in [
+            "inference.1",
+            "compaction.2",
+            "compaction_fallback.1",
+            "title.1",
+            "oneshot.1",
+        ] {
+            let scope: CaptureScope = label.parse().expect(label);
+            assert_eq!(scope.to_string(), label);
+        }
+        for bad in [
+            "",
+            "inference",
+            "inference.",
+            ".1",
+            "inference.0x2",
+            "inference.+2",
+            "inference. 2",
+            "mystery.1",
+            "inference.1.2",
+        ] {
+            assert!(bad.parse::<CaptureScope>().is_err(), "{bad:?} must not parse");
+        }
+    }
+
+    #[test]
+    fn order_key_sorts_seq_numerically_not_lexically() {
+        let key = |label: &str, turn_index, attempt| CaptureOrderKey {
+            scope: label.parse().unwrap(),
+            turn_index,
+            attempt,
+        };
+        let mut keys = vec![
+            key("inference.10", 0, 0),
+            key("inference.2", 3, 1),
+            key("inference.2", 3, 0),
+        ];
+        keys.sort();
+        assert_eq!(keys[0], key("inference.2", 3, 0));
+        assert_eq!(keys[1], key("inference.2", 3, 1));
+        assert_eq!(keys[2], key("inference.10", 0, 0));
+
+        // padded() must agree with Ord under lexical sort.
+        let padded: Vec<String> = keys.iter().map(CaptureOrderKey::padded).collect();
+        let mut lexical = padded.clone();
+        lexical.sort();
+        assert_eq!(padded, lexical);
+    }
+
+    /// Cross-kind ordering is by declaration order — a stable identity order,
+    /// pinned so a reordered enum shows up as a test failure and a conscious
+    /// decision, not a silent re-sort of every consumer.
+    #[test]
+    fn order_key_orders_kinds_by_declaration() {
+        let scopes: Vec<CaptureScope> = [
+            "oneshot.1",
+            "title.1",
+            "compaction_fallback.1",
+            "compaction.1",
+            "inference.1",
+        ]
+        .iter()
+        .map(|label| label.parse().unwrap())
+        .collect();
+        let mut sorted = scopes.clone();
+        sorted.sort();
+        assert_eq!(
+            sorted.iter().map(|s| s.kind.as_str()).collect::<Vec<_>>(),
+            vec![
+                "inference",
+                "compaction",
+                "compaction_fallback",
+                "title",
+                "oneshot"
+            ]
+        );
+    }
+
+    #[test]
+    fn manifest_reader_gates_on_version() {
+        let v2 = json!({
+            "manifest_version": 2,
+            "status": "captured_only",
+            "status_reason": "r",
+            "capture_seam": "transport_body",
+            "capture_scope": "inference.1",
+            "assembly_trace": {
+                "trace_version": 2,
+                "build_path": "budgeted",
+                "effective_message_count": 0,
+                "assistant_message_ids": [],
+                "threaded_tool_results": []
+            }
+        });
+        let parsed = ProvenanceManifest::parse(&v2.to_string()).expect("v2 parses");
+        match parsed {
+            ParsedProvenance::Manifest(manifest) => {
+                assert_eq!(manifest.manifest_version, 2);
+                assert_eq!(manifest.capture_scope, "inference.1");
+                assert_eq!(manifest.status, ProvenanceStatus::CapturedOnly);
+            }
+            other => panic!("expected manifest, got {other:?}"),
+        }
+
+        let v99 = json!({ "manifest_version": 99, "anything": true });
+        assert_eq!(
+            ProvenanceManifest::parse(&v99.to_string()).expect("well-formed unknown version"),
+            ParsedProvenance::Unsupported {
+                manifest_version: 99
+            }
+        );
+
+        assert!(matches!(
+            ProvenanceManifest::parse(""),
+            Err(ProvenanceParseError::Empty)
+        ));
+        assert!(matches!(
+            ProvenanceManifest::parse("not json"),
+            Err(ProvenanceParseError::InvalidJson(_))
+        ));
+        assert!(matches!(
+            ProvenanceManifest::parse(r#"{"status":"captured_only"}"#),
+            Err(ProvenanceParseError::MissingVersion)
+        ));
+        // In-range version whose body does not match the declared shape.
+        assert!(matches!(
+            ProvenanceManifest::parse(r#"{"manifest_version":2}"#),
+            Err(ProvenanceParseError::InvalidManifest(_))
+        ));
+    }
+
+    /// What the producer writes, the reader reads — through the version gate,
+    /// not around it.
+    #[test]
+    fn manifest_reader_round_trips_the_producer_shape() {
+        let manifest = ProvenanceManifest::captured_only(
+            "compaction.2".to_string(),
+            Some("https://api.example.test".to_string()),
+            Some(AdmissionJoin {
+                call_id: "call-7".to_string(),
+                call_seq: 7,
+            }),
+            AssemblyTrace::from_effective_messages(
+                AssemblyBuildPath::Repair,
+                vec![Message::user("hi")],
+            ),
+        );
+        let serialized = serde_json::to_string(&manifest).expect("serialize manifest");
+        assert_eq!(
+            ProvenanceManifest::parse(&serialized).expect("reader accepts producer output"),
+            ParsedProvenance::Manifest(manifest)
+        );
+    }
+
+    #[test]
+    fn reconstructible_trace_does_not_duplicate_message_bodies() {
+        let marker = "ordinary-message-body-".repeat(1_000);
+        let messages = vec![Message::user(marker.clone()), Message::assistant("done")];
+        let compact = AssemblyTrace::from_reconstructible_messages(
+            AssemblyBuildPath::Budgeted,
+            messages.clone(),
+        );
+        let oracle = AssemblyTrace::from_effective_messages(AssemblyBuildPath::Budgeted, messages);
+
+        let compact_json = serde_json::to_string(&compact).expect("compact trace");
+        let oracle_json = serde_json::to_string(&oracle).expect("oracle trace");
+        assert_eq!(compact.effective_message_count, 2);
+        assert!(compact.effective_messages.is_none());
+        assert!(!compact_json.contains(&marker));
+        assert!(oracle_json.len() > compact_json.len() + marker.len());
+    }
+}

--- a/crates/gents-protocol/src/rendered_request.rs
+++ b/crates/gents-protocol/src/rendered_request.rs
@@ -226,11 +226,7 @@ impl CaptureOrderKey {
     pub fn padded(&self) -> String {
         format!(
             "{:02}.{}.{:010}.{:06}.{:06}",
-            self.scope.kind as u8,
-            self.scope.kind,
-            self.scope.seq,
-            self.turn_index,
-            self.attempt
+            self.scope.kind as u8, self.scope.kind, self.scope.seq, self.turn_index, self.attempt
         )
     }
 }
@@ -277,7 +273,9 @@ pub enum ParsedProvenance {
     Manifest(ProvenanceManifest),
     /// The row was written by a runtime this reader does not understand. The
     /// row is still real and still listed; only its provenance is opaque.
-    Unsupported { manifest_version: u32 },
+    Unsupported {
+        manifest_version: u32,
+    },
 }
 
 /// Why a `provenance_json` column failed to read. Distinct from
@@ -303,7 +301,10 @@ impl std::fmt::Display for ProvenanceParseError {
                 write!(f, "provenance_json carries no numeric manifest_version")
             }
             Self::InvalidManifest(err) => {
-                write!(f, "provenance_json does not match its declared version: {err}")
+                write!(
+                    f,
+                    "provenance_json does not match its declared version: {err}"
+                )
             }
         }
     }
@@ -831,7 +832,10 @@ mod tests {
             "mystery.1",
             "inference.1.2",
         ] {
-            assert!(bad.parse::<CaptureScope>().is_err(), "{bad:?} must not parse");
+            assert!(
+                bad.parse::<CaptureScope>().is_err(),
+                "{bad:?} must not parse"
+            );
         }
     }
 

--- a/crates/gents-protocol/src/row.rs
+++ b/crates/gents-protocol/src/row.rs
@@ -558,8 +558,10 @@ impl RenderedRequestRow {
     /// a real first-turn capture.
     pub fn order_key(
         &self,
-    ) -> Result<crate::rendered_request::CaptureOrderKey, crate::rendered_request::CaptureOrderKeyError>
-    {
+    ) -> Result<
+        crate::rendered_request::CaptureOrderKey,
+        crate::rendered_request::CaptureOrderKeyError,
+    > {
         use crate::rendered_request::{CaptureOrderKey, CaptureOrderKeyError, CaptureScope};
 
         let scope: CaptureScope = self
@@ -582,8 +584,10 @@ impl RenderedRequestRow {
     /// Read the row's provenance manifest through the versioned reader.
     pub fn provenance(
         &self,
-    ) -> Result<crate::rendered_request::ParsedProvenance, crate::rendered_request::ProvenanceParseError>
-    {
+    ) -> Result<
+        crate::rendered_request::ParsedProvenance,
+        crate::rendered_request::ProvenanceParseError,
+    > {
         crate::rendered_request::ProvenanceManifest::parse(
             self.provenance_json
                 .as_deref()

--- a/crates/gents-protocol/src/row.rs
+++ b/crates/gents-protocol/src/row.rs
@@ -506,6 +506,92 @@ pub struct CompactionEntryRow {
     pub created_at: Option<String>,
 }
 
+/// One durable rendered-request fact (#840/#1059): the exact provider request
+/// body persisted before it was sent, keyed uniquely by `capture_key`.
+///
+/// Wire-shape mirror like every row here — only the identity key is required.
+/// `request_json` is the captured provider body; consumers that only need
+/// metadata should not select it (and the run timeline never does).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RenderedRequestRow {
+    pub capture_key: String,
+    #[serde(default)]
+    pub request_doc_id: Option<String>,
+    #[serde(default)]
+    pub request_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub agent_did: Option<String>,
+    #[serde(default)]
+    pub requester_did: Option<String>,
+    #[serde(default)]
+    pub behavior_id: Option<String>,
+    #[serde(default)]
+    pub capture_scope: Option<String>,
+    #[serde(default)]
+    pub turn_index: Option<i64>,
+    #[serde(default)]
+    pub attempt: Option<i64>,
+    #[serde(default)]
+    pub capture_version: Option<i64>,
+    #[serde(default)]
+    pub model_name: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub request_json: Option<String>,
+    #[serde(default)]
+    pub prompt_hash: Option<String>,
+    #[serde(default)]
+    pub tools_hash: Option<String>,
+    #[serde(default)]
+    pub provenance_json: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
+impl RenderedRequestRow {
+    /// The row's stable identity ordering. Errors when `capture_scope`,
+    /// `turn_index`, or `attempt` is missing or malformed: those are core
+    /// facts, and defaulting them to zero would silently collide the row with
+    /// a real first-turn capture.
+    pub fn order_key(
+        &self,
+    ) -> Result<crate::rendered_request::CaptureOrderKey, crate::rendered_request::CaptureOrderKeyError>
+    {
+        use crate::rendered_request::{CaptureOrderKey, CaptureOrderKeyError, CaptureScope};
+
+        let scope: CaptureScope = self
+            .capture_scope
+            .as_deref()
+            .ok_or(CaptureOrderKeyError::MissingScope)?
+            .parse()
+            .map_err(CaptureOrderKeyError::Scope)?;
+        let turn_index = self
+            .turn_index
+            .ok_or(CaptureOrderKeyError::MissingTurnIndex)?;
+        let attempt = self.attempt.ok_or(CaptureOrderKeyError::MissingAttempt)?;
+        Ok(CaptureOrderKey {
+            scope,
+            turn_index,
+            attempt,
+        })
+    }
+
+    /// Read the row's provenance manifest through the versioned reader.
+    pub fn provenance(
+        &self,
+    ) -> Result<crate::rendered_request::ParsedProvenance, crate::rendered_request::ProvenanceParseError>
+    {
+        crate::rendered_request::ProvenanceManifest::parse(
+            self.provenance_json
+                .as_deref()
+                .ok_or(crate::rendered_request::ProvenanceParseError::Empty)?,
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskRow {
     pub task_id: String,
@@ -873,6 +959,71 @@ pub struct ToolServiceHealthStateRow {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rendered_request_row_parses_a_graphql_response_row() {
+        let json = r#"{
+            "capture_key": "rendered:v1:abc",
+            "request_doc_id": "bae-doc-1",
+            "request_id": "req-1",
+            "session_id": "s-1",
+            "agent_did": "did:test:amy",
+            "requester_did": "",
+            "behavior_id": "amy-code",
+            "capture_scope": "compaction.2",
+            "turn_index": 1,
+            "attempt": 0,
+            "capture_version": 1,
+            "model_name": "test-model",
+            "source": "openai_chat_completions",
+            "request_json": "{\"model\":\"test-model\"}",
+            "prompt_hash": "aa",
+            "tools_hash": "bb",
+            "provenance_json": "{\"manifest_version\":99}",
+            "created_at": "2026-08-07T12:00:00Z"
+        }"#;
+        let row: RenderedRequestRow = serde_json::from_str(json).expect("parse");
+        assert_eq!(row.capture_key, "rendered:v1:abc");
+
+        let key = row.order_key().expect("order key");
+        assert_eq!(key.scope.kind.as_str(), "compaction");
+        assert_eq!(key.scope.seq, 2);
+        assert_eq!((key.turn_index, key.attempt), (1, 0));
+
+        // Unknown manifest versions are reported, not guessed at.
+        assert_eq!(
+            row.provenance().expect("well-formed provenance"),
+            crate::rendered_request::ParsedProvenance::Unsupported {
+                manifest_version: 99
+            }
+        );
+    }
+
+    /// A DefraDB response may omit unpopulated columns entirely; the row still
+    /// deserializes, but it cannot be ordered — and must say so rather than
+    /// defaulting into a first-turn collision.
+    #[test]
+    fn rendered_request_row_without_order_facts_deserializes_but_will_not_order() {
+        let row: RenderedRequestRow =
+            serde_json::from_str(r#"{ "capture_key": "rendered:v1:abc" }"#).expect("parse");
+        assert_eq!(
+            row.order_key(),
+            Err(crate::rendered_request::CaptureOrderKeyError::MissingScope)
+        );
+
+        let row: RenderedRequestRow = serde_json::from_str(
+            r#"{ "capture_key": "rendered:v1:abc", "capture_scope": "inference.1", "attempt": 0 }"#,
+        )
+        .expect("parse");
+        assert_eq!(
+            row.order_key(),
+            Err(crate::rendered_request::CaptureOrderKeyError::MissingTurnIndex)
+        );
+        assert!(matches!(
+            row.provenance(),
+            Err(crate::rendered_request::ProvenanceParseError::Empty)
+        ));
+    }
 
     #[test]
     fn agent_request_row_roundtrips() {

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/RenderedCapture.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/RenderedCapture.lean
@@ -201,4 +201,142 @@ theorem renderedCaptureKeyCases_pinned :
       ] := by
   rfl
 
+/-! ## Capture scope labels and the consumer ordering (#1066)
+
+The producer writes the loop discriminator as `"{kind}.{seq}"`. These cases fix
+the label vocabulary a consumer's parser must accept, the reject vectors it
+must error on (never default), and the identity ordering
+`(kind rank, seq, turn, attempt)` — with `seq` compared numerically, because a
+lexical sort of the raw column puts `inference.10` before `inference.2`. -/
+
+inductive CaptureScopeKind
+  | inference
+  | compaction
+  | compactionFallback
+  | title
+  | oneshot
+  deriving Repr, DecidableEq
+
+def CaptureScopeKind.label : CaptureScopeKind → String
+  | .inference => "inference"
+  | .compaction => "compaction"
+  | .compactionFallback => "compaction_fallback"
+  | .title => "title"
+  | .oneshot => "oneshot"
+
+/-- Declaration-order rank — the stable identity order across kinds. Not a
+temporal order: loops interleave in wall-clock time. -/
+def CaptureScopeKind.rank : CaptureScopeKind → Nat
+  | .inference => 0
+  | .compaction => 1
+  | .compactionFallback => 2
+  | .title => 3
+  | .oneshot => 4
+
+def allCaptureScopeKinds : List CaptureScopeKind :=
+  [.inference, .compaction, .compactionFallback, .title, .oneshot]
+
+structure CaptureScopeCase where
+  label : String
+  kind : String
+  seq : Nat
+  valid : Bool
+  deriving Repr
+
+private def validScopeCase (kind : CaptureScopeKind) (seq : Nat) : CaptureScopeCase :=
+  { label := kind.label ++ "." ++ toString seq
+  , kind := kind.label
+  , seq := seq
+  , valid := true
+  }
+
+private def invalidScopeCase (label : String) : CaptureScopeCase :=
+  { label := label, kind := "", seq := 0, valid := false }
+
+/-- Every kind at seq 1, multi-digit seqs (so a lexical sort cannot pass the
+ordering fence), and the parser's reject vectors. -/
+def captureScopeCases : List CaptureScopeCase :=
+  (allCaptureScopeKinds.map (validScopeCase · 1))
+    ++ [ validScopeCase .inference 2
+       , validScopeCase .inference 10
+       , validScopeCase .compaction 2
+       ]
+    ++ [ invalidScopeCase ""
+       , invalidScopeCase "inference"
+       , invalidScopeCase "inference."
+       , invalidScopeCase ".1"
+       , invalidScopeCase "mystery.1"
+       , invalidScopeCase "inference.0x2"
+       , invalidScopeCase "inference.1.2"
+       , invalidScopeCase "inference. 2"
+       ]
+
+/-- Valid labels are pairwise distinct — the label round-trip is injective over
+the emitted vocabulary. -/
+theorem captureScopeCases_valid_labels_distinct :
+    ((captureScopeCases.filter (·.valid)).map (·.label)).Nodup := by
+  decide
+
+structure CaptureOrderCase where
+  name : String
+  leftLabel : String
+  leftTurn : Nat
+  leftAttempt : Nat
+  rightLabel : String
+  rightTurn : Nat
+  rightAttempt : Nat
+  leftBeforeRight : Bool
+  deriving Repr
+
+private def orderTuple
+    (kind : CaptureScopeKind) (seq turn attempt : Nat) : Nat × Nat × Nat × Nat :=
+  (kind.rank, seq, turn, attempt)
+
+private def tupleLt : Nat × Nat × Nat × Nat → Nat × Nat × Nat × Nat → Bool
+  | (a1, a2, a3, a4), (b1, b2, b3, b4) =>
+    if a1 ≠ b1 then a1 < b1
+    else if a2 ≠ b2 then a2 < b2
+    else if a3 ≠ b3 then a3 < b3
+    else a4 < b4
+
+private def orderCase (name : String)
+    (leftKind : CaptureScopeKind) (leftSeq leftTurn leftAttempt : Nat)
+    (rightKind : CaptureScopeKind) (rightSeq rightTurn rightAttempt : Nat) :
+    CaptureOrderCase :=
+  { name := name
+  , leftLabel := (validScopeCase leftKind leftSeq).label
+  , leftTurn := leftTurn
+  , leftAttempt := leftAttempt
+  , rightLabel := (validScopeCase rightKind rightSeq).label
+  , rightTurn := rightTurn
+  , rightAttempt := rightAttempt
+  , leftBeforeRight :=
+      tupleLt (orderTuple leftKind leftSeq leftTurn leftAttempt)
+        (orderTuple rightKind rightSeq rightTurn rightAttempt)
+  }
+
+def captureOrderCases : List CaptureOrderCase :=
+  [ orderCase "numeric_seq_dominates_lexical" .inference 2 3 1 .inference 10 0 0
+  , orderCase "attempt_breaks_turn_tie" .inference 1 0 0 .inference 1 0 1
+  , orderCase "turn_dominates_attempt" .inference 1 0 5 .inference 1 1 0
+  , orderCase "kind_rank_dominates_seq" .inference 9 9 9 .compaction 1 0 0
+  , orderCase "fallback_ranks_after_compaction" .compaction 5 0 0 .compactionFallback 1 0 0
+  , orderCase "oneshot_ranks_last" .title 1 0 0 .oneshot 1 0 0
+  , orderCase "equal_keys_do_not_order" .inference 1 2 3 .inference 1 2 3
+  ]
+
+/-- Pinned so a change to the rank or comparison shows up as a Lean build
+failure and a conscious decision, not a silent re-sort of every consumer. -/
+theorem captureOrderCases_pinned :
+    captureOrderCases.map (fun row => (row.name, row.leftBeforeRight)) =
+      [ ("numeric_seq_dominates_lexical", true)
+      , ("attempt_breaks_turn_tie", true)
+      , ("turn_dominates_attempt", true)
+      , ("kind_rank_dominates_seq", true)
+      , ("fallback_ranks_after_compaction", true)
+      , ("oneshot_ranks_last", true)
+      , ("equal_keys_do_not_order", false)
+      ] := by
+  rfl
+
 end Conformance.ContractCases

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/RenderedCapture.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/RenderedCapture.lean
@@ -47,4 +47,30 @@ def renderedCaptureKeyCaseJson (witness : RenderedCaptureKeyCase) : String :=
 def renderedCaptureKeyCasesJson : String :=
   jsonArray (renderedCaptureKeyCases.map renderedCaptureKeyCaseJson)
 
+def captureScopeCaseJson (witness : CaptureScopeCase) : String :=
+  "{"
+    ++ "\"label\":" ++ jsonString witness.label ++ ","
+    ++ "\"kind\":" ++ jsonString witness.kind ++ ","
+    ++ "\"seq\":" ++ toString witness.seq ++ ","
+    ++ "\"valid\":" ++ boolString witness.valid
+    ++ "}"
+
+def captureScopeCasesJson : String :=
+  jsonArray (captureScopeCases.map captureScopeCaseJson)
+
+def captureOrderCaseJson (witness : CaptureOrderCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"left_label\":" ++ jsonString witness.leftLabel ++ ","
+    ++ "\"left_turn\":" ++ toString witness.leftTurn ++ ","
+    ++ "\"left_attempt\":" ++ toString witness.leftAttempt ++ ","
+    ++ "\"right_label\":" ++ jsonString witness.rightLabel ++ ","
+    ++ "\"right_turn\":" ++ toString witness.rightTurn ++ ","
+    ++ "\"right_attempt\":" ++ toString witness.rightAttempt ++ ","
+    ++ "\"left_before_right\":" ++ boolString witness.leftBeforeRight
+    ++ "}"
+
+def captureOrderCasesJson : String :=
+  jsonArray (captureOrderCases.map captureOrderCaseJson)
+
 end Conformance.Contracts

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -219,6 +219,10 @@ def snapshotJson : String :=
       ++ renderedCaptureCasesJson ++ ","
     ++ "\"rendered_capture_key_cases\":"
       ++ renderedCaptureKeyCasesJson ++ ","
+    ++ "\"capture_scope_cases\":"
+      ++ captureScopeCasesJson ++ ","
+    ++ "\"capture_order_cases\":"
+      ++ captureOrderCasesJson ++ ","
     ++ "\"compaction_reducer_cases\":"
       ++ jsonArray
         (Compaction.compactionReducerCases.map compactionReducerCaseJson) ++ ","

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -192,13 +192,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := []
     }
   , { feature := "rendered-capture"
-    , required := [Surface.runtimeInternal]
-    , deferred :=
-        [ (Surface.operatorCli,
-            "#840 — `trace timeline|project` surfacing of captured requests lands with the projection slice; rows accumulate from this release onward with no reader")
-        , (Surface.operatorUi,
-            "#840 — the desktop rendered-request view lands with the same projection slice")
-        ]
+    , required := [Surface.runtimeInternal, Surface.operatorCli, Surface.operatorUi]
+    , deferred := []
     }
   , { feature := "streaming-response"
     , required := [Surface.agentFacing, Surface.operatorUi]
@@ -922,6 +917,26 @@ def caseCoverage : List CoverageEntry :=
       "RenderedCaptureKeyCases"
       "conformance::rendered_capture::generated_rendered_capture_key_cases_pin_the_capture_key_tuple")
       "rendered-capture" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "rendered_capture_cases"
+      "CaptureScopeCases"
+      "conformance::rendered_capture::generated_capture_scope_cases_pin_the_shared_parser_and_order")
+      "rendered-capture" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "rendered_capture_cases"
+      "CaptureOrderCases"
+      "conformance::rendered_capture::generated_capture_scope_cases_pin_the_shared_parser_and_order")
+      "rendered-capture" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "rendered_capture_cases"
+      "RenderedCaptureCases"
+      "cli_trace_export::trace_capture_fetches_metadata_with_field_commit_cid")
+      "rendered-capture" [Surface.operatorCli]
+  , tagged (consumerCoverage
+      "rendered_capture_cases"
+      "RenderedCaptureCases"
+      "apps/gents-desktop/tests/request-trace.test.tsx::request trace panel renders the reconstructed event stream")
+      "rendered-capture" [Surface.operatorUi]
   , tagged (consumerCoverage
       "event_delivery_cases"
       "EventDeliveryTransitionCases"

--- a/crates/gents/src/adapter_projection.rs
+++ b/crates/gents/src/adapter_projection.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::run_timeline::{
-    RunTimeline, RunTimelineEvent, TimelineRequestEvent, TimelineResponseEvent,
+    RunTimeline, RunTimelineEvent, TimelineRenderedRequestEvent, TimelineRequestEvent,
+    TimelineResponseEvent,
 };
 
 mod atif;
@@ -85,7 +86,38 @@ pub struct AdapterProjectionEnvelope {
     pub source_behavior_id: Option<String>,
     pub redaction_mode: ProjectionRedactionMode,
     pub provenance: ProjectionProvenance,
+    /// Rendered-request capture metadata for the projected request — the
+    /// timeline's capture events verbatim: keys, hashes, ordering facts, and
+    /// the admission join. **Never bodies.** The timeline never selects
+    /// `request_json`, so a captured body cannot reach this envelope in any
+    /// redaction mode; the one body read in the system is the CLI's explicit
+    /// `--include-body`. Uniform across all four projections, including the
+    /// two whose native shapes are closed to extension.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rendered_captures: Vec<TimelineRenderedRequestEvent>,
     pub output: AdapterProjection,
+}
+
+/// The capture events of a timeline, in timeline order.
+fn rendered_capture_events(timeline: &RunTimeline) -> Vec<TimelineRenderedRequestEvent> {
+    timeline
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            RunTimelineEvent::RenderedRequest(event) => Some(event.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The same capture events as a JSON array, for open extension surfaces
+/// (ATIF `extra`, LangGraph `values`). `None` when the timeline has none.
+pub(crate) fn rendered_captures_json(timeline: &RunTimeline) -> Option<Value> {
+    let captures = rendered_capture_events(timeline);
+    if captures.is_empty() {
+        return None;
+    }
+    serde_json::to_value(captures).ok()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -382,6 +414,7 @@ pub fn build_adapter_projection(
             source_projection_version: ADAPTER_PROJECTION_VERSION.to_string(),
             actor_did: context.actor_did.clone(),
         },
+        rendered_captures: rendered_capture_events(timeline),
         output: match kind {
             AdapterProjectionKind::AtifTrajectory => {
                 AdapterProjection::AtifTrajectory(atif::build_atif_trajectory(timeline, context))
@@ -1011,6 +1044,7 @@ pub fn adapter_projection_json_schema(kind: AdapterProjectionKind) -> Value {
             "source_behavior_id": optional_string_schema(),
             "redaction_mode": redaction_mode_schema(),
             "provenance": provenance_schema(),
+            "rendered_captures": rendered_captures_schema(),
             "output": {
                 "type": "object",
                 "additionalProperties": false,
@@ -1019,6 +1053,40 @@ pub fn adapter_projection_json_schema(kind: AdapterProjectionKind) -> Value {
                     "adapter": { "const": kind.id() },
                     "projection": envelope_projection_json_schema(kind)
                 }
+            }
+        }
+    })
+}
+
+/// Schema for the envelope's `rendered_captures` section: capture metadata
+/// only — the shape has no field a captured body could travel in.
+fn rendered_captures_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["capture_key", "provenance_status"],
+            "properties": {
+                "capture_key": string_schema(),
+                "request_doc_id": optional_string_schema(),
+                "request_id": optional_string_schema(),
+                "session_id": optional_string_schema(),
+                "capture_scope": optional_string_schema(),
+                "scope_kind": optional_string_schema(),
+                "scope_seq": { "type": "integer" },
+                "turn_index": { "type": "integer" },
+                "attempt": { "type": "integer" },
+                "capture_version": { "type": "integer" },
+                "model_name": optional_string_schema(),
+                "source": optional_string_schema(),
+                "prompt_hash": optional_string_schema(),
+                "tools_hash": optional_string_schema(),
+                "provenance_status": string_schema(),
+                "manifest_version": { "type": "integer" },
+                "call_id": optional_string_schema(),
+                "call_seq": { "type": "integer" },
+                "created_at": optional_string_schema()
             }
         }
     })
@@ -1707,6 +1775,9 @@ fn build_openai_codex_run_trace(
                     timestamp: event.timestamp.clone(),
                 });
             }
+            // Captures ride the envelope's `rendered_captures`; the Codex
+            // native item shapes are additionalProperties:false throughout.
+            RunTimelineEvent::RenderedRequest(_) => {}
             RunTimelineEvent::InferenceCall(_) => {}
             RunTimelineEvent::Message(event) => {
                 items.push(OpenAiCodexTraceItem::Message {
@@ -1792,6 +1863,9 @@ fn build_langgraph_state_history(
             parent_tool_call_id,
             status,
         ) = match event {
+            // Captures surface in `values.rendered_captures`, not as graph
+            // nodes — a capture is a fact about an inference call, not a step.
+            RunTimelineEvent::RenderedRequest(_) => continue,
             RunTimelineEvent::Request(event) => (
                 format!("request:{}", event.request_id),
                 "request".to_string(),
@@ -1898,6 +1972,9 @@ fn build_langgraph_state_history(
             json!(redact_option(response.content.as_deref(), context)),
         );
     }
+    if let Some(rendered_captures) = rendered_captures_json(timeline) {
+        values.insert("rendered_captures".to_string(), rendered_captures);
+    }
 
     let mut projection = LangGraphStateHistoryProjection {
         thread_id: timeline.session_id.clone(),
@@ -1983,6 +2060,9 @@ fn build_multi_agent_task(
                     });
                 }
             }
+            // Captures ride the envelope's `rendered_captures`; the
+            // multi-agent native shape is additionalProperties:false.
+            RunTimelineEvent::RenderedRequest(_) => {}
             RunTimelineEvent::InferenceCall(_) => {}
             RunTimelineEvent::Message(message) => {
                 messages.push(MultiAgentMessage {

--- a/crates/gents/src/adapter_projection/atif.rs
+++ b/crates/gents/src/adapter_projection/atif.rs
@@ -204,6 +204,7 @@ pub(super) fn build_atif_trajectory(
                 apply_root_response(&mut steps, response, context);
             }
             RunTimelineEvent::Request(_)
+            | RunTimelineEvent::RenderedRequest(_)
             | RunTimelineEvent::InferenceCall(_)
             | RunTimelineEvent::Message(_)
             | RunTimelineEvent::ToolCall(_)
@@ -301,6 +302,13 @@ pub(super) fn build_atif_trajectory(
         extra: optional_extra([
             ("source_projection_id", string_value("run_timeline")),
             ("source_request_id", string_value(&timeline.request_id)),
+            // Capture metadata only (keys, hashes, ordering, admission join).
+            // ATIF `extra` bypasses redaction, which is safe here precisely
+            // because bodies never enter the timeline this is derived from.
+            (
+                "rendered_captures",
+                super::rendered_captures_json(timeline),
+            ),
         ]),
     }
 }

--- a/crates/gents/src/adapter_projection/tests.rs
+++ b/crates/gents/src/adapter_projection/tests.rs
@@ -2,9 +2,182 @@ use super::*;
 use std::collections::BTreeSet;
 
 use crate::run_timeline::{
-    build_run_timeline, RunTimelineRows, TimelineMessageRow, TimelineRequestRow,
-    TimelineResponseRow, TimelineToolCallRow,
+    build_run_timeline, RunTimelineRows, TimelineInferenceCallRow, TimelineMessageRow,
+    TimelineRenderedRequestRow, TimelineRequestRow, TimelineResponseRow, TimelineToolCallRow,
 };
+
+const BODY_SENTINEL: &str = "SENTINEL_RENDERED_BODY_9f3a";
+
+/// A timeline whose capture rows carry the sentinel in the one place a body
+/// realistically travels — `assembly_trace.effective_messages` inside
+/// `provenance_json`. Built through `build_run_timeline`, not hand-crafted
+/// events, so the test fences the whole rows→events→projection pipeline.
+fn timeline_with_captures() -> crate::run_timeline::RunTimeline {
+    let provenance = serde_json::json!({
+        "manifest_version": 3,
+        "status": "captured_only",
+        "status_reason": "fixture",
+        "capture_seam": "transport_body",
+        "capture_scope": "inference.1",
+        "admission": { "call_id": "call-1", "call_seq": 1 },
+        "assembly_trace": {
+            "trace_version": 2,
+            "build_path": "budgeted",
+            "effective_message_count": 1,
+            "effective_messages": [
+                { "role": "user", "content": [{ "type": "text", "text": BODY_SENTINEL }] }
+            ],
+            "assistant_message_ids": [],
+            "threaded_tool_results": []
+        }
+    })
+    .to_string();
+
+    let capture = |capture_key: &str, attempt: i64, created_at: &str, provenance: String| {
+        TimelineRenderedRequestRow {
+            capture_key: capture_key.to_string(),
+            request_doc_id: Some("doc-req-1".to_string()),
+            request_id: Some("req-1".to_string()),
+            session_id: Some("session-1".to_string()),
+            capture_scope: Some("inference.1".to_string()),
+            turn_index: Some(0),
+            attempt: Some(attempt),
+            capture_version: Some(1),
+            model_name: Some("test-model".to_string()),
+            source: Some("openai_chat_completions".to_string()),
+            prompt_hash: Some("aa".to_string()),
+            tools_hash: Some("bb".to_string()),
+            provenance_json: Some(provenance),
+            created_at: Some(created_at.to_string()),
+            ..Default::default()
+        }
+    };
+
+    build_run_timeline(RunTimelineRows {
+        request: TimelineRequestRow {
+            request_id: "req-1".to_string(),
+            agent_did: Some("did:test:amy".to_string()),
+            behavior_id: Some("amy".to_string()),
+            session_id: Some("session-1".to_string()),
+            content: Some("hello".to_string()),
+            status: Some("completed".to_string()),
+            created_at: Some("2026-08-07T12:00:00Z".to_string()),
+            ..Default::default()
+        },
+        inference_calls: vec![TimelineInferenceCallRow {
+            call_id: "call-1".to_string(),
+            request_id: "req-1".to_string(),
+            call_seq: 1,
+            attempt: 1,
+            call_state: "completed".to_string(),
+            call_kind: "inference".to_string(),
+            queued_at: Some("2026-08-07T12:00:01Z".to_string()),
+            ..Default::default()
+        }],
+        rendered_requests: vec![
+            capture("rendered:v1:one", 0, "2026-08-07T12:00:02Z", provenance),
+            capture(
+                "rendered:v1:two",
+                1,
+                "2026-08-07T12:00:03Z",
+                format!(r#"{{"manifest_version":99,"body":{body:?}}}"#, body = BODY_SENTINEL),
+            ),
+        ],
+        ..Default::default()
+    })
+}
+
+/// Capture metadata surfaces in every projection's envelope; captured bodies
+/// never appear in ANY serialized output, in any redaction mode. This is the
+/// positive default #1066 demands — Harbor invokes `trace project` with
+/// neither `--redaction` nor `--actor-did`, so the exclusion cannot be a
+/// caller responsibility.
+#[test]
+fn rendered_captures_surface_as_metadata_and_bodies_never_leak() {
+    let timeline = timeline_with_captures();
+    for kind in [
+        AdapterProjectionKind::AtifTrajectory,
+        AdapterProjectionKind::OpenAiCodexRunTrace,
+        AdapterProjectionKind::LangGraphStateHistory,
+        AdapterProjectionKind::MultiAgentTask,
+    ] {
+        for mode in [
+            ProjectionRedactionMode::Full,
+            ProjectionRedactionMode::TrainingSafe,
+            ProjectionRedactionMode::Public,
+        ] {
+            let envelope = build_adapter_projection(
+                kind,
+                &timeline,
+                &ProjectionContext {
+                    actor_did: None,
+                    redaction_mode: mode,
+                },
+            );
+            let serialized = serde_json::to_string(&envelope).unwrap();
+            assert!(
+                !serialized.contains(BODY_SENTINEL),
+                "{kind:?}/{mode:?} leaked a captured body"
+            );
+            assert_eq!(
+                envelope.rendered_captures.len(),
+                2,
+                "{kind:?}/{mode:?} lost capture metadata"
+            );
+            assert_eq!(
+                envelope.rendered_captures[0].call_seq,
+                Some(1),
+                "{kind:?}/{mode:?} lost the admission join"
+            );
+            assert_eq!(
+                envelope.rendered_captures[1].provenance_status,
+                "unsupported_manifest"
+            );
+            assert_adapter_projection_matches_json_schema(&envelope);
+        }
+    }
+}
+
+/// The open extension surfaces carry the same metadata: ATIF at trajectory
+/// `extra.rendered_captures`, LangGraph in `values.rendered_captures`.
+#[test]
+fn open_extension_surfaces_carry_capture_metadata() {
+    let timeline = timeline_with_captures();
+    let context = ProjectionContext::default();
+
+    let atif = build_adapter_projection(
+        AdapterProjectionKind::AtifTrajectory,
+        &timeline,
+        &context,
+    );
+    let AdapterProjection::AtifTrajectory(trajectory) = &atif.output else {
+        panic!("expected ATIF output");
+    };
+    let captures = trajectory
+        .extra
+        .as_ref()
+        .and_then(|extra| extra.get("rendered_captures"))
+        .and_then(Value::as_array)
+        .expect("ATIF trajectory extra.rendered_captures");
+    assert_eq!(captures.len(), 2);
+    assert_eq!(captures[0]["capture_key"], "rendered:v1:one");
+
+    let langgraph = build_adapter_projection(
+        AdapterProjectionKind::LangGraphStateHistory,
+        &timeline,
+        &context,
+    );
+    let AdapterProjection::LangGraphStateHistory(projection) = &langgraph.output else {
+        panic!("expected LangGraph output");
+    };
+    let captures = projection
+        .values
+        .get("rendered_captures")
+        .and_then(Value::as_array)
+        .expect("LangGraph values.rendered_captures");
+    assert_eq!(captures.len(), 2);
+    assert_eq!(captures[1]["provenance_status"], "unsupported_manifest");
+}
 
 fn workspace_root() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/gents/src/adapter_projection/tests.rs
+++ b/crates/gents/src/adapter_projection/tests.rs
@@ -80,7 +80,10 @@ fn timeline_with_captures() -> crate::run_timeline::RunTimeline {
                 "rendered:v1:two",
                 1,
                 "2026-08-07T12:00:03Z",
-                format!(r#"{{"manifest_version":99,"body":{body:?}}}"#, body = BODY_SENTINEL),
+                format!(
+                    r#"{{"manifest_version":99,"body":{body:?}}}"#,
+                    body = BODY_SENTINEL
+                ),
             ),
         ],
         ..Default::default()
@@ -145,11 +148,7 @@ fn open_extension_surfaces_carry_capture_metadata() {
     let timeline = timeline_with_captures();
     let context = ProjectionContext::default();
 
-    let atif = build_adapter_projection(
-        AdapterProjectionKind::AtifTrajectory,
-        &timeline,
-        &context,
-    );
+    let atif = build_adapter_projection(AdapterProjectionKind::AtifTrajectory, &timeline, &context);
     let AdapterProjection::AtifTrajectory(trajectory) = &atif.output else {
         panic!("expected ATIF output");
     };

--- a/crates/gents/src/admission/client.rs
+++ b/crates/gents/src/admission/client.rs
@@ -152,6 +152,17 @@ impl CallKind {
     }
 }
 
+/// The identity of the admission call currently in flight on this task:
+/// exactly what `next_call` minted for it. This is what makes the
+/// capture-to-`InferenceCall` join exact instead of ordinal — an admission
+/// rejection consumes no `call_seq` and stores no join.
+#[derive(Clone, Debug)]
+pub(crate) struct CurrentCallJoin {
+    pub(crate) call_id: String,
+    pub(crate) call_seq: i64,
+    pub(crate) call_kind: CallKind,
+}
+
 #[derive(Clone)]
 pub(crate) struct AdmissionCallContext {
     pub(super) request_id: String,
@@ -162,6 +173,11 @@ pub(crate) struct AdmissionCallContext {
     pub(super) call_kind: CallKind,
     pub(super) attempt: i64,
     pub(super) call_seq: Arc<AtomicU64>,
+    /// Written by `next_call`, read by `current_call_join()` at the transport
+    /// seam. Shared (`Arc`) across the request's call scopes — `scope_call`
+    /// clones the context, and the clone must observe the same slot the
+    /// admitted call writes.
+    pub(super) current_call: Arc<Mutex<Option<CurrentCallJoin>>>,
     pub(super) inference_token: Option<CancellationToken>,
     pub(super) terminal_failure_reason: Option<TerminalFailureReasonObserver>,
 }
@@ -181,6 +197,7 @@ impl AdmissionCallContext {
             call_kind: CallKind::Inference,
             attempt: 1,
             call_seq: Arc::new(AtomicU64::new(0)),
+            current_call: Arc::new(Mutex::new(None)),
             inference_token: None,
             terminal_failure_reason: None,
         }
@@ -188,7 +205,7 @@ impl AdmissionCallContext {
 
     pub(super) fn next_call(&self, runtime_instance_id: &str) -> PendingCallMetadata {
         let call_seq = self.call_seq.fetch_add(1, Ordering::SeqCst) + 1;
-        PendingCallMetadata {
+        let metadata = PendingCallMetadata {
             call_id: uuid::Uuid::new_v4().to_string(),
             runtime_instance_id: runtime_instance_id.to_string(),
             request_id: self.request_id.clone(),
@@ -198,7 +215,17 @@ impl AdmissionCallContext {
             agent_did: self.agent_did.clone(),
             call_kind: self.call_kind,
             attempt: self.attempt,
+        };
+        let join = CurrentCallJoin {
+            call_id: metadata.call_id.clone(),
+            call_seq: i64::try_from(call_seq).unwrap_or(i64::MAX),
+            call_kind: self.call_kind,
+        };
+        match self.current_call.lock() {
+            Ok(mut slot) => *slot = Some(join),
+            Err(poisoned) => *poisoned.into_inner() = Some(join),
         }
+        metadata
     }
 }
 
@@ -280,4 +307,17 @@ pub(crate) fn current_session_id() -> Option<String> {
     ADMISSION_CALL_CONTEXT
         .try_with(|context| context.session_id.clone())
         .ok()
+}
+
+/// The admission identity of the call currently in flight on this task, if
+/// one has been admitted. `None` outside an admission scope (one-shot runs)
+/// and before the first `next_call` of a scope.
+pub(crate) fn current_call_join() -> Option<CurrentCallJoin> {
+    ADMISSION_CALL_CONTEXT
+        .try_with(|context| match context.current_call.lock() {
+            Ok(slot) => slot.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        })
+        .ok()
+        .flatten()
 }

--- a/crates/gents/src/admission/mod.rs
+++ b/crates/gents/src/admission/mod.rs
@@ -10,9 +10,9 @@ mod slot_accounting;
 pub(crate) mod stream_guard;
 
 pub(crate) use client::{
-    current_call_join, current_session_id, scope_call,
-    scope_call_with_token_and_failure_reason, scope_request, set_terminal_failure_reason,
-    terminal_failure_reason_observer, AdmissionCallContext, AdmittedCompletionClient, CallKind,
+    current_call_join, current_session_id, scope_call, scope_call_with_token_and_failure_reason,
+    scope_request, set_terminal_failure_reason, terminal_failure_reason_observer,
+    AdmissionCallContext, AdmittedCompletionClient, CallKind,
 };
 pub(crate) use config::backend_admission_configs_from_backends;
 pub use config::BackendAdmissionConfig;

--- a/crates/gents/src/admission/mod.rs
+++ b/crates/gents/src/admission/mod.rs
@@ -10,9 +10,9 @@ mod slot_accounting;
 pub(crate) mod stream_guard;
 
 pub(crate) use client::{
-    current_session_id, scope_call, scope_call_with_token_and_failure_reason, scope_request,
-    set_terminal_failure_reason, terminal_failure_reason_observer, AdmissionCallContext,
-    AdmittedCompletionClient, CallKind,
+    current_call_join, current_session_id, scope_call,
+    scope_call_with_token_and_failure_reason, scope_request, set_terminal_failure_reason,
+    terminal_failure_reason_observer, AdmissionCallContext, AdmittedCompletionClient, CallKind,
 };
 pub(crate) use config::backend_admission_configs_from_backends;
 pub use config::BackendAdmissionConfig;

--- a/crates/gents/src/admission/registry.rs
+++ b/crates/gents/src/admission/registry.rs
@@ -164,6 +164,7 @@ impl AdmissionRegistry {
             call_kind,
             attempt: 1,
             call_seq: Arc::new(AtomicU64::new(0)),
+            current_call: Arc::new(std::sync::Mutex::new(None)),
             inference_token: None,
             terminal_failure_reason: None,
         };

--- a/crates/gents/src/admission/tests.rs
+++ b/crates/gents/src/admission/tests.rs
@@ -88,6 +88,39 @@ async fn current_session_id_reflects_request_scope() {
     assert_eq!(super::current_session_id(), None);
 }
 
+/// `next_call` publishes the minted call identity to the shared slot, and
+/// `current_call_join()` reads it back on the same task — the seam the
+/// rendered-request capture uses for its exact `InferenceCall` join.
+#[tokio::test]
+async fn current_call_join_reflects_the_minted_call() {
+    assert!(super::current_call_join().is_none());
+
+    let context = AdmissionCallContext::for_request(&request("req-j"), "default", "backend-1");
+    // Keep a handle sharing the same slot Arc, exactly like scope_call clones do.
+    let minting_handle = context.clone();
+    scope_request(context, async move {
+        // Scoped but nothing admitted yet: no join to report.
+        assert!(super::current_call_join().is_none());
+
+        let first = minting_handle.next_call("runtime-test");
+        let join = super::current_call_join().expect("join after mint");
+        assert_eq!(join.call_id, first.call_id);
+        assert_eq!(join.call_seq, 1);
+
+        // A second admitted call replaces the slot; the join always names the
+        // call currently in flight.
+        let second = minting_handle.next_call("runtime-test");
+        let join = super::current_call_join().expect("join after second mint");
+        assert_eq!(join.call_id, second.call_id);
+        assert_eq!(join.call_seq, 2);
+        assert_ne!(first.call_id, second.call_id);
+    })
+    .await;
+
+    // Cleared with the scope: no ambient join leaks across requests.
+    assert!(super::current_call_join().is_none());
+}
+
 const ADMISSION_TERMINAL_REASON_SOURCES: &[&str] = &[
     include_str!("controller.rs"),
     include_str!("permit.rs"),

--- a/crates/gents/src/external_adapter_capture.rs
+++ b/crates/gents/src/external_adapter_capture.rs
@@ -481,6 +481,7 @@ fn import_langgraph_capture(
             tool_calls,
             inference_calls: Vec::new(),
             responses,
+            rendered_requests: Vec::new(),
         },
     })
 }
@@ -1065,6 +1066,7 @@ fn import_multi_agent_capture(
             tool_calls,
             inference_calls: Vec::new(),
             responses,
+            rendered_requests: Vec::new(),
         },
     })
 }

--- a/crates/gents/src/lean_vocab_test/rendered_capture.rs
+++ b/crates/gents/src/lean_vocab_test/rendered_capture.rs
@@ -51,3 +51,29 @@ pub(crate) struct LeanRenderedCaptureKeyCase {
     pub(crate) right_attempt: u32,
     pub(crate) same_fact: bool,
 }
+
+/// One `capture_scope` label vector (#1066): what the shared consumer parser
+/// (`gents_protocol::rendered_request::CaptureScope`) must accept — with the
+/// kind and numeric seq it must recover — or reject, never default.
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct LeanCaptureScopeCase {
+    pub(crate) label: String,
+    pub(crate) kind: String,
+    pub(crate) seq: u64,
+    pub(crate) valid: bool,
+}
+
+/// One ordering verdict over `(kind rank, seq, turn, attempt)`, decided by the
+/// Lean comparison. `inference.10` vs `inference.2` is in the list precisely
+/// so a lexical implementation cannot pass.
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct LeanCaptureOrderCase {
+    pub(crate) name: String,
+    pub(crate) left_label: String,
+    pub(crate) left_turn: i64,
+    pub(crate) left_attempt: i64,
+    pub(crate) right_label: String,
+    pub(crate) right_turn: i64,
+    pub(crate) right_attempt: i64,
+    pub(crate) left_before_right: bool,
+}

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -151,6 +151,10 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) rendered_capture_cases: Vec<LeanRenderedCaptureCase>,
     #[serde(default)]
     pub(crate) rendered_capture_key_cases: Vec<LeanRenderedCaptureKeyCase>,
+    #[serde(default)]
+    pub(crate) capture_scope_cases: Vec<LeanCaptureScopeCase>,
+    #[serde(default)]
+    pub(crate) capture_order_cases: Vec<LeanCaptureOrderCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
     pub(crate) feature_surface_requirements: Vec<LeanFeatureSurfaceRequirement>,
@@ -882,6 +886,14 @@ pub(crate) fn lean_rendered_capture_cases() -> &'static [LeanRenderedCaptureCase
 
 pub(crate) fn lean_rendered_capture_key_cases() -> &'static [LeanRenderedCaptureKeyCase] {
     &lean_contract_snapshot().rendered_capture_key_cases
+}
+
+pub(crate) fn lean_capture_scope_cases() -> &'static [LeanCaptureScopeCase] {
+    &lean_contract_snapshot().capture_scope_cases
+}
+
+pub(crate) fn lean_capture_order_cases() -> &'static [LeanCaptureOrderCase] {
+    &lean_contract_snapshot().capture_order_cases
 }
 
 pub(crate) fn lean_compaction_reducer_case(name: &str) -> &'static LeanCompactionReducerCase {

--- a/crates/gents/src/rendered_request/commits.rs
+++ b/crates/gents/src/rendered_request/commits.rs
@@ -66,9 +66,7 @@ fn select_request_json_commit(response: &serde_json::Value) -> Result<Option<Req
                 height: commit.get("height").and_then(serde_json::Value::as_i64)?,
             })
         })
-        .max_by(|left, right| {
-            (left.height, &left.cid).cmp(&(right.height, &right.cid))
-        }))
+        .max_by(|left, right| (left.height, &left.cid).cmp(&(right.height, &right.cid))))
 }
 
 #[cfg(test)]

--- a/crates/gents/src/rendered_request/commits.rs
+++ b/crates/gents/src/rendered_request/commits.rs
@@ -1,0 +1,129 @@
+//! The one implementation of the `request_json` field-commit read.
+//!
+//! The CID of the `request_json` field commit is this fact record's content
+//! address — integrity comes from the database, not from a stored digest (see
+//! the module doc in `mod.rs`). Reading it has two traps every consumer would
+//! otherwise rediscover:
+//!
+//! * `_commits` accepts exactly ONE `docID`; two or more is a parse error.
+//! * Its `fieldName` filter is evaluated **in memory**, with
+//!   `filter.matches(..).unwrap_or(true)` — a malformed filter silently
+//!   degrades to *no* filter, which combined with `limit: 1` returns an
+//!   arbitrary commit. So this helper sends no `fieldName` filter at all and
+//!   selects the `request_json` commit in Rust, where a mistake is a type
+//!   error instead of a wrong answer.
+//!
+//! `[]` from `_commits` is reported as explicit *Unavailable* (`Ok(None)`),
+//! never "unchanged"; a GraphQL error is an error.
+
+use anyhow::{Context, Result};
+
+use crate::config_client::ConfigAccess;
+use crate::graphql::escape_graphql_string;
+
+/// The field-commit witness for a stored `request_json` value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestJsonCommit {
+    pub cid: String,
+    pub height: i64,
+}
+
+/// Read the current `request_json` field-commit CID for one `RenderedRequest`
+/// document. `Ok(None)` is explicit *Unavailable*: the document has no commits
+/// visible on this node, or none for `request_json`.
+pub async fn request_json_commit(
+    access: &ConfigAccess,
+    doc_id: &str,
+) -> Result<Option<RequestJsonCommit>> {
+    let query = format!(
+        r#"query {{ _commits(docID: "{doc_id}") {{ cid height fieldName }} }}"#,
+        doc_id = escape_graphql_string(doc_id),
+    );
+    let response = access
+        .execute(&query)
+        .await
+        .with_context(|| format!("reading _commits for rendered request {doc_id}"))?;
+    select_request_json_commit(&response)
+}
+
+/// Pure selection over a `_commits` response: pick the highest
+/// `request_json` field commit, in Rust rather than in a query filter.
+fn select_request_json_commit(response: &serde_json::Value) -> Result<Option<RequestJsonCommit>> {
+    let commits = response
+        .get("data")
+        .and_then(|data| data.get("_commits"))
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("_commits response carried no data._commits array"))?;
+
+    Ok(commits
+        .iter()
+        .filter(|commit| {
+            commit.get("fieldName").and_then(serde_json::Value::as_str) == Some("request_json")
+        })
+        .filter_map(|commit| {
+            Some(RequestJsonCommit {
+                cid: commit.get("cid")?.as_str()?.to_string(),
+                height: commit.get("height").and_then(serde_json::Value::as_i64)?,
+            })
+        })
+        .max_by(|left, right| {
+            (left.height, &left.cid).cmp(&(right.height, &right.cid))
+        }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn selects_the_highest_request_json_commit() {
+        let response = json!({
+            "data": {
+                "_commits": [
+                    { "cid": "bafy-composite", "height": 3, "fieldName": "_C" },
+                    { "cid": "bafy-old", "height": 1, "fieldName": "request_json" },
+                    { "cid": "bafy-current", "height": 2, "fieldName": "request_json" },
+                    { "cid": "bafy-prov", "height": 2, "fieldName": "provenance_json" },
+                ]
+            }
+        });
+        assert_eq!(
+            select_request_json_commit(&response).unwrap(),
+            Some(RequestJsonCommit {
+                cid: "bafy-current".to_string(),
+                height: 2,
+            })
+        );
+    }
+
+    /// Commits exist, but none for `request_json` — that is Unavailable, not
+    /// "take whichever commit came back", which is exactly the in-memory
+    /// filter failure mode this helper exists to rule out.
+    #[test]
+    fn commits_without_a_request_json_field_are_unavailable() {
+        let response = json!({
+            "data": {
+                "_commits": [
+                    { "cid": "bafy-composite", "height": 1, "fieldName": "_C" },
+                ]
+            }
+        });
+        assert_eq!(select_request_json_commit(&response).unwrap(), None);
+    }
+
+    #[test]
+    fn an_empty_commit_list_is_unavailable_never_unchanged() {
+        let response = json!({ "data": { "_commits": [] } });
+        assert_eq!(select_request_json_commit(&response).unwrap(), None);
+    }
+
+    /// A response with no `data._commits` array at all is an error — a missing
+    /// `data` field is not the same statement as "no rows".
+    #[test]
+    fn a_shapeless_response_is_an_error() {
+        assert!(select_request_json_commit(&json!({})).is_err());
+        assert!(select_request_json_commit(&json!({ "data": {} })).is_err());
+    }
+}

--- a/crates/gents/src/rendered_request/mod.rs
+++ b/crates/gents/src/rendered_request/mod.rs
@@ -62,47 +62,24 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
-use crate::llm::message::{Message, ToolResultContent, UserContent};
-
+pub mod commits;
 pub(crate) mod scope;
 pub mod sink;
 pub(crate) mod transport;
 
-pub use scope::CaptureScopeKind;
+pub use gents_protocol::rendered_request::{
+    AdmissionJoin, AssemblyBuildPath, AssemblyTrace, AssistantMessageId, CaptureOrderKey,
+    CaptureScope, CaptureScopeKind, CaptureSeam, ParsedProvenance, ProvenanceManifest,
+    ProvenanceStatus, RenderedRequestSource, ThreadedToolResult, ASSEMBLY_TRACE_VERSION,
+    CAPTURE_VERSION, PROVENANCE_MANIFEST_VERSION,
+};
 pub(crate) use sink::defra_rendered_request_capture_factory;
 pub use sink::DefraRenderedRequestSink;
 pub use transport::RenderedRequestCapturingHttpClient;
 
-/// Capture format version stamped onto every row. Bump when the *set of
-/// columns* a reader must understand changes.
-pub const CAPTURE_VERSION: u32 = 1;
-
-/// Provenance manifest version. Bump when `ProvenanceManifest`'s serialized
-/// shape changes. A reader that does not know this number must report
-/// `UnsupportedManifest` rather than guessing.
-pub const PROVENANCE_MANIFEST_VERSION: u32 = 2;
-
-/// Assembly-trace version. Bump when `AssemblyTrace`'s serialized shape
-/// changes. Versioned independently of the manifest so a manifest that later
-/// gains pinned config CIDs does not have to re-version the trace.
-pub const ASSEMBLY_TRACE_VERSION: u32 = 2;
-
 /// Prefix on every capture key. Bound to the *key derivation*, not to
 /// `CAPTURE_VERSION`: adding a column must not silently re-key existing facts.
 const CAPTURE_KEY_PREFIX: &str = "rendered:v1";
-
-/// Request paths whose body is a completion request, and the wire shape each
-/// one implies. The capturing transport only claims a pending capture for one
-/// of these, so a `/models` listing or a token-refresh call issued while a
-/// capture is armed passes through untouched instead of consuming — and
-/// mis-describing — the turn's fact.
-const COMPLETION_REQUEST_PATHS: &[(&str, RenderedRequestSource)] = &[
-    ("/responses", RenderedRequestSource::OpenAiResponses),
-    (
-        "/chat/completions",
-        RenderedRequestSource::OpenAiChatCompletions,
-    ),
-];
 
 pub(crate) type RenderedRequestCaptureSink = Arc<
     dyn Fn(RenderedCompletionRequest) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>
@@ -112,322 +89,6 @@ pub(crate) type RenderedRequestCaptureSink = Arc<
 
 pub(crate) type RenderedRequestCaptureFactory =
     Arc<dyn Fn(RenderedRequestContext) -> RenderedRequestCaptureSink + Send + Sync>;
-
-/// The provider wire shape a captured body was actually sent on.
-///
-/// Derived from the request path the transport posted to, never from behavior
-/// configuration: configuration says what the runtime *intended*, and this
-/// column has to say what the provider *received*. The two can disagree — a
-/// backend document can be edited between reconcile and send.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum RenderedRequestSource {
-    #[serde(rename = "openai_responses")]
-    OpenAiResponses,
-    #[serde(rename = "openai_chat_completions")]
-    OpenAiChatCompletions,
-}
-
-impl RenderedRequestSource {
-    /// Classify by the completion request path. `None` means "not a completion
-    /// request", which is the transport's signal to forward without capturing.
-    pub(crate) fn for_request_path(path: &str) -> Option<Self> {
-        COMPLETION_REQUEST_PATHS
-            .iter()
-            .find(|(suffix, _)| path.ends_with(suffix))
-            .map(|(_, source)| *source)
-    }
-
-    /// The body field carrying the provider message list on this wire shape.
-    fn messages_field(self) -> &'static str {
-        match self {
-            Self::OpenAiResponses => "input",
-            Self::OpenAiChatCompletions => "messages",
-        }
-    }
-}
-
-/// Which of the owned loop's two request builders produced the captured
-/// `CompletionRequest`.
-///
-/// This is one of the four unrecoverable inputs. `build_budgeted_request`
-/// applies `clamp_request_output_budget` before returning
-/// (`agent/loop_stream.rs`), but the completion-retry `Repair` directive calls
-/// `build_request` directly (`agent/loop_stream.rs:353,447`) and never clamps.
-/// A repaired attempt therefore carries the raw configured `max_tokens` while
-/// the original attempt for the same turn carries the clamped one. Without this
-/// discriminator a reconstructor cannot tell which of the two it should
-/// reproduce, and both are legal.
-///
-/// The clamp *value* is deliberately not stored: it is a pure function of the
-/// assembled request plus durable config, and `completion_request_input_estimate`
-/// does not read `max_tokens`, so a single reconstruction pass reproduces it.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AssemblyBuildPath {
-    /// `build_budgeted_request`: ordinary assembly, output clamp applied, and
-    /// per-turn compaction when the request exceeded the input budget.
-    Budgeted,
-    /// `build_request` invoked directly by a completion-retry repair. No output
-    /// clamp is applied on this path.
-    Repair,
-}
-
-impl AssemblyBuildPath {
-    /// Whether the loop applied `clamp_request_output_budget` on this path.
-    pub fn applies_output_clamp(self) -> bool {
-        matches!(self, Self::Budgeted)
-    }
-}
-
-/// A provider-assigned assistant message id, positioned in the effective
-/// message list.
-///
-/// One of the four unrecoverable inputs. `close_streaming_turn` stamps the
-/// provider's `MessageId` event onto the threaded assistant message
-/// (`agent/loop_stream.rs:802-806`) because OpenAI Responses and ChatGPT Codex
-/// follow-up requests reference prior `msg_` ids. The persistence path builds
-/// its assistant message with `id: None`
-/// (`agent/stream_processor.rs:305`), so the id exists in the provider request
-/// and nowhere in the durable transcript.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AssistantMessageId {
-    /// Index into `AssemblyTrace::effective_messages`.
-    pub message_index: usize,
-    pub message_id: String,
-}
-
-/// The exact tool-result content threaded back into provider history for one
-/// tool call.
-///
-/// One of the four unrecoverable inputs. The loop threads
-/// `truncate_text(outcome.model_facing_text(), tool_result_truncation_mode(name),
-/// &TruncationLimits::default())` (`agent/loop_stream.rs:655-658`). Persistence
-/// re-derives its text from the stored `AgentToolCall.result` with
-/// `TruncationMode::Head`, the hook's own `truncation_limits`, and
-/// `model_observation_for_tool_result`
-/// (`hook/persistence/message_spawn.rs:296-324`). Those are different functions
-/// over different inputs, so replaying from the transcript does not reproduce
-/// the bytes the model actually saw.
-///
-/// `content` is the full threaded `Vec<ToolResultContent>`, not a flattened
-/// string: `ToolResultContent::from_tool_output` can split a JSON payload into
-/// several parts, and that split is part of what the provider received.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ThreadedToolResult {
-    /// Index into `AssemblyTrace::effective_messages`.
-    pub message_index: usize,
-    /// `ToolResult.id` — rig's locally minted tool-call id.
-    pub tool_call_id: String,
-    /// `ToolResult.call_id` — the provider-side call id when one exists.
-    pub call_id: Option<String>,
-    pub content: Vec<ToolResultContent>,
-}
-
-/// The genuinely unrecoverable inputs to one rendered provider request.
-///
-/// Everything else that shapes a request is either durable (transcript rows,
-/// behavior/profile/backend/skill documents) or a pure function of durable data.
-/// These four are not:
-///
-/// 1. `assistant_message_ids` — provider-assigned, persisted as `None`.
-/// 2. `threaded_tool_results` — the loop and the persistence path derive
-///    different text from different sources.
-/// 3. `effective_messages` — when a rendered request-context message or
-///    per-turn compaction adds ephemeral content. Compaction is a *sticky*
-///    mutation
-///    (`*history = compacted; *new_messages = vec![compacted_prompt]`,
-///    `agent/loop_stream.rs:1350-1351`), so one turn's model-generated summary
-///    governs every later turn of the same request, and that summary is never
-///    written as an `AgentCompactionEntry`. Re-running the summarizer does not
-///    produce the same words.
-/// 4. `build_path` — see `AssemblyBuildPath`.
-///
-/// `assistant_message_ids` and `threaded_tool_results` are projections of the
-/// effective message list, derived by the same constructor so they cannot drift
-/// from it.
-/// They are carried explicitly because a reconstructor rebuilds its message
-/// list from `AgentMessage` rows and needs these as an *overlay* keyed by
-/// position and call id; `effective_messages` is the oracle it checks itself
-/// against. `effective_messages` is present only when that list contains a
-/// rendered request-context message, a model-generated per-turn compaction
-/// summary, or the result of a repair rewrite. Otherwise the durable transcript
-/// plus these overlays reconstructs it exactly.
-///
-/// ## Size
-///
-/// Ordinary turns do not retain the full native message list next to the
-/// provider-wire copy in `request_json`; that list is reconstructible from
-/// durable rows plus the overlays. Once request-context rendering, per-turn
-/// compaction, or a repair introduces content no durable row reproduces, the
-/// full native list becomes the oracle and is retained on that and every later
-/// turn of the request. Compacted lists are bounded by the context window
-/// rather than growing with the unabridged session.
-///
-/// `threaded_tool_results` is carried on **every** turn, compact path included,
-/// because rig joins multi-part tool-result content with `"\n"` on the Chat
-/// Completions wire — the native `Vec<ToolResultContent>` split is genuinely
-/// unrecoverable from `request_json`. So a tool-heavy turn does duplicate its
-/// tool-result payloads; only the surrounding message list is elided.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct AssemblyTrace {
-    pub trace_version: u32,
-    pub build_path: AssemblyBuildPath,
-    /// Number of native messages passed to assembly. This validates positional
-    /// overlays even when the reconstructible common-path list is omitted.
-    pub effective_message_count: usize,
-    /// The full effective provider message list at capture time, retained only
-    /// after request-context rendering or per-turn compaction introduces
-    /// ephemeral content. Native `Message`s, not provider wire shapes: this is
-    /// the *input* to assembly, whereas `request_json` is its output.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effective_messages: Option<Vec<Message>>,
-    pub assistant_message_ids: Vec<AssistantMessageId>,
-    pub threaded_tool_results: Vec<ThreadedToolResult>,
-}
-
-impl AssemblyTrace {
-    /// The only constructor that keeps the overlays consistent with
-    /// `effective_messages`. Build traces with this, never with a struct
-    /// literal.
-    pub fn from_effective_messages(
-        build_path: AssemblyBuildPath,
-        effective_messages: Vec<Message>,
-    ) -> Self {
-        Self::from_messages(build_path, effective_messages, true)
-    }
-
-    /// Build the compact common-path trace when the native list can be rebuilt
-    /// from durable transcript/configuration documents plus the overlays.
-    pub(crate) fn from_reconstructible_messages(
-        build_path: AssemblyBuildPath,
-        effective_messages: Vec<Message>,
-    ) -> Self {
-        Self::from_messages(build_path, effective_messages, false)
-    }
-
-    fn from_messages(
-        build_path: AssemblyBuildPath,
-        effective_messages: Vec<Message>,
-        retain_effective_messages: bool,
-    ) -> Self {
-        let mut assistant_message_ids = Vec::new();
-        let mut threaded_tool_results = Vec::new();
-
-        for (message_index, message) in effective_messages.iter().enumerate() {
-            match message {
-                Message::Assistant {
-                    id: Some(message_id),
-                    ..
-                } => assistant_message_ids.push(AssistantMessageId {
-                    message_index,
-                    message_id: message_id.clone(),
-                }),
-                Message::User { content } => {
-                    for item in content {
-                        if let UserContent::ToolResult(result) = item {
-                            threaded_tool_results.push(ThreadedToolResult {
-                                message_index,
-                                tool_call_id: result.id.clone(),
-                                call_id: result.call_id.clone(),
-                                content: result.content.clone(),
-                            });
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let effective_message_count = effective_messages.len();
-        Self {
-            trace_version: ASSEMBLY_TRACE_VERSION,
-            build_path,
-            effective_message_count,
-            effective_messages: retain_effective_messages.then_some(effective_messages),
-            assistant_message_ids,
-            threaded_tool_results,
-        }
-    }
-}
-
-/// How much this capture claims about reconstructibility.
-///
-/// Explicit, never inferred from an absent field. A manifest that simply omits
-/// pinned CIDs must not read as "nothing needed pinning".
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ProvenanceStatus {
-    /// The rendered request is durable and exact, but no durable source
-    /// versions are pinned alongside it, so a reconstruction cannot be
-    /// verified against it. This is the only status version 1 emits.
-    CapturedOnly,
-}
-
-/// Where in the send path the captured bytes were read.
-///
-/// Recorded positively so a reader never has to infer it. A row that says
-/// `TransportBody` is claiming the stronger thing: these are the bytes the HTTP
-/// client forwarded, after every provider-specific rewrite.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CaptureSeam {
-    /// The last `HttpClientExt` before the network client. The only seam
-    /// version 1 emits.
-    TransportBody,
-}
-
-/// Versioned provenance travelling in the `provenance_json` column.
-///
-/// Version 1 carries the assembly trace, the seam the bytes came from, the
-/// capture scope, and an honest `CapturedOnly` status. Pinned
-/// config/transcript CIDs are a later version; when they arrive, a version-1
-/// row must still be readable and must still report `CapturedOnly`.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ProvenanceManifest {
-    pub manifest_version: u32,
-    pub status: ProvenanceStatus,
-    /// Why this row is not `Verified`, in words, so a projection can say so
-    /// without the reader reverse-engineering it from missing fields.
-    pub status_reason: String,
-    pub capture_seam: CaptureSeam,
-    /// Mirrors the `capture_scope` column. Duplicated here so a manifest read
-    /// in isolation still identifies which completion loop it describes.
-    pub capture_scope: String,
-    /// Scheme and authority the body was actually posted to, observed at the
-    /// seam. `None` only when the URI carried no authority.
-    ///
-    /// This is the one routing fact that is otherwise lost in time. `model_name`
-    /// alone cannot distinguish OpenAI from OpenRouter from a local vLLM from
-    /// Grok, and for daemon requests the answer is recoverable only by joining
-    /// to `InferenceCall.backend_id` — a join that does not exist for one-shot
-    /// runs, which never enter an admission scope. Configuration says where the
-    /// bytes were meant to go; this says where they went.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider_endpoint: Option<String>,
-    pub assembly_trace: AssemblyTrace,
-}
-
-impl ProvenanceManifest {
-    const CAPTURED_ONLY_REASON: &'static str =
-        "this provenance manifest pins no config or transcript versions, so a \
-         reconstruction cannot be verified against this capture";
-
-    pub fn captured_only(
-        capture_scope: String,
-        provider_endpoint: Option<String>,
-        assembly_trace: AssemblyTrace,
-    ) -> Self {
-        Self {
-            manifest_version: PROVENANCE_MANIFEST_VERSION,
-            status: ProvenanceStatus::CapturedOnly,
-            status_reason: Self::CAPTURED_ONLY_REASON.to_string(),
-            capture_seam: CaptureSeam::TransportBody,
-            capture_scope,
-            provider_endpoint,
-            assembly_trace,
-        }
-    }
-}
 
 /// Identity and routing for every capture belonging to one request.
 ///
@@ -605,6 +266,7 @@ pub(crate) fn build_rendered_completion_request(
     let manifest = ProvenanceManifest::captured_only(
         capture_scope.to_string(),
         provider_endpoint,
+        admission_join_for_scope(capture_scope),
         assembly_trace.clone(),
     );
     let provenance_json = canonical_json(
@@ -640,6 +302,43 @@ pub(crate) fn build_rendered_completion_request(
         assembly_trace,
         provenance_json,
     })
+}
+
+/// The admission identity to stamp into this capture's provenance, if the call
+/// in flight on this task belongs to the loop the capture describes.
+///
+/// The kind guard is what keeps a cross-loop race honest: the `current_call`
+/// slot is shared across every admission scope of the request, so a title
+/// call minted concurrently with an inference capture must not be joined to
+/// it. A dropped join degrades to the pre-#1066 ordinal situation; a wrong
+/// join would be worse than none. One-shot captures never join — no admission
+/// scope exists there.
+fn admission_join_for_scope(capture_scope: &str) -> Option<AdmissionJoin> {
+    let join = crate::admission::current_call_join()?;
+    let scope_kind = capture_scope.parse::<CaptureScope>().ok()?.kind;
+    admission_kind_matches_scope(join.call_kind, scope_kind).then(|| AdmissionJoin {
+        call_id: join.call_id,
+        call_seq: join.call_seq,
+    })
+}
+
+/// Which admission [`CallKind`](crate::admission::CallKind) legitimately
+/// produces captures of which [`CaptureScopeKind`]. `OneShot` maps to nothing:
+/// one-shot runs have no admission scope at all, so a join observed under a
+/// oneshot capture could only be another loop's call.
+pub(crate) fn admission_kind_matches_scope(
+    call_kind: crate::admission::CallKind,
+    scope_kind: CaptureScopeKind,
+) -> bool {
+    use crate::admission::CallKind;
+
+    matches!(
+        (call_kind, scope_kind),
+        (CallKind::Inference, CaptureScopeKind::Inference)
+            | (CallKind::Compaction, CaptureScopeKind::Compaction)
+            | (CallKind::Compaction, CaptureScopeKind::CompactionFallback)
+            | (CallKind::OneOff, CaptureScopeKind::Title)
+    )
 }
 
 /// Derive the durable capture key from the five-component identity tuple.
@@ -726,7 +425,9 @@ pub(crate) fn sha256_canonical_json(value: &Value) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use gents_protocol::message::{AssistantContent, Text, ToolCall, ToolFunction};
+    use gents_protocol::message::{
+        AssistantContent, Message, ToolCall, ToolFunction, ToolResultContent, UserContent,
+    };
     use serde_json::json;
 
     use super::*;
@@ -893,40 +594,6 @@ mod tests {
         );
         assert_eq!(rendered.tool_choice_json, Value::Null);
         assert_eq!(rendered.sampling_json["temperature"], Value::Null);
-    }
-
-    /// The wire shape is read off the path the transport posted to, so the
-    /// column reports what was sent rather than what was configured.
-    #[test]
-    fn rendered_source_follows_the_request_path() {
-        assert_eq!(
-            RenderedRequestSource::for_request_path("/v1/responses"),
-            Some(RenderedRequestSource::OpenAiResponses)
-        );
-        assert_eq!(
-            RenderedRequestSource::for_request_path("/backend-api/codex/responses"),
-            Some(RenderedRequestSource::OpenAiResponses)
-        );
-        assert_eq!(
-            RenderedRequestSource::for_request_path("/v1/chat/completions"),
-            Some(RenderedRequestSource::OpenAiChatCompletions)
-        );
-        assert_eq!(RenderedRequestSource::for_request_path("/v1/models"), None);
-        assert_eq!(RenderedRequestSource::for_request_path("/key"), None);
-    }
-
-    /// Every suffix the capture path claims must classify to the wire shape the
-    /// table names, and the table must stay the only definition of "completion
-    /// request".
-    #[test]
-    fn completion_path_suffixes_all_classify() {
-        for (suffix, source) in COMPLETION_REQUEST_PATHS {
-            assert_eq!(
-                RenderedRequestSource::for_request_path(suffix),
-                Some(*source),
-                "{suffix} must classify as a completion path"
-            );
-        }
     }
 
     /// A Responses body names its message list `input`, and the derived views
@@ -1118,128 +785,6 @@ mod tests {
     }
 
     #[test]
-    fn assembly_trace_records_assistant_message_ids_by_position() {
-        let trace = AssemblyTrace::from_effective_messages(
-            AssemblyBuildPath::Budgeted,
-            vec![
-                Message::user("hi"),
-                assistant_with_tool_call(Some("msg_abc"), "call-1"),
-                tool_result_message("call-1", Some("fc_1"), "ok"),
-                // An assistant turn the provider gave no id for.
-                Message::assistant("done"),
-            ],
-        );
-
-        assert_eq!(
-            trace.assistant_message_ids,
-            vec![AssistantMessageId {
-                message_index: 1,
-                message_id: "msg_abc".to_string(),
-            }]
-        );
-    }
-
-    #[test]
-    fn assembly_trace_records_threaded_tool_results_by_call_identity() {
-        let trace = AssemblyTrace::from_effective_messages(
-            AssemblyBuildPath::Budgeted,
-            vec![
-                assistant_with_tool_call(Some("msg_abc"), "call-1"),
-                tool_result_message("call-1", Some("fc_1"), "threaded bytes"),
-                tool_result_message("call-2", None, "no provider call id"),
-            ],
-        );
-
-        assert_eq!(
-            trace.threaded_tool_results,
-            vec![
-                ThreadedToolResult {
-                    message_index: 1,
-                    tool_call_id: "call-1".to_string(),
-                    call_id: Some("fc_1".to_string()),
-                    content: vec![ToolResultContent::Text(Text {
-                        text: "threaded bytes".to_string()
-                    })],
-                },
-                ThreadedToolResult {
-                    message_index: 2,
-                    tool_call_id: "call-2".to_string(),
-                    call_id: None,
-                    content: vec![ToolResultContent::Text(Text {
-                        text: "no provider call id".to_string()
-                    })],
-                },
-            ]
-        );
-    }
-
-    /// The overlays index into `effective_messages`; a projection that reads
-    /// them has to land back on the message it came from.
-    #[test]
-    fn assembly_trace_overlay_indexes_address_the_effective_messages() {
-        let messages = vec![
-            Message::user("hi"),
-            assistant_with_tool_call(Some("msg_abc"), "call-1"),
-            tool_result_message("call-1", Some("fc_1"), "threaded bytes"),
-        ];
-        let trace =
-            AssemblyTrace::from_effective_messages(AssemblyBuildPath::Budgeted, messages.clone());
-
-        let effective_messages = trace
-            .effective_messages
-            .as_ref()
-            .expect("explicit oracle trace");
-        assert_eq!(effective_messages, &messages);
-        for overlay in &trace.assistant_message_ids {
-            assert!(matches!(
-                &effective_messages[overlay.message_index],
-                Message::Assistant { id: Some(id), .. } if *id == overlay.message_id
-            ));
-        }
-        for overlay in &trace.threaded_tool_results {
-            assert!(matches!(
-                &effective_messages[overlay.message_index],
-                Message::User { .. }
-            ));
-        }
-    }
-
-    /// Per-turn compaction rewrites `history` and `new_messages` in place, so
-    /// the trace has to describe the *post*-compaction list. Nothing else
-    /// records it: the summary is model-generated and never becomes an
-    /// `AgentCompactionEntry`.
-    #[test]
-    fn assembly_trace_carries_the_post_compaction_message_list() {
-        let compacted = vec![
-            Message::system("<system-reminder>continuation checkpoint</system-reminder>"),
-            Message::user("continue"),
-        ];
-        let trace =
-            AssemblyTrace::from_effective_messages(AssemblyBuildPath::Budgeted, compacted.clone());
-
-        assert_eq!(trace.effective_messages, Some(compacted));
-        assert_eq!(trace.trace_version, ASSEMBLY_TRACE_VERSION);
-    }
-
-    #[test]
-    fn reconstructible_trace_does_not_duplicate_message_bodies() {
-        let marker = "ordinary-message-body-".repeat(1_000);
-        let messages = vec![Message::user(marker.clone()), Message::assistant("done")];
-        let compact = AssemblyTrace::from_reconstructible_messages(
-            AssemblyBuildPath::Budgeted,
-            messages.clone(),
-        );
-        let oracle = AssemblyTrace::from_effective_messages(AssemblyBuildPath::Budgeted, messages);
-
-        let compact_json = serde_json::to_string(&compact).expect("compact trace");
-        let oracle_json = serde_json::to_string(&oracle).expect("oracle trace");
-        assert_eq!(compact.effective_message_count, 2);
-        assert!(compact.effective_messages.is_none());
-        assert!(!compact_json.contains(&marker));
-        assert!(oracle_json.len() > compact_json.len() + marker.len());
-    }
-
-    #[test]
     fn build_path_records_whether_the_output_clamp_ran() {
         assert!(AssemblyBuildPath::Budgeted.applies_output_clamp());
         assert!(!AssemblyBuildPath::Repair.applies_output_clamp());
@@ -1320,6 +865,50 @@ mod tests {
 
         assert_eq!(rendered.provenance_json["capture_seam"], "transport_body");
         assert_eq!(rendered.provenance_json["capture_scope"], "inference.1");
+    }
+
+    /// Outside an admission scope (the one-shot situation) there is no join,
+    /// and its absence is an absent key — never a null or a placeholder.
+    #[test]
+    fn provenance_without_an_admission_scope_carries_no_join() {
+        let rendered = build(0, 0, empty_trace(), components());
+
+        assert!(rendered.provenance_json.get("admission").is_none());
+        assert_eq!(
+            rendered.provenance_json["manifest_version"],
+            PROVENANCE_MANIFEST_VERSION
+        );
+    }
+
+    /// The kind guard: a join is stamped only when the admitted call's kind
+    /// legitimately produces the capture's loop. A wrong join would be worse
+    /// than none.
+    #[test]
+    fn admission_kinds_map_to_their_capture_scopes() {
+        use crate::admission::CallKind;
+
+        let cases = [
+            (CallKind::Inference, CaptureScopeKind::Inference, true),
+            (CallKind::Inference, CaptureScopeKind::Compaction, false),
+            (CallKind::Compaction, CaptureScopeKind::Compaction, true),
+            (
+                CallKind::Compaction,
+                CaptureScopeKind::CompactionFallback,
+                true,
+            ),
+            (CallKind::Compaction, CaptureScopeKind::Inference, false),
+            (CallKind::OneOff, CaptureScopeKind::Title, true),
+            (CallKind::OneOff, CaptureScopeKind::OneShot, false),
+            (CallKind::Inference, CaptureScopeKind::OneShot, false),
+            (CallKind::Scheduled, CaptureScopeKind::Inference, false),
+        ];
+        for (call_kind, scope_kind, expected) in cases {
+            assert_eq!(
+                admission_kind_matches_scope(call_kind, scope_kind),
+                expected,
+                "{call_kind:?} vs {scope_kind:?}"
+            );
+        }
     }
 
     fn agent_request() -> crate::watcher::AgentRequest {

--- a/crates/gents/src/rendered_request/scope.rs
+++ b/crates/gents/src/rendered_request/scope.rs
@@ -53,42 +53,10 @@ use std::sync::{Arc, Mutex};
 use super::{AssemblyTrace, RenderedRequestCaptureSink, RenderedRequestContext};
 use crate::agent::loop_stream::RenderedRequestSink;
 
-/// Which completion loop inside a request is issuing provider calls.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum CaptureScopeKind {
-    /// The request's own owned completion loop (`agent/loop_stream.rs`).
-    Inference,
-    /// The guided per-turn compaction summarizer. Its output is the ephemeral
-    /// continuation checkpoint injected straight into provider history and
-    /// never written as an `AgentCompactionEntry`, which is the single fact
-    /// this whole design exists to make explainable.
-    Compaction,
-    /// The strict-JSON compaction fallback, taken when guided structured output
-    /// exhausts its recovery.
-    CompactionFallback,
-    /// Conversation title generation.
-    Title,
-    /// The one-shot runner (`oneshot::run_openai_oneshot_with_tools`).
-    OneShot,
-}
-
-impl CaptureScopeKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Inference => "inference",
-            Self::Compaction => "compaction",
-            Self::CompactionFallback => "compaction_fallback",
-            Self::Title => "title",
-            Self::OneShot => "oneshot",
-        }
-    }
-}
-
-impl std::fmt::Display for CaptureScopeKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
+// Re-exported here as well: the arming call sites name the kind through this
+// module (`rendered_request::scope::CaptureScopeKind`), and the type's home is
+// now `gents-protocol`.
+pub use super::CaptureScopeKind;
 
 /// One armed provider attempt, waiting for the transport to supply its body.
 #[derive(Clone, Debug)]

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeSet;
 
 use chrono::DateTime;
+use gents_protocol::rendered_request::{
+    CaptureOrderKey, CaptureScope, ParsedProvenance, ProvenanceManifest, ProvenanceStatus,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -20,6 +23,8 @@ pub struct RunTimelineRows {
     pub inference_calls: Vec<TimelineInferenceCallRow>,
     #[serde(default)]
     pub responses: Vec<TimelineResponseRow>,
+    #[serde(default)]
+    pub rendered_requests: Vec<TimelineRenderedRequestRow>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -76,6 +81,12 @@ pub struct TimelineRequestRow {
     pub caused_by_parent_request_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caused_by_parent_tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_origin: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caused_by_trigger_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caused_by_trigger_kind: Option<String>,
     #[serde(default, skip_serializing_if = "RetrySummary::is_empty")]
     pub retry_summary: RetrySummary,
 }
@@ -174,6 +185,53 @@ pub struct TimelineInferenceCallRow {
     pub backend_id: Option<String>,
     #[serde(default)]
     pub call_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_input_tokens: Option<i64>,
+}
+
+/// One `RenderedRequest` capture row, as the timeline reads it.
+///
+/// Deliberately has **no `request_json` field**: the fetch layer never selects
+/// the captured body, so nothing downstream of the timeline — events,
+/// projections, default CLI output — can leak it. The one body read in the
+/// system is the CLI's explicit `--include-body`, which goes straight to the
+/// collection, not through here.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimelineRenderedRequestRow {
+    #[serde(default, rename = "_docID", skip_serializing)]
+    pub doc_id: Option<String>,
+    #[serde(default)]
+    pub capture_key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_doc_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_index: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capture_version: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -290,6 +348,7 @@ pub struct TimelineConversationRow {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RunTimelineEvent {
     Request(TimelineRequestEvent),
+    RenderedRequest(TimelineRenderedRequestEvent),
     InferenceCall(TimelineInferenceCallEvent),
     Message(TimelineMessageEvent),
     ToolCall(TimelineToolCallEvent),
@@ -318,9 +377,63 @@ pub struct TimelineRequestEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_origin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caused_by_trigger_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caused_by_trigger_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
     #[serde(default, skip_serializing_if = "RetrySummary::is_empty")]
     pub retry_summary: RetrySummary,
+}
+
+/// A rendered-request capture in the timeline — metadata only, always.
+///
+/// `provenance_status` is derived through the versioned reader:
+/// `"captured_only"` (the manifest's own claim), `"unsupported_manifest"`
+/// (well-formed, unknown version — the row is still listed), `"unavailable"`
+/// (no provenance column), or `"malformed"` (unreadable column; surfaced,
+/// never a panic). `call_id`/`call_seq` are the exact admission join when the
+/// manifest carries one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimelineRenderedRequestEvent {
+    pub capture_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_doc_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture_scope: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope_seq: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_index: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture_version: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools_hash: Option<String>,
+    pub provenance_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_version: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call_seq: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -335,6 +448,12 @@ pub struct TimelineInferenceCallEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backend_id: Option<String>,
     pub call_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_input_tokens: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub queued_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -468,11 +587,26 @@ pub fn build_run_timeline(mut rows: RunTimelineRows) -> RunTimeline {
                 failure_reason: call.failure_reason.clone(),
                 backend_id: call.backend_id.clone(),
                 call_kind: call.call_kind.clone(),
+                prompt_tokens: call.prompt_tokens,
+                completion_tokens: call.completion_tokens,
+                cached_input_tokens: call.cached_input_tokens,
                 queued_at: call.queued_at.clone(),
                 started_at: call.started_at.clone(),
                 ended_at: call.ended_at.clone(),
             },
         ));
+    }
+
+    for rendered in &rows.rendered_requests {
+        let belongs = rendered
+            .request_id
+            .as_deref()
+            .is_some_and(|request_id| included_request_ids.contains(request_id));
+        if belongs {
+            events.push(RunTimelineEvent::RenderedRequest(rendered_request_event(
+                rendered,
+            )));
+        }
     }
 
     for message in &rows.messages {
@@ -670,9 +804,94 @@ fn push_request_event(events: &mut Vec<RunTimelineEvent>, request: &TimelineRequ
         lifecycle_state: request.lifecycle_state.clone(),
         failure_reason: request.failure_reason.clone(),
         metadata: request.metadata.clone(),
+        execution_origin: request.execution_origin.clone(),
+        caused_by_trigger_id: request.caused_by_trigger_id.clone(),
+        caused_by_trigger_kind: request.caused_by_trigger_kind.clone(),
         timestamp: request.created_at.clone(),
         retry_summary: request.retry_summary.clone(),
     }));
+}
+
+/// Derive the metadata-only capture event from its row. The scope parse and
+/// the provenance read both go through the shared `gents-protocol` vocabulary;
+/// their failures are surfaced as explicit statuses, never defaults.
+///
+/// Public because the CLI's `trace capture` renders single rows through the
+/// same derivation the timeline uses — one metadata surface, not two.
+pub fn rendered_request_event(row: &TimelineRenderedRequestRow) -> TimelineRenderedRequestEvent {
+    let scope = row
+        .capture_scope
+        .as_deref()
+        .and_then(|scope| scope.parse::<CaptureScope>().ok());
+    let (provenance_status, manifest_version, call_id, call_seq) =
+        match row.provenance_json.as_deref() {
+            None => ("unavailable".to_string(), None, None, None),
+            Some(raw) => match ProvenanceManifest::parse(raw) {
+                Ok(ParsedProvenance::Manifest(manifest)) => (
+                    provenance_status_label(manifest.status).to_string(),
+                    Some(i64::from(manifest.manifest_version)),
+                    manifest
+                        .admission
+                        .as_ref()
+                        .map(|admission| admission.call_id.clone()),
+                    manifest.admission.as_ref().map(|admission| admission.call_seq),
+                ),
+                Ok(ParsedProvenance::Unsupported { manifest_version }) => (
+                    "unsupported_manifest".to_string(),
+                    Some(i64::from(manifest_version)),
+                    None,
+                    None,
+                ),
+                Err(_) => ("malformed".to_string(), None, None, None),
+            },
+        };
+
+    TimelineRenderedRequestEvent {
+        capture_key: row.capture_key.clone(),
+        request_doc_id: row.request_doc_id.clone(),
+        request_id: row.request_id.clone(),
+        session_id: row.session_id.clone(),
+        capture_scope: row.capture_scope.clone(),
+        scope_kind: scope.map(|scope| scope.kind.as_str().to_string()),
+        scope_seq: scope.map(|scope| i64::try_from(scope.seq).unwrap_or(i64::MAX)),
+        turn_index: row.turn_index,
+        attempt: row.attempt,
+        capture_version: row.capture_version,
+        model_name: row.model_name.clone(),
+        source: row.source.clone(),
+        prompt_hash: row.prompt_hash.clone(),
+        tools_hash: row.tools_hash.clone(),
+        provenance_status,
+        manifest_version,
+        call_id,
+        call_seq,
+        created_at: row.created_at.clone(),
+    }
+}
+
+fn provenance_status_label(status: ProvenanceStatus) -> &'static str {
+    match status {
+        ProvenanceStatus::CapturedOnly => "captured_only",
+    }
+}
+
+/// Deterministic same-timestamp ordering for capture events: the numeric
+/// order key when the row's identity facts parse, the capture key otherwise
+/// (unique, so still deterministic — just not meaningfully ordered).
+fn rendered_request_tiebreak(event: &TimelineRenderedRequestEvent) -> String {
+    let scope = event
+        .capture_scope
+        .as_deref()
+        .and_then(|scope| scope.parse::<CaptureScope>().ok());
+    match (scope, event.turn_index, event.attempt) {
+        (Some(scope), Some(turn_index), Some(attempt)) => CaptureOrderKey {
+            scope,
+            turn_index,
+            attempt,
+        }
+        .padded(),
+        _ => event.capture_key.clone(),
+    }
 }
 
 fn infer_request_id_for_message<'a>(
@@ -764,6 +983,10 @@ fn should_include_event(
         .unwrap_or_else(|| event_session_id.is_some() && event_session_id == root_session_id)
 }
 
+/// `(timestamp_millis, family_rank, intra_rank, tiebreak)`. Family ranks are
+/// unserialized internals and only break same-millisecond ties: request 0,
+/// rendered_request 1 (persist-before-send puts the capture before the bytes
+/// leave), inference_call 2, message 3, tool_call 4, response 5.
 fn event_sort_key(event: &RunTimelineEvent) -> (i64, i64, i64, String) {
     match event {
         RunTimelineEvent::Request(event) => (
@@ -776,6 +999,16 @@ fn event_sort_key(event: &RunTimelineEvent) -> (i64, i64, i64, String) {
             -1,
             event.request_id.clone(),
         ),
+        RunTimelineEvent::RenderedRequest(event) => (
+            event
+                .created_at
+                .as_deref()
+                .and_then(timestamp_millis)
+                .unwrap_or(i64::MIN),
+            1,
+            event.call_seq.unwrap_or(i64::MAX),
+            rendered_request_tiebreak(event),
+        ),
         RunTimelineEvent::InferenceCall(event) => (
             first_nonempty([
                 event.queued_at.as_deref(),
@@ -784,7 +1017,7 @@ fn event_sort_key(event: &RunTimelineEvent) -> (i64, i64, i64, String) {
             ])
             .and_then(timestamp_millis)
             .unwrap_or(i64::MIN),
-            1,
+            2,
             event.call_seq,
             event.call_id.clone(),
         ),
@@ -794,7 +1027,7 @@ fn event_sort_key(event: &RunTimelineEvent) -> (i64, i64, i64, String) {
                 .as_deref()
                 .and_then(timestamp_millis)
                 .unwrap_or(i64::MIN),
-            2,
+            3,
             event.sequence,
             format!("{}:{}", event.session_id, event.sequence),
         ),
@@ -804,7 +1037,7 @@ fn event_sort_key(event: &RunTimelineEvent) -> (i64, i64, i64, String) {
                 .as_deref()
                 .and_then(timestamp_millis)
                 .unwrap_or(i64::MIN),
-            3,
+            4,
             event.message_sequence.unwrap_or(i64::MAX),
             event.tool_call_id.clone(),
         ),
@@ -814,7 +1047,7 @@ fn event_sort_key(event: &RunTimelineEvent) -> (i64, i64, i64, String) {
                 .as_deref()
                 .and_then(timestamp_millis)
                 .unwrap_or(i64::MIN),
-            4,
+            5,
             event.materialized_message_sequence.unwrap_or(i64::MAX),
             event.request_id.clone(),
         ),
@@ -941,6 +1174,258 @@ mod tests {
         assert_eq!(tool.request_id.as_deref(), Some("req-1"));
         assert_eq!(tool.child_request_id.as_deref(), Some("child-1"));
         assert_eq!(tool.denial_reason.as_deref(), Some("not allowed"));
+    }
+
+    fn provenance_fixture(scope: &str, call_id: Option<(&str, i64)>) -> String {
+        let mut manifest = serde_json::json!({
+            "manifest_version": 3,
+            "status": "captured_only",
+            "status_reason": "fixture",
+            "capture_seam": "transport_body",
+            "capture_scope": scope,
+            "assembly_trace": {
+                "trace_version": 2,
+                "build_path": "budgeted",
+                "effective_message_count": 0,
+                "assistant_message_ids": [],
+                "threaded_tool_results": []
+            }
+        });
+        if let Some((call_id, call_seq)) = call_id {
+            manifest["admission"] =
+                serde_json::json!({ "call_id": call_id, "call_seq": call_seq });
+        }
+        manifest.to_string()
+    }
+
+    fn rendered_row(
+        capture_key: &str,
+        scope: &str,
+        turn_index: i64,
+        attempt: i64,
+        created_at: &str,
+        provenance_json: Option<String>,
+    ) -> TimelineRenderedRequestRow {
+        TimelineRenderedRequestRow {
+            capture_key: capture_key.to_string(),
+            request_doc_id: Some("doc-req-1".to_string()),
+            request_id: Some("req-1".to_string()),
+            session_id: Some("session-1".to_string()),
+            capture_scope: Some(scope.to_string()),
+            turn_index: Some(turn_index),
+            attempt: Some(attempt),
+            capture_version: Some(1),
+            model_name: Some("test-model".to_string()),
+            source: Some("openai_chat_completions".to_string()),
+            prompt_hash: Some("aa".to_string()),
+            tools_hash: Some("bb".to_string()),
+            provenance_json,
+            created_at: Some(created_at.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Captures interleave with the inference calls they precede, the exact
+    /// admission join surfaces on the event, an unknown manifest version is
+    /// reported rather than guessed at, and `inference.2` sorts before
+    /// `inference.10` — the ordering is numeric, not lexical.
+    #[test]
+    fn rendered_captures_interleave_with_their_inference_calls() {
+        let rows = RunTimelineRows {
+            request: TimelineRequestRow {
+                request_id: "req-1".to_string(),
+                session_id: Some("session-1".to_string()),
+                execution_origin: Some("triggered".to_string()),
+                caused_by_trigger_id: Some("trigger-9".to_string()),
+                caused_by_trigger_kind: Some("schedule".to_string()),
+                created_at: Some("2026-08-07T12:00:00Z".to_string()),
+                ..Default::default()
+            },
+            inference_calls: vec![
+                TimelineInferenceCallRow {
+                    call_id: "call-1".to_string(),
+                    request_id: "req-1".to_string(),
+                    call_seq: 1,
+                    attempt: 1,
+                    call_state: "completed".to_string(),
+                    call_kind: "inference".to_string(),
+                    prompt_tokens: Some(120),
+                    completion_tokens: Some(30),
+                    cached_input_tokens: Some(64),
+                    queued_at: Some("2026-08-07T12:00:01Z".to_string()),
+                    started_at: Some("2026-08-07T12:00:03Z".to_string()),
+                    ..Default::default()
+                },
+                TimelineInferenceCallRow {
+                    call_id: "call-2".to_string(),
+                    request_id: "req-1".to_string(),
+                    call_seq: 2,
+                    attempt: 2,
+                    call_state: "completed".to_string(),
+                    call_kind: "inference".to_string(),
+                    queued_at: Some("2026-08-07T12:00:05Z".to_string()),
+                    ..Default::default()
+                },
+            ],
+            rendered_requests: vec![
+                rendered_row(
+                    "rendered:v1:b-second",
+                    "inference.1",
+                    0,
+                    1,
+                    "2026-08-07T12:00:06Z",
+                    Some(provenance_fixture("inference.1", Some(("call-2", 2)))),
+                ),
+                rendered_row(
+                    "rendered:v1:a-first",
+                    "inference.1",
+                    0,
+                    0,
+                    "2026-08-07T12:00:02Z",
+                    Some(provenance_fixture("inference.1", Some(("call-1", 1)))),
+                ),
+                rendered_row(
+                    "rendered:v1:c-unknown",
+                    "compaction.1",
+                    0,
+                    0,
+                    "2026-08-07T12:00:04Z",
+                    Some(r#"{"manifest_version":99,"opaque":true}"#.to_string()),
+                ),
+                // Same timestamp: only the numeric order key separates these.
+                rendered_row(
+                    "rendered:v1:e-ten",
+                    "inference.10",
+                    0,
+                    0,
+                    "2026-08-07T12:00:07Z",
+                    None,
+                ),
+                rendered_row(
+                    "rendered:v1:d-two",
+                    "inference.2",
+                    3,
+                    0,
+                    "2026-08-07T12:00:07Z",
+                    None,
+                ),
+            ],
+            ..Default::default()
+        };
+
+        let timeline = build_run_timeline(rows);
+
+        let kinds: Vec<&str> = timeline
+            .events
+            .iter()
+            .map(|event| match event {
+                RunTimelineEvent::Request(_) => "request",
+                RunTimelineEvent::RenderedRequest(event) => {
+                    event.capture_scope.as_deref().unwrap_or("rendered")
+                }
+                RunTimelineEvent::InferenceCall(event) => match event.call_seq {
+                    1 => "call-1",
+                    _ => "call-2",
+                },
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                "request",
+                "call-1",       // queued 12:00:01
+                "inference.1",  // captured 12:00:02 (turn 0 attempt 0)
+                "compaction.1", // captured 12:00:04, unknown manifest
+                "call-2",       // queued 12:00:05
+                "inference.1",  // captured 12:00:06 (turn 0 attempt 1)
+                "inference.2",  // 12:00:07 — numeric order key…
+                "inference.10", // …not lexical
+            ]
+        );
+
+        let captures: Vec<&TimelineRenderedRequestEvent> = timeline
+            .events
+            .iter()
+            .filter_map(|event| match event {
+                RunTimelineEvent::RenderedRequest(event) => Some(event),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(captures[0].call_id.as_deref(), Some("call-1"));
+        assert_eq!(captures[0].call_seq, Some(1));
+        assert_eq!(captures[0].provenance_status, "captured_only");
+        assert_eq!(captures[0].manifest_version, Some(3));
+        assert_eq!(captures[0].scope_kind.as_deref(), Some("inference"));
+        assert_eq!(captures[0].scope_seq, Some(1));
+
+        assert_eq!(captures[1].provenance_status, "unsupported_manifest");
+        assert_eq!(captures[1].manifest_version, Some(99));
+        assert_eq!(captures[1].call_seq, None);
+
+        assert_eq!(captures[2].call_id.as_deref(), Some("call-2"));
+        assert_eq!(captures[3].provenance_status, "unavailable");
+
+        let request_event = timeline
+            .events
+            .iter()
+            .find_map(|event| match event {
+                RunTimelineEvent::Request(event) => Some(event),
+                _ => None,
+            })
+            .expect("request event");
+        assert_eq!(request_event.execution_origin.as_deref(), Some("triggered"));
+        assert_eq!(
+            request_event.caused_by_trigger_id.as_deref(),
+            Some("trigger-9")
+        );
+        assert_eq!(
+            request_event.caused_by_trigger_kind.as_deref(),
+            Some("schedule")
+        );
+
+        let call_event = timeline
+            .events
+            .iter()
+            .find_map(|event| match event {
+                RunTimelineEvent::InferenceCall(event) if event.call_seq == 1 => Some(event),
+                _ => None,
+            })
+            .expect("inference call event");
+        assert_eq!(call_event.prompt_tokens, Some(120));
+        assert_eq!(call_event.completion_tokens, Some(30));
+        assert_eq!(call_event.cached_input_tokens, Some(64));
+    }
+
+    /// A capture row whose `request_id` is not part of this timeline (another
+    /// request in the session) stays out of the event stream.
+    #[test]
+    fn rendered_captures_for_other_requests_are_excluded() {
+        let mut row = rendered_row(
+            "rendered:v1:other",
+            "inference.1",
+            0,
+            0,
+            "2026-08-07T12:00:02Z",
+            None,
+        );
+        row.request_id = Some("req-other".to_string());
+        let rows = RunTimelineRows {
+            request: TimelineRequestRow {
+                request_id: "req-1".to_string(),
+                session_id: Some("session-1".to_string()),
+                created_at: Some("2026-08-07T12:00:00Z".to_string()),
+                ..Default::default()
+            },
+            rendered_requests: vec![row],
+            ..Default::default()
+        };
+
+        let timeline = build_run_timeline(rows);
+        assert!(!timeline
+            .events
+            .iter()
+            .any(|event| matches!(event, RunTimelineEvent::RenderedRequest(_))));
     }
 
     #[test]

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -834,7 +834,10 @@ pub fn rendered_request_event(row: &TimelineRenderedRequestRow) -> TimelineRende
                         .admission
                         .as_ref()
                         .map(|admission| admission.call_id.clone()),
-                    manifest.admission.as_ref().map(|admission| admission.call_seq),
+                    manifest
+                        .admission
+                        .as_ref()
+                        .map(|admission| admission.call_seq),
                 ),
                 Ok(ParsedProvenance::Unsupported { manifest_version }) => (
                     "unsupported_manifest".to_string(),
@@ -1192,8 +1195,7 @@ mod tests {
             }
         });
         if let Some((call_id, call_seq)) = call_id {
-            manifest["admission"] =
-                serde_json::json!({ "call_id": call_id, "call_seq": call_seq });
+            manifest["admission"] = serde_json::json!({ "call_id": call_id, "call_seq": call_seq });
         }
         manifest.to_string()
     }

--- a/crates/gents/src/run_timeline_fetch.rs
+++ b/crates/gents/src/run_timeline_fetch.rs
@@ -13,8 +13,8 @@ use crate::config_client::ConfigAccess;
 use crate::graphql::escape_graphql_string;
 use crate::run_timeline::{
     build_run_timeline, RunTimeline, RunTimelineRows, TimelineConversationRow,
-    TimelineInferenceCallRow, TimelineMessageRow, TimelineRequestRow, TimelineResponseRow,
-    TimelineSessionRow, TimelineToolCallRow,
+    TimelineInferenceCallRow, TimelineMessageRow, TimelineRenderedRequestRow, TimelineRequestRow,
+    TimelineResponseRow, TimelineSessionRow, TimelineToolCallRow,
 };
 use gents_protocol::graphql::graphql_rows_from_response;
 
@@ -57,6 +57,15 @@ pub async fn load_run_timeline_rows(
         inference_calls
             .extend(load_timeline_inference_calls_for_request(access, &request_id).await?);
     }
+    let mut rendered_requests = Vec::new();
+    for session_id in &session_ids {
+        rendered_requests
+            .extend(load_timeline_rendered_requests_for_session(access, session_id).await?);
+    }
+    if session_ids.is_empty() || root_session_id.is_none() {
+        rendered_requests
+            .extend(load_timeline_rendered_requests_for_request(access, &request.request_id).await?);
+    }
 
     let session = match root_session_id.as_deref() {
         Some(session_id) => load_timeline_session(access, session_id).await?,
@@ -76,6 +85,7 @@ pub async fn load_run_timeline_rows(
         tool_calls,
         inference_calls,
         responses,
+        rendered_requests,
     })
 }
 
@@ -106,6 +116,9 @@ async fn load_timeline_request_by_id(
                 interrupt_requested_at
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
+                execution_origin
+                caused_by_trigger_id
+                caused_by_trigger_kind
             }}
         }}"#,
         escape_graphql_string(request_id)
@@ -143,6 +156,9 @@ async fn load_timeline_requests_for_session(
                 interrupt_requested_at
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
+                execution_origin
+                caused_by_trigger_id
+                caused_by_trigger_kind
             }}
         }}"#,
         escape_graphql_string(session_id)
@@ -176,6 +192,9 @@ async fn load_timeline_child_requests(
                 interrupt_requested_at
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
+                execution_origin
+                caused_by_trigger_id
+                caused_by_trigger_kind
             }}
         }}"#,
         escape_graphql_string(parent_request_id)
@@ -363,11 +382,83 @@ async fn load_timeline_inference_calls_for_request(
                 ended_at
                 backend_id
                 call_kind
+                prompt_tokens
+                completion_tokens
+                cached_input_tokens
             }}
         }}"#,
         escape_graphql_string(request_id)
     );
     load_rows(access, "InferenceCall", &query).await
+}
+
+/// The rendered-request capture rows for one session, metadata columns only.
+/// `request_json` is deliberately never selected here — see
+/// `TimelineRenderedRequestRow`. Pre-#1059 databases have no `RenderedRequest`
+/// collection; `load_rows` reports that as an empty section, not a failed
+/// timeline.
+async fn load_timeline_rendered_requests_for_session(
+    access: &ConfigAccess,
+    session_id: &str,
+) -> Result<Vec<TimelineRenderedRequestRow>> {
+    let query = format!(
+        r#"{{
+            RenderedRequest(
+                filter: {{ session_id: {{ _eq: "{}" }} }},
+                order: {{ created_at: ASC }}
+            ) {{
+                _docID
+                capture_key
+                request_doc_id
+                request_id
+                session_id
+                capture_scope
+                turn_index
+                attempt
+                capture_version
+                model_name
+                source
+                prompt_hash
+                tools_hash
+                provenance_json
+                created_at
+            }}
+        }}"#,
+        escape_graphql_string(session_id)
+    );
+    load_rows(access, "RenderedRequest", &query).await
+}
+
+async fn load_timeline_rendered_requests_for_request(
+    access: &ConfigAccess,
+    request_id: &str,
+) -> Result<Vec<TimelineRenderedRequestRow>> {
+    let query = format!(
+        r#"{{
+            RenderedRequest(
+                filter: {{ request_id: {{ _eq: "{}" }} }},
+                order: {{ created_at: ASC }}
+            ) {{
+                _docID
+                capture_key
+                request_doc_id
+                request_id
+                session_id
+                capture_scope
+                turn_index
+                attempt
+                capture_version
+                model_name
+                source
+                prompt_hash
+                tools_hash
+                provenance_json
+                created_at
+            }}
+        }}"#,
+        escape_graphql_string(request_id)
+    );
+    load_rows(access, "RenderedRequest", &query).await
 }
 
 async fn load_timeline_session(

--- a/crates/gents/src/run_timeline_fetch.rs
+++ b/crates/gents/src/run_timeline_fetch.rs
@@ -63,8 +63,9 @@ pub async fn load_run_timeline_rows(
             .extend(load_timeline_rendered_requests_for_session(access, session_id).await?);
     }
     if session_ids.is_empty() || root_session_id.is_none() {
-        rendered_requests
-            .extend(load_timeline_rendered_requests_for_request(access, &request.request_id).await?);
+        rendered_requests.extend(
+            load_timeline_rendered_requests_for_request(access, &request.request_id).await?,
+        );
     }
 
     let session = match root_session_id.as_deref() {

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -805,6 +805,18 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "RenderedCaptureKeyCases".to_string(),
         ));
     }
+    if !snapshot.capture_scope_cases.is_empty() {
+        emitted.insert((
+            "rendered_capture_cases".to_string(),
+            "CaptureScopeCases".to_string(),
+        ));
+    }
+    if !snapshot.capture_order_cases.is_empty() {
+        emitted.insert((
+            "rendered_capture_cases".to_string(),
+            "CaptureOrderCases".to_string(),
+        ));
+    }
     assert_eq!(
         snapshot.event_delivery_transition_case_count,
         snapshot.event_delivery_transition_cases.len(),

--- a/crates/gents/tests/conformance/rendered_capture.rs
+++ b/crates/gents/tests/conformance/rendered_capture.rs
@@ -148,6 +148,7 @@ fn rendered_in_scope(
         provenance_json: serde_json::to_value(ProvenanceManifest::captured_only(
             capture_scope.to_string(),
             None,
+            None,
             assembly_trace.clone(),
         ))
         .expect("provenance manifest"),
@@ -388,4 +389,72 @@ fn generated_rendered_capture_cases_never_permit_an_uncaptured_send() {
         "the generated rows must include an identical recapture; without it \
          idempotent redelivery is untested"
     );
+}
+
+/// #1066: the shared consumer vocabulary is the Lean vocabulary. Every emitted
+/// `capture_scope` label parses to the emitted `(kind, seq)` — or errors,
+/// never defaults — and `CaptureOrderKey` agrees with the model's
+/// `(kind rank, seq, turn, attempt)` comparison. `inference.10` vs
+/// `inference.2` is among the generated rows, so a lexical implementation
+/// cannot pass.
+#[test]
+fn generated_capture_scope_cases_pin_the_shared_parser_and_order() {
+    use gents::rendered_request::{CaptureOrderKey, CaptureScope};
+
+    let scope_cases = crate::lean_vocab_test::lean_capture_scope_cases();
+    assert!(
+        !scope_cases.is_empty(),
+        "Lean emitted no capture scope cases"
+    );
+    for case in scope_cases {
+        let parsed = case.label.parse::<CaptureScope>();
+        if case.valid {
+            let scope = parsed.unwrap_or_else(|error| {
+                panic!("{label:?} must parse: {error}", label = case.label)
+            });
+            assert_eq!(scope.kind.as_str(), case.kind, "{:?}", case.label);
+            assert_eq!(scope.seq, case.seq, "{:?}", case.label);
+            assert_eq!(
+                scope.to_string(),
+                case.label,
+                "label round trip must be exact"
+            );
+        } else {
+            assert!(
+                parsed.is_err(),
+                "{label:?} must be rejected, never defaulted",
+                label = case.label
+            );
+        }
+    }
+
+    let order_cases = crate::lean_vocab_test::lean_capture_order_cases();
+    assert!(
+        !order_cases.is_empty(),
+        "Lean emitted no capture order cases"
+    );
+    for case in order_cases {
+        let left = CaptureOrderKey {
+            scope: case.left_label.parse::<CaptureScope>().expect("left label"),
+            turn_index: case.left_turn,
+            attempt: case.left_attempt,
+        };
+        let right = CaptureOrderKey {
+            scope: case
+                .right_label
+                .parse::<CaptureScope>()
+                .expect("right label"),
+            turn_index: case.right_turn,
+            attempt: case.right_attempt,
+        };
+        assert_eq!(left < right, case.left_before_right, "{}", case.name);
+        // The padded rendering exists for string-only sort slots; its lexical
+        // order must agree with `Ord` everywhere the model decides.
+        assert_eq!(
+            left.padded() < right.padded(),
+            case.left_before_right,
+            "{} (padded)",
+            case.name
+        );
+    }
 }

--- a/crates/gents/tests/e2e_runtime/rendered_request_capture.rs
+++ b/crates/gents/tests/e2e_runtime/rendered_request_capture.rs
@@ -491,6 +491,44 @@ async fn a_multi_turn_tool_using_request_captures_every_turn_in_order() {
         "the assembly trace must carry the threaded tool result verbatim: {threaded}"
     );
 
+    // #1066: the provenance manifest carries the exact admission join — the
+    // `call_id`/`call_seq` the admission registry minted for the call this
+    // capture preceded. This is the Rust fence for the task-local plumbing:
+    // `next_call` writes the slot, the transport-side capture reads it, and
+    // the values must be the ones persisted on the request's `InferenceCall`
+    // rows, not an ordinal guess.
+    let calls = inference_calls(db.node.as_ref(), "req-capture-multi-turn").await;
+    let inference_call_seqs: Vec<i64> = calls
+        .iter()
+        .filter(|call| call["call_kind"].as_str() == Some("inference"))
+        .filter_map(|call| call["call_seq"].as_i64())
+        .collect();
+    let mut seen_call_ids = std::collections::BTreeSet::new();
+    for row in &rows {
+        let manifest = parse_json(&row["provenance_json"]);
+        assert_eq!(manifest["manifest_version"], 3, "manifest version");
+        let admission = manifest
+            .get("admission")
+            .unwrap_or_else(|| panic!("daemon capture must carry an admission join: {manifest}"));
+        let call_seq = admission["call_seq"].as_i64().expect("join call_seq");
+        assert!(
+            inference_call_seqs.contains(&call_seq),
+            "joined call_seq {call_seq} must name a persisted inference InferenceCall \
+             (persisted: {inference_call_seqs:?})"
+        );
+        let call_id = admission["call_id"].as_str().expect("join call_id");
+        assert!(
+            calls
+                .iter()
+                .any(|call| call["call_id"].as_str() == Some(call_id)),
+            "joined call_id {call_id} must name a persisted InferenceCall row"
+        );
+        assert!(
+            seen_call_ids.insert(call_id.to_string()),
+            "each capture joins a distinct provider call"
+        );
+    }
+
     agent.shutdown().await;
 }
 
@@ -1164,6 +1202,7 @@ fn rendered_fixture(request_json: Value) -> RenderedCompletionRequest {
             gents::rendered_request::ProvenanceManifest::captured_only(
                 capture_scope,
                 None,
+                None,
                 assembly_trace.clone(),
             ),
         )
@@ -1245,6 +1284,33 @@ async fn rendered_requests(node: &EmbeddedNode, request_id: &str) -> Vec<Value> 
         )
     });
     rows
+}
+
+/// The persisted `InferenceCall` rows for one request — the other half of the
+/// provenance admission join.
+async fn inference_calls(node: &EmbeddedNode, request_id: &str) -> Vec<Value> {
+    let query = format!(
+        r#"query {{
+            InferenceCall(filter: {{ request_id: {{ _eq: "{request_id}" }} }}) {{
+                call_id
+                call_seq
+                call_kind
+                attempt
+            }}
+        }}"#,
+        request_id = escape_graphql_string(request_id),
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "InferenceCall query failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .and_then(|data| data.get("InferenceCall").cloned())
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default()
 }
 
 /// Every `(field_name, cid)` DefraDB holds for the row under `capture_key`,

--- a/crates/gents/tests/fixtures/adapter_projections/contracts/langgraph_state_history.schema.json
+++ b/crates/gents/tests/fixtures/adapter_projections/contracts/langgraph_state_history.schema.json
@@ -237,6 +237,153 @@
         "public"
       ]
     },
+    "rendered_captures": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "attempt": {
+            "type": "integer"
+          },
+          "call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "call_seq": {
+            "type": "integer"
+          },
+          "capture_key": {
+            "type": "string"
+          },
+          "capture_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "capture_version": {
+            "type": "integer"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "manifest_version": {
+            "type": "integer"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provenance_status": {
+            "type": "string"
+          },
+          "request_doc_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scope_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scope_seq": {
+            "type": "integer"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tools_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "turn_index": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "capture_key",
+          "provenance_status"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "source_agent_did": {
       "anyOf": [
         {

--- a/crates/gents/tests/fixtures/adapter_projections/contracts/multi_agent_task.schema.json
+++ b/crates/gents/tests/fixtures/adapter_projections/contracts/multi_agent_task.schema.json
@@ -295,6 +295,153 @@
         "public"
       ]
     },
+    "rendered_captures": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "attempt": {
+            "type": "integer"
+          },
+          "call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "call_seq": {
+            "type": "integer"
+          },
+          "capture_key": {
+            "type": "string"
+          },
+          "capture_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "capture_version": {
+            "type": "integer"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "manifest_version": {
+            "type": "integer"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provenance_status": {
+            "type": "string"
+          },
+          "request_doc_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scope_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scope_seq": {
+            "type": "integer"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tools_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "turn_index": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "capture_key",
+          "provenance_status"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "source_agent_did": {
       "anyOf": [
         {

--- a/crates/gents/tests/fixtures/adapter_projections/contracts/openai_codex_run_trace.schema.json
+++ b/crates/gents/tests/fixtures/adapter_projections/contracts/openai_codex_run_trace.schema.json
@@ -384,6 +384,153 @@
         "public"
       ]
     },
+    "rendered_captures": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "attempt": {
+            "type": "integer"
+          },
+          "call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "call_seq": {
+            "type": "integer"
+          },
+          "capture_key": {
+            "type": "string"
+          },
+          "capture_scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "capture_version": {
+            "type": "integer"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "manifest_version": {
+            "type": "integer"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provenance_status": {
+            "type": "string"
+          },
+          "request_doc_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "request_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scope_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "scope_seq": {
+            "type": "integer"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tools_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "turn_index": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "capture_key",
+          "provenance_status"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "source_agent_did": {
       "anyOf": [
         {

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -652,6 +652,27 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_rendered_capture_key_cases_pin_the_capture_key_tuple",
         },
         ConformanceConsumer::RustTest {
+            id: "conformance::rendered_capture::generated_capture_scope_cases_pin_the_shared_parser_and_order",
+            package: "gents",
+            source_path: "crates/gents/tests/conformance/rendered_capture.rs",
+            module_path: "conformance::rendered_capture",
+            function: "generated_capture_scope_cases_pin_the_shared_parser_and_order",
+        },
+        ConformanceConsumer::RustTest {
+            id: "cli_trace_export::trace_capture_fetches_metadata_with_field_commit_cid",
+            package: "gents-cli",
+            source_path: "crates/gents-cli/tests/cli_trace_export.rs",
+            module_path: "cli_trace_export",
+            function: "trace_capture_fetches_metadata_with_field_commit_cid",
+        },
+        ConformanceConsumer::TypeScriptTest {
+            id: "apps/gents-desktop/tests/request-trace.test.tsx::request trace panel renders the reconstructed event stream",
+            app: "gents-desktop",
+            source_path: "apps/gents-desktop/tests/request-trace.test.tsx",
+            suite: "request trace panel",
+            test: "renders the reconstructed event stream",
+        },
+        ConformanceConsumer::RustTest {
             id: "agent::loop_stream::tests::generated_layer_cases_pin_the_assembled_request_order",
             package: "gents",
             source_path: "crates/gents/src/agent/loop_stream/tests.rs",

--- a/docs/superpowers/plans/2026-08-07-capture-consumers.md
+++ b/docs/superpowers/plans/2026-08-07-capture-consumers.md
@@ -1,0 +1,441 @@
+# Capture Consumers Implementation Plan (#1066)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `RenderedRequest` fact records readable — protocol row type + shared parse/ordering/manifest vocabulary, central `_commits` helper, run-timeline events with an exact admission join, metadata-only projection exposure, CLI `trace capture`, desktop rendering, and Lean coverage-ledger discharge.
+
+**Architecture:** Shared capture vocabulary moves from `gents::rendered_request` to `gents-protocol::rendered_request` (runtime re-exports, producer call sites unchanged), mirroring the message-family precedent. All consumers read through that one vocabulary. Captured bodies never enter the timeline/projection model structurally; the only body read is the explicit CLI `--include-body`.
+
+**Tech Stack:** Rust (workspace crates `gents-protocol`, `gents`, `gents-cli`), Lean 4 (`crates/gents/proofs`), TypeScript (desktop trace panel), DefraDB GraphQL.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-capture-consumers-design.md` (committed in this worktree). Read it first.
+
+## Global Constraints
+
+- Worktree: `/Users/johnzampolin/go/src/github.com/source-inc/gents-1066-capture-consumers`, branch `agent/1066-capture-consumers`, based on `415a2ef6`.
+- Warm test builds before first test run: `cargo build --tests -p gents-protocol -p gents -p gents-cli` (check artifacts don't warm test artifacts).
+- Always `crate::graphql::escape_graphql_string()` (or `gents_protocol::graphql::escape_graphql_string`) for GraphQL string literals. `_commits` `fieldName` is a string literal, never an identifier.
+- Never emit `[]` in a DefraDB mutation — emit `null`. (Consumer side is read-mostly; applies to test fixtures.)
+- GraphQL response errors are errors; missing `data` ≠ "no rows".
+- Test gates: `cargo test -p gents` (never `--lib`), `cargo test -p gents-protocol`, `cargo test -p gents-cli`, `cd crates/gents/proofs && lake build` (zero `sorry`s), `cargo check --workspace --all-targets` before push.
+- CLI tests that construct `EmbeddedNode`s must pin RocksDb (cli-shard flake class).
+- `tracing`, never `println` (CLI user output via the existing `output` helpers in `gents-cli`).
+- Serde field names must match GraphQL column names exactly; protocol rows: identity key required, everything else `#[serde(default)] Option<T>`.
+- Commit after every task with a focused message ending in the Claude co-author trailer.
+
+**Producer-side line references** (all valid at `415a2ef6`): capture DTO/types `crates/gents/src/rendered_request/mod.rs` (`RenderedRequestSource:123-146`, `AssemblyBuildPath:166-177`, `AssistantMessageId:193-197`, `ThreadedToolResult:216-224`, `AssemblyTrace:272-330`, `ProvenanceStatus:359-364`, `CaptureSeam:373-377`, `ProvenanceManifest:386-430`, constants `:78-92`, `capture_key():673-690`, canonical json `:701-725`); `CaptureScopeKind` `crates/gents/src/rendered_request/scope.rs:58-91`; manifest assembly `mod.rs:605-612` via `ProvenanceManifest::captured_only` `mod.rs:415-429`; admission context `crates/gents/src/admission/client.rs:155-207` (`next_call:189-202`), registry call site `crates/gents/src/admission/registry.rs:177`; timeline `crates/gents/src/run_timeline.rs` (`RunTimelineRows:7`, event enum `:295-303` at this commit, `event_sort_key:~772-827`), fetch `crates/gents/src/run_timeline_fetch.rs` (`load_run_timeline_rows:27-80`, inference query `:344-371`, request queries `:82-182`, `rows_or_empty_if_collection_missing:~483`); projections `crates/gents/src/adapter_projection.rs` (envelope `:73-98`, envelope schema `:990-1025`, dispatch `:366-402`), ATIF `adapter_projection/atif.rs`; CLI `crates/gents-cli/src/cli/args.rs:1029-1181`, `crates/gents-cli/src/commands/trace.rs`; ledger `crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean:194-202` (deferral), `:915-924` (existing tagged rows); e2e helpers `crates/gents/tests/e2e_runtime/rendered_request_capture.rs:1201-1317`.
+
+---
+
+### Task 1: Move the capture vocabulary to `gents-protocol::rendered_request`
+
+Pure move + re-export. No behavior change; the fence is that every existing test stays green and serialization is byte-identical.
+
+**Files:**
+- Create: `crates/gents-protocol/src/rendered_request.rs`
+- Modify: `crates/gents-protocol/src/lib.rs` (add `pub mod rendered_request;` to the alphabetized module list)
+- Modify: `crates/gents/src/rendered_request/mod.rs`
+- Modify: `crates/gents/src/rendered_request/scope.rs`
+
+**Interfaces:**
+- Produces: `gents_protocol::rendered_request::{RenderedRequestSource, CaptureScopeKind, AssemblyBuildPath, AssistantMessageId, ThreadedToolResult, AssemblyTrace, ProvenanceStatus, CaptureSeam, ProvenanceManifest, CAPTURE_VERSION, PROVENANCE_MANIFEST_VERSION, ASSEMBLY_TRACE_VERSION}` — exact same serde shapes as today.
+- `gents::rendered_request` re-exports all of the above at their current paths (`crate::rendered_request::ProvenanceManifest` etc. keep resolving).
+
+- [ ] **Step 1: Cut the types from `gents`**
+
+Move verbatim into `crates/gents-protocol/src/rendered_request.rs` (module doc: "Shared vocabulary for RenderedRequest capture rows. Producer lives in `gents::rendered_request`; every consumer reads through these types."):
+- From `mod.rs`: constants `CAPTURE_VERSION`, `PROVENANCE_MANIFEST_VERSION`, `ASSEMBLY_TRACE_VERSION` (`:78-88`); `RenderedRequestSource` incl. `for_request_path`/`messages_field` and `COMPLETION_REQUEST_PATHS` (`:99-146`); `AssemblyBuildPath` (`:166-177`); `AssistantMessageId` (`:193-197`); `ThreadedToolResult` (`:216-224`); `AssemblyTrace` + constructors (`:272-330`); `ProvenanceStatus` (`:359-364`); `CaptureSeam` (`:373-377`); `ProvenanceManifest` + `captured_only` + `CAPTURED_ONLY_REASON` (`:386-430`).
+- From `scope.rs`: `CaptureScopeKind` + `as_str` + `Display` (`:58-91`).
+- Message imports become `crate::message::{Message, ToolResultContent}` (they already live in `gents-protocol`).
+- `CAPTURE_KEY_PREFIX` and `capture_key()` STAY in `gents` (producer-only; key derivation is not consumer vocabulary).
+- Unit tests colocated with the moved types move too if they only touch moved items; tests that touch the sink/scope machinery stay in `gents`.
+
+- [ ] **Step 2: Re-export from `gents`**
+
+In `crates/gents/src/rendered_request/mod.rs`, replace the moved definitions with:
+
+```rust
+pub use gents_protocol::rendered_request::{
+    AssemblyBuildPath, AssemblyTrace, AssistantMessageId, CaptureSeam, CaptureScopeKind,
+    ProvenanceManifest, ProvenanceStatus, RenderedRequestSource, ThreadedToolResult,
+    ASSEMBLY_TRACE_VERSION, CAPTURE_VERSION, PROVENANCE_MANIFEST_VERSION,
+};
+```
+
+In `scope.rs`, delete the local `CaptureScopeKind` and `use super::CaptureScopeKind;` (the `mod.rs:67-74` re-export block already exposes it; keep that block consistent).
+
+- [ ] **Step 3: Verify no behavior change**
+
+Run: `cargo test -p gents-protocol && cargo test -p gents rendered_request && cargo test -p gents --test conformance rendered_capture && cargo test -p gents --test e2e_runtime rendered_request_capture`
+Expected: all PASS with zero source diffs outside the move.
+
+- [ ] **Step 4: Commit** — `refactor: move capture vocabulary to gents-protocol (#1066)`
+
+---
+
+### Task 2: Scope parse, order key, manifest reader (TDD)
+
+**Files:**
+- Modify: `crates/gents-protocol/src/rendered_request.rs`
+
+**Interfaces:**
+- Produces:
+  - `CaptureScope { pub kind: CaptureScopeKind, pub seq: u64 }` with `impl FromStr` (error type `CaptureScopeParseError`), `impl Display` (`"{kind}.{seq}"` round-trip), and `CaptureScopeKind::from_label(&str) -> Option<CaptureScopeKind>`.
+  - `CaptureOrderKey { pub scope: CaptureScope, pub turn_index: i64, pub attempt: i64 }` with derived `PartialOrd/Ord` over `(scope.kind, scope.seq, turn_index, attempt)` (derive `Ord` on `CaptureScopeKind` in declaration order), plus `fn padded(&self) -> String` returning `format!("{}.{:010}.{:06}.{:06}", self.scope.kind, self.scope.seq, self.turn_index, self.attempt)` for lexical-sort contexts.
+  - `ProvenanceManifest::parse(&str) -> Result<ParsedProvenance, ProvenanceParseError>` where:
+
+```rust
+pub const SUPPORTED_PROVENANCE_MANIFEST_VERSIONS: std::ops::RangeInclusive<u32> = 2..=3;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedProvenance {
+    Manifest(ProvenanceManifest),
+    Unsupported { manifest_version: u32 },
+}
+
+#[derive(Debug, thiserror::Error)]  // use the crate's existing error idiom; anyhow if thiserror is absent
+pub enum ProvenanceParseError { /* Empty, InvalidJson(..), MissingVersion */ }
+```
+
+  Parse peeks `manifest_version` from a `serde_json::Value` first; out-of-range → `Unsupported` (not an error); in-range → full typed deserialize (a v3 manifest with the Task 4 `admission` field must parse when the field is absent, i.e. the field is `#[serde(default)]`).
+
+- [ ] **Step 1: Write failing tests** (in `#[cfg(test)] mod tests` of the same file)
+
+```rust
+#[test]
+fn capture_scope_round_trips_and_rejects_garbage() {
+    for label in ["inference.1", "compaction.2", "compaction_fallback.1", "title.1", "oneshot.1"] {
+        let scope: CaptureScope = label.parse().expect(label);
+        assert_eq!(scope.to_string(), label);
+    }
+    for bad in ["", "inference", "inference.", ".1", "inference.0x2", "mystery.1", "inference.1.2"] {
+        assert!(bad.parse::<CaptureScope>().is_err(), "{bad}");
+    }
+}
+
+#[test]
+fn order_key_sorts_seq_numerically_not_lexically() {
+    let key = |l: &str, t, a| CaptureOrderKey { scope: l.parse().unwrap(), turn_index: t, attempt: a };
+    let mut keys = vec![key("inference.10", 0, 0), key("inference.2", 3, 1), key("inference.2", 3, 0)];
+    keys.sort();
+    assert_eq!(keys[0], key("inference.2", 3, 0));
+    assert_eq!(keys[1], key("inference.2", 3, 1));
+    assert_eq!(keys[2], key("inference.10", 0, 0));
+    // padded() must agree with Ord under lexical sort
+    let mut padded: Vec<String> = keys.iter().map(|k| k.padded()).collect();
+    let sorted = padded.clone();
+    padded.sort();
+    assert_eq!(padded, sorted);
+}
+
+#[test]
+fn manifest_reader_gates_on_version() {
+    let v2 = serde_json::json!({
+        "manifest_version": 2, "status": "captured_only", "status_reason": "r",
+        "capture_seam": "transport_body", "capture_scope": "inference.1",
+        "assembly_trace": { "trace_version": 2, "build_path": "budgeted",
+            "effective_message_count": 0, "assistant_message_ids": [], "threaded_tool_results": [] }
+    });
+    assert!(matches!(ProvenanceManifest::parse(&v2.to_string()), Ok(ParsedProvenance::Manifest(_))));
+    let v99 = serde_json::json!({ "manifest_version": 99 });
+    assert!(matches!(ProvenanceManifest::parse(&v99.to_string()),
+        Ok(ParsedProvenance::Unsupported { manifest_version: 99 })));
+    assert!(ProvenanceManifest::parse("").is_err());
+    assert!(ProvenanceManifest::parse("{\"status\":\"captured_only\"}").is_err()); // no version
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `cargo test -p gents-protocol rendered_request` → FAIL (types missing)
+- [ ] **Step 3: Implement** the three items exactly as the Interfaces block specifies. `FromStr` splits on the LAST `.`, requires nonempty kind matched via `from_label`, `seq` via `str::parse::<u64>` rejecting leading `+`/whitespace; no silent defaults.
+- [ ] **Step 4: Run to verify pass** — same command → PASS
+- [ ] **Step 5: Commit** — `feat: capture scope parse, order key, versioned manifest reader (#1066)`
+
+---
+
+### Task 3: `RenderedRequestRow` in `gents-protocol::row`
+
+**Files:**
+- Modify: `crates/gents-protocol/src/row.rs` (append after `CompactionEntryRow:485-507`, its closest analogue)
+
+**Interfaces:**
+- Produces:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RenderedRequestRow {
+    pub capture_key: String,
+    #[serde(default)] pub request_doc_id: Option<String>,
+    #[serde(default)] pub request_id: Option<String>,
+    #[serde(default)] pub session_id: Option<String>,
+    #[serde(default)] pub agent_did: Option<String>,
+    #[serde(default)] pub requester_did: Option<String>,
+    #[serde(default)] pub behavior_id: Option<String>,
+    #[serde(default)] pub capture_scope: Option<String>,
+    #[serde(default)] pub turn_index: Option<i64>,
+    #[serde(default)] pub attempt: Option<i64>,
+    #[serde(default)] pub capture_version: Option<i64>,
+    #[serde(default)] pub model_name: Option<String>,
+    #[serde(default)] pub source: Option<String>,
+    #[serde(default)] pub request_json: Option<String>,
+    #[serde(default)] pub prompt_hash: Option<String>,
+    #[serde(default)] pub tools_hash: Option<String>,
+    #[serde(default)] pub provenance_json: Option<String>,
+    #[serde(default)] pub created_at: Option<String>,
+}
+
+impl RenderedRequestRow {
+    pub fn order_key(&self) -> Result<crate::rendered_request::CaptureOrderKey, crate::rendered_request::CaptureScopeParseError>;
+    pub fn provenance(&self) -> Result<crate::rendered_request::ParsedProvenance, crate::rendered_request::ProvenanceParseError>;
+}
+```
+
+`order_key()` errors on missing/malformed `capture_scope` and treats missing `turn_index`/`attempt` as malformed (they are core facts; a row without them cannot be ordered — do not default to 0, which would silently collide with real first-turn rows).
+
+- [ ] **Step 1: Write failing test** (row.rs test module) — deserialize a raw GraphQL-shaped `serde_json::json!` fixture with all 18 fields, assert `order_key()` == `("compaction", 2, 1, 0)` parse, and a second fixture missing `turn_index` errors from `order_key()` but still deserializes.
+- [ ] **Step 2: Run** — `cargo test -p gents-protocol row::` → FAIL
+- [ ] **Step 3: Implement**; **Step 4: Run** → PASS
+- [ ] **Step 5: Commit** — `feat: RenderedRequestRow protocol row with order-key and provenance bridges (#1066)`
+
+---### Task 4: Admission stamp — manifest v3
+
+**Files:**
+- Modify: `crates/gents/src/admission/client.rs`, `crates/gents/src/admission/mod.rs`
+- Modify: `crates/gents-protocol/src/rendered_request.rs` (manifest field + version bump)
+- Modify: `crates/gents/src/rendered_request/mod.rs` (`build_rendered_completion_request`), `crates/gents/src/rendered_request/scope.rs`, `crates/gents/src/rendered_request/transport.rs` (only if plumbing forces it — prefer reading the task-local inside `build_rendered_completion_request`)
+- Test: `crates/gents/src/rendered_request/mod.rs` unit tests + `crates/gents/tests/e2e_runtime/rendered_request_capture.rs`
+
+**Interfaces:**
+- Produces:
+  - `gents_protocol::rendered_request::AdmissionJoin { pub call_id: String, pub call_seq: i64 }`; `ProvenanceManifest.admission: Option<AdmissionJoin>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`; `PROVENANCE_MANIFEST_VERSION` = 3; `SUPPORTED_PROVENANCE_MANIFEST_VERSIONS` = 2..=3.
+  - `gents::admission::current_call_join() -> Option<(String, i64)>` (`pub(crate)`), reading a new `pub(super) current_call: Arc<std::sync::Mutex<Option<(String, i64)>>>` slot on `AdmissionCallContext`, written by `next_call` (`client.rs:189-202`) right after it mints `PendingCallMetadata` (store `(call_id.clone(), call_seq as i64)`). Follow the `current_session_id` precedent (`client.rs:279-283`) for the accessor shape. Verify the slot's `Arc` survives however `scope_call` (`client.rs:216`) constructs per-call contexts from the request-scope context — the transport capture must observe the value `next_call` wrote for THIS call. The e2e assertion in Step 4 is the fence for that plumbing, not code review.
+- Consumes: Task 2's reader (a v3 manifest with `admission` absent must parse — oneshot).
+
+- [ ] **Step 1: Failing unit test** in `rendered_request/mod.rs` tests: build a manifest via `ProvenanceManifest::captured_only(...)` with an injected join, assert serialized JSON contains `"manifest_version":3` and the `admission` object; build without a join (oneshot path) and assert the key is absent; `ProvenanceManifest::parse` accepts both.
+- [ ] **Step 2: Run** — `cargo test -p gents rendered_request` → FAIL
+- [ ] **Step 3: Implement**: `captured_only` gains `admission: Option<AdmissionJoin>` parameter; `build_rendered_completion_request` (`mod.rs:576-643`) passes `crate::admission::current_call_join().map(|(call_id, call_seq)| AdmissionJoin { call_id, call_seq })`. Update the existing oneshot caveat comment (`mod.rs:399-404`).
+- [ ] **Step 4: Extend e2e**: in `rendered_request_capture.rs`, extend the multi-turn test to parse each captured row's provenance and assert (a) every `inference.*` capture carries `admission` whose `call_seq` matches a persisted `InferenceCall` row for the same request with `call_kind == "inference"`, and distinct captures carry distinct `call_id`s; (b) provenance for a title/oneshot capture (where the fixture produces one) has `admission: None`.
+- [ ] **Step 5: Run** — `cargo test -p gents rendered_request && cargo test -p gents --test e2e_runtime rendered_request_capture` → PASS
+- [ ] **Step 6: Commit** — `feat: stamp admission call_id/call_seq into capture provenance, manifest v3 (#1066)`
+
+---
+
+### Task 5: Central `_commits` helper
+
+**Files:**
+- Create: `crates/gents/src/rendered_request/commits.rs` (`pub mod commits;` in `mod.rs`)
+- Test: same file, `#[cfg(test)]` + e2e usage in Task 8
+
+**Interfaces:**
+- Produces:
+
+```rust
+pub struct RequestJsonCommit { pub cid: String, pub height: i64 }
+
+/// Ok(None) is explicit *Unavailable*: no commits, or none for request_json.
+pub async fn request_json_commit(
+    access: &crate::config::ConfigAccess,
+    doc_id: &str,
+) -> anyhow::Result<Option<RequestJsonCommit>>;
+```
+
+Contract (from spec §3): one docID; **no `fieldName` filter in the query** (in-memory `filter.matches(..).unwrap_or(true)` degrades malformed filters to no filter); select `cid height fieldName`; pick `fieldName == "request_json"` rows in Rust, take max `height`; `[]` → `Ok(None)`; GraphQL errors → `Err`. Query text:
+
+```rust
+let query = format!(
+    r#"query {{ _commits(docID: "{doc_id}") {{ cid height fieldName }} }}"#,
+    doc_id = escape_graphql_string(doc_id),
+);
+```
+
+Route through the same `ConfigAccess` execution path `run_timeline_fetch.rs` uses (see `load_rows`/raw query execution there) so both Graphql and Local transports work.
+
+- [ ] **Step 1: Failing unit test** with a canned response `Value` (happy path picks max-height `request_json` commit; response with commits but none for `request_json` → `None`; empty array → `None`; error body → `Err`). Factor the response→result selection into a pure `fn select_request_json_commit(response: &serde_json::Value) -> anyhow::Result<Option<RequestJsonCommit>>` so it unit-tests without a node.
+- [ ] **Step 2: Run** — `cargo test -p gents rendered_request::commits` → FAIL; **Step 3: Implement**; **Step 4: Run** → PASS
+- [ ] **Step 5: Commit** — `feat: central _commits request_json CID helper (#1066)`
+
+---
+
+### Task 6: Run timeline — capture events, ordering, #991/#841 fold-ins
+
+**Files:**
+- Modify: `crates/gents/src/run_timeline.rs`, `crates/gents/src/run_timeline_fetch.rs`
+- Test: `run_timeline.rs` `#[cfg(test)]` (fixture-driven `build_run_timeline` tests live there)
+
+**Interfaces:**
+- Consumes: `RenderedRequestRow` (Task 3) is NOT used here — timeline has its own row structs with `_docID`; define `TimelineRenderedRequestRow` matching that local convention, **without a `request_json` field** (structural body exclusion — the query never selects it).
+- Produces:
+
+```rust
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TimelineRenderedRequestRow {
+    #[serde(default, rename = "_docID", skip_serializing)] pub doc_id: Option<String>,
+    pub capture_key: String,
+    #[serde(default)] pub request_doc_id: Option<String>,
+    #[serde(default)] pub request_id: Option<String>,
+    #[serde(default)] pub session_id: Option<String>,
+    #[serde(default)] pub capture_scope: Option<String>,
+    #[serde(default)] pub turn_index: Option<i64>,
+    #[serde(default)] pub attempt: Option<i64>,
+    #[serde(default)] pub capture_version: Option<i64>,
+    #[serde(default)] pub model_name: Option<String>,
+    #[serde(default)] pub source: Option<String>,
+    #[serde(default)] pub prompt_hash: Option<String>,
+    #[serde(default)] pub tools_hash: Option<String>,
+    #[serde(default)] pub provenance_json: Option<String>,
+    #[serde(default)] pub created_at: Option<String>,
+}
+```
+
+  - `RunTimelineRows.rendered_requests: Vec<TimelineRenderedRequestRow>` (`#[serde(default)]` so existing fixture ingest keeps deserializing).
+  - `RunTimelineEvent::RenderedRequest(TimelineRenderedRequestEvent)` (serde kind `"rendered_request"`), event fields: `capture_key, request_doc_id, request_id, capture_scope, scope_kind: Option<String>, scope_seq: Option<i64>, turn_index, attempt, capture_version, model_name, source, prompt_hash, tools_hash, provenance_status: Option<String>, manifest_version: Option<i64>, call_id: Option<String>, call_seq: Option<i64>, created_at` — scalars only; `provenance_status` is `"captured_only"` / `"unsupported_manifest"` / `"unavailable"` / `"malformed"` derived via Task 2's reader (parse failure → `"malformed"`, never a panic; `scope_kind`/`scope_seq` from `CaptureScope` parse, `None` on malformed).
+  - `TimelineInferenceCallRow`/`TimelineInferenceCallEvent` + inference query gain `prompt_tokens`, `completion_tokens`, `cached_input_tokens` (`Option<i64>`, skip-if-none on the event) — #991.
+  - `TimelineRequestRow`/`TimelineRequestEvent` + all three AgentRequest queries gain `execution_origin`, `caused_by_trigger_id`, `caused_by_trigger_kind` (`Option<String>`, skip-if-none on the event) — #841.
+  - Fetch: `load_timeline_rendered_requests_for_session(access, session_id)` and `..._for_request(access, request_id)` (no-session fallback), selecting exactly the row's fields (never `request_json`), `order: { created_at: ASC }`, wrapped in `rows_or_empty_if_collection_missing` so pre-#1059 DBs yield empty. Wire into `load_run_timeline_rows` next to the per-session loop (`:47-51`).
+  - Ordering in `event_sort_key`: family ranks become Request 0, **RenderedRequest 1**, InferenceCall 2, Message 3, ToolCall 4, Response 5 (ranks are unserialized internals — renumbering is safe; update the rank table comment). RenderedRequest: timestamp = `created_at` millis; intra rank = `call_seq.unwrap_or(i64::MAX)`; tiebreak = `CaptureOrderKey::padded()` when the scope parses, else `capture_key`.
+
+- [ ] **Step 1: Failing fixture test** in `run_timeline.rs` tests: `RunTimelineRows` fixture with 2 inference calls (call_seq 1,2 with token fields), 3 rendered rows (`inference.1` turns 0/0, 0/1 with `call_seq` 1 and 2 stamped in provenance fixtures, plus `compaction.1` 0/0 with a **v99 manifest**), request row with trigger lineage. Assert: event order interleaves capture-before-its-call; token and lineage fields present on events; v99 row surfaces `provenance_status == "unsupported_manifest"`; seq-10-vs-2 ordering via two extra unstamped rows (`inference.10`/`inference.2` fixtures — unstamped path sorts by padded key).
+- [ ] **Step 2: Run** — `cargo test -p gents run_timeline` → FAIL; **Step 3: Implement**; **Step 4: Run** → PASS; also `cargo test -p gents adapter_projection` (existing projections consume the enum — exhaustive matches gain an ignore arm here; Task 7 fills them in).
+- [ ] **Step 5: Commit** — `feat: rendered-capture timeline events; fold InferenceCall tokens (#991) and trigger lineage (#841) into fetch (#1066)`
+
+---
+
+### Task 7: Projections — envelope + ATIF/LangGraph metadata, sentinel leak test
+
+**Files:**
+- Modify: `crates/gents/src/adapter_projection.rs`, `crates/gents/src/adapter_projection/atif.rs`
+- Test: `crates/gents/src/adapter_projection/tests.rs`
+
+**Interfaces:**
+- Consumes: `RunTimelineEvent::RenderedRequest` events + `RunTimeline` (Task 6).
+- Produces:
+  - `RenderedCaptureSummary` (serialize-only struct in `adapter_projection.rs`): exactly the `TimelineRenderedRequestEvent` scalar fields minus nothing — derive it by `From<&TimelineRenderedRequestEvent>`.
+  - `AdapterProjectionEnvelope.rendered_captures: Vec<RenderedCaptureSummary>` with `#[serde(default, skip_serializing_if = "Vec::is_empty")]`; envelope schema (`adapter_projection_json_schema:990-1025`) gains the matching `"rendered_captures"` array property (objects fully typed, `additionalProperties: false`), root stays `additionalProperties: false`.
+  - ATIF: trajectory-level `extra.rendered_captures` = the same summaries as JSON; per-step `extra.rendered_capture` on the inference-derived step whose `InferenceCall.call_seq` equals a summary's `call_seq` (exact join only — no ordinal fallback).
+  - LangGraph: default `values.rendered_captures` = same JSON summaries (the `apply_langgraph_metadata_hint` wholesale-replace path may drop it; that is the hint contract's existing semantics — do not fight it).
+  - OpenAI-Codex / multi-agent native shapes: untouched (closed schemas); their envelope carries the section. `RunTimelineEvent::RenderedRequest` is explicitly ignored in their builders like `InferenceCall` already is (`:1710`, `:1986`).
+- **Bodies never appear**: input events have no body fields (Task 6 structural guarantee); this task's test pins it end-to-end.
+
+- [ ] **Step 1: Failing tests** in `adapter_projection/tests.rs`:
+
+```rust
+const BODY_SENTINEL: &str = "SENTINEL_RENDERED_BODY_9f3a";
+
+#[test]
+fn rendered_captures_surface_as_metadata_and_bodies_never_leak() {
+    // fixture timeline: one request, two inference calls, two stamped rendered events,
+    // provenance fixture strings containing BODY_SENTINEL inside an effective_messages
+    // text (the realistic leak vector) — Task 6's event derivation must have dropped it.
+    for kind in [AdapterProjectionKind::Atif, AdapterProjectionKind::OpenAiCodex,
+                 AdapterProjectionKind::LangGraph, AdapterProjectionKind::MultiAgent] {
+        for mode in [ProjectionRedactionMode::Full, ProjectionRedactionMode::TrainingSafe,
+                     ProjectionRedactionMode::Public] {
+            let envelope = build_adapter_projection(kind, &timeline, &ProjectionContext {
+                actor_did: None, redaction_mode: mode });
+            let serialized = serde_json::to_string(&envelope).unwrap();
+            assert!(!serialized.contains(BODY_SENTINEL), "{kind:?}/{mode:?}");
+            assert_eq!(envelope.rendered_captures.len(), 2, "{kind:?}/{mode:?}");
+        }
+    }
+}
+```
+
+  (Note: the sentinel lives in the ROW fixture's `provenance_json`; Task 6's event carries only scalars, so the timeline built from rows must already be clean — build the fixture through `build_run_timeline(rows)`, not by hand-crafting events, so the test fences the whole pipeline.) Plus: an ATIF test asserting trajectory `extra.rendered_captures` length and the per-step join lands on the step with matching `call_seq`; a LangGraph test for `values.rendered_captures`; a schema-validation test running the existing `validate_adapter_projection_contract` over an envelope with captures.
+- [ ] **Step 2: Run** — `cargo test -p gents adapter_projection` → FAIL; **Step 3: Implement**; **Step 4: Run** → PASS
+- [ ] **Step 5: Commit** — `feat: metadata-only rendered-capture exposure in projection envelope, ATIF extras, LangGraph values (#1066)`
+
+---
+
+### Task 8: CLI `gents trace capture`
+
+**Files:**
+- Modify: `crates/gents-cli/src/cli/args.rs` (extend `TraceCommand:1029-1048`), `crates/gents-cli/src/commands/trace.rs`
+- Test: `crates/gents-cli/tests/cli_trace_export.rs` (same harness; RocksDb-pinned EmbeddedNodes)
+
+**Interfaces:**
+- Consumes: `gents_protocol::row::RenderedRequestRow` (Task 3), `gents::rendered_request::commits::request_json_commit` (Task 5), Task 6 timeline (for `trace timeline` output assertions).
+- Produces: `TraceCommand::Capture(TraceCaptureArgs)`:
+
+```rust
+#[derive(Debug, Parser)]
+pub(crate) struct TraceCaptureArgs {
+    #[arg(long)] pub(crate) home: Option<PathBuf>,          // same access pattern as TraceTimelineArgs
+    #[arg(long)] pub(crate) graphql: Option<String>,
+    #[arg(long, help = "Fetch one capture by its capture_key")] pub(crate) capture_key: Option<String>,
+    #[arg(long, help = "List/narrow captures for a request")] pub(crate) request_id: Option<String>,
+    #[arg(long, requires = "request_id")] pub(crate) scope: Option<String>,     // e.g. inference.1
+    #[arg(long, requires = "request_id")] pub(crate) turn: Option<i64>,
+    #[arg(long, requires = "request_id")] pub(crate) attempt: Option<i64>,
+    #[arg(long, help = "List all matches instead of requiring exactly one")] pub(crate) list: bool,
+    #[arg(long, help = "Include request_json and full provenance in the output")] pub(crate) include_body: bool,
+    #[arg(long)] pub(crate) output_file: Option<PathBuf>,
+}
+```
+
+Behavior: query `RenderedRequest` by key or filters (escape every literal; select all columns EXCEPT `request_json` unless `--include-body`); rows sort by `order_key()` (malformed scope → row still listed with an explicit `"order": "unparseable"` marker, sorted last by `capture_key`). Exactly-one match → JSON object: metadata + `request_json_commit` result rendered as `{"cid": ..., "height": ...}` or `"unavailable"` + (with `--include-body`) `request_json` and raw `provenance_json`. Multiple matches without `--list` → print metadata list, exit nonzero with a "narrow with --scope/--turn/--attempt or pass --list" error. Zero matches → nonzero exit, no existence-oracle wording beyond "no capture rows matched".
+
+- [ ] **Step 1: Failing tests** in `cli_trace_export.rs` (follow its existing seeded-node pattern): seed two captures for one request (same scope, turns 0/1) with realistic v3 provenance; assert (a) `trace capture --request-id X --list` prints both with numeric-order keys; (b) `--request-id X --scope inference.1 --turn 0 --attempt 0` prints one object whose `commit.cid` is nonempty and which has NO `request_json` key; (c) `--include-body` includes it; (d) ambiguous without `--list` exits nonzero; (e) `trace timeline` output for the request contains `"kind":"rendered_request"` events.
+- [ ] **Step 2: Run** — `cargo test -p gents-cli cli_trace_export` → FAIL; **Step 3: Implement** (`dispatch` arm in `trace.rs:43-50`, new `trace_capture` fn using the `ConfigAccess` construction `trace_timeline:52-63` uses); **Step 4: Run** → PASS
+- [ ] **Step 5: Commit** — `feat: gents trace capture — fetch capture metadata with request_json field-commit CID (#1066)`
+
+---
+
+### Task 9: Desktop trace panel renders capture events
+
+**Files:**
+- Modify: `packages/gents-desktop-operations/src/components/trace/RequestTracePanel.tsx` (`eventSummary:151`, `eventTimestamp:140`)
+- Test: `apps/gents-desktop/tests/request-trace.test.tsx`
+
+**Interfaces:** consumes the serialized `"rendered_request"` event kind (open-shaped `RunTimelineEventView` — no type changes needed).
+
+- [ ] **Step 1: Failing test**: render `RequestTracePanel` with a fixture timeline containing a `rendered_request` event (`capture_scope: "inference.1"`, `turn_index: 0`, `attempt: 1`, `model_name: "gpt-5"`, `provenance_status: "captured_only"`); assert the row shows a summary like `captured inference.1 turn 0 attempt 1 · gpt-5 · captured_only` and uses `created_at` for its timestamp. Follow the test file's existing fixture/render pattern.
+- [ ] **Step 2: Run** the desktop test suite the way `apps/gents-desktop/package.json` defines (`npm test -- request-trace` from `apps/gents-desktop`) → FAIL
+- [ ] **Step 3: Implement** the `case "rendered_request":` arm in `eventSummary` (and `eventTimestamp` if kinds are switched there) rendering exactly that summary from the event's fields with sensible fallbacks (missing model → omit segment).
+- [ ] **Step 4: Run** → PASS
+- [ ] **Step 5: Commit** — `feat: desktop trace panel renders rendered-capture events (#1066)`
+
+---
+
+### Task 10: Lean — conformance cases for the parse/order vocabulary, ledger discharge
+
+**Files:**
+- Modify: `crates/gents/proofs/Proofs/Conformance/ContractCases/RenderedCapture.lean`, `crates/gents/proofs/Proofs/Conformance/Contracts/Json/RenderedCapture.lean` (case emission), `crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean`
+- Modify: `crates/gents/tests/conformance/rendered_capture.rs` (consume new cases), `crates/gents/tests/support/conformance_consumers.rs` (register new consumers)
+
+**Interfaces:** consumes Task 2 (`CaptureScope` parse), Task 8 test name, Task 9 test name.
+
+- [ ] **Step 1: Scope cases in Lean.** In `ContractCases/RenderedCapture.lean`, add a `CaptureScopeCase` list: for each kind in the existing Lean capture vocabulary (inference, compaction, compaction_fallback, title, oneshot) emit `{ label := "<kind>.<seq>", kind := "<kind>", seq := <n>, valid := true }` cases (seqs 1, 2, 10 — 10 pins numeric ordering) plus invalid cases (`""`, `"inference"`, `"mystery.1"`, `"inference.0x2"`) with `valid := false`, and an `ordering` list pinning that `inference.2 < inference.10` at equal turn/attempt. Emit through `Contracts/Json/RenderedCapture.lean` following the existing key-case emission shape there.
+- [ ] **Step 2: Consume from Rust.** In `tests/conformance/rendered_capture.rs`, add `generated_capture_scope_cases_pin_the_parser`: for each valid case `label.parse::<CaptureScope>()` succeeds with matching kind/seq; each invalid case errs; the ordering list matches `CaptureOrderKey` comparison. Run `cd crates/gents/proofs && lake build && cargo test -p gents --test conformance rendered_capture` → PASS (iterate until).
+- [ ] **Step 3: Discharge the deferrals.** In `CoverageLedger.lean:194-202`: `required := [Surface.runtimeInternal, Surface.operatorCli, Surface.operatorUi]`, `deferred := []`. Next to the existing tagged rows (`:915-924`) add:
+
+```lean
+  , tagged (consumerCoverage
+      "rendered_capture_cases"
+      "RenderedCaptureCliSurface"
+      "gents-cli::cli_trace_export::<actual Task 8 test fn name>")
+      "rendered-capture" [Surface.operatorCli]
+  , tagged (consumerCoverage
+      "rendered_capture_cases"
+      "RenderedCaptureDesktopSurface"
+      "gents-desktop::request-trace::<actual Task 9 test name>")
+      "rendered-capture" [Surface.operatorUi]
+```
+
+  Match the consumer-string format to what `conformance_consumers.rs` validates (read its existing entries first and register the two new consumers there in the same shape).
+- [ ] **Step 4: Run** — `cd crates/gents/proofs && lake build` (zero `sorry`s) then `cargo test -p gents --test conformance` → PASS (coverage test enforces the discharge).
+- [ ] **Step 5: Commit** — `feat: fence capture-scope parsing in conformance; discharge rendered-capture operatorCli/operatorUi deferrals (#1066)`
+
+---
+
+### Task 11: Final verification and PR
+
+- [ ] **Step 1:** `cd crates/gents/proofs && lake build`
+- [ ] **Step 2:** `cargo test -p gents-protocol && cargo test -p gents && cargo test -p gents-cli`
+- [ ] **Step 3:** desktop test suite (as run in Task 9)
+- [ ] **Step 4:** `cargo check --workspace --all-targets`
+- [ ] **Step 5:** `git log --oneline origin/main..HEAD` sanity; push branch; open PR titled "Capture consumers: rendered-request fact records readable once, centrally (#1066)" with body covering: closes #1066; folds #991 + #841 timeline fields; explicitly NOT fixed: #842 (training_safe masking — nothing here routes bodies through redaction), #523 (reconstruction — unblocked, not built), ACP/encryption (defradb.rs#1318); manifest v2→v3 note for PR #1065's provenance slice; note the sibling 1059-worktree uncommitted ATIF/Harbor token-metrics slice overlaps only on the #991 timeline fields. End body with the standard generated-with footer.
+
+## Self-Review Notes
+
+- Spec §1→Tasks 1-3, §2→Task 4, §3→Task 5, §4→Task 6, §5→Task 7, §6→Task 8, §7→Task 9, §8→Task 10, error table→Tasks 2/5/6/8, testing section→each task's Step 1, gates→Task 11. No gaps found.
+- Type names cross-checked: `CaptureScope`/`CaptureOrderKey`/`ParsedProvenance`/`AdmissionJoin`/`RenderedRequestRow`/`TimelineRenderedRequestRow`/`RenderedCaptureSummary` used consistently.
+- Two deliberate verify-by-test seams (admission Arc plumbing in Task 4, consumer-string format in Task 10) are fenced by concrete named tests, not left open.

--- a/docs/superpowers/specs/2026-08-07-capture-consumers-design.md
+++ b/docs/superpowers/specs/2026-08-07-capture-consumers-design.md
@@ -1,0 +1,191 @@
+# Capture consumers: make the RenderedRequest fact record readable, once, centrally
+
+Date: 2026-08-07
+Issue: #1066 (consumer side of #840's durable capture; producer landed in #1059 at `415a2ef6`)
+Folds in: #991 (InferenceCall token fields), #841 (AgentRequest trigger lineage in timeline)
+Out of scope: ACP/`@policy` (defradb.rs#1318), at-rest encryption, retention/off-switch,
+verified reconstruction (#523), the `training_safe` redaction defect (#842 — but see §5:
+nothing this design ships routes captured bodies through redaction at all).
+
+## Goal
+
+`RenderedRequest` rows accumulate from #1059 onward and nothing reads them. Make the fact
+record reachable through the run timeline, the adapter projections, and the CLI — with the
+three sharp reads (ordering, `_commits`, provenance manifest) implemented exactly once —
+and keep captured bodies out of every default export as a positive default.
+
+## Design
+
+### 1. Shared vocabulary moves to `gents-protocol`
+
+The repo's precedent is the message family: native types live in `gents-protocol`, the
+runtime re-exports them. Captures follow it. A new `gents-protocol::rendered_request`
+module takes ownership (moved, not mirrored — `gents::rendered_request` re-exports and
+deletes its local definitions, so producer call sites do not change) of:
+
+- `RenderedRequestSource`, `CaptureScopeKind`, `ProvenanceStatus`, `CaptureSeam`,
+  `AssemblyBuildPath`, `AssistantMessageId`, `ThreadedToolResult`, `AssemblyTrace`,
+  `ProvenanceManifest`, and the `CAPTURE_VERSION` / `PROVENANCE_MANIFEST_VERSION` /
+  `ASSEMBLY_TRACE_VERSION` constants. `AssemblyTrace.effective_messages` already uses
+  `gents-protocol::message::Message`, so the move introduces no new dependency edge.
+- **`CaptureScope` parse**: `"{kind}.{seq}"` → `{ kind: CaptureScopeKind, seq: u64 }`,
+  with `Display` round-trip. Malformed scope is an error, never a default.
+- **`CaptureOrderKey`**: `(kind, seq, turn_index, attempt)` with derived `Ord`. This is
+  the stable identity ordering within a request. It parses `seq` numerically — the e2e
+  helper's lexical `capture_scope` sort would order `inference.10` before `inference.2`;
+  the shared key is where that class of bug dies. Cross-loop interleaving *in time* is
+  the timeline's job (created_at / admission join), not this key's.
+- **Manifest reader**: `ProvenanceManifest::parse(&str)` peeks `manifest_version` first
+  and returns `UnsupportedManifest { version }` for anything outside the supported range
+  (2..=3 after §2) rather than guessing. Absent/empty provenance is `Unavailable`.
+
+`RenderedRequestRow` joins its siblings in `gents-protocol::row` per the file's stated
+convention: `capture_key: String` required, every other column `#[serde(default)]
+Option<T>`, field names exactly matching the 18 GraphQL columns. A `RenderedRequestRow::
+order_key()` accessor bridges to `CaptureOrderKey` (erroring on malformed scope), and
+`provenance()` bridges to the manifest reader.
+
+### 2. Producer stamp: exact admission join, manifest v3
+
+Capture↔`InferenceCall` correspondence is currently ordinal; an admission rejection
+desynchronises it. Fix at the source:
+
+- `admission` gains a `pub(crate)` accessor exposing the *current call's* minted
+  metadata (`call_id`, `call_seq`) — set when `acquire_current_call` mints
+  `PendingCallMetadata`, cleared when the call scope ends. Note `AdmissionCallContext.
+  call_seq` is the shared `Arc<AtomicU64>` counter, not the current value, and `call_id`
+  today lives only in `PendingCallMetadata`; the accessor is the smallest honest seam.
+- `ProvenanceManifest` gains optional `admission: Option<{ call_id, call_seq }>`
+  (skip-if-none). One-shot runs never enter an admission scope and legitimately carry
+  none — that stays a documented absence, not an error.
+- `PROVENANCE_MANIFEST_VERSION` bumps 2 → 3. The reader accepts 2 and 3; v2 rows written
+  since #1059 merged stay readable forever. (PR #1065's provisional slice wants an exact
+  AgentRequest doc-version in provenance later; it will be v4 on the same reader pattern.)
+
+### 3. The `_commits` read, once
+
+`gents::rendered_request::commits` (runtime crate — it needs `ConfigAccess`):
+`request_json_commit(access, doc_id) -> Result<Option<RequestJsonCommit>>` where the
+`Option::None` is explicit *Unavailable*. Contract, lifted from the only existing
+implementation (the e2e helper) and the #1059 plan's citation fixes:
+
+- exactly one `docID` per query — two or more is a DefraDB parse error;
+- **no `fieldName` filter in the query** — that filter is evaluated in memory and a
+  malformed filter silently degrades to no filter; the helper fetches all commits and
+  selects `fieldName == "request_json"` in Rust, taking max height;
+- `[]` from `_commits` is `Unavailable`, never "unchanged";
+- GraphQL response errors are errors — a missing `data` field is not "no rows".
+
+The e2e helper keeps its own assertion-oriented `commit_set` (it deliberately inspects
+*all* field commits); the CLI and any future reconstructor use this helper.
+
+### 4. Run timeline
+
+- `RunTimelineRows` gains `rendered_requests: Vec<TimelineRenderedRequestRow>`; the fetch
+  layer loads them per session (fallback per request) via the existing
+  `rows_or_empty_if_collection_missing` escape hatch, so a pre-#1059 database yields an
+  empty section — never a failed timeline.
+- New event variant `RunTimelineEvent::RenderedRequest(TimelineRenderedRequestEvent)`,
+  kind `"rendered_request"` — **metadata only**: capture_key, request_doc_id, request_id,
+  capture_scope (+ parsed kind/seq), turn_index, attempt, capture_version, model_name,
+  source, prompt_hash, tools_hash, provenance status + manifest_version, the admission
+  join (call_id/call_seq) when stamped, created_at. `request_json` is never on the event.
+- Ordering: timestamp = `created_at`; persist-before-send means a capture's timestamp
+  precedes its provider call's `started_at`, and the family rank places
+  `rendered_request` immediately before `inference_call` on ties. Intra rank uses the
+  stamped `call_seq` when present (exact join); the tiebreak string is the zero-padded
+  order key (`{kind}.{seq:010}.{turn:06}.{attempt:06}`) so unstamped rows (v2, oneshot)
+  still order deterministically and numerically.
+- Fold-ins while in the fetch layer: `prompt_tokens` / `completion_tokens` /
+  `cached_input_tokens` on `TimelineInferenceCallRow`+event+query (#991);
+  `execution_origin` / `caused_by_trigger_id` / `caused_by_trigger_kind` on
+  `TimelineRequestRow`+event+queries (#841). (Note: a sibling worktree holds uncommitted
+  edits doing the #991 part plus an ATIF/Harbor token-metrics slice; the latter is not
+  absorbed here.)
+
+### 5. Adapter projections: metadata yes, bodies never
+
+The #1059 plan imagined "decrypted request_json only in an explicitly authorized full
+projection" — but ACP is deferred, so *authorized* cannot currently be expressed. Until
+it can, projections carry capture **metadata only**, unconditionally. This is the
+positive default the issue demands: Harbor invokes `trace project` with neither
+`--redaction` nor `--actor-did`, redaction defaults to `Full`, ATIF `extra` bypasses
+redaction — none of that matters if bodies never enter the projection model.
+
+- The projection input is the timeline event (metadata-only by construction in §4), so
+  the property holds structurally, and a leak test pins it: build every projection in
+  every redaction mode over a fixture whose `request_json` contains a sentinel; assert
+  the sentinel appears in no serialized output.
+- `AdapterProjectionEnvelope` gains optional `rendered_captures` (array of the metadata
+  shape; skip-if-empty; envelope schema updated, still `additionalProperties: false`
+  with the new property defined). This gives all four projections one documented,
+  uniform surface even where native shapes are closed.
+- Native shapes: ATIF attaches trajectory-level `extra.rendered_captures` and, where the
+  admission join identifies a step's call, per-step `extra.rendered_capture`; LangGraph
+  adds `values.rendered_captures`. OpenAI-Codex and multi-agent native shapes are closed
+  (`additionalProperties: false` throughout) and stay untouched — their envelope carries
+  the section.
+
+### 6. CLI
+
+- `gents trace timeline` surfaces capture events with no further work (it serializes the
+  timeline).
+- New `gents trace capture`: fetch by `--capture-key`, or by `--request-id` with optional
+  `--scope/--turn/--attempt` narrowing. Default output is metadata plus the
+  `request_json` field-commit CID from §3 (CID lookup requires the doc; `Unavailable` is
+  printed honestly). `--include-body` opts into printing `request_json` and the full
+  provenance manifest — the one deliberate, explicit body read in the system.
+  Multiple matches print the metadata list (with order keys) and exit nonzero unless
+  listing was the intent (`--list`). `--output-file` / JSON output follow `trace
+  timeline` conventions.
+
+### 7. Desktop (operatorUi)
+
+The timeline event flows through `desktop_request_timeline`'s untyped passthrough and the
+client's open-shaped `RunTimelineEventView` with zero plumbing. `RequestTracePanel.
+eventSummary` gains a `rendered_request` case (scope, turn/attempt, model, provenance
+status) plus a test — that is the operatorUi consumer.
+
+### 8. Lean coverage ledger
+
+`CoverageLedger.lean`'s `rendered-capture` entry: delete both deferrals, move
+`operatorCli` and `operatorUi` into `required`, and add tagged consumer rows pointing at
+the CLI trace-capture test and the desktop trace-panel test (consumer registry entries
+included). `lake build` stays at zero `sorry`s; the conformance coverage test enforces
+the discharge. No lifecycle/invariant change is being made, so no new Lean model is
+required; the existing `RenderedCaptureKeyCases` continue to pin the key tuple. The
+scope-parse and order-key comparator added in §1 get conformance cases emitted through
+the existing RenderedCapture contract JSON so the parser is spec-fenced, not just
+unit-tested.
+
+## Error handling summary
+
+| Condition | Behavior |
+|---|---|
+| Pre-#1059 DB, no collection | empty timeline section; no error |
+| Malformed `capture_scope` | row surfaces with an explicit parse error marker in CLI; excluded from order-sensitive joins; never a panic |
+| Unknown `manifest_version` | `UnsupportedManifest` surfaced as provenance status; row still listed |
+| `_commits` returns `[]` or no `request_json` field | explicit `Unavailable` |
+| Multiple rows for one `(request, scope, turn, attempt)` | integrity error (unique `capture_key` makes it corruption) |
+
+## Testing
+
+- Unit: scope parse/round-trip, order-key comparator (incl. seq ≥ 10), manifest version
+  gate (2 ok, 3 ok, 4 unsupported, garbage error), row deserialization from a raw
+  GraphQL response fixture.
+- Conformance: scope/order cases emitted from Lean; ledger discharge test.
+- Timeline: fixture with retries + compaction loop asserting capture events interleave
+  correctly with inference calls (stamped and unstamped).
+- Projection: the sentinel leak test across all four projections × three redaction
+  modes; envelope schema validation.
+- CLI: `trace capture` happy path, `--include-body`, ambiguous match, missing collection
+  (`cli_trace_export`-style harness); timeline output includes capture events.
+- E2E: extend `rendered_request_capture.rs` with a read-back through
+  `load_run_timeline` + CLI path against a multi-turn retry session.
+- Desktop: `request-trace.test.tsx` case for the new event kind.
+
+## Verification gates
+
+`cd crates/gents/proofs && lake build` · `cargo test -p gents` (full package) ·
+`cargo test -p gents-protocol -p gents-cli` · desktop test suite ·
+`cargo check --workspace --all-targets`.

--- a/packages/gents-desktop-operations/src/components/trace/RequestTracePanel.tsx
+++ b/packages/gents-desktop-operations/src/components/trace/RequestTracePanel.tsx
@@ -180,6 +180,20 @@ export function eventSummary(event: RunTimelineEventView): string {
       ]
         .filter(Boolean)
         .join(" — ");
+    case "rendered_request": {
+      const turn =
+        typeof event.turn_index === "number" ? `turn ${event.turn_index}` : null;
+      const attempt =
+        typeof event.attempt === "number" ? `attempt ${event.attempt}` : null;
+      return [
+        `captured ${str(event.capture_scope) ?? "request"}`,
+        [turn, attempt].filter(Boolean).join(" ") || null,
+        str(event.model_name),
+        str(event.provenance_status),
+      ]
+        .filter(Boolean)
+        .join(" — ");
+    }
     case "response":
       return [str(event.status) ?? "response", str(event.error_message)]
         .filter(Boolean)


### PR DESCRIPTION
## Summary

PR #1059 landed durable rendered-request capture; rows accumulated with no reader. This is the consumer side, built so the three sharp reads — ordering, `_commits`, and the provenance manifest — are implemented exactly once, in shared vocabulary:

- **`gents-protocol::rendered_request`** now owns the capture vocabulary (moved from the runtime, which re-exports it — producer call sites unchanged), plus the consumer half: the `"{kind}.{seq}"` `CaptureScope` parser, `CaptureOrderKey` with **numeric** seq ordering (a lexical sort puts `inference.10` before `inference.2`), a versioned `ProvenanceManifest` reader (v2–v3; `UnsupportedManifest` beyond, never guessed), and `RenderedRequestRow` beside its row siblings.
- **Exact admission join.** `next_call` publishes the minted `call_id`/`call_seq`; captures stamp it into provenance **manifest v3**, guarded by call-kind↔scope-kind compatibility (a race can drop the join, never mis-join). The capture↔`InferenceCall` correspondence is now a stored key, not an ordinal guess. E2E-fenced against persisted rows. One-shot captures carry no join, by documented design.
- **One `_commits` reader** (`rendered_request::commits`): single docID, **no in-query `fieldName` filter** (evaluated in memory; malformed filters silently degrade to no filter), `request_json` commit selected in Rust, `[]` is explicit *Unavailable*.
- **Run timeline** gains a `rendered_request` event family — metadata only. The fetch layer never selects `request_json`, so captured bodies are structurally unreachable by everything downstream. Pre-#1059 databases read as an empty section, never a failed timeline. Folds in `InferenceCall` token fields and `AgentRequest` trigger lineage while in that layer (partial progress on #991/#841 — both are much broader and stay open).
- **Projections**: a uniform `rendered_captures` metadata section on the envelope (schema snapshots regenerated); ATIF `extra` and LangGraph `values` carry it natively; the closed Codex/multi-agent native shapes are untouched. **Captured bodies appear in no projection, in any redaction mode** — a positive default, pinned by a sentinel leak test across all 4 projections × 3 modes (Harbor passes neither `--redaction` nor `--actor-did`, so exclusion cannot be caller responsibility). Access control stays DefraDB's: reads executed under a requester identity return only the rows that identity may see, so the projection read filter passes captures through like any other collection — when `RenderedRequest` gains its `@policy`, exclusion happens at the database read with no application change.
- **CLI**: `gents trace capture` — list/narrow/fetch-one with the `request_json` field-commit CID; `--include-body` is the one deliberate body read in the system. `trace timeline` surfaces the events automatically.
- **Desktop**: the request trace panel renders capture events.
- **Lean**: capture-scope/order contract cases are emitted and `rfl`-pinned; the Rust fence consumes them. The order fence caught a real bug during development — kind labels sort lexically against declaration rank — so `CaptureOrderKey::padded()` carries a numeric rank prefix. The `rendered-capture` coverage deferrals for `operatorCli`/`operatorUi` are discharged with registered consumers (CLI + desktop tests).

## Explicitly not in scope

- **#842** (`training_safe` masking destroys signal) — unchanged, and nothing here routes captured bodies through redaction at all.
- **#523** (verified reconstruction) — unblocked by the reader, not built.
- **ACP / at-rest encryption** — added later, and deliberately not re-implemented here: DefraDB enforces document ACP at the read path given the requester's identity DID (`acp::read_access` in the query txn), so the add is a `@policy` on the collection plus identity-carrying reads once the EmbeddedNode seam lands (sourcenetwork/defradb.rs#1318). One transition fact from defradb's `collection_acp.rs` worth carrying into #1065's ledger: a policy added later protects documents created *with identity after* it — rows captured before stay public unless explicitly registered.
- Retention / size bounds / capture off-switch (separate issue per #1066).

## Coordination notes

- **#1065** (schema review contract): its provisional slice pins an AgentRequest doc-version into provenance — that lands as manifest **v4** on the same reader pattern; this PR's reader takes v2..=3 and reports anything newer honestly.
- A sibling worktree holds uncommitted ATIF/Harbor token-metrics work that overlaps only on the #991 timeline token fields (identical three-field addition; trivial to reconcile).

## Validation

- `cd crates/gents/proofs && lake build` — clean, zero `sorry`s
- `cargo test -p gents-protocol` — 128 passed
- `cargo test -p gents` — lib 1371, conformance 335, e2e (incl. new admission-join fence) all green
- `cargo test -p gents-cli` — full suite green (incl. new `trace capture` test, RocksDb-pinned node)
- `apps/gents-desktop` `npm test` — 350 passed
- `cargo check --workspace --all-targets` — clean

Closes #1066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
