### PR TITLE
Land durable Codex projection on main

### DIFF
--- a/crates/gents-cli/src/commands/codex_shim.rs
+++ b/crates/gents-cli/src/commands/codex_shim.rs
@@ -32,6 +32,7 @@ mod handlers;
 mod history_projection;
 mod host_runtime;
 mod progress;
+mod projection_state;
 mod protocol;
 mod store;
 mod subagent_projection;

--- a/crates/gents-cli/src/commands/codex_shim/background.rs
+++ b/crates/gents-cli/src/commands/codex_shim/background.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -12,12 +12,13 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 use super::command_projection::{
-    command_execution_item, command_output_payload, tool_projection_status, ToolProjectionStatus,
+    codex_command_status, command_execution_item, command_output_payload,
 };
 use super::progress::{
-    decode_gents_tool_call_progress, gents_tool_progress_query, tool_completed_at_ms,
-    GentsToolCallProgress,
+    decode_gents_tool_call_progress, gents_tool_progress_query, observed_tool_status,
+    tool_completed_at_ms, GentsToolCallProgress,
 };
+use super::projection_state::ProjectionStatus;
 use super::protocol::{now_millis, send_notification};
 use super::store::query_node_json;
 use super::{ConnectionState, ShimState};
@@ -30,7 +31,7 @@ pub(super) fn spawn_background_tool_watcher(
     thread_id: String,
     turn_id: String,
     cwd: PathBuf,
-    running: BTreeMap<String, codex::CommandExecutionStatus>,
+    running: BTreeSet<String>,
 ) {
     let _ = spawn_background_tool_watcher_handle(
         connection, state, request_id, session_id, thread_id, turn_id, cwd, running, None,
@@ -45,7 +46,7 @@ fn spawn_background_tool_watcher_handle(
     thread_id: String,
     turn_id: String,
     cwd: PathBuf,
-    mut running: BTreeMap<String, codex::CommandExecutionStatus>,
+    mut running: BTreeSet<String>,
     mut first_query_observed: Option<oneshot::Sender<()>>,
 ) -> Option<JoinHandle<()>> {
     if running.is_empty() {
@@ -66,76 +67,56 @@ fn spawn_background_tool_watcher_handle(
             )
             .await
             {
-                Ok(response) => response,
+                Ok(response) => Some(response),
                 Err(error) => {
                     tracing::warn!(%error, "Codex shim background tool watcher query failed");
-                    break;
+                    None
                 }
             };
             if let Some(observed) = first_query_observed.take() {
                 let _ = observed.send(());
             }
 
-            let tool_rows = response
-                .pointer("/data/AgentToolCall")
-                .and_then(Value::as_array)
-                .cloned()
-                .unwrap_or_default();
-            let current_tools = tool_rows
-                .iter()
-                .filter_map(decode_gents_tool_call_progress)
-                .map(|tool| (tool.tool_call_key.clone(), tool))
-                .collect::<BTreeMap<_, _>>();
+            if let Some(response) = response {
+                let tool_rows = response
+                    .pointer("/data/AgentToolCall")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                let current_tools = tool_rows
+                    .iter()
+                    .filter_map(decode_gents_tool_call_progress)
+                    .map(|tool| (tool.tool_call_key.clone(), tool))
+                    .collect::<BTreeMap<_, _>>();
 
-            let tracked = running.keys().cloned().collect::<Vec<_>>();
-            for tool_key in tracked {
-                let Some(tool) = current_tools.get(&tool_key) else {
-                    running.remove(&tool_key);
-                    continue;
-                };
-                match tool_projection_status(tool) {
-                    ToolProjectionStatus::Command(codex::CommandExecutionStatus::InProgress) => {}
-                    ToolProjectionStatus::Command(status) => {
-                        if let Err(error) = send_background_tool_completion(
-                            &connection.outbound,
-                            &state,
-                            &thread_id,
-                            &turn_id,
-                            tool,
-                            status,
-                            &cwd,
-                        )
-                        .await
-                        {
-                            tracing::warn!(%error, "Codex shim background tool completion send failed");
-                            return;
+                let tracked = running.iter().cloned().collect::<Vec<_>>();
+                for tool_key in tracked {
+                    let Some(tool) = current_tools.get(&tool_key) else {
+                        // A missing row is not a terminal observation. DefraDB can
+                        // briefly expose an incomplete replicated/query snapshot;
+                        // forgetting the key here would strand the already-emitted
+                        // Codex command item in progress forever.
+                        continue;
+                    };
+                    match observed_tool_status(tool) {
+                        ProjectionStatus::InProgress => {}
+                        status => {
+                            if let Err(error) = send_background_tool_completion(
+                                &connection.outbound,
+                                &state,
+                                &thread_id,
+                                &turn_id,
+                                tool,
+                                codex_command_status(status),
+                                &cwd,
+                            )
+                            .await
+                            {
+                                tracing::warn!(%error, "Codex shim background tool completion send failed");
+                                return;
+                            }
+                            running.remove(&tool_key);
                         }
-                        running.remove(&tool_key);
-                    }
-                    ToolProjectionStatus::Mcp(_) => {
-                        let mut foreground_tool = tool.clone();
-                        foreground_tool.result.clear();
-                        if let Err(error) = send_background_tool_completion(
-                            &connection.outbound,
-                            &state,
-                            &thread_id,
-                            &turn_id,
-                            &foreground_tool,
-                            codex::CommandExecutionStatus::Completed,
-                            &cwd,
-                        )
-                        .await
-                        {
-                            tracing::warn!(%error, "Codex shim background foreground send failed");
-                            return;
-                        }
-                        running.remove(&tool_key);
-                    }
-                    ToolProjectionStatus::Collab(_)
-                    | ToolProjectionStatus::DeferredCollab
-                    | ToolProjectionStatus::DeferredFileChange
-                    | ToolProjectionStatus::FileChange(_) => {
-                        running.remove(&tool_key);
                     }
                 }
             }
@@ -147,7 +128,6 @@ fn spawn_background_tool_watcher_handle(
             tokio::select! {
                 _ = connection.outbound.closed() => {
                     tracing::debug!("Codex shim background tool watcher stopped after outbound closed");
-                    break;
                 }
                 _ = tokio::time::sleep(state.poll_interval) => {}
                 msg = updates.recv() => {
@@ -287,11 +267,167 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use gents_codex_protocol as codex;
     use tokio::sync::{mpsc, oneshot, Mutex};
 
     use super::super::{CodexSidecar, ConnectionState, ShimState};
     use super::*;
+
+    fn test_connection() -> (ConnectionState, mpsc::UnboundedReceiver<String>) {
+        let (outbound, outbound_rx) = mpsc::unbounded_channel::<String>();
+        (
+            ConnectionState {
+                outbound,
+                turn_streams: Arc::new(Mutex::new(BTreeMap::new())),
+                fuzzy_file_search_sessions: Arc::new(Mutex::new(BTreeMap::new())),
+                pending_steering_inputs: Arc::new(Mutex::new(BTreeMap::new())),
+                child_thread_streams: Arc::new(Mutex::new(BTreeMap::new())),
+            },
+            outbound_rx,
+        )
+    }
+
+    fn test_state(
+        tempdir: &tempfile::TempDir,
+        node: Arc<EmbeddedNode>,
+        poll_interval: Duration,
+    ) -> ShimState {
+        ShimState {
+            codex_home: tempdir.path().join("codex-home"),
+            trace_path: tempdir
+                .path()
+                .join("codex-home/log/codex-shim-events.jsonl"),
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            fs_root: None,
+            node,
+            background_execution_registry: gents::BackgroundExecutionRegistry::default(),
+            graphql: Arc::from("http://127.0.0.1/graphql"),
+            agent_did: Arc::from("did:test:background-watcher"),
+            behavior_id: Arc::from("did:test:background-watcher:default"),
+            id_counter: Arc::new(AtomicU64::new(1)),
+            timeout: Duration::from_secs(5),
+            poll_interval,
+            sidecar: Arc::new(Mutex::new(CodexSidecar::default())),
+            auth_token: None,
+        }
+    }
+
+    async fn seed_background_tool(
+        node: &EmbeddedNode,
+        request_id: &str,
+        session_id: &str,
+        tool_call_id: &str,
+        lifecycle_state: &str,
+        status: &str,
+    ) {
+        let tool_call_key = format!("{session_id}:{tool_call_id}");
+        let mutation = format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "{tool_call_key}",
+                    request_id: "{request_id}",
+                    session_id: "{session_id}",
+                    message_sequence: 1,
+                    tool_name: "bash",
+                    tool_call_id: "{tool_call_id}",
+                    args: "{{\"command\":\"true\"}}",
+                    result: "done",
+                    status: "{status}",
+                    lifecycle_state: "{lifecycle_state}",
+                    started_at: "2026-07-07T12:00:00Z",
+                    completed_at: "2026-07-07T12:00:01Z",
+                    await_mode: "background"
+                }}) {{ _docID }}
+            }}"#
+        );
+        let response = node.execute(&mutation).await;
+        assert!(
+            !response.has_errors(),
+            "seed AgentToolCall failed: {:?}",
+            response.errors
+        );
+    }
+
+    async fn receive_item_completed(outbound_rx: &mut mpsc::UnboundedReceiver<String>) -> Value {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let message = outbound_rx.recv().await.expect("watcher outbound message");
+                let value: Value = serde_json::from_str(&message).expect("valid JSON notification");
+                if value.get("method").and_then(Value::as_str) == Some("item/completed") {
+                    return value;
+                }
+            }
+        })
+        .await
+        .expect("watcher should emit item/completed")
+    }
+
+    async fn assert_watcher_recovers_after_initial_observation(
+        test_name: &str,
+        schemas_before_start: bool,
+    ) {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(tempdir.path().join("node"))
+                .with_storage_backend(gents::defra_node::StorageBackend::RocksDb)
+                .build()
+                .await
+                .expect("embedded node"),
+        );
+        if schemas_before_start {
+            gents::schema::ensure_runtime_schemas(&node)
+                .await
+                .expect("runtime schemas");
+        }
+
+        let request_id = format!("req-{test_name}");
+        let session_id = format!("session-{test_name}");
+        let tool_call_id = format!("call-{test_name}");
+        let tool_call_key = format!("{session_id}:{tool_call_id}");
+        let (connection, mut outbound_rx) = test_connection();
+        let state = test_state(&tempdir, node.clone(), Duration::from_millis(10));
+        let running = BTreeSet::from([tool_call_key.clone()]);
+        let (observed_tx, observed_rx) = oneshot::channel();
+        let handle = spawn_background_tool_watcher_handle(
+            connection,
+            state,
+            request_id.clone(),
+            session_id.clone(),
+            session_id.clone(),
+            request_id.clone(),
+            tempdir.path().to_path_buf(),
+            running,
+            Some(observed_tx),
+        )
+        .expect("watcher should spawn for tracked tool");
+
+        tokio::time::timeout(Duration::from_secs(5), observed_rx)
+            .await
+            .expect("watcher should make its initial observation")
+            .expect("watcher should signal first query attempt");
+        if !schemas_before_start {
+            gents::schema::ensure_runtime_schemas(&node)
+                .await
+                .expect("runtime schemas");
+        }
+        seed_background_tool(
+            &node,
+            &request_id,
+            &session_id,
+            &tool_call_id,
+            "completed",
+            "completed",
+        )
+        .await;
+
+        let completed = receive_item_completed(&mut outbound_rx).await;
+        assert_eq!(completed["params"]["item"]["id"], tool_call_key);
+        assert_eq!(completed["params"]["item"]["status"], "completed");
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("watcher should exit after durable terminal observation")
+            .expect("watcher task should not panic");
+    }
 
     #[tokio::test]
     async fn background_tool_watcher_exits_when_outbound_closes_while_tool_is_running() {
@@ -341,35 +477,11 @@ mod tests {
             response.errors
         );
 
-        let (outbound, outbound_rx) = mpsc::unbounded_channel::<String>();
-        let connection = ConnectionState {
-            outbound,
-            turn_streams: Arc::new(Mutex::new(BTreeMap::new())),
-            fuzzy_file_search_sessions: Arc::new(Mutex::new(BTreeMap::new())),
-            pending_steering_inputs: Arc::new(Mutex::new(BTreeMap::new())),
-            child_thread_streams: Arc::new(Mutex::new(BTreeMap::new())),
-        };
-        let state = ShimState {
-            codex_home: tempdir.path().join("codex-home"),
-            trace_path: tempdir
-                .path()
-                .join("codex-home/log/codex-shim-events.jsonl"),
-            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            fs_root: None,
-            node,
-            background_execution_registry: gents::BackgroundExecutionRegistry::default(),
-            graphql: Arc::from("http://127.0.0.1/graphql"),
-            agent_did: Arc::from("did:test:background-disconnect-test"),
-            behavior_id: Arc::from("did:test:background-disconnect-test:default"),
-            id_counter: Arc::new(AtomicU64::new(1)),
-            timeout: Duration::from_secs(5),
-            poll_interval: Duration::from_secs(60),
-            sidecar: Arc::new(Mutex::new(CodexSidecar::default())),
-            auth_token: None,
-        };
+        let (connection, outbound_rx) = test_connection();
+        let state = test_state(&tempdir, node, Duration::from_secs(60));
 
-        let mut running = BTreeMap::new();
-        running.insert(tool_call_key, codex::CommandExecutionStatus::InProgress);
+        let mut running = BTreeSet::new();
+        running.insert(tool_call_key);
         let (observed_tx, observed_rx) = oneshot::channel();
         let handle = spawn_background_tool_watcher_handle(
             connection,
@@ -394,5 +506,15 @@ mod tests {
             .await
             .expect("watcher should exit promptly when outbound closes")
             .expect("watcher task should not panic");
+    }
+
+    #[tokio::test]
+    async fn background_tool_watcher_retains_key_while_row_is_temporarily_missing() {
+        assert_watcher_recovers_after_initial_observation("background-missing", true).await;
+    }
+
+    #[tokio::test]
+    async fn background_tool_watcher_retries_after_query_error() {
+        assert_watcher_recovers_after_initial_observation("background-query-retry", false).await;
     }
 }

--- a/crates/gents-cli/src/commands/codex_shim/child_stream.rs
+++ b/crates/gents-cli/src/commands/codex_shim/child_stream.rs
@@ -61,7 +61,10 @@ async fn watch_loaded_subagent_thread(
     let child_thread_id = initial_link.session_id.clone();
     let root_session_id = initial_link.root_session_id.clone();
     let mut projected_request_id = initial_link.latest_request_id.clone();
-    if child_request_is_active(&initial_link.lifecycle_state) {
+    if initial_link
+        .client_projection
+        .is_some_and(|head| head.is_active())
+    {
         let announce_turn = baseline_turn.is_none();
         let options = baseline_turn.map_or_else(
             || TurnStreamOptions::fresh_subagent(root_session_id.clone()),
@@ -215,26 +218,4 @@ async fn project_child_request(
             link.session_id, link.latest_request_id
         )
     })
-}
-
-fn child_request_is_active(lifecycle_state: &str) -> bool {
-    matches!(
-        lifecycle_state.trim(),
-        "pending" | "claimed" | "processing" | "inputRequired"
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::child_request_is_active;
-
-    #[test]
-    fn only_nonterminal_child_states_start_resumed_projection() {
-        for state in ["pending", "claimed", "processing", "inputRequired"] {
-            assert!(child_request_is_active(state), "{state}");
-        }
-        for state in ["completed", "failed", "dead", "interrupted"] {
-            assert!(!child_request_is_active(state), "{state}");
-        }
-    }
 }

--- a/crates/gents-cli/src/commands/codex_shim/command_projection.rs
+++ b/crates/gents-cli/src/commands/codex_shim/command_projection.rs
@@ -1,37 +1,17 @@
-use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::path::Path;
 
 use gents_codex_protocol as codex;
 use serde_json::Value;
 
 use super::progress::{
-    gents_exec_metadata, gents_tool_call_status, tool_duration_ms, GentsToolCallProgress,
+    gents_exec_metadata, observed_tool_status, tool_duration_ms, GentsToolCallProgress,
 };
-use super::subagent_projection::{collab_projection, is_subagent_control_tool, CollabProjection};
+use super::projection_state::ProjectionStatus;
+pub(super) use super::projection_state::ToolProjectionStatus;
+use super::subagent_projection::{collab_projection, is_subagent_control_tool};
 
-#[derive(Clone, Debug, PartialEq)]
-pub(super) enum ToolProjectionStatus {
-    Mcp(codex::McpToolCallStatus),
-    Command(codex::CommandExecutionStatus),
-    Collab(CollabProjection),
-    DeferredCollab,
-    DeferredFileChange,
-    FileChange(codex::PatchApplyStatus),
-}
-
-impl ToolProjectionStatus {
-    pub(super) fn command_status(&self) -> codex::CommandExecutionStatus {
-        match self {
-            Self::Mcp(_) => codex::CommandExecutionStatus::InProgress,
-            Self::Command(status) => status.clone(),
-            Self::Collab(_)
-            | Self::DeferredCollab
-            | Self::DeferredFileChange
-            | Self::FileChange(_) => codex::CommandExecutionStatus::InProgress,
-        }
-    }
-}
-
+#[cfg(test)]
 pub(super) fn tool_projection_status(tool: &GentsToolCallProgress) -> ToolProjectionStatus {
     tool_projection_status_with_settled(tool, false, false)
 }
@@ -41,14 +21,12 @@ pub(super) fn tool_projection_status_with_settled(
     projection_settled: bool,
     link_settle_expired: bool,
 ) -> ToolProjectionStatus {
-    let status = gents_tool_call_status(tool);
+    let status = observed_tool_status(tool);
     if is_subagent_control_tool(&tool.tool_name) {
         if let Some(projection) = collab_projection(tool) {
             ToolProjectionStatus::Collab(projection)
-        } else if status == codex::McpToolCallStatus::Failed
-            || (projection_settled
-                && link_settle_expired
-                && status == codex::McpToolCallStatus::Completed)
+        } else if status == ProjectionStatus::Failed
+            || (projection_settled && link_settle_expired && status == ProjectionStatus::Completed)
         {
             ToolProjectionStatus::Mcp(status)
         } else {
@@ -58,20 +36,64 @@ pub(super) fn tool_projection_status_with_settled(
         if file_update_change(tool).is_none() {
             ToolProjectionStatus::DeferredFileChange
         } else {
-            ToolProjectionStatus::FileChange(patch_status_from_mcp_status(status))
+            ToolProjectionStatus::FileChange(status)
         }
     } else if should_project_as_command_execution(tool) {
-        ToolProjectionStatus::Command(command_status_from_mcp_status(status))
+        ToolProjectionStatus::Command(status)
     } else {
         ToolProjectionStatus::Mcp(status)
     }
 }
 
-fn patch_status_from_mcp_status(status: codex::McpToolCallStatus) -> codex::PatchApplyStatus {
+pub(super) fn codex_patch_status(status: ProjectionStatus) -> codex::PatchApplyStatus {
     match status {
-        codex::McpToolCallStatus::InProgress => codex::PatchApplyStatus::InProgress,
-        codex::McpToolCallStatus::Completed => codex::PatchApplyStatus::Completed,
-        codex::McpToolCallStatus::Failed => codex::PatchApplyStatus::Failed,
+        ProjectionStatus::InProgress => codex::PatchApplyStatus::InProgress,
+        ProjectionStatus::Completed => codex::PatchApplyStatus::Completed,
+        ProjectionStatus::Failed => codex::PatchApplyStatus::Failed,
+    }
+}
+
+pub(super) fn codex_mcp_status(status: ProjectionStatus) -> codex::McpToolCallStatus {
+    match status {
+        ProjectionStatus::InProgress => codex::McpToolCallStatus::InProgress,
+        ProjectionStatus::Completed => codex::McpToolCallStatus::Completed,
+        ProjectionStatus::Failed => codex::McpToolCallStatus::Failed,
+    }
+}
+
+pub(super) fn codex_command_status(status: ProjectionStatus) -> codex::CommandExecutionStatus {
+    match status {
+        ProjectionStatus::InProgress => codex::CommandExecutionStatus::InProgress,
+        ProjectionStatus::Completed => codex::CommandExecutionStatus::Completed,
+        ProjectionStatus::Failed => codex::CommandExecutionStatus::Failed,
+    }
+}
+
+pub(super) fn observed_mcp_status(status: &codex::McpToolCallStatus) -> ProjectionStatus {
+    match status {
+        codex::McpToolCallStatus::InProgress => ProjectionStatus::InProgress,
+        codex::McpToolCallStatus::Completed => ProjectionStatus::Completed,
+        codex::McpToolCallStatus::Failed => ProjectionStatus::Failed,
+    }
+}
+
+pub(super) fn observed_command_status(status: &codex::CommandExecutionStatus) -> ProjectionStatus {
+    match status {
+        codex::CommandExecutionStatus::InProgress => ProjectionStatus::InProgress,
+        codex::CommandExecutionStatus::Completed => ProjectionStatus::Completed,
+        codex::CommandExecutionStatus::Failed | codex::CommandExecutionStatus::Declined => {
+            ProjectionStatus::Failed
+        }
+    }
+}
+
+pub(super) fn observed_patch_status(status: &codex::PatchApplyStatus) -> ProjectionStatus {
+    match status {
+        codex::PatchApplyStatus::InProgress => ProjectionStatus::InProgress,
+        codex::PatchApplyStatus::Completed => ProjectionStatus::Completed,
+        codex::PatchApplyStatus::Failed | codex::PatchApplyStatus::Declined => {
+            ProjectionStatus::Failed
+        }
     }
 }
 
@@ -99,29 +121,16 @@ fn is_gents_fs_command_tool(tool: &GentsToolCallProgress) -> bool {
     )
 }
 
-fn command_status_from_mcp_status(
-    status: codex::McpToolCallStatus,
-) -> codex::CommandExecutionStatus {
-    match status {
-        codex::McpToolCallStatus::InProgress => codex::CommandExecutionStatus::InProgress,
-        codex::McpToolCallStatus::Completed => codex::CommandExecutionStatus::Completed,
-        codex::McpToolCallStatus::Failed => codex::CommandExecutionStatus::Failed,
-    }
-}
-
 pub(super) fn update_running_background_tools(
-    running: &mut BTreeMap<String, codex::CommandExecutionStatus>,
+    running: &mut BTreeSet<String>,
     tool: &GentsToolCallProgress,
     status: &ToolProjectionStatus,
 ) {
     match status {
-        ToolProjectionStatus::Command(codex::CommandExecutionStatus::InProgress)
+        ToolProjectionStatus::Command(ProjectionStatus::InProgress)
             if is_gents_background_tool(tool) =>
         {
-            running.insert(
-                tool.tool_call_key.clone(),
-                codex::CommandExecutionStatus::InProgress,
-            );
+            running.insert(tool.tool_call_key.clone());
         }
         ToolProjectionStatus::Mcp(_)
         | ToolProjectionStatus::Command(_)
@@ -156,9 +165,7 @@ fn file_update_change(tool: &GentsToolCallProgress) -> Option<codex::FileUpdateC
         "write_file" => {
             let content = args.get("content")?.as_str()?.to_string();
             let metadata = gents_fs_metadata(&tool.result);
-            if gents_tool_call_status(tool) == codex::McpToolCallStatus::InProgress
-                && metadata.is_none()
-            {
+            if observed_tool_status(tool) == ProjectionStatus::InProgress && metadata.is_none() {
                 return None;
             }
             let created = metadata
@@ -263,8 +270,10 @@ pub(super) fn command_execution_item(
     let command = command_execution_display(tool);
     let command_actions = command_actions_for_tool(cwd, tool, &command);
     let exit_code = match status {
-        codex::CommandExecutionStatus::Completed => gents_exec_exit_code(&tool.result).or(Some(0)),
-        codex::CommandExecutionStatus::Failed => gents_exec_exit_code(&tool.result).or(Some(1)),
+        codex::CommandExecutionStatus::Completed => Some(0),
+        codex::CommandExecutionStatus::Failed => gents_exec_exit_code(&tool.result)
+            .filter(|exit_code| *exit_code != 0)
+            .or(Some(1)),
         codex::CommandExecutionStatus::InProgress | codex::CommandExecutionStatus::Declined => None,
     };
     let is_background = is_gents_background_tool(tool);
@@ -450,7 +459,7 @@ mod tests {
         );
         assert_eq!(
             tool_projection_status_with_settled(&tool, true, true),
-            ToolProjectionStatus::Mcp(codex::McpToolCallStatus::Completed)
+            ToolProjectionStatus::Mcp(ProjectionStatus::Completed)
         );
     }
 
@@ -461,7 +470,7 @@ mod tests {
 
         assert_eq!(
             tool_projection_status(&tool),
-            ToolProjectionStatus::Command(codex::CommandExecutionStatus::InProgress)
+            ToolProjectionStatus::Command(ProjectionStatus::InProgress)
         );
 
         let item = command_execution_item(
@@ -498,7 +507,7 @@ mod tests {
 
         assert_eq!(
             tool_projection_status(&tool),
-            ToolProjectionStatus::Command(codex::CommandExecutionStatus::Completed)
+            ToolProjectionStatus::Command(ProjectionStatus::Completed)
         );
 
         let item = command_execution_item(
@@ -532,7 +541,7 @@ mod tests {
 
         assert_eq!(
             tool_projection_status(&tool),
-            ToolProjectionStatus::Command(codex::CommandExecutionStatus::InProgress)
+            ToolProjectionStatus::Command(ProjectionStatus::InProgress)
         );
 
         let item = command_execution_item(
@@ -558,13 +567,11 @@ mod tests {
 
     #[test]
     fn gents_exec_exit_nonzero_projects_as_failed_command_execution() {
-        let tool = test_tool("bash_unrestricted", "completed", r#"{"command":"false"}"#)
+        let mut tool = test_tool("bash_unrestricted", "failed", r#"{"command":"false"}"#)
             .with_result(r#"gents_exec: {"ok":false,"status":"exit_nonzero","exit_code":42}"#);
+        tool.tool_failure_class = Some("toolReturnedError".to_string());
 
-        assert_eq!(
-            gents_tool_call_status(&tool),
-            codex::McpToolCallStatus::Failed
-        );
+        assert_eq!(observed_tool_status(&tool), ProjectionStatus::Failed);
 
         let item = command_execution_item(
             Path::new("/tmp"),
@@ -582,6 +589,23 @@ mod tests {
     }
 
     #[test]
+    fn durable_completed_command_does_not_leak_failure_shaped_exit_code() {
+        let tool = test_tool("bash_unrestricted", "completed", r#"{"command":"true"}"#)
+            .with_result(r#"gents_exec: {"ok":false,"status":"exit_nonzero","exit_code":42}"#);
+
+        assert_eq!(observed_tool_status(&tool), ProjectionStatus::Completed);
+        let item = command_execution_item(
+            Path::new("/tmp"),
+            &tool,
+            codex::CommandExecutionStatus::Completed,
+        );
+        let codex::ThreadItem::CommandExecution { exit_code, .. } = item else {
+            panic!("expected command execution item");
+        };
+        assert_eq!(exit_code, Some(0));
+    }
+
+    #[test]
     fn read_file_projects_as_native_exploring_command() {
         let tool = test_tool(
             "read_file",
@@ -591,7 +615,7 @@ mod tests {
 
         assert_eq!(
             tool_projection_status(&tool),
-            ToolProjectionStatus::Command(codex::CommandExecutionStatus::Completed)
+            ToolProjectionStatus::Command(ProjectionStatus::Completed)
         );
 
         let item = command_execution_item(
@@ -673,7 +697,7 @@ mod tests {
 
         assert_eq!(
             tool_projection_status(&write),
-            ToolProjectionStatus::FileChange(codex::PatchApplyStatus::Completed)
+            ToolProjectionStatus::FileChange(ProjectionStatus::Completed)
         );
 
         let write_item =
@@ -731,7 +755,7 @@ mod tests {
 
         assert_eq!(
             tool_projection_status(&edit),
-            ToolProjectionStatus::FileChange(codex::PatchApplyStatus::InProgress)
+            ToolProjectionStatus::FileChange(ProjectionStatus::InProgress)
         );
 
         let edit_item =

--- a/crates/gents-cli/src/commands/codex_shim/history_projection.rs
+++ b/crates/gents-cli/src/commands/codex_shim/history_projection.rs
@@ -4,17 +4,18 @@ use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
 use gents_codex_protocol as codex;
 use gents_codex_protocol::MessagePhase;
+use gents_protocol::client_protocol::derive_persisted_attempt;
 use gents_protocol::transcript::present_persisted_message;
 use serde::{Deserialize, Deserializer};
 use serde_json::{json, Value};
 
 use super::command_projection::{
-    command_execution_item, file_change_item, tool_projection_status_with_settled,
-    ToolProjectionStatus,
+    codex_command_status, codex_mcp_status, codex_patch_status, command_execution_item,
+    file_change_item, tool_projection_status_with_settled, ToolProjectionStatus,
 };
 use super::compaction_projection::context_compaction_item;
 use super::progress::{
-    decode_gents_tool_call_progress, gents_tool_item, terminal_error_message, terminal_turn_status,
+    codex_turn_status, decode_gents_tool_call_progress, gents_tool_item, terminal_error_message,
     GentsToolCallProgress,
 };
 use super::protocol::{
@@ -591,12 +592,12 @@ fn append_request_items(
     compactions: &[CompactionRow],
     messages_by_sequence: &BTreeMap<i64, MessageRow>,
 ) {
-    let projection_settled = matches!(
+    let projection_settled = derive_persisted_attempt(
         request.lifecycle_state.trim(),
-        "completed" | "failed" | "dead" | "interrupted" | "superseded"
-    ) || response.is_some_and(|response| {
-        matches!(response.status.trim(), "complete" | "completed" | "error")
-    });
+        false,
+        response.map(|row| row.status.trim()),
+    )
+    .is_some_and(|state| state.is_terminal());
     tools.sort_by(|left, right| {
         left.message_sequence
             .cmp(&right.message_sequence)
@@ -707,16 +708,20 @@ fn project_tool(
     projection_settled: bool,
 ) -> Option<codex::ThreadItem> {
     match tool_projection_status_with_settled(tool, projection_settled, true) {
-        ToolProjectionStatus::Mcp(status) => Some(gents_tool_item(tool, status)),
-        ToolProjectionStatus::Command(status) => {
-            Some(command_execution_item(&record.cwd, tool, status))
-        }
+        ToolProjectionStatus::Mcp(status) => Some(gents_tool_item(tool, codex_mcp_status(status))),
+        ToolProjectionStatus::Command(status) => Some(command_execution_item(
+            &record.cwd,
+            tool,
+            codex_command_status(status),
+        )),
         ToolProjectionStatus::Collab(projection) => {
             Some(collab_tool_item(&record.session_id, tool, &projection))
         }
         ToolProjectionStatus::DeferredCollab => None,
         ToolProjectionStatus::DeferredFileChange => None,
-        ToolProjectionStatus::FileChange(status) => file_change_item(tool, status),
+        ToolProjectionStatus::FileChange(status) => {
+            file_change_item(tool, codex_patch_status(status))
+        }
     }
 }
 
@@ -728,20 +733,9 @@ fn turn_status(request: &RequestRow, response: Option<&ResponseRow>) -> codex::T
         .and_then(|response| normalized_nonempty(&response.status))
         .unwrap_or_default();
 
-    if response_status == "interrupted" {
-        codex::TurnStatus::Interrupted
-    } else if response_status == "complete"
-        || response_status == "completed"
-        || response_status == "error"
-        || matches!(
-            lifecycle_state.as_str(),
-            "completed" | "failed" | "dead" | "interrupted" | "superseded"
-        )
-    {
-        terminal_turn_status(&lifecycle_state, &response_status)
-    } else {
-        codex::TurnStatus::InProgress
-    }
+    derive_persisted_attempt(&lifecycle_state, false, Some(&response_status))
+        .map(codex_turn_status)
+        .unwrap_or(codex::TurnStatus::InProgress)
 }
 
 fn turn_error(request: &RequestRow, response: Option<&ResponseRow>) -> Option<codex::TurnError> {

--- a/crates/gents-cli/src/commands/codex_shim/progress.rs
+++ b/crates/gents-cli/src/commands/codex_shim/progress.rs
@@ -1,7 +1,10 @@
 use gents::graphql::escape_graphql_string;
+use gents::tool_call_lifecycle::{FailureClass, ToolCallState};
 use gents_codex_protocol as codex;
+use gents_protocol::client_protocol::ClientTurnState;
 use serde_json::{json, Value};
 
+use super::projection_state::ProjectionStatus;
 use super::subagent_projection::LinkedSubagentThread;
 
 #[derive(Debug, Clone, Default)]
@@ -280,29 +283,51 @@ pub(super) fn timestamp_millis(raw: &str) -> Option<i64> {
         .map(|timestamp| timestamp.timestamp_millis())
 }
 
-pub(super) fn gents_tool_call_status(tool: &GentsToolCallProgress) -> codex::McpToolCallStatus {
-    let status = tool
+pub(super) fn observed_tool_status(tool: &GentsToolCallProgress) -> ProjectionStatus {
+    let persisted_failure = tool
+        .tool_failure_class
+        .as_deref()
+        .map(str::trim)
+        .filter(|class| !class.is_empty())
+        .and_then(FailureClass::from_persisted)
+        .is_some();
+    if persisted_failure {
+        return ProjectionStatus::Failed;
+    }
+
+    if let Some(lifecycle_state) = tool
         .lifecycle_state
         .as_deref()
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or(&tool.status)
-        .trim()
-        .to_ascii_lowercase();
+    {
+        return match ToolCallState::from_persisted(lifecycle_state.trim()) {
+            Some(ToolCallState::Completed) => ProjectionStatus::Completed,
+            Some(ToolCallState::Failed | ToolCallState::TimedOut | ToolCallState::Cancelled) => {
+                ProjectionStatus::Failed
+            }
+            _ => ProjectionStatus::InProgress,
+        };
+    }
+
+    // Compatibility is intentionally isolated to rows written before the
+    // durable lifecycle field existed. Current rows never derive execution
+    // semantics from model-facing result text.
+    let status = tool.status.trim().to_ascii_lowercase();
     if matches!(
         status.as_str(),
         "cancelled" | "dead" | "error" | "failed" | "failure" | "timedout"
     ) || tool_result_looks_error(&tool.result)
         || gents_exec_result_failed(&tool.result)
     {
-        return codex::McpToolCallStatus::Failed;
+        return ProjectionStatus::Failed;
     }
     if matches!(
         status.as_str(),
         "completed" | "complete" | "success" | "succeeded"
     ) {
-        return codex::McpToolCallStatus::Completed;
+        return ProjectionStatus::Completed;
     }
-    codex::McpToolCallStatus::InProgress
+    ProjectionStatus::InProgress
 }
 
 pub(super) fn content_delta(previous: &str, current: &str) -> String {
@@ -339,16 +364,16 @@ pub(super) fn response_field_is_blank(response: &Value, field: &str) -> bool {
         .is_empty()
 }
 
-pub(super) fn terminal_turn_status(
-    lifecycle_state: &str,
-    response_status: &str,
-) -> codex::TurnStatus {
-    match (lifecycle_state, response_status) {
-        ("interrupted" | "superseded", _) => codex::TurnStatus::Interrupted,
-        ("failed" | "dead", _) => codex::TurnStatus::Failed,
-        ("completed", _) => codex::TurnStatus::Completed,
-        (_, "error") => codex::TurnStatus::Failed,
-        _ => codex::TurnStatus::Completed,
+pub(super) fn codex_turn_status(state: ClientTurnState) -> codex::TurnStatus {
+    match state {
+        ClientTurnState::WaitingForClaim | ClientTurnState::Streaming => {
+            codex::TurnStatus::InProgress
+        }
+        ClientTurnState::Completed => codex::TurnStatus::Completed,
+        ClientTurnState::Failed => codex::TurnStatus::Failed,
+        ClientTurnState::Superseded | ClientTurnState::Interrupted => {
+            codex::TurnStatus::Interrupted
+        }
     }
 }
 
@@ -436,14 +461,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn gents_tool_errors_render_as_failed_codex_tool_calls() {
-        let tool = test_tool("glob", "completed", r#"{"pattern":"**/*.lean"}"#)
+    fn legacy_tool_errors_render_as_failed_codex_tool_calls() {
+        let mut tool = test_tool("glob", "completed", r#"{"pattern":"**/*.lean"}"#)
             .with_result("Toolset error: missing runner");
+        tool.lifecycle_state = None;
 
-        assert_eq!(
-            gents_tool_call_status(&tool),
-            codex::McpToolCallStatus::Failed
-        );
+        assert_eq!(observed_tool_status(&tool), ProjectionStatus::Failed);
         let item = gents_tool_item(&tool, codex::McpToolCallStatus::Failed);
         let codex::ThreadItem::McpToolCall {
             server,
@@ -467,6 +490,36 @@ mod tests {
     }
 
     #[test]
+    fn persisted_failure_class_overrides_legacy_completed_status() {
+        let mut tool = test_tool("bash", "completed", r#"{"command":"false"}"#)
+            .with_result("legacy row without a parseable command envelope");
+        tool.lifecycle_state = Some("completed".to_string());
+        tool.tool_failure_class = Some("toolReturnedError".to_string());
+
+        assert_eq!(observed_tool_status(&tool), ProjectionStatus::Failed);
+    }
+
+    #[test]
+    fn durable_completed_status_ignores_failure_shaped_result_text() {
+        let tool = test_tool("bash", "completed", r#"{"command":"true"}"#)
+            .with_result(r#"gents_exec: {"ok":false,"status":"exit_nonzero"}"#);
+
+        assert_eq!(
+            observed_tool_status(&tool),
+            ProjectionStatus::Completed,
+            "model-facing result text is not authoritative for durable rows"
+        );
+    }
+
+    #[test]
+    fn unknown_failure_class_does_not_override_durable_lifecycle() {
+        let mut tool = test_tool("bash", "completed", r#"{"command":"true"}"#);
+        tool.tool_failure_class = Some("futureUnknownClass".to_string());
+
+        assert_eq!(observed_tool_status(&tool), ProjectionStatus::Completed);
+    }
+
+    #[test]
     fn content_delta_ignores_terminal_leading_whitespace_normalization() {
         assert_eq!(
             content_delta("\n\nAnswer with context", "Answer with context"),
@@ -479,21 +532,21 @@ mod tests {
     }
 
     #[test]
-    fn terminal_turn_status_matches_codex_projection_request_precedence() {
+    fn codex_turn_status_is_only_a_wire_vocabulary_mapping() {
         assert_eq!(
-            terminal_turn_status("completed", "error"),
+            codex_turn_status(ClientTurnState::Completed),
             codex::TurnStatus::Completed
         );
         assert_eq!(
-            terminal_turn_status("processing", "error"),
+            codex_turn_status(ClientTurnState::Failed),
             codex::TurnStatus::Failed
         );
         assert_eq!(
-            terminal_turn_status("failed", "complete"),
-            codex::TurnStatus::Failed
+            codex_turn_status(ClientTurnState::Streaming),
+            codex::TurnStatus::InProgress
         );
         assert_eq!(
-            terminal_turn_status("superseded", "error"),
+            codex_turn_status(ClientTurnState::Superseded),
             codex::TurnStatus::Interrupted
         );
     }

--- a/crates/gents-cli/src/commands/codex_shim/projection_state.rs
+++ b/crates/gents-cli/src/commands/codex_shim/projection_state.rs
@@ -1,0 +1,181 @@
+//! Codex-independent state used to decide whether a durable observation is
+//! semantically new. Wire-protocol types belong in the emit/read boundary,
+//! not in the stream's equality and de-duplication model.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ProjectionStatus {
+    InProgress,
+    Completed,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CollabTool {
+    SpawnAgent,
+    ResumeAgent,
+    Wait,
+    SendInput,
+    CloseAgent,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ChildStatus {
+    Pending,
+    Running,
+    Interrupted,
+    Completed,
+    Errored,
+    Shutdown,
+    NotFound,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct CollabProjection {
+    pub(super) status: ProjectionStatus,
+    pub(super) tool: CollabTool,
+    pub(super) receiver_thread_id: String,
+    pub(super) child_model: Option<String>,
+    pub(super) child_status: ChildStatus,
+    pub(super) child_failure_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum ToolProjectionStatus {
+    Mcp(ProjectionStatus),
+    Command(ProjectionStatus),
+    Collab(CollabProjection),
+    DeferredCollab,
+    DeferredFileChange,
+    FileChange(ProjectionStatus),
+}
+
+impl ToolProjectionStatus {
+    pub(super) fn command_status(&self) -> ProjectionStatus {
+        match self {
+            Self::Command(status) => *status,
+            Self::Mcp(_)
+            | Self::Collab(_)
+            | Self::DeferredCollab
+            | Self::DeferredFileChange
+            | Self::FileChange(_) => ProjectionStatus::InProgress,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ProjectionEvent {
+    Started,
+    Completed,
+}
+
+pub(super) fn collab_projection_events(
+    previous: Option<&ToolProjectionStatus>,
+    current: &CollabProjection,
+) -> Vec<ProjectionEvent> {
+    match previous {
+        Some(ToolProjectionStatus::Collab(previous)) => {
+            if previous.status == ProjectionStatus::InProgress
+                && current.status != ProjectionStatus::InProgress
+            {
+                vec![ProjectionEvent::Completed]
+            } else {
+                // Child presentation fields may keep changing after the spawn
+                // operation completed. They do not reopen its item lifecycle.
+                Vec::new()
+            }
+        }
+        None | Some(ToolProjectionStatus::DeferredCollab) => {
+            if current.status == ProjectionStatus::InProgress {
+                vec![ProjectionEvent::Started]
+            } else {
+                vec![ProjectionEvent::Started, ProjectionEvent::Completed]
+            }
+        }
+        Some(_) if current.status == ProjectionStatus::InProgress => {
+            vec![ProjectionEvent::Started]
+        }
+        Some(_) => vec![ProjectionEvent::Completed],
+    }
+}
+
+pub(super) fn stabilize_projection_kind(
+    previous: Option<&ToolProjectionStatus>,
+    current: ToolProjectionStatus,
+) -> ToolProjectionStatus {
+    match (previous, current) {
+        (Some(ToolProjectionStatus::Collab(previous)), ToolProjectionStatus::DeferredCollab) => {
+            ToolProjectionStatus::Collab(previous.clone())
+        }
+        (Some(ToolProjectionStatus::Collab(previous)), ToolProjectionStatus::Mcp(status)) => {
+            let mut current = previous.clone();
+            current.status = status;
+            ToolProjectionStatus::Collab(current)
+        }
+        (Some(ToolProjectionStatus::Mcp(_)), ToolProjectionStatus::DeferredCollab) => previous
+            .cloned()
+            .expect("matched a previous MCP projection"),
+        (Some(ToolProjectionStatus::Mcp(_)), ToolProjectionStatus::Collab(current)) => {
+            ToolProjectionStatus::Mcp(current.status)
+        }
+        (_, current) => current,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn running_spawn() -> CollabProjection {
+        CollabProjection {
+            status: ProjectionStatus::Completed,
+            tool: CollabTool::SpawnAgent,
+            receiver_thread_id: "child-thread".to_string(),
+            child_model: Some("model".to_string()),
+            child_status: ChildStatus::Running,
+            child_failure_reason: None,
+        }
+    }
+
+    #[test]
+    fn one_spawn_emits_one_lifecycle_despite_child_presentation_updates() {
+        let running = running_spawn();
+        assert_eq!(
+            collab_projection_events(None, &running),
+            vec![ProjectionEvent::Started, ProjectionEvent::Completed]
+        );
+
+        let previous = ToolProjectionStatus::Collab(running.clone());
+        assert!(collab_projection_events(Some(&previous), &running).is_empty());
+
+        let mut completed = running;
+        completed.child_status = ChildStatus::Completed;
+        assert!(collab_projection_events(Some(&previous), &completed).is_empty());
+
+        let in_progress = CollabProjection {
+            status: ProjectionStatus::InProgress,
+            ..completed.clone()
+        };
+        let previous = ToolProjectionStatus::Collab(in_progress);
+        assert_eq!(
+            collab_projection_events(Some(&previous), &completed),
+            vec![ProjectionEvent::Completed]
+        );
+    }
+
+    #[test]
+    fn emitted_projection_kind_survives_link_flicker_and_late_links() {
+        let collab = ToolProjectionStatus::Collab(running_spawn());
+        let stabilized =
+            stabilize_projection_kind(Some(&collab), ToolProjectionStatus::DeferredCollab);
+        assert_eq!(stabilized, collab);
+
+        let returned = ToolProjectionStatus::Collab(running_spawn());
+        let ToolProjectionStatus::Collab(returned_projection) = &returned else {
+            unreachable!();
+        };
+        assert!(collab_projection_events(Some(&stabilized), returned_projection).is_empty());
+
+        let mcp = ToolProjectionStatus::Mcp(ProjectionStatus::Completed);
+        assert_eq!(stabilize_projection_kind(Some(&mcp), returned), mcp);
+    }
+}

--- a/crates/gents-cli/src/commands/codex_shim/subagent_projection.rs
+++ b/crates/gents-cli/src/commands/codex_shim/subagent_projection.rs
@@ -4,17 +4,25 @@ use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
 use gents::tool_call_lifecycle::MAX_SUBAGENT_DEPTH;
 use gents_codex_protocol as codex;
+use gents_protocol::client_protocol::{
+    project_persisted_attempt, ClientHeadProjection, ClientTurnState, RequestLifecycleState,
+};
 use serde::Deserialize;
 use serde_json::Value;
 use uuid::Uuid;
 
 use super::bound_behavior::model_selection_id;
-use super::progress::{gents_tool_call_status, GentsToolCallProgress};
+use super::progress::{observed_tool_status, GentsToolCallProgress};
+use super::projection_state::{ChildStatus, CollabProjection, CollabTool, ProjectionStatus};
 use super::store::query_node_json;
 use super::ShimState;
 
-const SUBAGENT_PROJECTION_COLLECTIONS: [&str; 3] =
-    ["AgentRequest", "AgentToolCall", "AgentBehavior"];
+const SUBAGENT_PROJECTION_COLLECTIONS: [&str; 4] = [
+    "AgentRequest",
+    "AgentResponse",
+    "AgentToolCall",
+    "AgentBehavior",
+];
 
 #[derive(Clone, Debug)]
 pub(super) struct SubagentProjectionUpdateFilter {
@@ -77,19 +85,9 @@ pub(super) struct LinkedSubagentThread {
     pub(super) behavior_id: String,
     pub(super) model: Option<String>,
     pub(super) nickname: String,
-    pub(super) lifecycle_state: String,
+    pub(super) client_projection: Option<ClientHeadProjection>,
     pub(super) failure_reason: Option<String>,
     pub(super) created_at: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) struct CollabProjection {
-    pub(super) status: codex::CollabAgentToolCallStatus,
-    pub(super) tool: codex::CollabAgentTool,
-    pub(super) receiver_thread_id: String,
-    pub(super) child_model: Option<String>,
-    pub(super) child_lifecycle_state: String,
-    pub(super) child_failure_reason: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -105,6 +103,8 @@ struct RequestRow {
     metadata: Option<String>,
     #[serde(default)]
     lifecycle_state: Option<String>,
+    #[serde(default)]
+    superseded_by_request: Option<String>,
     #[serde(default)]
     failure_reason: Option<String>,
     #[serde(default)]
@@ -130,6 +130,22 @@ struct ToolLinkRow {
     spawn_target_did: Option<String>,
     #[serde(default)]
     args: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ResponseRow {
+    request_id: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ConversationHeadRow {
+    session_id: String,
+    #[serde(default)]
+    latest_request_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -163,6 +179,7 @@ const REQUEST_ROW_FIELDS: &str = r#"
     behavior_id
     metadata
     lifecycle_state
+    superseded_by_request
     failure_reason
     created_at
     subagent_depth
@@ -324,8 +341,113 @@ async fn load_authorized_subagent_threads_for_roots(
         state.agent_did.as_ref(),
         state.behavior_id.as_ref(),
     );
+    attach_canonical_request_heads(state, &requests, &mut links).await?;
+    attach_client_head_projections(state, &mut links).await?;
     attach_runtime_models(state, &mut links).await;
     Ok(links)
+}
+
+async fn attach_canonical_request_heads(
+    state: &ShimState,
+    requests: &[RequestRow],
+    links: &mut [LinkedSubagentThread],
+) -> Result<()> {
+    let mut session_ids = links
+        .iter()
+        .map(|link| link.session_id.clone())
+        .collect::<Vec<_>>();
+    session_ids.sort_unstable();
+    session_ids.dedup();
+    if session_ids.is_empty() {
+        return Ok(());
+    }
+    let response = query_node_json(
+        state.node.as_ref(),
+        &conversation_heads_for_sessions_query(&session_ids),
+    )
+    .await?;
+    let heads = decode_rows::<ConversationHeadRow>(&response, "AgentConversation")
+        .context("decoding subagent AgentConversation heads")?
+        .into_iter()
+        .filter_map(|row| {
+            nonempty(row.latest_request_id.as_deref())
+                .map(|request_id| (row.session_id, request_id.to_string()))
+        })
+        .collect::<HashMap<_, _>>();
+    apply_canonical_request_heads(requests, &heads, links);
+    Ok(())
+}
+
+fn apply_canonical_request_heads(
+    requests: &[RequestRow],
+    heads: &HashMap<String, String>,
+    links: &mut [LinkedSubagentThread],
+) {
+    let requests_by_id = requests
+        .iter()
+        .map(|row| (row.request_id.as_str(), row))
+        .collect::<HashMap<_, _>>();
+    for link in links {
+        let Some(request_id) = heads.get(&link.session_id) else {
+            continue;
+        };
+        let Some(request) = requests_by_id.get(request_id.as_str()) else {
+            continue;
+        };
+        if request.session_id != link.session_id
+            || request.agent_did != link.agent_did
+            || nonempty(request.behavior_id.as_deref()) != Some(link.behavior_id.as_str())
+            || request.subagent_depth.unwrap_or_default() != link.depth
+        {
+            continue;
+        }
+        apply_latest_request(link, request);
+    }
+}
+
+async fn attach_client_head_projections(
+    state: &ShimState,
+    links: &mut [LinkedSubagentThread],
+) -> Result<()> {
+    let mut request_ids = links
+        .iter()
+        .map(|link| link.latest_request_id.clone())
+        .filter(|request_id| !request_id.trim().is_empty())
+        .collect::<Vec<_>>();
+    request_ids.sort_unstable();
+    request_ids.dedup();
+    if request_ids.is_empty() {
+        return Ok(());
+    }
+
+    let response = query_node_json(
+        state.node.as_ref(),
+        &responses_for_request_ids_query(&request_ids),
+    )
+    .await?;
+    let latest_by_request = decode_rows::<ResponseRow>(&response, "AgentResponse")
+        .context("decoding subagent AgentResponse rows")?
+        .into_iter()
+        .fold(HashMap::<String, ResponseRow>::new(), |mut latest, row| {
+            let replace = latest
+                .get(&row.request_id)
+                .is_none_or(|previous| row.created_at > previous.created_at);
+            if replace {
+                latest.insert(row.request_id.clone(), row);
+            }
+            latest
+        });
+    for link in links {
+        let Some(head) = link.client_projection.filter(|head| head.is_active()) else {
+            continue;
+        };
+        let response_status = latest_by_request
+            .get(&link.latest_request_id)
+            .and_then(|row| nonempty(row.status.as_deref()));
+        link.client_projection =
+            project_persisted_attempt(head.request_state.as_str(), false, response_status);
+    }
+    Ok(())
 }
 
 async fn attach_runtime_models(state: &ShimState, links: &mut [LinkedSubagentThread]) {
@@ -447,6 +569,34 @@ fn graphql_string_list<'a>(values: impl IntoIterator<Item = &'a str>) -> String 
         .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn responses_for_request_ids_query(request_ids: &[String]) -> String {
+    format!(
+        r#"{{
+            AgentResponse(
+                filter: {{ request_id: {{ _in: [{}] }} }},
+                order: {{ created_at: ASC }}
+            ) {{
+                request_id
+                status
+                created_at
+            }}
+        }}"#,
+        graphql_string_list(request_ids.iter().map(String::as_str)),
+    )
+}
+
+fn conversation_heads_for_sessions_query(session_ids: &[String]) -> String {
+    format!(
+        r#"{{
+            AgentConversation(filter: {{ session_id: {{ _in: [{}] }} }}) {{
+                session_id
+                latest_request_id
+            }}
+        }}"#,
+        graphql_string_list(session_ids.iter().map(String::as_str)),
+    )
 }
 
 fn extend_unique_requests(
@@ -594,9 +744,11 @@ fn resolve_authorized_subagent_threads(
                 behavior_id,
                 model: None,
                 nickname,
-                lifecycle_state: nonempty(child.lifecycle_state.as_deref())
-                    .unwrap_or("")
-                    .to_string(),
+                client_projection: project_persisted_attempt(
+                    nonempty(child.lifecycle_state.as_deref()).unwrap_or(""),
+                    nonempty(child.superseded_by_request.as_deref()).is_some(),
+                    None,
+                ),
                 failure_reason: child
                     .failure_reason
                     .as_deref()
@@ -647,19 +799,25 @@ fn resolve_authorized_subagent_threads(
             continue;
         };
         let latest = &requests[*latest_index];
-        link.latest_request_id = latest.request_id.clone();
-        link.latest_request_content = latest.content.clone();
-        link.latest_request_created_at = latest.created_at.clone();
-        link.lifecycle_state = nonempty(latest.lifecycle_state.as_deref())
-            .unwrap_or("")
-            .to_string();
-        link.failure_reason = latest
-            .failure_reason
-            .as_deref()
-            .and_then(|value| nonempty(Some(value)))
-            .map(ToOwned::to_owned);
+        apply_latest_request(link, latest);
     }
     links
+}
+
+fn apply_latest_request(link: &mut LinkedSubagentThread, latest: &RequestRow) {
+    link.latest_request_id = latest.request_id.clone();
+    link.latest_request_content = latest.content.clone();
+    link.latest_request_created_at = latest.created_at.clone();
+    link.client_projection = project_persisted_attempt(
+        nonempty(latest.lifecycle_state.as_deref()).unwrap_or(""),
+        nonempty(latest.superseded_by_request.as_deref()).is_some(),
+        None,
+    );
+    link.failure_reason = latest
+        .failure_reason
+        .as_deref()
+        .and_then(|value| nonempty(Some(value)))
+        .map(ToOwned::to_owned);
 }
 
 fn request_context_key(row: &RequestRow) -> RequestContextKey {
@@ -715,12 +873,12 @@ pub(super) fn is_subagent_control_tool(tool_name: &str) -> bool {
     collab_tool(tool_name).is_some()
 }
 
-fn collab_tool(tool_name: &str) -> Option<codex::CollabAgentTool> {
+fn collab_tool(tool_name: &str) -> Option<CollabTool> {
     match tool_name {
-        "spawn_subagent" => Some(codex::CollabAgentTool::SpawnAgent),
-        "wait_subagent" => Some(codex::CollabAgentTool::Wait),
-        "steer_subagent" => Some(codex::CollabAgentTool::SendInput),
-        "cancel_subagent" => Some(codex::CollabAgentTool::CloseAgent),
+        "spawn_subagent" => Some(CollabTool::SpawnAgent),
+        "wait_subagent" => Some(CollabTool::Wait),
+        "steer_subagent" => Some(CollabTool::SendInput),
+        "cancel_subagent" => Some(CollabTool::CloseAgent),
         _ => None,
     }
 }
@@ -754,37 +912,49 @@ fn tool_child_request_id(tool: &GentsToolCallProgress) -> Option<String> {
 pub(super) fn collab_projection(tool: &GentsToolCallProgress) -> Option<CollabProjection> {
     let collab_tool = collab_tool(&tool.tool_name)?;
     let link = tool.subagent_link.as_ref()?;
-    let runtime_status = gents_tool_call_status(tool);
+    let runtime_status = observed_tool_status(tool);
     let status = match (&collab_tool, runtime_status) {
-        (_, codex::McpToolCallStatus::Failed) => codex::CollabAgentToolCallStatus::Failed,
-        (codex::CollabAgentTool::SpawnAgent, _) => {
+        (_, ProjectionStatus::Failed) => ProjectionStatus::Failed,
+        (CollabTool::SpawnAgent, _) => {
             // The reciprocal edge proves the spawn operation succeeded. GENTS
             // deliberately keeps the bridge row running while a background
             // child works; Codex represents that child lifecycle separately
             // in agentsStates, so the collaboration operation is complete.
-            codex::CollabAgentToolCallStatus::Completed
+            ProjectionStatus::Completed
         }
-        (_, codex::McpToolCallStatus::InProgress) => codex::CollabAgentToolCallStatus::InProgress,
-        (_, codex::McpToolCallStatus::Completed) => codex::CollabAgentToolCallStatus::Completed,
+        (_, ProjectionStatus::InProgress) => ProjectionStatus::InProgress,
+        (_, ProjectionStatus::Completed) => ProjectionStatus::Completed,
     };
     Some(CollabProjection {
         status,
         tool: collab_tool,
         receiver_thread_id: link.session_id.clone(),
         child_model: link.model.clone(),
-        child_lifecycle_state: link.lifecycle_state.clone(),
+        child_status: collab_agent_status(link.client_projection),
         child_failure_reason: link.failure_reason.clone(),
     })
 }
 
-pub(super) fn collab_agent_status(lifecycle_state: &str) -> codex::CollabAgentStatus {
-    match lifecycle_state.trim() {
-        "pending" => codex::CollabAgentStatus::PendingInit,
-        "claimed" | "processing" | "inputRequired" => codex::CollabAgentStatus::Running,
-        "completed" => codex::CollabAgentStatus::Completed,
-        "failed" | "dead" => codex::CollabAgentStatus::Errored,
-        "superseded" | "interrupted" => codex::CollabAgentStatus::Interrupted,
-        _ => codex::CollabAgentStatus::NotFound,
+pub(super) fn collab_agent_status(head: Option<ClientHeadProjection>) -> ChildStatus {
+    match head {
+        Some(ClientHeadProjection {
+            turn_state: ClientTurnState::Completed,
+            ..
+        }) => ChildStatus::Completed,
+        Some(ClientHeadProjection {
+            turn_state: ClientTurnState::Failed,
+            ..
+        }) => ChildStatus::Errored,
+        Some(ClientHeadProjection {
+            turn_state: ClientTurnState::Superseded | ClientTurnState::Interrupted,
+            ..
+        }) => ChildStatus::Interrupted,
+        Some(ClientHeadProjection {
+            turn_state: ClientTurnState::WaitingForClaim,
+            request_state: RequestLifecycleState::Pending,
+        }) => ChildStatus::Pending,
+        Some(_) => ChildStatus::Running,
+        None => ChildStatus::NotFound,
     }
 }
 
@@ -796,11 +966,11 @@ pub(super) fn collab_tool_item(
     let prompt = serde_json::from_str::<Value>(&tool.args)
         .ok()
         .and_then(|args| match projection.tool {
-            codex::CollabAgentTool::SpawnAgent => args
+            CollabTool::SpawnAgent => args
                 .get("prompt")
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned),
-            codex::CollabAgentTool::SendInput => args
+            CollabTool::SendInput => args
                 .get("message")
                 .and_then(Value::as_str)
                 .map(ToOwned::to_owned),
@@ -810,22 +980,84 @@ pub(super) fn collab_tool_item(
     agents_states.insert(
         projection.receiver_thread_id.clone(),
         codex::CollabAgentState {
-            status: collab_agent_status(&projection.child_lifecycle_state),
+            status: codex_child_status(projection.child_status),
             message: projection.child_failure_reason.clone(),
         },
     );
     codex::ThreadItem::CollabAgentToolCall {
         id: tool.tool_call_key.clone(),
-        tool: projection.tool.clone(),
-        status: projection.status.clone(),
+        tool: codex_collab_tool(projection.tool),
+        status: codex_collab_status(projection.status),
         sender_thread_id: sender_thread_id.to_string(),
         receiver_thread_ids: vec![projection.receiver_thread_id.clone()],
         prompt,
-        model: (projection.tool == codex::CollabAgentTool::SpawnAgent)
+        model: (projection.tool == CollabTool::SpawnAgent)
             .then(|| projection.child_model.clone())
             .flatten(),
         reasoning_effort: None,
         agents_states,
+    }
+}
+
+fn codex_collab_tool(tool: CollabTool) -> codex::CollabAgentTool {
+    match tool {
+        CollabTool::SpawnAgent => codex::CollabAgentTool::SpawnAgent,
+        CollabTool::ResumeAgent => codex::CollabAgentTool::ResumeAgent,
+        CollabTool::Wait => codex::CollabAgentTool::Wait,
+        CollabTool::SendInput => codex::CollabAgentTool::SendInput,
+        CollabTool::CloseAgent => codex::CollabAgentTool::CloseAgent,
+    }
+}
+
+fn codex_child_status(status: ChildStatus) -> codex::CollabAgentStatus {
+    match status {
+        ChildStatus::Pending => codex::CollabAgentStatus::PendingInit,
+        ChildStatus::Running => codex::CollabAgentStatus::Running,
+        ChildStatus::Interrupted => codex::CollabAgentStatus::Interrupted,
+        ChildStatus::Completed => codex::CollabAgentStatus::Completed,
+        ChildStatus::Errored => codex::CollabAgentStatus::Errored,
+        ChildStatus::Shutdown => codex::CollabAgentStatus::Shutdown,
+        ChildStatus::NotFound => codex::CollabAgentStatus::NotFound,
+    }
+}
+
+fn codex_collab_status(status: ProjectionStatus) -> codex::CollabAgentToolCallStatus {
+    match status {
+        ProjectionStatus::InProgress => codex::CollabAgentToolCallStatus::InProgress,
+        ProjectionStatus::Completed => codex::CollabAgentToolCallStatus::Completed,
+        ProjectionStatus::Failed => codex::CollabAgentToolCallStatus::Failed,
+    }
+}
+
+pub(super) fn observed_collab_status(
+    status: &codex::CollabAgentToolCallStatus,
+) -> ProjectionStatus {
+    match status {
+        codex::CollabAgentToolCallStatus::InProgress => ProjectionStatus::InProgress,
+        codex::CollabAgentToolCallStatus::Completed => ProjectionStatus::Completed,
+        codex::CollabAgentToolCallStatus::Failed => ProjectionStatus::Failed,
+    }
+}
+
+pub(super) fn observed_collab_tool(tool: &codex::CollabAgentTool) -> CollabTool {
+    match tool {
+        codex::CollabAgentTool::SpawnAgent => CollabTool::SpawnAgent,
+        codex::CollabAgentTool::ResumeAgent => CollabTool::ResumeAgent,
+        codex::CollabAgentTool::Wait => CollabTool::Wait,
+        codex::CollabAgentTool::SendInput => CollabTool::SendInput,
+        codex::CollabAgentTool::CloseAgent => CollabTool::CloseAgent,
+    }
+}
+
+pub(super) fn observed_child_status(status: &codex::CollabAgentStatus) -> ChildStatus {
+    match status {
+        codex::CollabAgentStatus::PendingInit => ChildStatus::Pending,
+        codex::CollabAgentStatus::Running => ChildStatus::Running,
+        codex::CollabAgentStatus::Interrupted => ChildStatus::Interrupted,
+        codex::CollabAgentStatus::Completed => ChildStatus::Completed,
+        codex::CollabAgentStatus::Errored => ChildStatus::Errored,
+        codex::CollabAgentStatus::Shutdown => ChildStatus::Shutdown,
+        codex::CollabAgentStatus::NotFound => ChildStatus::NotFound,
     }
 }
 
@@ -856,6 +1088,7 @@ mod tests {
                 }
                 .to_string(),
             ),
+            superseded_by_request: None,
             failure_reason: None,
             created_at: None,
             subagent_depth: Some(depth),
@@ -998,7 +1231,57 @@ mod tests {
             links[0].latest_request_content,
             "content for child-followup"
         );
-        assert_eq!(links[0].lifecycle_state, "processing");
+        assert_eq!(
+            links[0].client_projection,
+            project_persisted_attempt("processing", false, None)
+        );
+    }
+
+    #[test]
+    fn canonical_conversation_head_overrides_local_timestamp_fallback() {
+        let root_session = Uuid::new_v4().to_string();
+        let child_session = Uuid::new_v4().to_string();
+        let mut canonical = request(
+            "child-request",
+            &child_session,
+            1,
+            Some("root-request"),
+            Some("spawn-call"),
+        );
+        canonical.created_at = Some("2026-01-01T00:00:01Z".to_string());
+        canonical.lifecycle_state = Some("completed".to_string());
+        let mut timestamp_fallback = request("child-followup", &child_session, 1, None, None);
+        timestamp_fallback.created_at = Some("2026-01-01T00:00:02Z".to_string());
+        timestamp_fallback.lifecycle_state = Some("processing".to_string());
+        let requests = vec![
+            request("root-request", &root_session, 0, None, None),
+            canonical,
+            timestamp_fallback,
+        ];
+        let tools = vec![ToolLinkRow {
+            request_id: "root-request".to_string(),
+            session_id: root_session,
+            agent_did: "did:root".to_string(),
+            tool_call_id: "spawn-call".to_string(),
+            tool_name: "spawn_subagent".to_string(),
+            child_request_id: Some("child-request".to_string()),
+            spawn_target_did: Some("did:child".to_string()),
+            args: r#"{"name":"reviewer"}"#.to_string(),
+        }];
+        let mut links = resolve_authorized_subagent_threads(&requests, &tools, "did:root", "root");
+        assert_eq!(links[0].latest_request_id, "child-followup");
+
+        apply_canonical_request_heads(
+            &requests,
+            &HashMap::from([(child_session, "child-request".to_string())]),
+            &mut links,
+        );
+
+        assert_eq!(links[0].latest_request_id, "child-request");
+        assert_eq!(
+            links[0].client_projection,
+            project_persisted_attempt("completed", false, None)
+        );
     }
 
     #[test]
@@ -1018,45 +1301,29 @@ mod tests {
 
     #[test]
     fn lean_fenced_tool_and_status_mappings_match_codex_protocol() {
-        assert_eq!(
-            collab_tool("spawn_subagent"),
-            Some(codex::CollabAgentTool::SpawnAgent)
-        );
-        assert_eq!(
-            collab_tool("wait_subagent"),
-            Some(codex::CollabAgentTool::Wait)
-        );
-        assert_eq!(
-            collab_tool("steer_subagent"),
-            Some(codex::CollabAgentTool::SendInput)
-        );
-        assert_eq!(
-            collab_tool("cancel_subagent"),
-            Some(codex::CollabAgentTool::CloseAgent)
-        );
+        assert_eq!(collab_tool("spawn_subagent"), Some(CollabTool::SpawnAgent));
+        assert_eq!(collab_tool("wait_subagent"), Some(CollabTool::Wait));
+        assert_eq!(collab_tool("steer_subagent"), Some(CollabTool::SendInput));
+        assert_eq!(collab_tool("cancel_subagent"), Some(CollabTool::CloseAgent));
         assert_eq!(collab_tool("list_subagents"), None);
         assert_eq!(collab_tool("read_subagent"), None);
 
+        let status = |lifecycle, response| {
+            collab_agent_status(project_persisted_attempt(lifecycle, false, response))
+        };
+        assert_eq!(status("pending", None), ChildStatus::Pending);
+        assert_eq!(status("claimed", None), ChildStatus::Running);
+        assert_eq!(status("processing", None), ChildStatus::Running);
+        assert_eq!(status("inputRequired", None), ChildStatus::Running);
+        assert_eq!(status("completed", None), ChildStatus::Completed);
+        assert_eq!(status("failed", None), ChildStatus::Errored);
+        assert_eq!(status("interrupted", None), ChildStatus::Interrupted);
         assert_eq!(
-            collab_agent_status("pending"),
-            codex::CollabAgentStatus::PendingInit
+            status("processing", Some("complete")),
+            ChildStatus::Completed
         );
-        assert_eq!(
-            collab_agent_status("processing"),
-            codex::CollabAgentStatus::Running
-        );
-        assert_eq!(
-            collab_agent_status("completed"),
-            codex::CollabAgentStatus::Completed
-        );
-        assert_eq!(
-            collab_agent_status("failed"),
-            codex::CollabAgentStatus::Errored
-        );
-        assert_eq!(
-            collab_agent_status("interrupted"),
-            codex::CollabAgentStatus::Interrupted
-        );
+        assert_eq!(status("processing", Some("error")), ChildStatus::Errored);
+        assert_eq!(collab_agent_status(None), ChildStatus::NotFound);
     }
 
     #[test]
@@ -1089,14 +1356,14 @@ mod tests {
             behavior_id: "code-review".to_string(),
             model: Some("child-model".to_string()),
             nickname: "reviewer".to_string(),
-            lifecycle_state: "processing".to_string(),
+            client_projection: project_persisted_attempt("processing", false, None),
             failure_reason: None,
             created_at: None,
         });
         let projection = collab_projection(&tool).expect("authorized spawn projection");
         assert_eq!(
             projection.status,
-            codex::CollabAgentToolCallStatus::Completed,
+            ProjectionStatus::Completed,
             "the linked spawn operation completes while agentsStates tracks the running child"
         );
         let item = collab_tool_item("parent-thread", &tool, &projection);
@@ -1125,9 +1392,21 @@ mod tests {
             Some(&Value::String("running".to_string()))
         );
 
+        let mut claimed = tool.clone();
+        claimed
+            .subagent_link
+            .as_mut()
+            .expect("link")
+            .client_projection = project_persisted_attempt("claimed", false, None);
+        let claimed_projection = collab_projection(&claimed).expect("claimed projection");
+        assert_eq!(
+            projection, claimed_projection,
+            "storage lifecycle aliases with the same Codex status must not emit duplicate items"
+        );
+
         let mut completed = tool.clone();
         let link = completed.subagent_link.as_mut().expect("link");
-        link.lifecycle_state = "completed".to_string();
+        link.client_projection = project_persisted_attempt("completed", false, None);
         let completed_projection = collab_projection(&completed).expect("completed projection");
         assert_ne!(
             projection, completed_projection,
@@ -1140,6 +1419,7 @@ mod tests {
         let filter = SubagentProjectionUpdateFilter {
             collection_ids: HashSet::from([
                 "agent-request-id".to_string(),
+                "agent-response-id".to_string(),
                 "agent-tool-call-id".to_string(),
                 "agent-behavior-id".to_string(),
             ]),
@@ -1147,6 +1427,7 @@ mod tests {
         };
 
         assert!(filter.affects_collection_id("agent-request-id"));
+        assert!(filter.affects_collection_id("agent-response-id"));
         assert!(filter.affects_collection_id("agent-tool-call-id"));
         assert!(filter.affects_collection_id("agent-behavior-id"));
         assert!(!filter.affects_collection_id("agent-message-id"));

--- a/crates/gents-cli/src/commands/codex_shim/thread_projection.rs
+++ b/crates/gents-cli/src/commands/codex_shim/thread_projection.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use gents_protocol::client_protocol::ClientHeadProjection;
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;
 
@@ -81,8 +82,8 @@ pub(super) struct ConversationRow {
     pub(super) updated_at: Option<String>,
     #[serde(default, deserialize_with = "deserialize_nullable_string")]
     pub(super) latest_request_id: String,
-    #[serde(default)]
-    pub(super) latest_request_lifecycle_state: Option<String>,
+    #[serde(skip)]
+    pub(super) latest_request_projection: Option<ClientHeadProjection>,
     #[serde(default)]
     pub(super) latest_request_failure_reason: Option<String>,
     #[serde(default)]
@@ -488,7 +489,11 @@ mod tests {
                 behavior_id: "child-behavior".to_string(),
                 model: None,
                 nickname: format!("child-{index}"),
-                lifecycle_state: "running".to_string(),
+                client_projection: gents_protocol::client_protocol::project_persisted_attempt(
+                    "processing",
+                    false,
+                    None,
+                ),
                 failure_reason: None,
                 created_at: None,
             };

--- a/crates/gents-cli/src/commands/codex_shim/thread_projection/json.rs
+++ b/crates/gents-cli/src/commands/codex_shim/thread_projection/json.rs
@@ -1,4 +1,5 @@
 use gents_codex_protocol as codex;
+use gents_protocol::client_protocol::{ClientHeadProjection, ClientTurnState};
 use serde_json::{json, Value};
 
 use crate::commands::codex_shim::protocol::{absolute_path, thread_json};
@@ -105,29 +106,35 @@ pub(in crate::commands::codex_shim) fn codex_thread_status(
     record: &CodexThreadRecord,
 ) -> codex::ThreadStatus {
     if let Some(link) = record.subagent.as_ref() {
-        return projected_thread_status(Some(&link.lifecycle_state), "");
+        return projected_thread_status(link.client_projection, "");
     }
     let conversation = record.conversation.as_ref();
     projected_thread_status(
-        conversation.and_then(|row| row.latest_request_lifecycle_state.as_deref()),
+        conversation.and_then(|row| row.latest_request_projection),
         conversation.map(|row| row.status.as_str()).unwrap_or(""),
     )
 }
 
 pub(in crate::commands::codex_shim) fn projected_thread_status(
-    request_state: Option<&str>,
+    head: Option<ClientHeadProjection>,
     conversation_status: &str,
 ) -> codex::ThreadStatus {
-    match request_state.map(str::trim) {
-        Some("pending" | "claimed" | "processing") => codex::ThreadStatus::Active {
-            active_flags: Vec::new(),
-        },
-        Some("inputRequired") => codex::ThreadStatus::Active {
+    match head {
+        Some(head) if head.waiting_on_user_input() => codex::ThreadStatus::Active {
             active_flags: vec![codex::ThreadActiveFlag::WaitingOnUserInput],
         },
-        Some("failed" | "dead") => codex::ThreadStatus::SystemError,
-        Some("completed" | "superseded" | "interrupted") => codex::ThreadStatus::Idle,
-        _ if conversation_status.trim() == "error" => codex::ThreadStatus::SystemError,
+        Some(ClientHeadProjection {
+            turn_state: ClientTurnState::WaitingForClaim | ClientTurnState::Streaming,
+            ..
+        }) => codex::ThreadStatus::Active {
+            active_flags: Vec::new(),
+        },
+        Some(ClientHeadProjection {
+            turn_state: ClientTurnState::Failed,
+            ..
+        }) => codex::ThreadStatus::SystemError,
+        Some(_) => codex::ThreadStatus::Idle,
+        None if conversation_status.trim() == "error" => codex::ThreadStatus::SystemError,
         _ => codex::ThreadStatus::Idle,
     }
 }
@@ -240,7 +247,11 @@ mod tests {
                 behavior_id: "code-review".to_string(),
                 model: Some("child-model".to_string()),
                 nickname: "reviewer".to_string(),
-                lifecycle_state: "processing".to_string(),
+                client_projection: gents_protocol::client_protocol::project_persisted_attempt(
+                    "processing",
+                    false,
+                    None,
+                ),
                 failure_reason: None,
                 created_at: None,
             }),
@@ -269,19 +280,26 @@ mod tests {
     #[test]
     fn thread_status_projects_runtime_request_lifecycle() {
         let cases = [
-            (Some("pending"), "active", None),
-            (Some("claimed"), "active", None),
-            (Some("processing"), "active", None),
-            (Some("inputRequired"), "active", Some("waitingOnUserInput")),
-            (Some("completed"), "idle", None),
-            (Some("superseded"), "idle", None),
-            (Some("interrupted"), "idle", None),
-            (Some("failed"), "systemError", None),
-            (Some("dead"), "systemError", None),
+            ("pending", None, "active", None),
+            ("claimed", None, "active", None),
+            ("processing", None, "active", None),
+            ("inputRequired", None, "active", Some("waitingOnUserInput")),
+            ("completed", None, "idle", None),
+            ("superseded", None, "idle", None),
+            ("interrupted", None, "idle", None),
+            ("failed", None, "systemError", None),
+            ("dead", None, "systemError", None),
+            ("processing", Some("complete"), "idle", None),
+            ("processing", Some("error"), "systemError", None),
         ];
 
-        for (runtime_state, expected_type, expected_flag) in cases {
-            let encoded = serde_json::to_value(projected_thread_status(runtime_state, ""))
+        for (runtime_state, response_status, expected_type, expected_flag) in cases {
+            let head = gents_protocol::client_protocol::project_persisted_attempt(
+                runtime_state,
+                false,
+                response_status,
+            );
+            let encoded = serde_json::to_value(projected_thread_status(head, ""))
                 .expect("encode thread status");
             assert_eq!(
                 encoded.pointer("/type"),

--- a/crates/gents-cli/src/commands/codex_shim/thread_projection/storage.rs
+++ b/crates/gents-cli/src/commands/codex_shim/thread_projection/storage.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
+use gents_protocol::graphql::{parse_turn_state_response, turn_state_query, GraphqlTurnState};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -222,29 +223,49 @@ pub(super) async fn load_conversation(
         .map(serde_json::from_value)
         .transpose()
         .context("decoding AgentConversation row")?;
-    Ok(attach_latest_request(
-        conversation,
-        response.pointer("/data/AgentRequest/0"),
-    ))
+    let fallback_turn = GraphqlTurnState {
+        request: response
+            .pointer("/data/AgentRequest/0")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .context("decoding latest AgentRequest row")?,
+        response: None,
+    };
+    let mut conversation = attach_latest_request(conversation, Some(&fallback_turn));
+    let request_id = conversation
+        .as_ref()
+        .map(|row| row.latest_request_id.trim())
+        .filter(|request_id| !request_id.is_empty());
+    if let Some(request_id) = request_id {
+        let response = query_node_json(&state.node, &turn_state_query(request_id)).await?;
+        let turn = parse_turn_state_response(&response).context("decoding latest turn state")?;
+        if turn.request.is_some() {
+            conversation = attach_latest_request(conversation, Some(&turn));
+        }
+    }
+    Ok(conversation)
 }
 
 fn attach_latest_request(
     mut conversation: Option<ConversationRow>,
-    request: Option<&Value>,
+    turn: Option<&GraphqlTurnState>,
 ) -> Option<ConversationRow> {
+    let request = turn.and_then(|turn| turn.request.as_ref());
     if conversation.is_none() && request.is_some() {
         conversation = Some(ConversationRow::default());
     }
     if let Some(conversation) = conversation.as_mut() {
-        conversation.latest_request_lifecycle_state = request
-            .and_then(|row| row.get("lifecycle_state"))
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned);
+        if conversation.latest_request_id.trim().is_empty() {
+            conversation.latest_request_id = request
+                .map(|row| row.request_id.trim())
+                .filter(|request_id| !request_id.is_empty())
+                .unwrap_or_default()
+                .to_string();
+        }
+        conversation.latest_request_projection = turn.and_then(GraphqlTurnState::projected_head);
         conversation.latest_request_failure_reason = request
-            .and_then(|row| row.get("failure_reason"))
-            .and_then(Value::as_str)
+            .and_then(|row| row.failure_reason.as_deref())
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
@@ -349,17 +370,25 @@ mod tests {
 
     #[test]
     fn pending_request_projects_even_before_conversation_materializes() {
-        let request = json!({
+        let request = serde_json::from_value(json!({
             "request_id": "request-1",
             "lifecycle_state": "pending",
             "failure_reason": ""
-        });
-        let conversation = attach_latest_request(None, Some(&request))
+        }))
+        .expect("decode request");
+        let turn = GraphqlTurnState {
+            request: Some(request),
+            response: None,
+        };
+        let conversation = attach_latest_request(None, Some(&turn))
             .expect("request should provide a projection shell");
         assert_eq!(
-            conversation.latest_request_lifecycle_state.as_deref(),
-            Some("pending")
+            conversation
+                .latest_request_projection
+                .map(|head| head.request_state),
+            Some(gents_protocol::client_protocol::RequestLifecycleState::Pending)
         );
+        assert_eq!(conversation.latest_request_id, "request-1");
         assert_eq!(conversation.latest_request_failure_reason, None);
     }
 

--- a/crates/gents-cli/src/commands/codex_shim/turn/active.rs
+++ b/crates/gents-cli/src/commands/codex_shim/turn/active.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
+use gents_protocol::client_protocol::{project_persisted_attempt, RequestLifecycleState};
 use serde_json::{json, Value};
 use tokio::sync::watch;
 
@@ -24,7 +25,8 @@ pub(super) struct NextSteeringRequest {
 
 impl NextSteeringRequest {
     pub(super) fn is_pending(&self) -> bool {
-        self.lifecycle_state == "pending"
+        RequestLifecycleState::try_from(self.lifecycle_state.as_str())
+            .is_ok_and(|state| state == RequestLifecycleState::Pending)
     }
 }
 
@@ -32,6 +34,8 @@ impl NextSteeringRequest {
 struct RequestRow {
     request_id: String,
     lifecycle_state: String,
+    superseded_by_request: Option<String>,
+    response_status: Option<String>,
     metadata: Option<String>,
     created_at: String,
 }
@@ -125,7 +129,7 @@ pub(super) async fn steering_request_ids_for_turn_interrupt_cleanup(
     let mut request_ids = Vec::new();
     for row in rows.iter().filter(|row| {
         row.request_id != interrupt_request_id
-            && row.lifecycle_state_is_active()
+            && row.is_effectively_active()
             && steering_parent_id(row).is_some()
     }) {
         let (root, _) = codex_turn_root_and_depth(row, &by_id)?;
@@ -297,20 +301,66 @@ async fn load_thread_request_rows(state: &ShimState, thread_id: &str) -> Result<
             ) {{
                 request_id
                 lifecycle_state
+                superseded_by_request
                 metadata
+                created_at
+            }}
+            AgentResponse(
+                filter: {{
+                    session_id: {{ _eq: "{thread_id}" }},
+                    agent_did: {{ _eq: "{agent_did}" }}
+                }},
+                order: {{ created_at: ASC }}
+            ) {{
+                request_id
+                status
                 created_at
             }}
         }}"#
     );
     let response = query_node_json(state.node.as_ref(), &query).await?;
-    response
+    let mut rows = response
         .pointer("/data/AgentRequest")
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
         .into_iter()
         .map(decode_request_row)
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    let latest_response_status = response
+        .pointer("/data/AgentResponse")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .fold(
+            BTreeMap::<String, (String, String)>::new(),
+            |mut latest, row| {
+                let Some(request_id) = row.get("request_id").and_then(Value::as_str) else {
+                    return latest;
+                };
+                let Some(status) = row.get("status").and_then(Value::as_str) else {
+                    return latest;
+                };
+                let created_at = row
+                    .get("created_at")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let replace = latest
+                    .get(request_id)
+                    .is_none_or(|(_, previous_created_at)| created_at > *previous_created_at);
+                if replace {
+                    latest.insert(request_id.to_string(), (status.to_string(), created_at));
+                }
+                latest
+            },
+        );
+    for row in &mut rows {
+        row.response_status = latest_response_status
+            .get(&row.request_id)
+            .map(|(status, _)| status.clone());
+    }
+    Ok(rows)
 }
 
 fn decode_request_row(row: Value) -> Result<RequestRow> {
@@ -324,6 +374,12 @@ fn decode_request_row(row: Value) -> Result<RequestRow> {
         .and_then(Value::as_str)
         .unwrap_or("")
         .to_string();
+    let superseded_by_request = row
+        .get("superseded_by_request")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
     let metadata = row
         .get("metadata")
         .and_then(Value::as_str)
@@ -336,6 +392,8 @@ fn decode_request_row(row: Value) -> Result<RequestRow> {
     Ok(RequestRow {
         request_id,
         lifecycle_state,
+        superseded_by_request,
+        response_status: None,
         metadata,
         created_at,
     })
@@ -351,7 +409,7 @@ fn active_codex_turn_from_rows(
         .collect::<BTreeMap<_, _>>();
     let active_rows = rows
         .iter()
-        .filter(|row| row.lifecycle_state_is_active())
+        .filter(|row| row.is_effectively_active())
         .collect::<Vec<_>>();
 
     let mut candidates = Vec::<(&RequestRow, String, usize)>::new();
@@ -435,11 +493,13 @@ fn steering_parent_id(row: &RequestRow) -> Option<String> {
 }
 
 impl RequestRow {
-    fn lifecycle_state_is_active(&self) -> bool {
-        matches!(
-            self.lifecycle_state.as_str(),
-            "pending" | "claimed" | "processing" | "inputRequired"
+    fn is_effectively_active(&self) -> bool {
+        project_persisted_attempt(
+            &self.lifecycle_state,
+            self.superseded_by_request.is_some(),
+            self.response_status.as_deref(),
         )
+        .is_some_and(|head| head.is_active())
     }
 }
 
@@ -462,6 +522,8 @@ mod tests {
         RequestRow {
             request_id: request_id.to_string(),
             lifecycle_state: lifecycle_state.to_string(),
+            superseded_by_request: None,
+            response_status: None,
             metadata,
             created_at: request_id.to_string(),
         }
@@ -501,6 +563,20 @@ mod tests {
         assert_eq!(active.turn_id, "turn-1");
         assert_eq!(active.interrupt_request_id, "steer-1");
         assert_eq!(active.current_request_id, "steer-1");
+    }
+
+    #[test]
+    fn terminal_response_excludes_stale_processing_request_from_active_turn() {
+        let mut completed = row("turn-1", "processing", None);
+        completed.response_status = Some("complete".to_string());
+        assert_eq!(
+            active_codex_turn_from_rows(&[completed], None).unwrap(),
+            None
+        );
+
+        let mut failed = row("turn-2", "processing", None);
+        failed.response_status = Some("error".to_string());
+        assert_eq!(active_codex_turn_from_rows(&[failed], None).unwrap(), None);
     }
 
     #[test]

--- a/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
+++ b/crates/gents-cli/src/commands/codex_shim/turn/stream.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
@@ -6,25 +6,29 @@ use anyhow::{Context, Result};
 use gents::UpdateSubscriptionSource;
 use gents_codex_protocol as codex;
 use gents_codex_protocol::MessagePhase;
+use gents_protocol::client_protocol::project_persisted_attempt;
 use serde_json::{json, Value};
 use tokio::sync::watch;
 
 use super::super::background::spawn_background_tool_watcher;
 use super::super::bound_behavior::load_bound_context_window;
 use super::super::command_projection::{
+    observed_command_status, observed_mcp_status, observed_patch_status,
     tool_projection_status_with_settled, update_running_background_tools, ToolProjectionStatus,
 };
 use super::super::compaction_projection::decode_gents_compaction_progress;
 use super::super::progress::{
-    content_delta, decode_gents_tool_call_progress, gents_turn_progress_query,
-    response_field_is_blank, terminal_error_message, terminal_turn_status, timestamp_millis,
+    codex_turn_status, content_delta, decode_gents_tool_call_progress, gents_turn_progress_query,
+    response_field_is_blank, terminal_error_message, timestamp_millis,
 };
+use super::super::projection_state::{stabilize_projection_kind, ChildStatus, CollabProjection};
 use super::super::protocol::{
     send_committed_user_message, send_notification, send_thread_status_changed,
 };
 use super::super::store::{hydrate_materialized_response_content, query_node_json};
 use super::super::subagent_projection::{
     attach_subagent_link, is_subagent_control_tool, load_authorized_subagent_threads_for_root,
+    observed_child_status, observed_collab_status, observed_collab_tool,
     SubagentProjectionUpdateFilter,
 };
 use super::super::thread_projection::{
@@ -34,7 +38,7 @@ use super::super::thread_projection::{
 use super::super::turn_projection::TurnProjection;
 use super::super::{ConnectionState, ShimState};
 use super::active::next_steering_request_after;
-use crate::{is_terminal_lifecycle_state, request_diagnostic_hint, SubmittedRequest};
+use crate::{request_diagnostic_hint, SubmittedRequest};
 
 const SUBAGENT_LINK_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -193,8 +197,7 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
     let mut known_tool_markers: BTreeMap<String, ToolProgressMarker> = BTreeMap::new();
     let mut known_compaction_states: BTreeMap<String, String> = BTreeMap::new();
     let mut known_inference_usage_call_id: Option<String> = None;
-    let mut running_background_tools: BTreeMap<String, codex::CommandExecutionStatus> =
-        BTreeMap::new();
+    let mut running_background_tools = BTreeSet::new();
     let mut updates = state.node.subscribe_updates();
     let mut updates_closed = false;
     let subagent_update_filter = SubagentProjectionUpdateFilter::from_state(state);
@@ -282,8 +285,9 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
                 .and_then(response_terminal_timestamp)
                 .and_then(timestamp_millis),
         );
-        let projection_settled = is_terminal_lifecycle_state(lifecycle_state)
-            || matches!(response_status, "complete" | "completed" | "error");
+        let client_head = project_persisted_attempt(lifecycle_state, false, Some(response_status));
+        let client_turn_state = client_head.map(|head| head.turn_state);
+        let projection_settled = client_turn_state.is_some_and(|state| state.is_terminal());
 
         let marker = progress_marker(request_row, response_row, tool_rows, inference_call_rows);
         let marker_changed = latest_progress_marker.as_ref() != Some(&marker);
@@ -415,9 +419,11 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
             if has_subagent_control {
                 attach_subagent_link(&mut tool, &subagent_links);
             }
-            let projection_status =
+            let observed_projection_status =
                 tool_projection_status_with_settled(&tool, projection_settled, link_settle_expired);
             let previous_status = known_tool_calls.get(&tool.tool_call_key).cloned();
+            let projection_status =
+                stabilize_projection_kind(previous_status.as_ref(), observed_projection_status);
             update_running_background_tools(
                 &mut running_background_tools,
                 &tool,
@@ -462,10 +468,7 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
             .and_then(|row| row.get("failure_reason"))
             .and_then(Value::as_str)
             .unwrap_or("");
-        let terminal_by_request = is_terminal_lifecycle_state(lifecycle_state);
-        let terminal_by_response = matches!(response_status, "complete" | "completed" | "error");
-
-        if (terminal_by_request || terminal_by_response) && !waiting_for_subagent_links {
+        if projection_settled && !waiting_for_subagent_links {
             let mut terminal_response = response_row.cloned().unwrap_or_else(|| {
                 json!({
                     "request_id": current.request_id.clone(),
@@ -521,7 +524,9 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
                 projection.append_agent_delta(outbound, &delta).await?;
             }
 
-            let turn_status = terminal_turn_status(lifecycle_state, response_status);
+            let turn_status = codex_turn_status(
+                client_turn_state.expect("settled client turn state must be present"),
+            );
             let error_message = if turn_status == codex::TurnStatus::Failed {
                 terminal_error_message(
                     response_status,
@@ -639,7 +644,7 @@ pub(in crate::commands::codex_shim) async fn stream_gents_turn(
                 outbound,
                 state,
                 projection.thread_id,
-                projected_thread_status(Some(lifecycle_state), ""),
+                projected_thread_status(client_head, ""),
             )
             .await?;
             spawn_background_tool_watcher(
@@ -793,14 +798,22 @@ fn prime_projection_from_turn(
             }
             codex::ThreadItem::Reasoning { .. } => {}
             codex::ThreadItem::McpToolCall { id, status, .. } => {
-                known_tool_calls.insert(id.clone(), ToolProjectionStatus::Mcp(status.clone()));
+                known_tool_calls.insert(
+                    id.clone(),
+                    ToolProjectionStatus::Mcp(observed_mcp_status(status)),
+                );
             }
             codex::ThreadItem::CommandExecution { id, status, .. } => {
-                known_tool_calls.insert(id.clone(), ToolProjectionStatus::Command(status.clone()));
+                known_tool_calls.insert(
+                    id.clone(),
+                    ToolProjectionStatus::Command(observed_command_status(status)),
+                );
             }
             codex::ThreadItem::FileChange { id, status, .. } => {
-                known_tool_calls
-                    .insert(id.clone(), ToolProjectionStatus::FileChange(status.clone()));
+                known_tool_calls.insert(
+                    id.clone(),
+                    ToolProjectionStatus::FileChange(observed_patch_status(status)),
+                );
             }
             codex::ThreadItem::CollabAgentToolCall {
                 id,
@@ -817,19 +830,16 @@ fn prime_projection_from_turn(
                 let child = agents_states.get(receiver_thread_id);
                 known_tool_calls.insert(
                     id.clone(),
-                    ToolProjectionStatus::Collab(
-                        super::super::subagent_projection::CollabProjection {
-                            status: status.clone(),
-                            tool: tool.clone(),
-                            receiver_thread_id: receiver_thread_id.clone(),
-                            child_model: model.clone(),
-                            child_lifecycle_state: child
-                                .map(|state| collab_lifecycle_state(&state.status))
-                                .unwrap_or("")
-                                .to_string(),
-                            child_failure_reason: child.and_then(|state| state.message.clone()),
-                        },
-                    ),
+                    ToolProjectionStatus::Collab(CollabProjection {
+                        status: observed_collab_status(status),
+                        tool: observed_collab_tool(tool),
+                        receiver_thread_id: receiver_thread_id.clone(),
+                        child_model: model.clone(),
+                        child_status: child
+                            .map(|state| observed_child_status(&state.status))
+                            .unwrap_or(ChildStatus::NotFound),
+                        child_failure_reason: child.and_then(|state| state.message.clone()),
+                    }),
                 );
             }
             codex::ThreadItem::ContextCompaction { id } => {
@@ -868,16 +878,6 @@ fn resumable_reasoning_item(turn: &codex::Turn, preferred_id: &str) -> Option<(S
         };
         (!text.trim().is_empty()).then(|| (id.clone(), text))
     })
-}
-
-fn collab_lifecycle_state(status: &codex::CollabAgentStatus) -> &'static str {
-    match status {
-        codex::CollabAgentStatus::PendingInit => "pending",
-        codex::CollabAgentStatus::Running => "processing",
-        codex::CollabAgentStatus::Completed | codex::CollabAgentStatus::Shutdown => "completed",
-        codex::CollabAgentStatus::Errored | codex::CollabAgentStatus::NotFound => "failed",
-        codex::CollabAgentStatus::Interrupted => "interrupted",
-    }
 }
 
 fn content_delta_from_cursor(cursor: &mut ContentCursor, current: &str) -> String {
@@ -1275,7 +1275,7 @@ async fn finish_interrupted_turn(
     state: &ShimState,
     submitted: &SubmittedRequest,
     projection: &mut TurnProjection<'_>,
-    running_background_tools: BTreeMap<String, codex::CommandExecutionStatus>,
+    running_background_tools: BTreeSet<String>,
 ) -> Result<()> {
     projection
         .finish_turn(&connection.outbound, codex::TurnStatus::Interrupted, None)

--- a/crates/gents-cli/src/commands/codex_shim/turn_projection.rs
+++ b/crates/gents-cli/src/commands/codex_shim/turn_projection.rs
@@ -6,7 +6,8 @@ use gents_codex_protocol as codex;
 use gents_codex_protocol::MessagePhase;
 
 use super::command_projection::{
-    command_execution_item, command_output_payload, file_change_item, ToolProjectionStatus,
+    codex_command_status, codex_mcp_status, codex_patch_status, command_execution_item,
+    command_output_payload, file_change_item, ToolProjectionStatus,
 };
 use super::compaction_projection::{
     compaction_projection_events, context_compaction_item, CompactionProjectionEvent,
@@ -15,11 +16,14 @@ use super::compaction_projection::{
 use super::progress::{
     gents_tool_item, tool_completed_at_ms, tool_started_at_ms, GentsToolCallProgress,
 };
+use super::projection_state::{
+    collab_projection_events, CollabProjection, ProjectionEvent, ProjectionStatus,
+};
 use super::protocol::{
     agent_message_item, agent_message_item_with_phase, now_millis, send_notification,
     turn_value_with_timing,
 };
-use super::subagent_projection::{collab_tool_item, CollabProjection};
+use super::subagent_projection::collab_tool_item;
 use super::{Outbound, ShimState};
 
 #[derive(Default)]
@@ -56,7 +60,6 @@ pub(super) struct TurnProjection<'a> {
     active_reasoning_item_id: Option<String>,
     active_reasoning_text: String,
     completed_reasoning_items: ReasoningCompletionTracker,
-    completed_items: Vec<codex::ThreadItem>,
 }
 
 impl<'a> TurnProjection<'a> {
@@ -82,7 +85,6 @@ impl<'a> TurnProjection<'a> {
             active_reasoning_item_id: None,
             active_reasoning_text: String::new(),
             completed_reasoning_items: ReasoningCompletionTracker::default(),
-            completed_items: Vec::new(),
         }
     }
 
@@ -224,7 +226,6 @@ impl<'a> TurnProjection<'a> {
         )
         .await?;
         self.completed_reasoning_items.record(item_id);
-        self.completed_items.push(item);
         Ok(())
     }
 
@@ -311,7 +312,6 @@ impl<'a> TurnProjection<'a> {
             }),
         )
         .await?;
-        self.completed_items.push(completed_item);
         Ok(())
     }
 
@@ -355,7 +355,6 @@ impl<'a> TurnProjection<'a> {
             }),
         )
         .await?;
-        self.completed_items.push(completed_item);
         Ok(())
     }
 
@@ -415,7 +414,6 @@ impl<'a> TurnProjection<'a> {
             }),
         )
         .await?;
-        self.completed_items.push(completed_item);
         Ok(())
     }
 
@@ -451,7 +449,7 @@ impl<'a> TurnProjection<'a> {
         self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
             .await?;
         let mut started = projection.clone();
-        started.status = codex::CollabAgentToolCallStatus::InProgress;
+        started.status = ProjectionStatus::InProgress;
         send_notification(
             outbound,
             self.state,
@@ -485,15 +483,6 @@ impl<'a> TurnProjection<'a> {
             }),
         )
         .await?;
-        if let Some(existing) = self
-            .completed_items
-            .iter()
-            .position(|existing| existing.id() == item.id())
-        {
-            self.completed_items[existing] = item;
-        } else {
-            self.completed_items.push(item);
-        }
         Ok(())
     }
 
@@ -519,7 +508,6 @@ impl<'a> TurnProjection<'a> {
             }),
         )
         .await?;
-        self.completed_items.push(item);
         Ok(())
     }
 
@@ -530,6 +518,22 @@ impl<'a> TurnProjection<'a> {
         previous: Option<&ToolProjectionStatus>,
         current: &ToolProjectionStatus,
     ) -> Result<()> {
+        if let ToolProjectionStatus::Collab(projection) = current {
+            let events = collab_projection_events(previous, projection);
+            for event in events {
+                match event {
+                    ProjectionEvent::Started => {
+                        self.send_collab_started(outbound, tool, projection).await?
+                    }
+                    ProjectionEvent::Completed => {
+                        self.send_collab_completed(outbound, tool, projection)
+                            .await?
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         match (previous, current) {
             (Some(ToolProjectionStatus::Command(_)), ToolProjectionStatus::Mcp(status)) => {
                 let mut foreground_tool = tool.clone();
@@ -540,42 +544,40 @@ impl<'a> TurnProjection<'a> {
                     codex::CommandExecutionStatus::Completed,
                 )
                 .await?;
-                if *status != codex::McpToolCallStatus::InProgress {
+                if *status != ProjectionStatus::InProgress {
                     self.send_tool_started(outbound, tool).await?;
                 }
                 match status {
-                    codex::McpToolCallStatus::InProgress => {
-                        self.send_tool_started(outbound, tool).await
-                    }
-                    codex::McpToolCallStatus::Completed | codex::McpToolCallStatus::Failed => {
-                        self.send_tool_completed(outbound, tool, status.clone())
+                    ProjectionStatus::InProgress => self.send_tool_started(outbound, tool).await,
+                    ProjectionStatus::Completed | ProjectionStatus::Failed => {
+                        self.send_tool_completed(outbound, tool, codex_mcp_status(*status))
                             .await
                     }
                 }
             }
             (None, ToolProjectionStatus::Mcp(status))
-                if *status != codex::McpToolCallStatus::InProgress =>
+                if *status != ProjectionStatus::InProgress =>
             {
                 self.send_tool_started(outbound, tool).await?;
-                self.send_tool_completed(outbound, tool, status.clone())
+                self.send_tool_completed(outbound, tool, codex_mcp_status(*status))
                     .await
             }
             (Some(ToolProjectionStatus::DeferredCollab), ToolProjectionStatus::Mcp(status))
-                if *status != codex::McpToolCallStatus::InProgress =>
+                if *status != ProjectionStatus::InProgress =>
             {
                 self.send_tool_started(outbound, tool).await?;
-                self.send_tool_completed(outbound, tool, status.clone())
+                self.send_tool_completed(outbound, tool, codex_mcp_status(*status))
                     .await
             }
-            (_, ToolProjectionStatus::Mcp(codex::McpToolCallStatus::InProgress)) => {
+            (_, ToolProjectionStatus::Mcp(ProjectionStatus::InProgress)) => {
                 self.send_tool_started(outbound, tool).await
             }
             (_, ToolProjectionStatus::Mcp(status)) => {
-                self.send_tool_completed(outbound, tool, status.clone())
+                self.send_tool_completed(outbound, tool, codex_mcp_status(*status))
                     .await
             }
             (None, ToolProjectionStatus::Command(status))
-                if *status != codex::CommandExecutionStatus::InProgress =>
+                if *status != ProjectionStatus::InProgress =>
             {
                 self.send_command_execution_started(
                     outbound,
@@ -583,48 +585,38 @@ impl<'a> TurnProjection<'a> {
                     codex::CommandExecutionStatus::InProgress,
                 )
                 .await?;
-                self.send_command_execution_completed(outbound, tool, status.clone())
+                self.send_command_execution_completed(outbound, tool, codex_command_status(*status))
                     .await
             }
-            (_, ToolProjectionStatus::Command(codex::CommandExecutionStatus::InProgress)) => {
-                self.send_command_execution_started(outbound, tool, current.command_status())
-                    .await
+            (_, ToolProjectionStatus::Command(ProjectionStatus::InProgress)) => {
+                self.send_command_execution_started(
+                    outbound,
+                    tool,
+                    codex_command_status(current.command_status()),
+                )
+                .await
             }
             (_, ToolProjectionStatus::Command(status)) => {
-                self.send_command_execution_completed(outbound, tool, status.clone())
+                self.send_command_execution_completed(outbound, tool, codex_command_status(*status))
                     .await
             }
-            (
-                None | Some(ToolProjectionStatus::DeferredCollab),
-                ToolProjectionStatus::Collab(projection),
-            ) if projection.status != codex::CollabAgentToolCallStatus::InProgress => {
-                self.send_collab_started(outbound, tool, projection).await?;
-                self.send_collab_completed(outbound, tool, projection).await
-            }
-            (_, ToolProjectionStatus::Collab(projection))
-                if projection.status == codex::CollabAgentToolCallStatus::InProgress =>
-            {
-                self.send_collab_started(outbound, tool, projection).await
-            }
-            (_, ToolProjectionStatus::Collab(projection)) => {
-                self.send_collab_completed(outbound, tool, projection).await
-            }
+            (_, ToolProjectionStatus::Collab(_)) => unreachable!("handled above"),
             (_, ToolProjectionStatus::DeferredCollab) => Ok(()),
             (_, ToolProjectionStatus::DeferredFileChange) => Ok(()),
             (None, ToolProjectionStatus::FileChange(status))
             | (
                 Some(ToolProjectionStatus::DeferredFileChange),
                 ToolProjectionStatus::FileChange(status),
-            ) if *status != codex::PatchApplyStatus::InProgress => {
+            ) if *status != ProjectionStatus::InProgress => {
                 self.send_file_change_started(outbound, tool).await?;
-                self.send_file_change_completed(outbound, tool, status.clone())
+                self.send_file_change_completed(outbound, tool, codex_patch_status(*status))
                     .await
             }
-            (_, ToolProjectionStatus::FileChange(codex::PatchApplyStatus::InProgress)) => {
+            (_, ToolProjectionStatus::FileChange(ProjectionStatus::InProgress)) => {
                 self.send_file_change_started(outbound, tool).await
             }
             (_, ToolProjectionStatus::FileChange(status)) => {
-                self.send_file_change_completed(outbound, tool, status.clone())
+                self.send_file_change_completed(outbound, tool, codex_patch_status(*status))
                     .await
             }
         }
@@ -672,7 +664,6 @@ impl<'a> TurnProjection<'a> {
                         ),
                     )
                     .await?;
-                    self.completed_items.push(item);
                 }
             }
         }

--- a/crates/gents-cli/src/commands/trace.rs
+++ b/crates/gents-cli/src/commands/trace.rs
@@ -23,8 +23,8 @@ use gents::run_timeline::{
 };
 use gents::run_timeline_fetch::{load_run_timeline, load_run_timeline_rows};
 use gents::trace_export::{
-    analyze_request_failure, analyze_tool_call, extract_raw_tool_call_json, latency_ms,
-    raw_message_json, AmyToolCallTraceRecord,
+    analyze_request_failure, analyze_tool_call_with_persisted_outcome, extract_raw_tool_call_json,
+    latency_ms, raw_message_json, AmyToolCallTraceRecord,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -1178,11 +1178,18 @@ fn build_records(
             });
             let request_failure = combined_request_failure_text(request, response);
             let request_failure_class = analyze_request_failure(request_failure.as_deref());
-            let analysis = analyze_tool_call(
+            let lifecycle_state = tool_call
+                .lifecycle_state
+                .as_deref()
+                .filter(|state| !state.trim().is_empty());
+            let observed_tool_status = lifecycle_state.unwrap_or(&tool_call.status);
+            let analysis = analyze_tool_call_with_persisted_outcome(
                 &tool_call.tool_name,
                 &tool_call.args,
                 &tool_call.result,
                 &tool_call.status,
+                lifecycle_state,
+                tool_call.tool_failure_class.as_deref(),
             );
             let message = tool_call
                 .message_sequence
@@ -1260,8 +1267,8 @@ fn build_records(
                 tool_result: tool_call.result.clone(),
                 native_tool_output: analysis.native_tool_output,
                 tool_result_ok: analysis.tool_result_ok,
-                tool_call_completed: tool_call.status.eq_ignore_ascii_case("completed"),
-                tool_status: tool_call.status.clone(),
+                tool_call_completed: observed_tool_status.eq_ignore_ascii_case("completed"),
+                tool_status: observed_tool_status.to_string(),
                 task_outcome: None,
                 tool_failure_class: analysis.tool_failure_class,
                 tool_error: analysis.tool_error,
@@ -1306,6 +1313,8 @@ async fn load_tool_calls(
                 args
                 result
                 status
+                lifecycle_state
+                tool_failure_class
                 started_at
                 completed_at
             }}
@@ -1769,6 +1778,10 @@ struct ToolCallRow {
     result: String,
     #[serde(default)]
     status: String,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    tool_failure_class: Option<String>,
     #[serde(default)]
     started_at: Option<String>,
     #[serde(default)]
@@ -2472,6 +2485,8 @@ mod tests {
             args: String::new(),
             result: String::new(),
             status: String::new(),
+            lifecycle_state: None,
+            tool_failure_class: None,
             started_at: None,
             completed_at: None,
         }

--- a/crates/gents-desktop-core/src/client/store/turns.rs
+++ b/crates/gents-desktop-core/src/client/store/turns.rs
@@ -142,10 +142,5 @@ fn attempt_for_request_for_agent(
 }
 
 fn response_status(row: &AgentResponseRow) -> Option<ResponseStatus> {
-    match row.status.as_deref().unwrap_or_default() {
-        "streaming" => Some(ResponseStatus::Streaming),
-        "complete" | "completed" => Some(ResponseStatus::Complete),
-        "error" | "failed" => Some(ResponseStatus::Error),
-        _ => None,
-    }
+    ResponseStatus::try_from(row.status.as_deref().unwrap_or_default()).ok()
 }

--- a/crates/gents-protocol/src/client_protocol.rs
+++ b/crates/gents-protocol/src/client_protocol.rs
@@ -121,6 +121,40 @@ pub enum ResponseStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidResponseStatus {
+    status: String,
+}
+
+impl InvalidResponseStatus {
+    pub fn value(&self) -> &str {
+        &self.status
+    }
+}
+
+impl Display for InvalidResponseStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid response status: {}", self.status)
+    }
+}
+
+impl Error for InvalidResponseStatus {}
+
+impl TryFrom<&str> for ResponseStatus {
+    type Error = InvalidResponseStatus;
+
+    fn try_from(value: &str) -> Result<Self, InvalidResponseStatus> {
+        match value {
+            "streaming" => Ok(Self::Streaming),
+            "complete" | "completed" => Ok(Self::Complete),
+            "error" | "failed" | "failure" => Ok(Self::Error),
+            _ => Err(InvalidResponseStatus {
+                status: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RequestSnapshot {
     pub request_id: String,
     pub retry_parent_request: Option<String>,
@@ -139,12 +173,79 @@ pub struct AttemptView {
     pub response: Option<ResponseSnapshot>,
 }
 
+/// Response-aware state for the current request at the head of a client turn.
+///
+/// `turn_state` is the durable outcome projection. `request_state` preserves
+/// the request-side detail that clients need for presentation distinctions
+/// such as pending versus running and waiting for user input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClientHeadProjection {
+    pub turn_state: ClientTurnState,
+    pub request_state: RequestLifecycleState,
+}
+
+impl ClientHeadProjection {
+    pub fn is_terminal(self) -> bool {
+        self.turn_state.is_terminal()
+    }
+
+    pub fn is_active(self) -> bool {
+        !self.is_terminal()
+    }
+
+    pub fn waiting_on_user_input(self) -> bool {
+        self.is_active() && self.request_state == RequestLifecycleState::InputRequired
+    }
+}
+
+pub fn project_attempt(view: &AttemptView) -> ClientHeadProjection {
+    ClientHeadProjection {
+        turn_state: derive_observation(
+            view.request.lifecycle_state,
+            view.request.is_superseded,
+            view.response.as_ref().map(|response| response.status),
+        ),
+        request_state: view.request.lifecycle_state,
+    }
+}
+
 pub fn derive_attempt(view: &AttemptView) -> ClientTurnState {
-    if view.request.is_superseded {
+    project_attempt(view).turn_state
+}
+
+pub fn project_persisted_attempt(
+    lifecycle_state: &str,
+    is_superseded: bool,
+    response_status: Option<&str>,
+) -> Option<ClientHeadProjection> {
+    let lifecycle_state = RequestLifecycleState::try_from(lifecycle_state.trim()).ok()?;
+    let response_status =
+        response_status.and_then(|status| ResponseStatus::try_from(status.trim()).ok());
+    Some(ClientHeadProjection {
+        turn_state: derive_observation(lifecycle_state, is_superseded, response_status),
+        request_state: lifecycle_state,
+    })
+}
+
+pub fn derive_persisted_attempt(
+    lifecycle_state: &str,
+    is_superseded: bool,
+    response_status: Option<&str>,
+) -> Option<ClientTurnState> {
+    project_persisted_attempt(lifecycle_state, is_superseded, response_status)
+        .map(|head| head.turn_state)
+}
+
+fn derive_observation(
+    lifecycle_state: RequestLifecycleState,
+    is_superseded: bool,
+    response_status: Option<ResponseStatus>,
+) -> ClientTurnState {
+    if is_superseded {
         return ClientTurnState::Superseded;
     }
 
-    match view.request.lifecycle_state {
+    match lifecycle_state {
         RequestLifecycleState::Superseded => ClientTurnState::Superseded,
         RequestLifecycleState::Completed => ClientTurnState::Completed,
         RequestLifecycleState::Failed | RequestLifecycleState::Dead => ClientTurnState::Failed,
@@ -152,8 +253,8 @@ pub fn derive_attempt(view: &AttemptView) -> ClientTurnState {
         RequestLifecycleState::Pending
         | RequestLifecycleState::Claimed
         | RequestLifecycleState::Processing
-        | RequestLifecycleState::InputRequired => match &view.response {
-            Some(resp) => match resp.status {
+        | RequestLifecycleState::InputRequired => match response_status {
+            Some(status) => match status {
                 ResponseStatus::Complete => ClientTurnState::Completed,
                 ResponseStatus::Error => ClientTurnState::Failed,
                 ResponseStatus::Streaming => ClientTurnState::Streaming,

--- a/crates/gents-protocol/src/client_protocol/tests.rs
+++ b/crates/gents-protocol/src/client_protocol/tests.rs
@@ -219,6 +219,36 @@ fn pending_with_complete_response_trusts_response() {
 }
 
 #[test]
+fn head_projection_preserves_request_detail_but_trusts_terminal_response() {
+    let head = project_attempt(&attempt(
+        "req-1",
+        None,
+        "processing",
+        resp(ResponseStatus::Complete),
+    ));
+    assert_eq!(head.turn_state, ClientTurnState::Completed);
+    assert_eq!(head.request_state, RequestLifecycleState::Processing);
+    assert!(head.is_terminal());
+    assert!(!head.is_active());
+}
+
+#[test]
+fn input_required_head_is_active_and_waiting_on_user() {
+    let head = project_attempt(&attempt("req-1", None, "inputRequired", None));
+    assert_eq!(head.turn_state, ClientTurnState::WaitingForClaim);
+    assert!(head.is_active());
+    assert!(head.waiting_on_user_input());
+}
+
+#[test]
+fn terminal_response_clears_input_required_presentation() {
+    let head = project_persisted_attempt("inputRequired", false, Some("error")).unwrap();
+    assert_eq!(head.turn_state, ClientTurnState::Failed);
+    assert!(head.is_terminal());
+    assert!(!head.waiting_on_user_input());
+}
+
+#[test]
 fn claimed_with_streaming_response_trusts_response() {
     assert_eq!(
         derive_attempt(&attempt(
@@ -504,4 +534,53 @@ fn turn_replacement_supersession_rank() {
         response: resp(ResponseStatus::Streaming),
     };
     assert_eq!(derive_attempt(&view).rank(), 2);
+}
+
+#[test]
+fn persisted_response_status_aliases_share_one_decoder() {
+    assert_eq!(
+        ResponseStatus::try_from("streaming"),
+        Ok(ResponseStatus::Streaming)
+    );
+    assert_eq!(
+        ResponseStatus::try_from("complete"),
+        Ok(ResponseStatus::Complete)
+    );
+    assert_eq!(
+        ResponseStatus::try_from("completed"),
+        Ok(ResponseStatus::Complete)
+    );
+    for status in ["error", "failed", "failure"] {
+        assert_eq!(ResponseStatus::try_from(status), Ok(ResponseStatus::Error));
+    }
+    assert_eq!(
+        ResponseStatus::try_from("interrupted")
+            .expect_err("unsupported status should fail")
+            .value(),
+        "interrupted"
+    );
+}
+
+#[test]
+fn persisted_attempt_projection_uses_generic_client_precedence() {
+    assert_eq!(
+        derive_persisted_attempt("completed", false, Some("error")),
+        Some(ClientTurnState::Completed)
+    );
+    assert_eq!(
+        derive_persisted_attempt("processing", false, Some("error")),
+        Some(ClientTurnState::Failed)
+    );
+    assert_eq!(
+        derive_persisted_attempt("failed", false, Some("complete")),
+        Some(ClientTurnState::Failed)
+    );
+    assert_eq!(
+        derive_persisted_attempt("superseded", false, Some("error")),
+        Some(ClientTurnState::Superseded)
+    );
+    assert_eq!(
+        derive_persisted_attempt("processing", false, Some("streaming")),
+        Some(ClientTurnState::Streaming)
+    );
 }

--- a/crates/gents-protocol/src/graphql.rs
+++ b/crates/gents-protocol/src/graphql.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::client_protocol::{
-    derive_turn as derive_client_turn, AttemptView, ClientTurnState, RequestLifecycleState,
+    project_attempt, AttemptView, ClientHeadProjection, ClientTurnState, RequestLifecycleState,
     RequestSnapshot, ResponseSnapshot, ResponseStatus,
 };
 use crate::row::{
@@ -44,9 +44,12 @@ pub struct GraphqlTurnState {
 }
 
 impl GraphqlTurnState {
+    pub fn projected_head(&self) -> Option<ClientHeadProjection> {
+        self.attempt_view().as_ref().map(project_attempt)
+    }
+
     pub fn derived_turn_state(&self) -> Option<ClientTurnState> {
-        let attempt = self.attempt_view()?;
-        derive_client_turn(&[attempt])
+        self.projected_head().map(|head| head.turn_state)
     }
 
     pub fn response_is_durably_complete(&self) -> bool {
@@ -836,6 +839,7 @@ pub fn turn_state_query(request_id: &str) -> String {
                 max_total_tokens
                 metadata
                 lifecycle_state
+                failure_reason
                 interrupt_requested_at
                 valid_until
             }}
@@ -979,12 +983,7 @@ pub fn parse_session_shape_response(
 }
 
 fn graphql_response_status(row: &AgentResponseRow) -> Option<ResponseStatus> {
-    match row.status.as_deref().unwrap_or_default() {
-        "streaming" => Some(ResponseStatus::Streaming),
-        "complete" | "completed" => Some(ResponseStatus::Complete),
-        "error" | "failed" | "failure" => Some(ResponseStatus::Error),
-        _ => None,
-    }
+    ResponseStatus::try_from(row.status.as_deref().unwrap_or_default()).ok()
 }
 
 fn finish_graphql_response(graphql: &str, value: serde_json::Value) -> Result<serde_json::Value> {
@@ -1111,6 +1110,7 @@ mod tests {
         assert!(turn_query.contains("top_k"));
         assert!(turn_query.contains("max_tokens"));
         assert!(turn_query.contains("metadata"));
+        assert!(turn_query.contains("failure_reason"));
         assert!(turn_query.contains("interrupt_requested_at"));
         assert!(turn_query.contains("valid_until"));
         assert!(turn_query.contains("interrupted_at"));

--- a/crates/gents-schemas/schemas/agent/agent_tool_call.graphql
+++ b/crates/gents-schemas/schemas/agent/agent_tool_call.graphql
@@ -10,7 +10,11 @@ type AgentToolCall @branchable {
     tool_call_id: String @index
     args: String
     result: String
+    # Persistence/delivery state. A terminal failed tool may still use
+    # "completed" here once its result or background notification is durable.
     status: String
+    # Authoritative execution outcome: pending, awaitingApproval, running,
+    # completed, failed, timedOut, or cancelled.
     lifecycle_state: String @index
     started_at: DateTime
     deadline_at: DateTime

--- a/crates/gents/proofs/Proofs/Client/Types.lean
+++ b/crates/gents/proofs/Proofs/Client/Types.lean
@@ -72,6 +72,34 @@ def deriveAttempt : AttemptView → ClientTurnState
         | .streaming => .streaming
       | none => .waitingForClaim
 
+/-- Generic client projection for a session/request head.  The effective turn
+    state is response-aware, while the request state remains available for thin
+    clients that present pending/running or input-required distinctions. -/
+structure ClientHeadProjection where
+  turnState : ClientTurnState
+  requestState : RequestState
+  deriving DecidableEq, Repr
+
+def projectHead (view : AttemptView) : ClientHeadProjection :=
+  { turnState := deriveAttempt view
+  , requestState := view.request.lifecycleState
+  }
+
+def ClientHeadProjection.isTerminal (head : ClientHeadProjection) : Bool :=
+  head.turnState.isTerminal
+
+def ClientHeadProjection.isActive (head : ClientHeadProjection) : Bool :=
+  !head.isTerminal
+
+def ClientHeadProjection.waitingOnUserInput (head : ClientHeadProjection) : Bool :=
+  head.isActive && head.requestState == .inputRequired
+
+theorem projectHead_turnState (view : AttemptView) :
+    (projectHead view).turnState = deriveAttempt view := rfl
+
+theorem projectHead_terminal (view : AttemptView) :
+    (projectHead view).isTerminal = (deriveAttempt view).isTerminal := rfl
+
 def deriveTurn : List AttemptView → Option ClientTurnState
   | []          => none
   | [a]         => some (deriveAttempt a)

--- a/crates/gents/proofs/Proofs/CodexShim/Projection.lean
+++ b/crates/gents/proofs/Proofs/CodexShim/Projection.lean
@@ -1,27 +1,19 @@
-import Proofs.Client.Types
+import Proofs.Client
 import Proofs.CodexShim.TurnLifecycle
 import Proofs.InferenceCall.State
-import Proofs.Request.Transition
 
 namespace CodexShim
 
-def projectedRank : TurnPhase → Nat
-  | .notStarted => 0
-  | .inProgress => 1
-  | .completed => 2
-  | .failed => 2
-  | .interrupted => 2
-
-def projectRequestState : RequestState → TurnPhase
-  | .pending => .inProgress
-  | .claimed => .inProgress
-  | .processing => .inProgress
-  | .inputRequired => .inProgress
+def projectClientTurnState : ClientTurnState → TurnPhase
+  | .waitingForClaim | .streaming => .inProgress
   | .completed => .completed
   | .failed => .failed
-  | .dead => .failed
-  | .superseded => .interrupted
-  | .interrupted => .interrupted
+  | .superseded | .interrupted => .interrupted
+
+theorem projectClientTurnState_terminal (state : ClientTurnState) :
+    TurnPhase.terminal (projectClientTurnState state) ↔ state.isTerminal = true := by
+  cases state <;>
+    simp [projectClientTurnState, TurnPhase.terminal, ClientTurnState.isTerminal]
 
 inductive SubagentControlTool where
   | spawn
@@ -140,22 +132,24 @@ def CollabAgentPhase.terminal : CollabAgentPhase → Prop
   | .completed | .errored | .interrupted => True
   | .pendingInit | .running => False
 
-def projectSubagentState : RequestState → CollabAgentPhase
-  | .pending => .pendingInit
-  | .claimed | .processing | .inputRequired => .running
-  | .completed => .completed
-  | .failed | .dead => .errored
-  | .superseded | .interrupted => .interrupted
+def projectSubagentState : ClientHeadProjection → CollabAgentPhase
+  | ⟨.completed, _⟩ => .completed
+  | ⟨.failed, _⟩ => .errored
+  | ⟨.superseded, _⟩ | ⟨.interrupted, _⟩ => .interrupted
+  | ⟨.waitingForClaim, .pending⟩ => .pendingInit
+  | ⟨.waitingForClaim, _⟩ | ⟨.streaming, _⟩ => .running
 
 theorem subagent_status_terminal_precisely
-    (state : RequestState) :
-    CollabAgentPhase.terminal (projectSubagentState state) ↔
-      isTerminal state := by
-  cases state <;>
+    (head : ClientHeadProjection) :
+    CollabAgentPhase.terminal (projectSubagentState head) ↔
+      head.isTerminal = true := by
+  cases head with
+  | mk turnState requestState =>
+    cases turnState <;> cases requestState <;>
     simp [ projectSubagentState
          , CollabAgentPhase.terminal
-         , HasTerminal.isTerminal
-         , RequestState.instHasTerminal
+         , ClientHeadProjection.isTerminal
+         , ClientTurnState.isTerminal
          ]
 
 structure CollabPresentationFingerprint where
@@ -164,14 +158,14 @@ structure CollabPresentationFingerprint where
   deriving DecidableEq, Repr
 
 def collabPresentationFingerprint
-    (latestChildState : RequestState)
+    (latestChildState : ClientHeadProjection)
     (failureMessage : Option String) : CollabPresentationFingerprint :=
   { childPhase := projectSubagentState latestChildState
   , failureMessage := failureMessage
   }
 
 theorem collab_fingerprint_includes_latest_child_state
-    (state : RequestState)
+    (state : ClientHeadProjection)
     (failureMessage : Option String) :
     (collabPresentationFingerprint state failureMessage).childPhase =
       projectSubagentState state := rfl
@@ -469,12 +463,13 @@ inductive ThreadPresentationStatus where
   deriving DecidableEq, Repr
 
 def projectThreadStatus
-    (requestState : Option RequestState)
+    (head : Option ClientHeadProjection)
     (conversationStatus : String) : ThreadPresentationStatus :=
-  match requestState with
-  | some .pending | some .claimed | some .processing | some .inputRequired => .active
-  | some .failed | some .dead => .systemError
-  | some .completed | some .superseded | some .interrupted => .idle
+  match head with
+  | some ⟨.waitingForClaim, _⟩ | some ⟨.streaming, _⟩ => .active
+  | some ⟨.failed, _⟩ => .systemError
+  | some ⟨.completed, _⟩ | some ⟨.superseded, _⟩
+  | some ⟨.interrupted, _⟩ => .idle
   | none => if conversationStatus = "error" then .systemError else .idle
 
 def projectionBehaviorId (rootBehaviorId : String)
@@ -522,13 +517,16 @@ def projectedEventTimestampMs (persisted : Option Nat) (observed : Nat) : Nat :=
   persisted.getD observed
 
 theorem active_request_projects_active_thread :
-    projectThreadStatus (some .processing) "completed" = .active := rfl
+    projectThreadStatus (some ⟨.waitingForClaim, .processing⟩) "completed" = .active := rfl
+
+theorem terminal_response_projects_idle_thread_before_request_terminalizes :
+    projectThreadStatus (some ⟨.completed, .processing⟩) "active" = .idle := rfl
 
 theorem failed_request_projects_system_error_thread :
-    projectThreadStatus (some .failed) "active" = .systemError := rfl
+    projectThreadStatus (some ⟨.failed, .failed⟩) "active" = .systemError := rfl
 
 theorem completed_request_projects_idle_thread :
-    projectThreadStatus (some .completed) "error" = .idle := rfl
+    projectThreadStatus (some ⟨.completed, .completed⟩) "error" = .idle := rfl
 
 theorem missing_request_error_conversation_projects_system_error :
     projectThreadStatus none "error" = .systemError := rfl
@@ -679,94 +677,36 @@ structure ProjectionObservation where
   localInterruptAcked : Bool
   deriving DecidableEq, Repr
 
-def responseStatusTerminal : Option ResponseStatus → Prop
-  | some .complete => True
-  | some .error => True
-  | some .streaming => False
-  | none => False
+def clientAttemptObservation (obs : ProjectionObservation) : AttemptView :=
+  { request :=
+      { lifecycleState := obs.requestState
+      , isSuperseded := false
+      }
+  , response := obs.responseStatus.map fun status =>
+      { status := status
+      , tailEmpty := true
+      }
+  }
 
 def turnEffectivelyTerminal (obs : ProjectionObservation) : Prop :=
-  isTerminal obs.requestState ∨
-  obs.localInterruptAcked = true ∨
-  responseStatusTerminal obs.responseStatus
+  obs.localInterruptAcked = true ∨ effectivelyTerminal (clientAttemptObservation obs)
+
+instance (obs : ProjectionObservation) : Decidable (turnEffectivelyTerminal obs) := by
+  unfold turnEffectivelyTerminal
+  infer_instance
 
 def projectObservation (obs : ProjectionObservation) : TurnPhase :=
   if obs.localInterruptAcked then
     .interrupted
   else
-    match obs.requestState with
-    | .pending | .claimed | .processing | .inputRequired =>
-      match obs.responseStatus with
-      | some .complete => .completed
-      | some .error => .failed
-      | some .streaming => .inProgress
-      | none => .inProgress
-    | .completed => .completed
-    | .failed => .failed
-    | .dead => .failed
-    | .superseded => .interrupted
-    | .interrupted => .interrupted
+    projectClientTurnState (deriveAttempt (clientAttemptObservation obs))
 
-theorem project_pending_is_in_progress :
-    projectRequestState .pending = .inProgress := rfl
-
-theorem project_claimed_is_in_progress :
-    projectRequestState .claimed = .inProgress := rfl
-
-theorem project_processing_is_in_progress :
-    projectRequestState .processing = .inProgress := rfl
-
-theorem project_completed_is_completed :
-    projectRequestState .completed = .completed := rfl
-
-theorem project_failed_is_failed :
-    projectRequestState .failed = .failed := rfl
-
-theorem project_dead_is_failed :
-    projectRequestState .dead = .failed := rfl
-
-theorem project_superseded_is_interrupted :
-    projectRequestState .superseded = .interrupted := rfl
-
-theorem project_interrupted_is_interrupted :
-    projectRequestState .interrupted = .interrupted := rfl
-
-theorem nonterminal_without_response_projects_in_progress
-    {s : RequestState}
-    (h : s = .pending ∨ s = .claimed ∨ s = .processing ∨ s = .inputRequired) :
-    projectObservation
-      { requestState := s, responseStatus := none, localInterruptAcked := false } =
-        .inProgress := by
-  rcases h with h | h | h | h <;> subst s <;> rfl
-
-theorem response_complete_advances_nonterminal_to_completed
-    {s : RequestState}
-    (h : s = .pending ∨ s = .claimed ∨ s = .processing ∨ s = .inputRequired) :
-    projectObservation
-      { requestState := s
-      , responseStatus := some .complete
-      , localInterruptAcked := false } = .completed := by
-  rcases h with h | h | h | h <;> subst s <;> rfl
-
-theorem response_error_advances_nonterminal_to_failed
-    {s : RequestState}
-    (h : s = .pending ∨ s = .claimed ∨ s = .processing ∨ s = .inputRequired) :
-    projectObservation
-      { requestState := s
-      , responseStatus := some .error
-      , localInterruptAcked := false } = .failed := by
-  rcases h with h | h | h | h <;> subst s <;> rfl
-
-theorem terminal_request_overrides_response
-    {s : RequestState}
-    {resp : Option ResponseStatus}
-    (h : s = .completed ∨ s = .failed ∨ s = .dead ∨
-         s = .superseded ∨ s = .interrupted) :
-    projectObservation
-      { requestState := s
-      , responseStatus := resp
-      , localInterruptAcked := false } = projectRequestState s := by
-  rcases h with h | h | h | h | h <;> subst s <;> cases resp <;> rfl
+theorem projection_without_local_interrupt
+    {obs : ProjectionObservation}
+    (h : obs.localInterruptAcked = false) :
+    projectObservation obs =
+      projectClientTurnState (deriveAttempt (clientAttemptObservation obs)) := by
+  simp [projectObservation, h]
 
 theorem local_interrupt_projects_interrupted
     {obs : ProjectionObservation}
@@ -782,77 +722,17 @@ theorem local_interrupt_never_projects_in_progress
   intro h_eq
   cases h_eq
 
-theorem terminal_request_projects_terminal
-    {s : RequestState}
-    (h : s = .completed ∨ s = .failed ∨ s = .superseded ∨
-         s = .dead ∨ s = .interrupted) :
-    TurnPhase.terminal (projectRequestState s) := by
-  rcases h with h | h | h | h | h <;> subst s <;> trivial
-
 theorem codex_turn_terminates_precisely
     (obs : ProjectionObservation) :
     TurnPhase.terminal (projectObservation obs) ↔
       turnEffectivelyTerminal obs := by
-  obtain ⟨requestState, responseStatus, localInterruptAcked⟩ := obs
-  cases localInterruptAcked <;> cases requestState
-  all_goals
-    cases responseStatus with
-    | none =>
-        simp [ projectObservation
-             , turnEffectivelyTerminal
-             , responseStatusTerminal
-             , TurnPhase.terminal
-             , HasTerminal.isTerminal
-             , RequestState.instHasTerminal
-             ]
-    | some status =>
-        cases status <;>
-          simp [ projectObservation
-               , turnEffectivelyTerminal
-               , responseStatusTerminal
-               , TurnPhase.terminal
-               , HasTerminal.isTerminal
-               , RequestState.instHasTerminal
-               ]
-
-theorem request_transition_projection_monotonic
-    {pre post : RequestContext}
-    (h : RequestContext.Transition pre post) :
-    projectedRank (projectRequestState post.state) ≥
-      projectedRank (projectRequestState pre.state) := by
-  cases h with
-  | claim h_state _ _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | dedup_lose h_state _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | begin_inference h_state _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | advance h_state _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | finish h_state _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | fail h_state _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | fail_before_stream h_state _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | expire h_state _ _ _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | interrupt_before_claim h_state _ _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | interrupt_claimed h_state _ _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
-  | interrupt_processing h_state _ _ h_post =>
-      subst h_post
-      simp [projectRequestState, projectedRank, h_state]
+  cases h : obs.localInterruptAcked with
+  | false =>
+      rw [projection_without_local_interrupt h]
+      rw [projectClientTurnState_terminal]
+      rw [terminal_coherence]
+      simp [turnEffectivelyTerminal, h]
+  | true =>
+      simp [projectObservation, turnEffectivelyTerminal, h, TurnPhase.terminal]
 
 end CodexShim

--- a/crates/gents/proofs/Proofs/CodexShim/TurnLifecycle.lean
+++ b/crates/gents/proofs/Proofs/CodexShim/TurnLifecycle.lean
@@ -24,6 +24,9 @@ def terminal : TurnPhase → Prop
   | .notStarted => False
   | .inProgress => False
 
+instance (phase : TurnPhase) : Decidable (terminal phase) := by
+  cases phase <;> simp [terminal] <;> infer_instance
+
 def lexOrd : TurnPhase → Nat
   | .notStarted => 0
   | .inProgress => 1

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/CodexShim.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/CodexShim.lean
@@ -35,184 +35,79 @@ def codexShimProjectionCaseJson (witness : CodexShimProjectionCase) : String :=
       ++ boolString witness.interruptibleRequestState
     ++ "}"
 
+def responseStatusName : ResponseStatus → String
+  | .streaming => "streaming"
+  | .complete => "complete"
+  | .error => "error"
+
+def genericClientProjectionTheorems : List String :=
+  [ "deriveAttempt_total"
+  , "lifecycle_transition_monotonic"
+  , "terminal_coherence"
+  , "CodexShim.projectClientTurnState_terminal"
+  , "CodexShim.projection_without_local_interrupt"
+  , "CodexShim.codex_turn_terminates_precisely"
+  ]
+
+def localInterruptProjectionTheorems : List String :=
+  [ "CodexShim.local_interrupt_projects_interrupted"
+  , "CodexShim.local_interrupt_never_projects_in_progress"
+  , "CodexShim.codex_turn_terminates_precisely"
+  , "CodexShim.local_interrupt_requires_interruptible"
+  , "CodexShim.local_interrupt_shortcut_sound"
+  ]
+
+def codexShimProjectionCase
+    (witness : String)
+    (requestState : RequestState)
+    (responseStatus : Option ResponseStatus)
+    (localInterruptAcked : Bool) : CodexShimProjectionCase :=
+  let observation : CodexShim.ProjectionObservation :=
+    { requestState := requestState
+    , responseStatus := responseStatus
+    , localInterruptAcked := localInterruptAcked
+    }
+  let phase := CodexShim.projectObservation observation
+  { witness := witness
+  , leanTheorems :=
+      if localInterruptAcked then
+        localInterruptProjectionTheorems
+      else
+        genericClientProjectionTheorems
+  , requestState := requestState.toDefraDB
+  , responseStatus := responseStatus.map responseStatusName
+  , localInterruptAcked := localInterruptAcked
+  , projectedPhase := phase.toProtocol
+  , terminal := decide (CodexShim.TurnPhase.terminal phase)
+  , effectivelyTerminal := decide (CodexShim.turnEffectivelyTerminal observation)
+  , interruptibleRequestState := decide (CodexShim.interruptibleRequestState requestState)
+  }
+
 def codexShimProjectionCases : List CodexShimProjectionCase :=
-  [ { witness := "codex_shim.projection.pending_no_response"
-    , leanTheorems :=
-        [ "CodexShim.project_pending_is_in_progress"
-        , "CodexShim.nonterminal_without_response_projects_in_progress"
-        , "CodexShim.request_transition_projection_monotonic"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "pending"
-    , responseStatus := none
-    , localInterruptAcked := false
-    , projectedPhase := "inProgress"
-    , terminal := false
-    , effectivelyTerminal := false
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.claimed_no_response"
-    , leanTheorems :=
-        [ "CodexShim.project_claimed_is_in_progress"
-        , "CodexShim.nonterminal_without_response_projects_in_progress"
-        , "CodexShim.request_transition_projection_monotonic"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "claimed"
-    , responseStatus := none
-    , localInterruptAcked := false
-    , projectedPhase := "inProgress"
-    , terminal := false
-    , effectivelyTerminal := false
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.processing_streaming_response"
-    , leanTheorems :=
-        [ "CodexShim.project_processing_is_in_progress"
-        , "CodexShim.request_transition_projection_monotonic"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "processing"
-    , responseStatus := some "streaming"
-    , localInterruptAcked := false
-    , projectedPhase := "inProgress"
-    , terminal := false
-    , effectivelyTerminal := false
-    , interruptibleRequestState := true
-    }
-  , { witness := "codex_shim.projection.nonterminal_complete_response"
-    , leanTheorems :=
-        [ "CodexShim.response_complete_advances_nonterminal_to_completed"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "processing"
-    , responseStatus := some "complete"
-    , localInterruptAcked := false
-    , projectedPhase := "completed"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := true
-    }
-  , { witness := "codex_shim.projection.nonterminal_error_response"
-    , leanTheorems :=
-        [ "CodexShim.response_error_advances_nonterminal_to_failed"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "processing"
-    , responseStatus := some "error"
-    , localInterruptAcked := false
-    , projectedPhase := "failed"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := true
-    }
-  , { witness := "codex_shim.projection.completed_request"
-    , leanTheorems :=
-        [ "CodexShim.project_completed_is_completed"
-        , "CodexShim.terminal_request_overrides_response"
-        , "CodexShim.terminal_request_projects_terminal"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "completed"
-    , responseStatus := some "error"
-    , localInterruptAcked := false
-    , projectedPhase := "completed"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.failed_request"
-    , leanTheorems :=
-        [ "CodexShim.project_failed_is_failed"
-        , "CodexShim.terminal_request_overrides_response"
-        , "CodexShim.terminal_request_projects_terminal"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "failed"
-    , responseStatus := none
-    , localInterruptAcked := false
-    , projectedPhase := "failed"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.dead_request"
-    , leanTheorems :=
-        [ "CodexShim.project_dead_is_failed"
-        , "CodexShim.terminal_request_overrides_response"
-        , "CodexShim.terminal_request_projects_terminal"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "dead"
-    , responseStatus := none
-    , localInterruptAcked := false
-    , projectedPhase := "failed"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.superseded_request"
-    , leanTheorems :=
-        [ "CodexShim.project_superseded_is_interrupted"
-        , "CodexShim.terminal_request_overrides_response"
-        , "CodexShim.terminal_request_projects_terminal"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "superseded"
-    , responseStatus := none
-    , localInterruptAcked := false
-    , projectedPhase := "interrupted"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.interrupted_request"
-    , leanTheorems :=
-        [ "CodexShim.project_interrupted_is_interrupted"
-        , "CodexShim.terminal_request_overrides_response"
-        , "CodexShim.terminal_request_projects_terminal"
-        , "CodexShim.codex_turn_terminates_precisely"
-        ]
-    , requestState := "interrupted"
-    , responseStatus := none
-    , localInterruptAcked := false
-    , projectedPhase := "interrupted"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := false
-    }
-  , { witness := "codex_shim.projection.local_interrupt_preempts_core_state"
-    , leanTheorems :=
-        [ "CodexShim.local_interrupt_projects_interrupted"
-        , "CodexShim.local_interrupt_never_projects_in_progress"
-        , "CodexShim.codex_turn_terminates_precisely"
-        , "CodexShim.local_interrupt_requires_interruptible"
-        , "CodexShim.local_interrupt_shortcut_sound"
-        ]
-    , requestState := "processing"
-    , responseStatus := some "streaming"
-    , localInterruptAcked := true
-    , projectedPhase := "interrupted"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := true
-    }
-  , { witness := "codex_shim.projection.local_interrupt_input_required"
-    , leanTheorems :=
-        [ "CodexShim.local_interrupt_projects_interrupted"
-        , "CodexShim.local_interrupt_never_projects_in_progress"
-        , "CodexShim.codex_turn_terminates_precisely"
-        , "CodexShim.local_interrupt_requires_interruptible"
-        , "CodexShim.local_interrupt_shortcut_sound"
-        ]
-    , requestState := "inputRequired"
-    , responseStatus := none
-    , localInterruptAcked := true
-    , projectedPhase := "interrupted"
-    , terminal := true
-    , effectivelyTerminal := true
-    , interruptibleRequestState := true
-    }
+  [ codexShimProjectionCase "codex_shim.projection.pending_no_response"
+      .pending none false
+  , codexShimProjectionCase "codex_shim.projection.claimed_no_response"
+      .claimed none false
+  , codexShimProjectionCase "codex_shim.projection.processing_streaming_response"
+      .processing (some .streaming) false
+  , codexShimProjectionCase "codex_shim.projection.nonterminal_complete_response"
+      .processing (some .complete) false
+  , codexShimProjectionCase "codex_shim.projection.nonterminal_error_response"
+      .processing (some .error) false
+  , codexShimProjectionCase "codex_shim.projection.completed_request"
+      .completed (some .error) false
+  , codexShimProjectionCase "codex_shim.projection.failed_request"
+      .failed none false
+  , codexShimProjectionCase "codex_shim.projection.dead_request"
+      .dead none false
+  , codexShimProjectionCase "codex_shim.projection.superseded_request"
+      .superseded none false
+  , codexShimProjectionCase "codex_shim.projection.interrupted_request"
+      .interrupted none false
+  , codexShimProjectionCase "codex_shim.projection.local_interrupt_preempts_core_state"
+      .processing (some .streaming) true
+  , codexShimProjectionCase "codex_shim.projection.local_interrupt_input_required"
+      .inputRequired none true
   ]
 
 def codexShimProjectionCasesJson : String :=
@@ -351,8 +246,44 @@ structure CodexShimSubagentStatusCase where
   witness : String
   leanTheorems : List String
   requestState : String
+  responseStatus : Option String
   projectedAgentStatus : String
   terminal : Bool
+
+def clientHeadProjection
+    (requestState : RequestState)
+    (responseStatus : Option ResponseStatus) : ClientHeadProjection :=
+  projectHead
+    { request :=
+        { lifecycleState := requestState
+        , isSuperseded := false
+        }
+    , response := responseStatus.map fun status =>
+        { status := status
+        , tailEmpty := true
+        }
+    }
+
+def collabAgentPhaseName : CodexShim.CollabAgentPhase → String
+  | .pendingInit => "pendingInit"
+  | .running => "running"
+  | .completed => "completed"
+  | .errored => "errored"
+  | .interrupted => "interrupted"
+
+def codexShimSubagentStatusCase
+    (witness : String)
+    (requestState : RequestState)
+    (responseStatus : Option ResponseStatus) : CodexShimSubagentStatusCase :=
+  let head := clientHeadProjection requestState responseStatus
+  let phase := CodexShim.projectSubagentState head
+  { witness
+  , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
+  , requestState := requestState.toDefraDB
+  , responseStatus := responseStatus.map responseStatusName
+  , projectedAgentStatus := collabAgentPhaseName phase
+  , terminal := head.isTerminal
+  }
 
 def codexShimSubagentStatusCaseJson
     (witness : CodexShimSubagentStatusCase) : String :=
@@ -360,39 +291,28 @@ def codexShimSubagentStatusCaseJson
     ++ "\"witness\":" ++ jsonString witness.witness ++ ","
     ++ "\"lean_theorems\":" ++ jsonStringArray witness.leanTheorems ++ ","
     ++ "\"request_state\":" ++ jsonString witness.requestState ++ ","
+    ++ "\"response_status\":" ++ jsonOptionalString witness.responseStatus ++ ","
     ++ "\"projected_agent_status\":"
       ++ jsonString witness.projectedAgentStatus ++ ","
     ++ "\"terminal\":" ++ boolString witness.terminal
     ++ "}"
 
 def codexShimSubagentStatusCases : List CodexShimSubagentStatusCase :=
-  [ { witness := "codex_shim.subagent_status.pending"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "pending", projectedAgentStatus := "pendingInit", terminal := false }
-  , { witness := "codex_shim.subagent_status.claimed"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "claimed", projectedAgentStatus := "running", terminal := false }
-  , { witness := "codex_shim.subagent_status.processing"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "processing", projectedAgentStatus := "running", terminal := false }
-  , { witness := "codex_shim.subagent_status.input_required"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "inputRequired", projectedAgentStatus := "running", terminal := false }
-  , { witness := "codex_shim.subagent_status.completed"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "completed", projectedAgentStatus := "completed", terminal := true }
-  , { witness := "codex_shim.subagent_status.failed"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "failed", projectedAgentStatus := "errored", terminal := true }
-  , { witness := "codex_shim.subagent_status.dead"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "dead", projectedAgentStatus := "errored", terminal := true }
-  , { witness := "codex_shim.subagent_status.superseded"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "superseded", projectedAgentStatus := "interrupted", terminal := true }
-  , { witness := "codex_shim.subagent_status.interrupted"
-    , leanTheorems := [ "CodexShim.subagent_status_terminal_precisely" ]
-    , requestState := "interrupted", projectedAgentStatus := "interrupted", terminal := true }
+  [ codexShimSubagentStatusCase "codex_shim.subagent_status.pending" .pending none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.claimed" .claimed none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.processing" .processing none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.input_required" .inputRequired none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.completed" .completed none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.failed" .failed none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.dead" .dead none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.superseded" .superseded none
+  , codexShimSubagentStatusCase "codex_shim.subagent_status.interrupted" .interrupted none
+  , codexShimSubagentStatusCase
+      "codex_shim.subagent_status.processing_complete_response"
+      .processing (some .complete)
+  , codexShimSubagentStatusCase
+      "codex_shim.subagent_status.processing_error_response"
+      .processing (some .error)
   ]
 
 def codexShimSubagentStatusCasesJson : String :=
@@ -758,6 +678,7 @@ structure CodexShimThreadStatusCase where
   witness : String
   leanTheorems : List String
   requestState : Option String
+  responseStatus : Option String
   conversationStatus : String
   projectedStatus : String
 
@@ -765,14 +686,17 @@ def codexShimThreadStatusCase
     (witness : String)
     (leanTheorems : List String)
     (requestState : Option RequestState)
+    (responseStatus : Option ResponseStatus)
     (conversationStatus : String) : CodexShimThreadStatusCase :=
+  let head := requestState.map fun state => clientHeadProjection state responseStatus
   { witness
   , leanTheorems
   , requestState := requestState.map RequestState.toDefraDB
+  , responseStatus := responseStatus.map responseStatusName
   , conversationStatus
   , projectedStatus :=
       threadPresentationStatusName
-        (CodexShim.projectThreadStatus requestState conversationStatus)
+        (CodexShim.projectThreadStatus head conversationStatus)
   }
 
 def codexShimThreadStatusCaseJson (witness : CodexShimThreadStatusCase) : String :=
@@ -780,40 +704,48 @@ def codexShimThreadStatusCaseJson (witness : CodexShimThreadStatusCase) : String
     ++ "\"witness\":" ++ jsonString witness.witness ++ ","
     ++ "\"lean_theorems\":" ++ jsonStringArray witness.leanTheorems ++ ","
     ++ "\"request_state\":" ++ jsonOptionalString witness.requestState ++ ","
+    ++ "\"response_status\":" ++ jsonOptionalString witness.responseStatus ++ ","
     ++ "\"conversation_status\":" ++ jsonString witness.conversationStatus ++ ","
     ++ "\"projected_status\":" ++ jsonString witness.projectedStatus
     ++ "}"
 
 def codexShimThreadStatusCases : List CodexShimThreadStatusCase :=
-  [ codexShimThreadStatusCase "codex_shim.thread_status.pending" [] (some .pending) "active"
-  , codexShimThreadStatusCase "codex_shim.thread_status.claimed" [] (some .claimed) "active"
+  [ codexShimThreadStatusCase "codex_shim.thread_status.pending" [] (some .pending) none "active"
+  , codexShimThreadStatusCase "codex_shim.thread_status.claimed" [] (some .claimed) none "active"
   , codexShimThreadStatusCase
       "codex_shim.thread_status.processing"
       ["CodexShim.active_request_projects_active_thread"]
-      (some .processing) "completed"
+      (some .processing) none "completed"
   , codexShimThreadStatusCase "codex_shim.thread_status.input_required" []
-      (some .inputRequired) "active"
+      (some .inputRequired) none "active"
   , codexShimThreadStatusCase
       "codex_shim.thread_status.completed"
       ["CodexShim.completed_request_projects_idle_thread"]
-      (some .completed) "error"
+      (some .completed) none "error"
   , codexShimThreadStatusCase
       "codex_shim.thread_status.failed"
       ["CodexShim.failed_request_projects_system_error_thread"]
-      (some .failed) "active"
-  , codexShimThreadStatusCase "codex_shim.thread_status.dead" [] (some .dead) "active"
+      (some .failed) none "active"
+  , codexShimThreadStatusCase "codex_shim.thread_status.dead" [] (some .dead) none "active"
   , codexShimThreadStatusCase "codex_shim.thread_status.superseded" []
-      (some .superseded) "active"
+      (some .superseded) none "active"
   , codexShimThreadStatusCase "codex_shim.thread_status.interrupted" []
-      (some .interrupted) "active"
+      (some .interrupted) none "active"
+  , codexShimThreadStatusCase
+      "codex_shim.thread_status.processing_complete_response"
+      ["CodexShim.terminal_response_projects_idle_thread_before_request_terminalizes"]
+      (some .processing) (some .complete) "active"
+  , codexShimThreadStatusCase
+      "codex_shim.thread_status.processing_error_response"
+      [] (some .processing) (some .error) "active"
   , codexShimThreadStatusCase
       "codex_shim.thread_status.conversation_error"
       ["CodexShim.missing_request_error_conversation_projects_system_error"]
-      none "error"
+      none none "error"
   , codexShimThreadStatusCase
       "codex_shim.thread_status.quiescent"
       ["CodexShim.missing_request_active_conversation_is_quiescent"]
-      none "active"
+      none none "active"
   ]
 
 def codexShimThreadStatusCasesJson : String :=

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -837,6 +837,13 @@ accepted failure mode.
 
 The implementation-facing version is `client-state-machine.md`.
 
+The Codex shim reuses this projection directly. Its adapter only maps the
+generic `ClientTurnState` into Codex wire phases and applies the acknowledged
+local-interrupt override; request/response precedence, lifecycle monotonicity,
+and terminal coherence stay owned by `Proofs/Client.lean`. Generated Codex
+conformance rows are evaluated from that composition rather than restating a
+parallel Codex-specific state machine.
+
 ### Client Shell Workflow
 
 `Proofs/ClientShell.lean` sits above the per-turn projection and models the

--- a/crates/gents/src/hook/persistence/background_tools.rs
+++ b/crates/gents/src/hook/persistence/background_tools.rs
@@ -180,18 +180,23 @@ impl DefraSessionHook {
             match execution {
                 Ok(outcome) => match outcome {
                     crate::tool_call_lifecycle::ToolOutcome::TimedOut { .. } => {
-                        let won_terminal_compare =
-                            match lifecycle.bridge_failure(ChildTerminal::Dead).await {
-                                Ok(updated) => updated,
-                                Err(error) => {
-                                    tracing::warn!(
-                                        tool_call_id = %execution_call_id,
-                                        error = %error,
-                                        "failed to terminalize timed-out background tool"
-                                    );
-                                    false
-                                }
-                            };
+                        let won_terminal_compare = match lifecycle
+                            .bridge_failure_with_completion_reason(
+                                background_timeout_terminal(),
+                                BACKGROUND_TIMEOUT_COMPLETION_REASON,
+                            )
+                            .await
+                        {
+                            Ok(updated) => updated,
+                            Err(error) => {
+                                tracing::warn!(
+                                    tool_call_id = %execution_call_id,
+                                    error = %error,
+                                    "failed to terminalize timed-out background tool"
+                                );
+                                false
+                            }
+                        };
                         if let Some(Err(error)) = project_background_completion_if_owned(
                             won_terminal_compare,
                             crate::background_completion::append_background_tool_completion(
@@ -707,6 +712,15 @@ impl DefraSessionHook {
     }
 }
 
+fn background_timeout_terminal() -> ChildTerminal {
+    ChildTerminal::Failed {
+        reason: "background tool deadline exceeded".to_string(),
+        failure_class: FailureClass::External,
+    }
+}
+
+const BACKGROUND_TIMEOUT_COMPLETION_REASON: &str = "deadline_exceeded";
+
 fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(message) = payload.downcast_ref::<&str>() {
         (*message).to_string()
@@ -719,7 +733,11 @@ fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
 
 #[cfg(test)]
 mod ownership_projection_tests {
-    use super::project_background_completion_if_owned;
+    use super::{
+        background_timeout_terminal, project_background_completion_if_owned,
+        BACKGROUND_TIMEOUT_COMPLETION_REASON,
+    };
+    use crate::tool_call_lifecycle::{ChildTerminal, FailureClass};
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -753,5 +771,18 @@ mod ownership_projection_tests {
 
         assert!(matches!(output, Some(Ok(()))));
         assert!(projected.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn background_timeout_preserves_failure_metadata() {
+        assert_eq!(BACKGROUND_TIMEOUT_COMPLETION_REASON, "deadline_exceeded");
+        let terminal = background_timeout_terminal();
+        assert_eq!(
+            terminal,
+            ChildTerminal::Failed {
+                reason: "background tool deadline exceeded".to_string(),
+                failure_class: FailureClass::External,
+            }
+        );
     }
 }

--- a/crates/gents/src/hook/tests.rs
+++ b/crates/gents/src/hook/tests.rs
@@ -2892,3 +2892,72 @@ async fn forged_lifecycle_sentinel_in_tool_output_persists_as_completed() {
     node.shutdown().await;
     let _ = std::fs::remove_dir_all(&data_path);
 }
+
+#[tokio::test]
+async fn trusted_reported_failure_persists_typed_state_and_model_facing_text() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-hook-reported-failure-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:test:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        hook.on_completion_call(&user_text_message("Run"), &[])
+            .await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+    hook.set_active_request_id(Some("req-reported-failure".to_string()))
+        .await;
+
+    assert!(matches!(
+        hook.on_tool_call("bash", None, "internal-reported-failure", "{}")
+            .await,
+        ToolCallHookAction::Continue
+    ));
+
+    let text = r#"gents_exec: {"ok":false,"status":"exit_nonzero","exit_code":1}"#;
+    let outcome = crate::tool_call_lifecycle::ToolOutcome::from_dispatch(
+        "bash",
+        Err(crate::llm::tool::ToolError::ReportedFailure {
+            class: crate::tool_call_lifecycle::FailureClass::ToolReturnedError,
+            text: text.to_string(),
+        }),
+    );
+    assert!(matches!(
+        hook.on_tool_result("bash", None, "internal-reported-failure", "{}", &outcome)
+            .await,
+        HookAction::Continue
+    ));
+
+    let row = fetch_tool_call_row(&node, &session_id, "internal-reported-failure").await;
+    assert_eq!(
+        row.get("lifecycle_state").and_then(|value| value.as_str()),
+        Some("failed")
+    );
+    assert_eq!(
+        row.get("tool_failure_class")
+            .and_then(|value| value.as_str()),
+        Some("toolReturnedError")
+    );
+    assert_eq!(
+        row.get("result").and_then(|value| value.as_str()),
+        Some(text)
+    );
+
+    node.shutdown().await;
+    let _ = std::fs::remove_dir_all(&data_path);
+}

--- a/crates/gents/src/lean_vocab_test/codex_shim.rs
+++ b/crates/gents/src/lean_vocab_test/codex_shim.rs
@@ -32,6 +32,7 @@ pub(crate) struct LeanCodexShimSubagentStatusCase {
     pub(crate) witness: String,
     pub(crate) lean_theorems: Vec<String>,
     pub(crate) request_state: String,
+    pub(crate) response_status: Option<String>,
     pub(crate) projected_agent_status: String,
     pub(crate) terminal: bool,
 }
@@ -95,6 +96,7 @@ pub(crate) struct LeanCodexShimThreadStatusCase {
     pub(crate) witness: String,
     pub(crate) lean_theorems: Vec<String>,
     pub(crate) request_state: Option<String>,
+    pub(crate) response_status: Option<String>,
     pub(crate) conversation_status: String,
     pub(crate) projected_status: String,
 }

--- a/crates/gents/src/llm/tool.rs
+++ b/crates/gents/src/llm/tool.rs
@@ -3,6 +3,8 @@ use std::pin::Pin;
 
 use serde::{Deserialize, Serialize};
 
+use crate::tool_call_lifecycle::FailureClass;
+
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -33,6 +35,11 @@ pub enum ToolError {
         kind: UnparseableArgsKind,
         reason: String,
     },
+    /// A trusted tool adapter observed an execution failure and rendered the
+    /// model-facing detail without asking persistence to infer semantics from
+    /// arbitrary output text.
+    #[error("{text}")]
+    ReportedFailure { class: FailureClass, text: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,6 +73,13 @@ pub trait Tool: Sized + Send + Sync {
         &self,
         args: Self::Args,
     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+
+    /// Convert the concrete tool error at the trusted adapter boundary. Tools
+    /// that deliberately return a recoverable, model-facing failure override
+    /// this to preserve its typed class and rendered detail.
+    fn into_dyn_error(error: Self::Error) -> ToolError {
+        ToolError::ToolCallError(Box::new(error))
+    }
 }
 
 pub trait ToolDyn: Send + Sync {
@@ -95,7 +109,7 @@ impl<T: Tool> ToolDyn for T {
             let parsed = parse_tool_args::<<Self as Tool>::Args>(&args)?;
             <Self as Tool>::call(self, parsed)
                 .await
-                .map_err(|error| ToolError::ToolCallError(Box::new(error)))
+                .map_err(<Self as Tool>::into_dyn_error)
                 .and_then(|output| serialize_tool_output(output).map_err(ToolError::JsonError))
         })
     }

--- a/crates/gents/src/meta_tools/call.rs
+++ b/crates/gents/src/meta_tools/call.rs
@@ -76,13 +76,13 @@ impl Tool for CallToolTool {
             .ctx
             .blocked_service_error(&args.service_id, &args.tool_name)
         {
-            return Ok(error.to_result_text());
+            return Err(MetaToolError::structured(error));
         }
 
         let arguments =
             match normalize_arguments(&args.service_id, &args.tool_name, &args.arguments) {
                 Ok(arguments) => arguments,
-                Err(error) => return Ok(error.to_result_text()),
+                Err(error) => return Err(MetaToolError::structured(error)),
             };
 
         let Value::Object(argument_object) = &arguments else {
@@ -115,7 +115,7 @@ impl Tool for CallToolTool {
             )
             .await
         {
-            return Ok(error.to_result_text());
+            return Err(MetaToolError::structured(error));
         }
 
         let result = tokio::time::timeout(
@@ -165,6 +165,10 @@ impl Tool for CallToolTool {
         let (capped, _trigger, _was_truncated) =
             truncate_text(&text, TruncationMode::Head, &limits);
         Ok(capped)
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }
 
@@ -505,15 +509,15 @@ mod tests {
             allowed_mcp_service_ids: vec!["x-data".to_string()],
         });
 
-        let output = tool
+        let error = tool
             .call(CallToolArgs {
                 service_id: "observability-mcp".to_string(),
                 tool_name: "query_metrics".to_string(),
                 arguments: json!("not an object"),
             })
             .await
-            .expect("disallowed service should return structured text");
-        let value: Value = serde_json::from_str(&output).expect("structured json");
+            .expect_err("disallowed service should return a typed failure");
+        let value: Value = serde_json::from_str(&error.to_string()).expect("structured json");
 
         assert_eq!(value["ok"], false);
         assert_eq!(value["failure_class"], "tool_not_allowed");

--- a/crates/gents/src/meta_tools/describe.rs
+++ b/crates/gents/src/meta_tools/describe.rs
@@ -76,35 +76,37 @@ impl Tool for DescribeToolTool {
             .ctx
             .blocked_service_error(&args.service_id, &args.tool_name)
         {
-            return Ok(error.to_result_text());
+            return Err(MetaToolError::structured(error));
         }
 
         if let Err(error) = enforce_health_gate(&self.ctx.health, &args.service_id).await {
-            return Ok(StructuredToolError::service_unavailable(
-                &args.service_id,
-                &args.tool_name,
-                format!(
-                    "service '{}' is currently unavailable: {error:#}",
-                    args.service_id
+            return Err(MetaToolError::structured(
+                StructuredToolError::service_unavailable(
+                    &args.service_id,
+                    &args.tool_name,
+                    format!(
+                        "service '{}' is currently unavailable: {error:#}",
+                        args.service_id
+                    ),
+                    true,
                 ),
-                true,
-            )
-            .to_result_text());
+            ));
         }
 
         let service = match lookup_service(&self.ctx, &args.service_id).await {
             Ok(service) => service,
             Err(error) => {
-                return Ok(StructuredToolError::service_unavailable(
-                    &args.service_id,
-                    &args.tool_name,
-                    format!(
-                        "service '{}' is not available for describe_tool: {error:#}",
-                        args.service_id
+                return Err(MetaToolError::structured(
+                    StructuredToolError::service_unavailable(
+                        &args.service_id,
+                        &args.tool_name,
+                        format!(
+                            "service '{}' is not available for describe_tool: {error:#}",
+                            args.service_id
+                        ),
+                        false,
                     ),
-                    false,
-                )
-                .to_result_text());
+                ));
             }
         };
 
@@ -120,16 +122,17 @@ impl Tool for DescribeToolTool {
         {
             Ok(result) => result,
             Err(error) => {
-                return Ok(StructuredToolError::service_unavailable(
-                    &args.service_id,
-                    &args.tool_name,
-                    format!(
-                        "service '{}' could not list tools for describe_tool: {error:#}",
-                        args.service_id
+                return Err(MetaToolError::structured(
+                    StructuredToolError::service_unavailable(
+                        &args.service_id,
+                        &args.tool_name,
+                        format!(
+                            "service '{}' could not list tools for describe_tool: {error:#}",
+                            args.service_id
+                        ),
+                        true,
                     ),
-                    true,
-                )
-                .to_result_text());
+                ));
             }
         };
 
@@ -140,8 +143,12 @@ impl Tool for DescribeToolTool {
             &list_result,
         ) {
             Ok(result) => Ok(result),
-            Err(error) => Ok(error.to_result_text()),
+            Err(error) => Err(MetaToolError::structured(error)),
         }
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }
 
@@ -965,15 +972,15 @@ mod tests {
             allowed_mcp_service_ids: vec!["x-data".to_string()],
         });
 
-        let output = tool
+        let error = tool
             .call(DescribeToolArgs {
                 service_id: "observability-mcp".to_string(),
                 tool_name: "query_metrics".to_string(),
                 raw_schema: false,
             })
             .await
-            .expect("disallowed service should be model-readable");
-        let value: Value = serde_json::from_str(&output).expect("structured json");
+            .expect_err("disallowed service should return a typed failure");
+        let value: Value = serde_json::from_str(&error.to_string()).expect("structured json");
 
         assert_eq!(value["ok"], false);
         assert_eq!(value["failure_class"], "tool_not_allowed");
@@ -998,15 +1005,15 @@ mod tests {
             allowed_mcp_service_ids: Vec::new(),
         });
 
-        let output = tool
+        let error = tool
             .call(DescribeToolArgs {
                 service_id: "missing-service".to_string(),
                 tool_name: "search_posts".to_string(),
                 raw_schema: false,
             })
             .await
-            .expect("missing service should be model-readable");
-        let value: Value = serde_json::from_str(&output).expect("structured json");
+            .expect_err("missing service should return a typed failure");
+        let value: Value = serde_json::from_str(&error.to_string()).expect("structured json");
 
         assert_eq!(value["ok"], false);
         assert_eq!(value["failure_class"], "service_unavailable");

--- a/crates/gents/src/meta_tools/shared.rs
+++ b/crates/gents/src/meta_tools/shared.rs
@@ -8,6 +8,7 @@ use crate::graphql::escape_graphql_string;
 use crate::health_checker::{HealthStatus, ServiceHealth, ServiceHealthMap};
 use crate::mcp_pool::resolve_mcp_url;
 use crate::mcp_pool::McpPool;
+use crate::tool_call_lifecycle::FailureClass;
 
 #[derive(Clone)]
 pub struct MetaToolContext {
@@ -48,23 +49,53 @@ pub(super) fn mcp_service_allowed(allowed_mcp_service_ids: &[String], service_id
 }
 
 #[derive(Debug)]
-pub struct MetaToolError(anyhow::Error);
+pub struct MetaToolError(MetaToolErrorKind);
+
+#[derive(Debug)]
+enum MetaToolErrorKind {
+    Other(anyhow::Error),
+    Structured(StructuredToolError),
+}
+
+impl MetaToolError {
+    pub(super) fn structured(error: StructuredToolError) -> Self {
+        Self(MetaToolErrorKind::Structured(error))
+    }
+
+    pub(super) fn into_dispatch_error(self) -> crate::llm::tool::ToolError {
+        match self.0 {
+            MetaToolErrorKind::Structured(error) => crate::llm::tool::ToolError::ReportedFailure {
+                class: error.lifecycle_failure_class(),
+                text: error.to_result_text(),
+            },
+            MetaToolErrorKind::Other(error) => crate::llm::tool::ToolError::ToolCallError(
+                Box::new(MetaToolError(MetaToolErrorKind::Other(error))),
+            ),
+        }
+    }
+}
 
 impl std::fmt::Display for MetaToolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:#}", self.0)
+        match &self.0 {
+            MetaToolErrorKind::Other(error) => write!(f, "{error:#}"),
+            MetaToolErrorKind::Structured(error) => f.write_str(&error.to_result_text()),
+        }
     }
 }
 
 impl std::error::Error for MetaToolError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.0.root_cause())
+        match &self.0 {
+            MetaToolErrorKind::Other(error) => Some(error.root_cause()),
+            MetaToolErrorKind::Structured(_) => None,
+        }
     }
 }
 
 impl From<anyhow::Error> for MetaToolError {
     fn from(error: anyhow::Error) -> Self {
-        Self(error)
+        Self(MetaToolErrorKind::Other(error))
     }
 }
 
@@ -86,6 +117,21 @@ pub(super) struct StructuredToolError {
 }
 
 impl StructuredToolError {
+    fn lifecycle_failure_class(&self) -> FailureClass {
+        match self.failure_class {
+            "invalid_tool_arguments" | "invalid_json_arguments" | "arguments_not_object" => {
+                FailureClass::ArgumentInvalid
+            }
+            "tool_not_allowed" => FailureClass::PolicyDenied,
+            "service_unavailable"
+            | "tool_not_found"
+            | "resource_not_found"
+            | "service_schema_drift" => FailureClass::ServiceUnavailable,
+            "tool_timeout" | "deadline_or_inference_failure" => FailureClass::External,
+            _ => FailureClass::ToolReturnedError,
+        }
+    }
+
     pub(super) fn invalid_tool_arguments(
         service_id: &str,
         tool_name: &str,

--- a/crates/gents/src/meta_tools/tests.rs
+++ b/crates/gents/src/meta_tools/tests.rs
@@ -61,6 +61,32 @@ fn blocked_mcp_service_returns_tool_not_allowed_error() {
 }
 
 #[test]
+fn structured_meta_tool_error_becomes_a_typed_dispatch_failure() {
+    let error = StructuredToolError::invalid_tool_arguments(
+        "x-data",
+        "query",
+        "/arguments/limit",
+        "limit must be an integer",
+    );
+    let dispatch_error = MetaToolError::structured(error).into_dispatch_error();
+    let outcome =
+        crate::tool_call_lifecycle::ToolOutcome::from_dispatch("call_tool", Err(dispatch_error));
+
+    match outcome {
+        crate::tool_call_lifecycle::ToolOutcome::Failed { class, text, .. } => {
+            assert_eq!(
+                class,
+                crate::tool_call_lifecycle::FailureClass::ArgumentInvalid
+            );
+            let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(value["ok"], false);
+            assert_eq!(value["failure_class"], "invalid_tool_arguments");
+        }
+        other => panic!("structured meta-tool error must be typed failed, got {other:?}"),
+    }
+}
+
+#[test]
 fn extract_text_empty_content() {
     let result = make_call_result(&[]);
     assert_eq!(extract_text(&result), "");

--- a/crates/gents/src/tool_call_lifecycle.rs
+++ b/crates/gents/src/tool_call_lifecycle.rs
@@ -54,7 +54,7 @@ impl ToolCallState {
         }
     }
 
-    pub(crate) fn from_persisted(value: &str) -> Option<Self> {
+    pub fn from_persisted(value: &str) -> Option<Self> {
         match value {
             "pending" => Some(Self::Pending),
             "awaitingApproval" => Some(Self::AwaitingApproval),

--- a/crates/gents/src/tool_call_lifecycle/runtime.rs
+++ b/crates/gents/src/tool_call_lifecycle/runtime.rs
@@ -84,6 +84,11 @@ impl ToolOutcome {
                 denial: None,
                 text: error.to_string(),
             },
+            Err(ToolError::ReportedFailure { class, text }) => Self::Failed {
+                class,
+                denial: None,
+                text,
+            },
             Err(ToolError::ToolCallError(error)) => Self::from_tool_call_error(&error.to_string()),
         }
     }

--- a/crates/gents/src/toolset/bash_tools.rs
+++ b/crates/gents/src/toolset/bash_tools.rs
@@ -159,6 +159,10 @@ impl Tool for ReadOnlyBashTool {
         )
         .await
     }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
+    }
 }
 
 impl Tool for UnrestrictedBashTool {
@@ -181,7 +185,7 @@ impl Tool for UnrestrictedBashTool {
         ToolDefinition {
             name: Self::NAME.to_string(),
             description: format!(
-                "Run a write-capable command under the configured writable root. Relative cwd values resolve from the active request workspace when one is provided, otherwise from the root. Current command policy: {policy_description}. If args is empty, command may be a shell command string; if args is present, command is treated as an executable name or path. Returns compact text with first-line gents_exec metadata. Set raw_json=true for structured JSON."
+                "Run a write-capable command under the configured writable root. Relative cwd values resolve from the active request workspace when one is provided, otherwise from the root. Current command policy: {policy_description}. If args is empty, command may be a shell command string; if args is present, command is treated as an executable name or path. Shell pipelines normally report only their final command's exit status, so avoid pipelines that mask an upstream failure or invoke a shell with pipefail explicitly. Returns compact text with first-line gents_exec metadata. Set raw_json=true for structured JSON."
             ),
             parameters: serde_json::json!({
                 "type": "object",
@@ -236,5 +240,9 @@ impl Tool for UnrestrictedBashTool {
             args.raw_json,
         )
         .await
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }

--- a/crates/gents/src/toolset/file_tools.rs
+++ b/crates/gents/src/toolset/file_tools.rs
@@ -209,6 +209,10 @@ impl Tool for ListFilesTool {
             )
             .await
     }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
+    }
 }
 
 impl Tool for ReadFileTool {
@@ -293,6 +297,10 @@ impl Tool for ReadFileTool {
             args.raw_json,
         )?)
     }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
+    }
 }
 
 impl Tool for GlobTool {
@@ -350,6 +358,10 @@ impl Tool for GlobTool {
                 Self::NAME,
             )
             .await
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }
 
@@ -415,6 +427,10 @@ impl Tool for GrepTool {
                 Self::NAME,
             )
             .await
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }
 
@@ -485,6 +501,10 @@ impl Tool for WriteFileTool {
             &output,
             args.raw_json,
         )?)
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }
 
@@ -713,6 +733,10 @@ impl Tool for EditFileTool {
             )
             .into()),
         }
+    }
+
+    fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
+        error.into_dispatch_error()
     }
 }
 

--- a/crates/gents/src/toolset/native_runner.rs
+++ b/crates/gents/src/toolset/native_runner.rs
@@ -7,6 +7,7 @@ use gents_fs_runner::protocol::{NativeFsRunnerRequest, NativeFsRunnerResponse};
 use super::shared::{ToolContext, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
 use crate::tool_call_lifecycle::runtime::current_tool_runtime_context;
+use crate::tool_call_lifecycle::FailureClass;
 
 const MAX_NATIVE_RUNNER_OUTPUT_BYTES: usize = 2 * 1024 * 1024;
 const RUNNER_ENV: &str = "GENTS_FS_RUNNER";
@@ -45,6 +46,17 @@ fn fs_runner_timed_out_result(
     }
     format!(
         "native filesystem runner for {tool_name} exceeded the {MAX_FS_RUNNER_SECONDS}s per-call cap and was stopped before completing. Narrow the path or pattern (a more specific anchor prunes the walk), or split the search into smaller calls."
+    )
+}
+
+fn fs_runner_timed_out_error(
+    tool_name: &str,
+    request_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> ToolError {
+    ToolError::reported_failure(
+        FailureClass::External,
+        fs_runner_timed_out_result(tool_name, request_deadline, now),
     )
 }
 
@@ -109,7 +121,7 @@ impl NativeFsRunner {
                 stdout_truncated,
                 stderr_truncated,
             ),
-            ManagedExecOutcome::TimedOut { .. } => Ok(fs_runner_timed_out_result(
+            ManagedExecOutcome::TimedOut { .. } => Err(fs_runner_timed_out_error(
                 tool_name,
                 request_deadline,
                 chrono::Utc::now(),
@@ -358,6 +370,21 @@ mod tests {
         let now = Utc::now();
         let result = fs_runner_timed_out_result("grep", None, now);
         assert!(result.contains("per-call cap"), "{result}");
+    }
+
+    #[test]
+    fn cap_expiry_is_a_recoverable_typed_failure() {
+        let now = Utc::now();
+        let dispatch_error = fs_runner_timed_out_error("grep", None, now).into_dispatch_error();
+        let outcome =
+            crate::tool_call_lifecycle::ToolOutcome::from_dispatch("grep", Err(dispatch_error));
+        assert!(matches!(
+            outcome,
+            crate::tool_call_lifecycle::ToolOutcome::Failed {
+                class: FailureClass::External,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/gents/src/toolset/shared/command.rs
+++ b/crates/gents/src/toolset/shared/command.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use super::context::{ToolContext, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
 use crate::tool_call_lifecycle::runtime::current_tool_runtime_context;
+use crate::tool_call_lifecycle::FailureClass;
 use crate::toolset::{CommandPolicyDenial, DenialReason};
 use crate::truncation::{truncate, TruncationLimits, TruncationMode};
 
@@ -286,8 +287,17 @@ pub(crate) async fn run_command(
         stdout: stdout.content,
         stderr: stderr.content,
     };
-
-    render_command_output(&output, raw_json).map_err(Into::into)
+    let rendered = render_command_output(&output, raw_json).map_err(ToolError::from)?;
+    if output.metadata.ok {
+        Ok(rendered)
+    } else {
+        let class = if output.metadata.timed_out {
+            FailureClass::External
+        } else {
+            FailureClass::ToolReturnedError
+        };
+        Err(ToolError::reported_failure(class, rendered))
+    }
 }
 
 #[cfg(test)]

--- a/crates/gents/src/toolset/shared/context.rs
+++ b/crates/gents/src/toolset/shared/context.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
 
+use crate::tool_call_lifecycle::FailureClass;
 use crate::toolset::CommandPolicyDenial;
 
 #[derive(Clone)]
@@ -15,6 +16,7 @@ pub(crate) struct ToolContext {
 pub(crate) enum ToolError {
     Other(anyhow::Error),
     PolicyDenial(CommandPolicyDenial),
+    ReportedFailure { class: FailureClass, text: String },
 }
 
 impl ToolError {
@@ -22,11 +24,28 @@ impl ToolError {
         Self::PolicyDenial(denial)
     }
 
+    pub(crate) fn reported_failure(class: FailureClass, text: String) -> Self {
+        Self::ReportedFailure { class, text }
+    }
+
+    pub(crate) fn into_dispatch_error(self) -> crate::llm::tool::ToolError {
+        match self {
+            Self::PolicyDenial(denial) => crate::llm::tool::ToolError::ReportedFailure {
+                class: FailureClass::PolicyDenied,
+                text: denial.tool_error_payload(),
+            },
+            Self::ReportedFailure { class, text } => {
+                crate::llm::tool::ToolError::ReportedFailure { class, text }
+            }
+            other => crate::llm::tool::ToolError::ToolCallError(Box::new(other)),
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn command_policy_denial(&self) -> Option<&CommandPolicyDenial> {
         match self {
             Self::PolicyDenial(denial) => Some(denial),
-            Self::Other(_) => None,
+            Self::Other(_) | Self::ReportedFailure { .. } => None,
         }
     }
 }
@@ -36,6 +55,7 @@ impl std::fmt::Display for ToolError {
         match self {
             Self::Other(error) => write!(f, "{error:#}"),
             Self::PolicyDenial(denial) => write!(f, "{}", denial.tool_error_payload()),
+            Self::ReportedFailure { text, .. } => f.write_str(text),
         }
     }
 }
@@ -44,7 +64,7 @@ impl std::error::Error for ToolError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Other(error) => Some(error.root_cause()),
-            Self::PolicyDenial(_) => None,
+            Self::PolicyDenial(_) | Self::ReportedFailure { .. } => None,
         }
     }
 }

--- a/crates/gents/src/toolset/shared/context/tests.rs
+++ b/crates/gents/src/toolset/shared/context/tests.rs
@@ -1,4 +1,24 @@
-use super::{resolve_default_read_root, ToolContext};
+use super::{resolve_default_read_root, ToolContext, ToolError};
+use crate::tool_call_lifecycle::FailureClass;
+use crate::toolset::{CommandExecutionMode, CommandNetworkMode, CommandPolicyDenial, DenialReason};
+
+#[test]
+fn policy_denial_reaches_dispatch_as_typed_failure() {
+    let denial = CommandPolicyDenial::new(
+        DenialReason::DisabledNetworkUnenforceable,
+        CommandExecutionMode::ReadOnly,
+        CommandNetworkMode::Disabled,
+    );
+    let expected = denial.tool_error_payload();
+
+    match ToolError::policy_denial(denial).into_dispatch_error() {
+        crate::llm::tool::ToolError::ReportedFailure { class, text } => {
+            assert_eq!(class, FailureClass::PolicyDenied);
+            assert_eq!(text, expected);
+        }
+        other => panic!("expected typed policy denial, got {other:?}"),
+    }
+}
 
 #[test]
 fn default_read_root_prefers_current_dir() {

--- a/crates/gents/src/toolset/tests.rs
+++ b/crates/gents/src/toolset/tests.rs
@@ -1724,7 +1724,38 @@ async fn bash_output_supports_raw_json_escape_hatch() {
 }
 
 #[tokio::test]
-async fn bash_timeout_reports_metadata_instead_of_error() {
+async fn bash_nonzero_exit_is_a_typed_tool_failure_with_metadata() {
+    let root = temp_root("gents-bash-nonzero");
+    let tool = ReadOnlyBashTool::new(
+        ToolContext::new(root, false).unwrap(),
+        Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+        vec!["false".to_string()],
+    );
+    let boxed: Box<dyn crate::llm::tool::ToolDyn> = Box::new(tool);
+
+    let outcome = crate::tool_call_lifecycle::runtime::call_tool_managed(
+        boxed.as_ref(),
+        serde_json::json!({ "command": "false" }).to_string(),
+    )
+    .await;
+
+    match outcome {
+        crate::tool_call_lifecycle::ToolOutcome::Failed { class, text, .. } => {
+            assert_eq!(
+                class,
+                crate::tool_call_lifecycle::FailureClass::ToolReturnedError
+            );
+            let meta = compact_exec_meta(&text);
+            assert_eq!(meta["ok"], false);
+            assert_eq!(meta["status"], "exit_nonzero");
+            assert_ne!(meta["exit_code"], 0);
+        }
+        other => panic!("nonzero command must be a typed failure, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bash_per_call_timeout_is_a_recoverable_typed_failure_with_metadata() {
     let root = temp_root("gents-bash-timeout");
     let tool = ReadOnlyBashTool::new(
         ToolContext::new(root, false).unwrap(),
@@ -1732,24 +1763,29 @@ async fn bash_timeout_reports_metadata_instead_of_error() {
         vec!["sleep".to_string()],
     );
 
-    let output = crate::llm::tool::Tool::call(
-        &tool,
-        BashArgs {
-            command: "sleep".to_string(),
-            args: vec!["2".to_string()],
-            cwd: None,
-            timeout_secs: Some(1),
-            raw_json: false,
-        },
+    let boxed: Box<dyn crate::llm::tool::ToolDyn> = Box::new(tool);
+    let outcome = crate::tool_call_lifecycle::runtime::call_tool_managed(
+        boxed.as_ref(),
+        serde_json::json!({
+            "command": "sleep",
+            "args": ["2"],
+            "timeout_secs": 1,
+        })
+        .to_string(),
     )
-    .await
-    .unwrap();
+    .await;
 
-    let meta = compact_exec_meta(&output);
-    assert_eq!(meta["ok"], false);
-    assert_eq!(meta["status"], "timeout");
-    assert_eq!(meta["timed_out"], true);
-    assert!(meta["exit_code"].is_null());
+    match outcome {
+        crate::tool_call_lifecycle::ToolOutcome::Failed { class, text, .. } => {
+            assert_eq!(class, crate::tool_call_lifecycle::FailureClass::External);
+            let meta = compact_exec_meta(&text);
+            assert_eq!(meta["ok"], false);
+            assert_eq!(meta["status"], "timeout");
+            assert_eq!(meta["timed_out"], true);
+            assert!(meta["exit_code"].is_null());
+        }
+        other => panic!("per-call timeout must be a recoverable typed failure, got {other:?}"),
+    }
 }
 
 #[cfg(unix)]
@@ -1800,18 +1836,17 @@ async fn unrestricted_bash_timeout_kills_descendants_and_returns_promptly() {
     let command =
         "trap '' TERM; while :; do sleep 1; done & child=$!; printf '%s' \"$child\" > descendant.pid; wait";
 
-    let call = crate::llm::tool::Tool::call(
-        &tool,
-        BashArgs {
-            command: command.to_string(),
-            args: Vec::new(),
-            cwd: None,
-            timeout_secs: Some(1),
-            raw_json: false,
-        },
+    let boxed: Box<dyn crate::llm::tool::ToolDyn> = Box::new(tool);
+    let call = crate::tool_call_lifecycle::runtime::call_tool_managed(
+        boxed.as_ref(),
+        serde_json::json!({
+            "command": command,
+            "timeout_secs": 1,
+        })
+        .to_string(),
     );
-    let output = match tokio::time::timeout(Duration::from_secs(4), call).await {
-        Ok(result) => result.unwrap(),
+    let outcome = match tokio::time::timeout(Duration::from_secs(4), call).await {
+        Ok(outcome) => outcome,
         Err(_) => {
             if let Ok(pid) =
                 std::fs::read_to_string(&pid_file).map(|value| value.trim().parse::<i32>().unwrap())
@@ -1822,6 +1857,14 @@ async fn unrestricted_bash_timeout_kills_descendants_and_returns_promptly() {
             }
             panic!("bash timeout hung while a descendant held its output pipes open");
         }
+    };
+    let crate::tool_call_lifecycle::ToolOutcome::Failed {
+        class: crate::tool_call_lifecycle::FailureClass::External,
+        text: output,
+        ..
+    } = outcome
+    else {
+        panic!("background process-tree timeout must be typed failed, got {outcome:?}");
     };
 
     let meta = compact_exec_meta(&output);
@@ -1874,18 +1917,24 @@ async fn workspace_write_bash_contains_writes_to_tool_root() {
         outside.display()
     );
 
-    let output = crate::llm::tool::Tool::call(
-        &tool,
-        BashArgs {
-            command: shell,
-            args: Vec::new(),
-            cwd: None,
-            timeout_secs: Some(DEFAULT_COMMAND_TIMEOUT_SECS),
-            raw_json: false,
-        },
+    let boxed: Box<dyn crate::llm::tool::ToolDyn> = Box::new(tool);
+    let outcome = crate::tool_call_lifecycle::runtime::call_tool_managed(
+        boxed.as_ref(),
+        serde_json::json!({
+            "command": shell,
+            "timeout_secs": DEFAULT_COMMAND_TIMEOUT_SECS,
+        })
+        .to_string(),
     )
-    .await
-    .unwrap();
+    .await;
+    let crate::tool_call_lifecycle::ToolOutcome::Failed {
+        class: crate::tool_call_lifecycle::FailureClass::ToolReturnedError,
+        text: output,
+        ..
+    } = outcome
+    else {
+        panic!("seatbelt denial must be typed failed, got {outcome:?}");
+    };
 
     let meta = compact_exec_meta(&output);
     assert_eq!(meta["sandbox"], "macos_seatbelt");

--- a/crates/gents/src/trace_export.rs
+++ b/crates/gents/src/trace_export.rs
@@ -3,6 +3,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use crate::tool_call_lifecycle::ToolCallState;
+
 pub use crate::tool_call_lifecycle::FailureClass as ToolFailureClass;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -131,8 +133,54 @@ pub fn analyze_tool_call(
     result: &str,
     status: &str,
 ) -> ToolCallTraceAnalysis {
+    analyze_tool_call_with_persisted_outcome(tool_name, raw_args, result, status, None, None)
+}
+
+pub fn analyze_tool_call_with_persisted_outcome(
+    tool_name: &str,
+    raw_args: &str,
+    result: &str,
+    legacy_status: &str,
+    lifecycle_state: Option<&str>,
+    persisted_failure_class: Option<&str>,
+) -> ToolCallTraceAnalysis {
     let mut analysis = analyze_arguments(tool_name, raw_args);
     analysis.native_tool_output = native_tool_output_from_result(tool_name, result);
+
+    if let Some(lifecycle_state) = lifecycle_state.filter(|state| !state.trim().is_empty()) {
+        let lifecycle_state = ToolCallState::from_persisted(lifecycle_state.trim());
+        let persisted_failure_class = persisted_failure_class.and_then(failure_class_from_str);
+        let failure_class = persisted_failure_class.or_else(|| match lifecycle_state {
+            Some(ToolCallState::TimedOut) => Some(ToolFailureClass::External),
+            Some(ToolCallState::Failed) => Some(ToolFailureClass::ToolReturnedError),
+            _ => None,
+        });
+        let completed = lifecycle_state == Some(ToolCallState::Completed);
+
+        // Current rows carry their outcome explicitly. Keep result parsing useful
+        // for trace shape, but never let model-facing text override durable state.
+        analysis.tool_failure_class = failure_class;
+        analysis.tool_result_ok = completed && failure_class.is_none();
+        analysis.tool_error = failure_class.map(|failure_class| TraceToolError {
+            failure_class,
+            service_id: analysis.selected_service_id.clone(),
+            tool_name: analysis.selected_tool_name.clone(),
+            requested_tool_name: None,
+            path: analysis
+                .validation_errors
+                .first()
+                .map(|error| error.path.clone()),
+            message: analysis
+                .validation_errors
+                .first()
+                .map(|error| error.message.clone()),
+            retryable: retryable_for_failure_class(failure_class),
+            available_tools: None,
+            raw_error_text: raw_tool_error_text(result, &analysis),
+        });
+        return analysis;
+    }
+
     let structured_tool_error = structured_tool_error_from_result(result);
     if let Some(error) = &structured_tool_error {
         analysis.tool_failure_class = Some(error.failure_class);
@@ -157,7 +205,7 @@ pub fn analyze_tool_call(
         analysis.tool_failure_class = classify_result_text(result);
     }
 
-    let completed = status.trim().eq_ignore_ascii_case("completed");
+    let completed = legacy_status.trim().eq_ignore_ascii_case("completed");
     if analysis.tool_failure_class.is_none()
         && analysis
             .native_tool_output

--- a/crates/gents/src/trace_export/tests.rs
+++ b/crates/gents/src/trace_export/tests.rs
@@ -22,6 +22,65 @@ fn successful_completed_result_has_no_failure_class() {
 }
 
 #[test]
+fn persisted_outcome_is_authoritative_over_success_looking_result_text() {
+    let analysis = analyze_tool_call_with_persisted_outcome(
+        "call_tool",
+        r#"{"service_id":"x-data","tool_name":"query","arguments":{}}"#,
+        "ordinary model-facing detail",
+        "failed",
+        Some("failed"),
+        Some("serviceUnavailable"),
+    );
+
+    assert!(!analysis.tool_result_ok);
+    assert_eq!(
+        analysis.tool_failure_class,
+        Some(ToolFailureClass::ServiceUnavailable)
+    );
+    assert_eq!(
+        analysis
+            .tool_error
+            .as_ref()
+            .map(|error| error.failure_class),
+        Some(ToolFailureClass::ServiceUnavailable)
+    );
+}
+
+#[test]
+fn durable_completed_outcome_ignores_failure_shaped_result_text() {
+    let analysis = analyze_tool_call_with_persisted_outcome(
+        "read",
+        r#"{"path":"README.md"}"#,
+        "tool call failed: permission denied",
+        "completed",
+        Some("completed"),
+        None,
+    );
+
+    assert!(analysis.tool_result_ok);
+    assert_eq!(analysis.tool_failure_class, None);
+    assert_eq!(analysis.tool_error, None);
+}
+
+#[test]
+fn durable_timeout_uses_lifecycle_when_failure_class_is_absent() {
+    let analysis = analyze_tool_call_with_persisted_outcome(
+        "bash",
+        r#"{"command":"sleep"}"#,
+        "",
+        "failed",
+        Some("timedOut"),
+        None,
+    );
+
+    assert!(!analysis.tool_result_ok);
+    assert_eq!(
+        analysis.tool_failure_class,
+        Some(ToolFailureClass::External)
+    );
+}
+
+#[test]
 fn compact_contract_text_that_mentions_unknown_fields_is_successful() {
     let result = "## coding_overview\n\nInput contract:\n- Unknown top-level fields: rejected (`additionalProperties: false`)\n\nCommon mistakes:\n- Do not add unlisted top-level fields; this schema rejects unknown arguments.";
     let result = format!("{result}\n- Use the exact field names and JSON types shown above.");

--- a/crates/gents/tests/conformance/codex_shim.rs
+++ b/crates/gents/tests/conformance/codex_shim.rs
@@ -72,9 +72,11 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
     assert_eq!(
         pending.lean_theorems,
         vec![
-            "CodexShim.project_pending_is_in_progress".to_string(),
-            "CodexShim.nonterminal_without_response_projects_in_progress".to_string(),
-            "CodexShim.request_transition_projection_monotonic".to_string(),
+            "deriveAttempt_total".to_string(),
+            "lifecycle_transition_monotonic".to_string(),
+            "terminal_coherence".to_string(),
+            "CodexShim.projectClientTurnState_terminal".to_string(),
+            "CodexShim.projection_without_local_interrupt".to_string(),
             "CodexShim.codex_turn_terminates_precisely".to_string(),
         ]
     );
@@ -89,7 +91,7 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
     assert!(!completed.interruptible_request_state);
     assert!(completed
         .lean_theorems
-        .contains(&"CodexShim.terminal_request_overrides_response".to_string()));
+        .contains(&"terminal_coherence".to_string()));
 
     let local_interrupt = lean_codex_shim_projection_case(
         "codex_shim.projection.local_interrupt_preempts_core_state",
@@ -207,15 +209,27 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
     }
 
     let status_cases = lean_codex_shim_subagent_status_cases();
-    assert_eq!(status_cases.len(), 9);
+    assert_eq!(status_cases.len(), 11);
     for case in status_cases {
-        let expected = match case.request_state.as_str() {
-            "pending" => ("pendingInit", false),
-            "claimed" | "processing" | "inputRequired" => ("running", false),
-            "completed" => ("completed", true),
-            "failed" | "dead" => ("errored", true),
-            "superseded" | "interrupted" => ("interrupted", true),
-            other => panic!("{}: unmodeled child request state {other:?}", case.witness),
+        let head = gents_protocol::client_protocol::project_persisted_attempt(
+            &case.request_state,
+            false,
+            case.response_status.as_deref(),
+        )
+        .unwrap_or_else(|| panic!("{}: invalid client head", case.witness));
+        use gents_protocol::client_protocol::{ClientTurnState, RequestLifecycleState};
+        let expected = match (head.turn_state, head.request_state) {
+            (ClientTurnState::Completed, _) => ("completed", true),
+            (ClientTurnState::Failed, _) => ("errored", true),
+            (ClientTurnState::Superseded | ClientTurnState::Interrupted, _) => {
+                ("interrupted", true)
+            }
+            (ClientTurnState::WaitingForClaim, RequestLifecycleState::Pending) => {
+                ("pendingInit", false)
+            }
+            (ClientTurnState::WaitingForClaim | ClientTurnState::Streaming, _) => {
+                ("running", false)
+            }
         };
         assert_eq!(case.projected_agent_status, expected.0, "{}", case.witness);
         assert_eq!(case.terminal, expected.1, "{}", case.witness);
@@ -359,15 +373,26 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
     assert_eq!(reset_before_terminal.completed_text, None);
 
     let thread_status_cases = lean_codex_shim_thread_status_cases();
-    assert_eq!(thread_status_cases.len(), 11);
+    assert_eq!(thread_status_cases.len(), 13);
     for case in thread_status_cases {
-        let expected = match case.request_state.as_deref() {
-            Some("pending" | "claimed" | "processing" | "inputRequired") => "active",
-            Some("failed" | "dead") => "systemError",
-            Some("completed" | "superseded" | "interrupted") => "idle",
+        use gents_protocol::client_protocol::ClientTurnState;
+        let head = case.request_state.as_deref().and_then(|request_state| {
+            gents_protocol::client_protocol::project_persisted_attempt(
+                request_state,
+                false,
+                case.response_status.as_deref(),
+            )
+        });
+        let expected = match head.map(|head| head.turn_state) {
+            Some(ClientTurnState::WaitingForClaim | ClientTurnState::Streaming) => "active",
+            Some(ClientTurnState::Failed) => "systemError",
+            Some(
+                ClientTurnState::Completed
+                | ClientTurnState::Superseded
+                | ClientTurnState::Interrupted,
+            ) => "idle",
             None if case.conversation_status == "error" => "systemError",
             None => "idle",
-            Some(other) => panic!("{}: unknown request state {other}", case.witness),
         };
         assert_eq!(case.projected_status, expected, "{}", case.witness);
     }

--- a/crates/gents/tests/conformance/managed_exec.rs
+++ b/crates/gents/tests/conformance/managed_exec.rs
@@ -79,6 +79,15 @@ pub(super) fn managed_exec_liveness_cases_pin_native_process_boundary() {
     assert_eq!(cancel.expected_tool_state, "cancelled");
     assert!(cancel.kill_signal_required);
 
+    let nonzero = cases
+        .iter()
+        .find(|case| case.name == "nonzero_child_exit_fails_without_kill")
+        .expect("nonzero-exit outcome case must be emitted");
+    assert_eq!(nonzero.trigger, "observeExitFailure");
+    assert_eq!(nonzero.expected_exec_state, "exited");
+    assert_eq!(nonzero.expected_tool_state, "failed");
+    assert!(!nonzero.kill_signal_required);
+
     for case in cases {
         if case.expected_exec_state == "killSignaled" {
             assert!(


### PR DESCRIPTION
## What changed

Carries the already-reviewed and merged #1095 patch onto current main after its stacked base was squash-merged first. Centralizes Codex thread, child-agent, watcher, stream, and interrupt state on the generic durable client-head projection; prefers canonical conversation heads with deterministic replication-lag fallback; and adds Lean/Rust response-before-request conformance coverage.

## Why

#1095 merged into the now-closed staging branch after #1062 had already merged to main, so its commits were not reachable from the default branch. This PR contains the exact #1095 squash patch on top of current main.

## Validation

- lake build
- focused generated Codex conformance test
- 109 Codex shim unit tests
- 134 gents-protocol unit tests
- cargo check --workspace --all-targets
- full gents library: 1467 passed, 1 ignored
- full conformance: 336 passed

The full local package run also reached one repeatable failure in an unchanged P2P transport-wave test requiring zero failed pushes; that test and transport path are outside this patch.