### PR TITLE
fix(gents): accept provenance JSON without source_version_status (#1091)

### DIFF
--- a/crates/gents/src/adapter_projection.rs
+++ b/crates/gents/src/adapter_projection.rs
@@ -131,6 +131,10 @@ pub struct ProjectionProvenance {
     pub source_projection_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub actor_did: Option<String>,
+    /// Always serialized on Gents-authored envelopes; defaulted on ingest so
+    /// external captures and envelopes exported before this field existed
+    /// keep deserializing (the published schema does not require it).
+    #[serde(default)]
     pub source_version_status: ProjectionSourceVersionStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rendered_request_refs: Vec<RenderedRequestProvenanceRef>,

--- a/crates/gents/src/adapter_projection/tests.rs
+++ b/crates/gents/src/adapter_projection/tests.rs
@@ -545,6 +545,24 @@ fn blank_response_falls_back_to_materialized_assistant_message_across_adapters()
 }
 
 #[test]
+fn provenance_without_source_version_status_deserializes_with_captured_only_default() {
+    // External adapter captures and previously exported envelopes predate
+    // source_version_status, and the published provenance schema does not
+    // require it; deserialization must not either.
+    let provenance = serde_json::from_value::<ProjectionProvenance>(json!({
+        "runtime": "gents",
+        "source_projection_id": "run_timeline",
+        "source_projection_version": "v1",
+    }))
+    .expect("provenance JSON without source_version_status must deserialize");
+    assert_eq!(
+        provenance.source_version_status,
+        ProjectionSourceVersionStatus::CurrentStateCapturedOnly
+    );
+    assert!(provenance.rendered_request_refs.is_empty());
+}
+
+#[test]
 fn empty_response_without_materialized_message_does_not_substitute_older_assistant_output() {
     let timeline = build_run_timeline(RunTimelineRows {
         request: TimelineRequestRow {


### PR DESCRIPTION
Fixes the deterministic failure from #1091 (main red since the first full-suite run containing #1087).

## Root cause

#1087 added `source_version_status: ProjectionSourceVersionStatus` to `ProjectionProvenance` without `#[serde(default)]` — the only new envelope field that didn't get one. The enum has a single variant (`CurrentStateCapturedOnly`) which is its declared `#[default]`, and the published provenance JSON schema does not list the field as required, so requiring it at deserialization added no information while breaking every envelope authored before the field existed. External adapter captures embed such envelopes; `cli_adapter_interop_roundtrip::negative_external_capture_imports_reject_bad_mappings_without_partial_rows` died at fixture parse (`missing field 'source_version_status'`) before its rejection assertions ran.

The full CLI suite only runs on main pushes, so the PR shard never executed this test.

## Fix

One line: `#[serde(default)]` on the field, with a comment stating the contract — Gents-authored envelopes always serialize it explicitly (no skip attribute); only ingest defaults it. Plus a unit test at the contract layer pinning that pre-#1087 provenance JSON deserializes with the default status.

Writer/validator-mismatch class again: a narrowing on one side of a seam with a consumer on the other side that no test on the PR path exercises.

## The other two #1091 failures

`generated_streaming_response_idle_timeout_case_drives_daemon_contract` and `generated_streaming_response_interrupt_flow_cases_drive_daemon_contract` failed on CI with "agent did not reach ready state within 30s" — the startup-under-parallel-load shape. Both pass in the full local suite run below. Not addressed here; if they recur on the next main run they belong to the #330 / #1082–#1085 flake class.

## Validation

- `cargo fmt --all --check`, `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo test -p gents` full package suite green: 1,432 lib (1 ignored); 336 conformance; 41 lifecycle E2E; 59 runtime E2E (1 ignored); 99 subagent E2E; all remaining targets ok
- `cargo test -p gents-cli --test cli_adapter_interop_roundtrip`: reproduced the exact CI failure before the fix, green after

🤖 Generated with [Claude Code](https://claude.com/claude-code)
