### PR TITLE
test(cli): align the CLI suite with the #1087 initialized-home and lineage contracts

### DIFF
--- a/crates/gents-cli/tests/cli_background.rs
+++ b/crates/gents-cli/tests/cli_background.rs
@@ -2,7 +2,7 @@ mod support;
 use support::*;
 
 use anyhow::{Context, Result};
-use gents::defra_node::{EmbeddedNode, StorageBackend};
+use gents::defra_node::EmbeddedNode;
 use gents::ensure_runtime_schemas;
 use serde_json::Value;
 
@@ -10,15 +10,9 @@ use serde_json::Value;
 async fn background_list_json_filters_and_lists_backgrounded_tool_calls() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let agent_home = tempdir.path().join("agent-home");
-    let data_dir = agent_home.join("data");
 
     {
-        let node = EmbeddedNode::builder()
-            .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::RocksDb)
-            .build()
-            .await
-            .context("opening embedded node")?;
+        let node = initialized_agent_node(tempdir.path(), &agent_home, "background-test").await?;
         ensure_runtime_schemas(&node).await?;
         seed_background_tool_calls(&node).await?;
     }

--- a/crates/gents-cli/tests/cli_config_export_import.rs
+++ b/crates/gents-cli/tests/cli_config_export_import.rs
@@ -178,6 +178,10 @@ async fn config_import_round_trips_and_requires_override() -> Result<()> {
     let target_home = tempdir.path().join("target-home");
     fs::create_dir_all(&source_home)?;
     fs::create_dir_all(&target_home)?;
+    run_init_json(
+        &target_home,
+        &["--identity-only", "--agent-name", "cli-import-target"],
+    )?;
 
     let agent_name = format!("cli-import-{}", Uuid::new_v4().simple());
     let agent_did = format!("did:key:z{}", Uuid::new_v4().simple());
@@ -327,6 +331,14 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
     let reapply_root = tempdir.path().join("reapply-root");
     fs::create_dir_all(&source_home)?;
     fs::create_dir_all(&target_home)?;
+    run_init_json(
+        &source_home,
+        &["--identity-only", "--agent-name", "cli-export-source"],
+    )?;
+    run_init_json(
+        &target_home,
+        &["--identity-only", "--agent-name", "cli-export-target"],
+    )?;
 
     let agent_name = format!("cli-export-apply-{}", Uuid::new_v4().simple());
     let model_name = format!("mock-model-{}", Uuid::new_v4().simple());

--- a/crates/gents-cli/tests/cli_mcp_probe.rs
+++ b/crates/gents-cli/tests/cli_mcp_probe.rs
@@ -2,7 +2,7 @@ mod support;
 use support::*;
 
 use anyhow::{Context, Result};
-use gents::defra_node::{EmbeddedNode, StorageBackend};
+use gents::defra_node::EmbeddedNode;
 use gents::ensure_runtime_schemas;
 use serde_json::Value;
 use uuid::Uuid;
@@ -11,16 +11,10 @@ use uuid::Uuid;
 async fn mcp_probe_json_reports_health_snapshot_for_registry_service() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let agent_home = tempdir.path().join("agent-home");
-    let data_dir = agent_home.join("data");
     let service_id = format!("fixture-mcp-{}", Uuid::new_v4().simple());
 
     {
-        let node = EmbeddedNode::builder()
-            .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::RocksDb)
-            .build()
-            .await
-            .context("opening embedded node")?;
+        let node = initialized_agent_node(tempdir.path(), &agent_home, "mcp-probe-test").await?;
         ensure_runtime_schemas(&node).await?;
         seed_mcp_service(&node, &service_id, "fixture-host", "", "", 0, "online").await?;
     }
@@ -82,18 +76,12 @@ async fn mcp_probe_json_reports_health_snapshot_for_registry_service() -> Result
 async fn mcp_probe_all_json_lists_each_online_service() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let agent_home = tempdir.path().join("agent-home");
-    let data_dir = agent_home.join("data");
     let missing_port_id = format!("a-fixture-mcp-{}", Uuid::new_v4().simple());
     let missing_address_id = format!("b-fixture-mcp-{}", Uuid::new_v4().simple());
     let offline_id = format!("z-fixture-mcp-{}", Uuid::new_v4().simple());
 
     {
-        let node = EmbeddedNode::builder()
-            .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::RocksDb)
-            .build()
-            .await
-            .context("opening embedded node")?;
+        let node = initialized_agent_node(tempdir.path(), &agent_home, "mcp-probe-all").await?;
         ensure_runtime_schemas(&node).await?;
         seed_mcp_service(&node, &missing_port_id, "fixture-host", "", "", 0, "online").await?;
         seed_mcp_service(&node, &missing_address_id, "", "", "", 9201, "online").await?;
@@ -141,15 +129,9 @@ async fn mcp_probe_all_json_lists_each_online_service() -> Result<()> {
 async fn mcp_probe_single_missing_service_fails() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let agent_home = tempdir.path().join("agent-home");
-    let data_dir = agent_home.join("data");
 
     {
-        let node = EmbeddedNode::builder()
-            .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::RocksDb)
-            .build()
-            .await
-            .context("opening embedded node")?;
+        let node = initialized_agent_node(tempdir.path(), &agent_home, "mcp-probe-missing").await?;
         ensure_runtime_schemas(&node).await?;
     }
 

--- a/crates/gents-cli/tests/cli_p2p.rs
+++ b/crates/gents-cli/tests/cli_p2p.rs
@@ -425,6 +425,10 @@ fn p2p_pairings_manage_desired_rows_locally() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home = tempdir.path().join("pairings-agent");
     fs::create_dir_all(&home)?;
+    run_init_json(
+        &home,
+        &["--identity-only", "--agent-name", "pairings-agent"],
+    )?;
 
     let set = run_cli_json(
         &home,

--- a/crates/gents-cli/tests/cli_provision.rs
+++ b/crates/gents-cli/tests/cli_provision.rs
@@ -74,7 +74,7 @@ async fn provision_initializes_home_binds_manifest_and_diff_exact() -> Result<()
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn provision_accepts_initialized_home_did_without_file_key_path() -> Result<()> {
+async fn provision_rejects_initialized_home_without_loadable_identity() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_env = tempdir.path().join("home-env");
     let home = tempdir.path().join("secure-enclave-home");
@@ -102,7 +102,7 @@ async fn provision_accepts_initialized_home_did_without_file_key_path() -> Resul
     )?;
     write_portable_manifest_root(tempdir.path(), &root, placeholder_did)?;
 
-    let report = run_cli_json(
+    let stderr = run_cli_failure_stderr(
         &home_env,
         &[
             "provision",
@@ -112,25 +112,13 @@ async fn provision_accepts_initialized_home_did_without_file_key_path() -> Resul
             root.to_str().expect("utf-8 root"),
         ],
     )?;
-    assert_eq!(
-        report.pointer("/identity/status").and_then(Value::as_str),
-        Some("existing")
-    );
-    assert_eq!(
-        report.get("agent_did").and_then(Value::as_str),
-        Some(agent_did.as_str())
-    );
-    assert_eq!(
-        report.pointer("/apply/ok").and_then(Value::as_bool),
-        Some(true)
-    );
-    assert_eq!(
-        report.pointer("/diff/ok").and_then(Value::as_bool),
-        Some(true)
+    assert!(
+        stderr.contains("has no key_path and unsupported identity_backend"),
+        "expected fail-closed unloadable-identity error, got:\n{stderr}"
     );
     assert!(
         !home.join("keys").exists(),
-        "provision should not create a file-key identity when init.json already contains a real DID without key_path"
+        "provision must not mint a file-key identity for a home whose signer it cannot load"
     );
 
     Ok(())

--- a/crates/gents-cli/tests/cli_schema.rs
+++ b/crates/gents-cli/tests/cli_schema.rs
@@ -12,6 +12,10 @@ fn schema_apply_registers_sdl_and_additive_patch_idempotently() -> Result<()> {
     let schema_dir = tempdir.path().join("schemas");
     fs::create_dir_all(&home_dir)?;
     fs::create_dir_all(&schema_dir)?;
+    run_init_json(
+        &home_dir,
+        &["--identity-only", "--agent-name", "schema-apply"],
+    )?;
 
     fs::write(
         schema_dir.join("action_request.graphql"),

--- a/crates/gents-cli/tests/cli_server.rs
+++ b/crates/gents-cli/tests/cli_server.rs
@@ -777,7 +777,7 @@ async fn server_rejects_real_initialized_did_without_key_path() -> Result<()> {
         ],
     )?;
     assert!(
-        stderr.contains("no key_path or identity_backend"),
+        stderr.contains("has no key_path and unsupported identity_backend"),
         "expected no-key-path/backend error, got:\n{stderr}"
     );
     assert!(

--- a/crates/gents-cli/tests/cli_trace_export.rs
+++ b/crates/gents-cli/tests/cli_trace_export.rs
@@ -448,7 +448,7 @@ async fn trace_timeline_reconstructs_request_events_from_persisted_rows() -> Res
 /// Seed one request with two rendered-request captures (turn 0 attempts 0 and
 /// 1) carrying v3 provenance manifests with the admission join.
 async fn seed_rendered_request_rows(node: &EmbeddedNode) -> Result<()> {
-    exec(
+    let request_doc_id = exec_doc_id(
         node,
         r#"mutation {
             create_AgentRequest(input: {
@@ -466,8 +466,34 @@ async fn seed_rendered_request_rows(node: &EmbeddedNode) -> Result<()> {
                 retry_count: 0
             }) { _docID }
         }"#,
+        "AgentRequest",
     )
     .await?;
+    let response = node
+        .execute(&format!(
+            r#"query {{ _commits(docID: "{}") {{ cid fieldName }} }}"#,
+            gents::graphql::escape_graphql_string(&request_doc_id)
+        ))
+        .await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "querying seeded request commits failed: {:?}",
+            response.errors
+        );
+    }
+    let request_commit_cid = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("_commits"))
+        .and_then(Value::as_array)
+        .and_then(|rows| {
+            rows.iter()
+                .find(|row| row.get("fieldName").and_then(Value::as_str) == Some("_C"))
+        })
+        .and_then(|row| row.get("cid"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .context("seeded AgentRequest has no composite commit cid")?;
     for (suffix, attempt, call_id, call_seq, created_at) in [
         ("a0", 0, "call-cap-1", 1, "2026-08-07T12:00:02Z"),
         ("a1", 1, "call-cap-2", 2, "2026-08-07T12:00:04Z"),
@@ -499,7 +525,8 @@ async fn seed_rendered_request_rows(node: &EmbeddedNode) -> Result<()> {
                 r#"mutation {{
                     create_RenderedRequest(input: {{
                         capture_key: "rendered:v1:seeded-{suffix}",
-                        request_doc_id: "doc-req-cap",
+                        request_doc_id: "{request_doc_id}",
+                        request_commit_cid: "{request_commit_cid}",
                         request_id: "req-cap",
                         session_id: "session-cap",
                         agent_did: "did:test:amy",
@@ -529,15 +556,9 @@ async fn seed_rendered_request_rows(node: &EmbeddedNode) -> Result<()> {
 async fn trace_capture_fetches_metadata_with_field_commit_cid() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let agent_home = tempdir.path().join("agent-home");
-    let data_dir = agent_home.join("data");
 
     {
-        let node = EmbeddedNode::builder()
-            .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::RocksDb)
-            .build()
-            .await
-            .context("opening embedded node")?;
+        let node = initialized_trace_node(tempdir.path(), &agent_home).await?;
         ensure_runtime_schemas(&node).await?;
         seed_rendered_request_rows(&node).await?;
     }

--- a/crates/gents-cli/tests/support/mod.rs
+++ b/crates/gents-cli/tests/support/mod.rs
@@ -38,6 +38,45 @@ pub use waits::{
 pub const DEFAULT_MODEL_ENDPOINT: &str = "http://192.168.1.78:8000/v1";
 pub const DEFAULT_MODEL_NAME: &str = "MiniMax-M2.7-NVFP4";
 
+/// Initialize an agent home through `gents init --identity-only` and open its
+/// embedded node with the registered signing identity. Homes assembled without
+/// this fail the CLI's initialized-home check, and their commits would be
+/// unsigned.
+pub async fn initialized_agent_node(
+    cwd: &std::path::Path,
+    agent_home: &std::path::Path,
+    agent_name: &str,
+) -> anyhow::Result<gents::defra_node::EmbeddedNode> {
+    use anyhow::Context as _;
+
+    let home = agent_home.to_str().context("agent home utf8")?;
+    let init = run_init_json(
+        cwd,
+        &[
+            "--identity-only",
+            "--agent-name",
+            agent_name,
+            "--home",
+            home,
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let key_path = init
+        .get("key_path")
+        .and_then(serde_json::Value::as_str)
+        .context("identity-only init output missing key_path")?;
+    let _identity = gents::KeyIdentity::load_or_create(key_path, None)
+        .context("loading initialized agent identity")?;
+
+    gents::defra_node::EmbeddedNode::builder()
+        .data_path(agent_home.join("data"))
+        .with_storage_backend(gents::defra_node::StorageBackend::RocksDb)
+        .with_node_identity_did(&agent_did)
+        .build()
+        .await
+        .context("opening initialized embedded node")
+}
+
 pub fn agent_did_from_init(init: &serde_json::Value) -> anyhow::Result<String> {
     let agent_did = init
         .get("agent_did")


### PR DESCRIPTION
Second and final part of #1091: after #1092 fixed the envelope-serde failure, the main-push CLI suite marched one binary further and failed in `cli_background` — revealing an onion: the full CLI suite only runs on main pushes and fail-fasts per test binary, so #1087's test breakage was surfacing one binary per push. A local `cargo test -p gents-cli --no-fail-fast` enumerated all of it at once: **11 tests across 8 binaries**, in three classes.

## Class 1 — hand-crafted homes (9 tests, 6 files)

Tests assembled agent homes by opening an embedded node at `<home>/data` directly, bypassing `gents init`. Post-#1087 the CLI refuses uninitialized homes — there is no registered signer, and opening the data directory outside the initialized path would author unsigned commits. Fix: a shared `initialized_agent_node` test helper (same pattern #1087 itself added to `cli_trace_export`) runs `gents init --identity-only` and opens the node with the registered signing identity. Pure-CLI tests call `run_init_json` directly. Files: `cli_background`, `cli_config_export_import`, `cli_mcp_probe`, `cli_p2p`, `cli_schema`, `cli_trace_export`.

## Class 2 — stale expectations (2 tests)

- `cli_server`: the keyless-home rejection message changed; updated the asserted substring (`has no key_path and unsupported identity_backend`).
- `cli_provision`: `provision_accepts_initialized_home_did_without_file_key_path` asserted provision proceeds against a home with a DID but no loadable identity. Under #1087's fail-closed signing contract that must refuse (writes would be unsigned), so the test now asserts the rejection and is renamed `provision_rejects_initialized_home_without_loadable_identity`. The invariant that provision must not mint a fallback file key is preserved. Real keychain/Secure Enclave homes are unaffected — production `gents init` writes `identity_backend` + label, which the loader supports.

## Class 3 — forged physical lineage (1 test)

`trace_capture_fetches_metadata_with_field_commit_cid` seeded a `RenderedRequest` with a literal `request_doc_id: "doc-req-cap"` and no `request_commit_cid`. The timeline now corroborates physical edges (that's #1087 working as designed), so the fixture failed twice over. The seeder now threads the seeded `AgentRequest`'s real `_docID` and composite commit CID (queried via `_commits`, `fieldName == "_C"`).

## What this deliberately does not touch

The intermittent conformance ready-state timeouts and their #1087 boot-cost driver stay tracked in #1093 (with #330/#1082–#1085); no timeout was bumped and no runtime code changed here — this PR is test-only.

## Validation

- `cargo test -p gents-cli --no-fail-fast`: **zero failing test binaries** (previously 8)
- Each previously-failing binary green individually
- `cargo check --workspace --all-targets` clean, `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
