### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.10.1"
+        default: "0.11.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.10.1"
+        default: "0.11.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.11.0 - 2026-08-11
+
+### Bridge contract
+
+- Advance the additive desktop bridge contract from 0.5 to 0.9: Grok OAuth
+  login, managed local-server lifecycle and tray events, and provider-account
+  inventory/disconnect controls (#973, #1013, #1089).
+- Advance the Rust and npm desktop package train together to 0.11.0.
+
+### Runtime and formal foundation
+
+- Make schema provenance and signing DefraDB-native, and persist the exact
+  rendered provider request before send (#1087, #1059).
+- Add deterministic inference seeds and request-wide token budgets (#1062).
+- Extend the Lean-fenced runtime foundation across prompt assembly, compaction,
+  admission slot accounting, tool-call CAS transitions, recovery, and
+  background/subagent lifecycle convergence (#999, #998, #1007, #1006).
+- Align durable tool outcomes across timeline projections and add
+  Harbor-compatible ATIF trace export (#1095, #1098, #988).
+
+### Agents, configuration, and automation
+
+- Add persona request flows, reusable directory persona and inference-profile
+  catalogs, and safer self-configuration ergonomics (#1028, #1014, #1050,
+  #1052, #1056, #1057).
+- Add document-driven EventTrigger graph experiments and capture consumers
+  for persisted runtime facts (#1081, #1080).
+
+### Providers, CLI, and desktop
+
+- Add Grok/xAI subscription OAuth across the runtime, CLI, and desktop (#973,
+  #974), plus provider-account settings and disconnect controls (#1089).
+- Make local desktop agent onboarding optional and add managed-server controls
+  (#1013).
+- Align CLI initialization and lineage behavior with signed provenance, while
+  retaining compatibility with older provenance JSON (#1094, #1092).
+
+### Build and reliability
+
+- Split and cache Rust CI workloads, slim the CLI dependency graph, and add
+  release dependency/binary metrics (#1011, #1024, #1097).
+- Favor faster local and release builds with non-LTO profiles and parallel code
+  generation; harden runtime cancellation, bridge reconciliation, and
+  resource-contended conformance startup (#1097).
+
+### Dependencies
+
+- Advance DefraDB to v0.18.0 (`61e429fc`).
+
 ## 0.10.1 - 2026-07-30
 
 ### Dependencies
@@ -91,6 +140,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 | Tag        | Bridge crate | npm packages | contract_version | Notes                                         |
 | ---------- | ------------ | ------------ | ---------------- | --------------------------------------------- |
+| v0.11.0    | 0.11.0       | 0.11.0       | 0.9              | DefraDB v0.18.0; signed provenance and build metrics |
 | v0.10.1    | 0.10.1       | 0.10.1       | 0.5              | DefraDB v0.17.4; mobile/subagent/migration fixes |
 | v0.10.0    | 0.10.0       | 0.10.0       | 0.5              | Reusable desktop packages implemented in #878 |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4482,7 +4482,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "gents-chatgpt-login"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.2",
@@ -4994,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "gents-codex-protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.10.1"
+version = "0.11.0"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.10.1",
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-fleet": "0.10.1",
-    "@source-inc/gents-desktop-operations": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1",
+    "@source-inc/gents-desktop-chat": "0.11.0",
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-fleet": "0.11.0",
+    "@source-inc/gents-desktop-operations": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -52,12 +52,12 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-chat": "0.10.1",
-    "@source-inc/gents-desktop-fleet": "0.10.1",
-    "@source-inc/gents-desktop-operations": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1"
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-chat": "0.11.0",
+    "@source-inc/gents-desktop-fleet": "0.11.0",
+    "@source-inc/gents-desktop-operations": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0"
   },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.6.0",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.10.1</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.10.1</string>
+	<string>0.11.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.10.1
-        CFBundleVersion: "0.10.1"
+        CFBundleShortVersionString: 0.11.0
+        CFBundleVersion: "0.11.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -301,7 +301,7 @@
     "desktop://managed-server-updated",
     "desktop://managed-server-tray-stop"
   ],
-  "packageVersion": "0.10.1",
+  "packageVersion": "0.11.0",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
+++ b/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
@@ -10,7 +10,7 @@
         },
         "model_name": "deepseek-ai/DeepSeek-V4-Flash-0731",
         "name": "terminal-bench",
-        "version": "0.10.1"
+        "version": "0.11.0"
       },
       "extra": {
         "source_projection_id": "run_timeline",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.10.1
-docker run --rm ghcr.io/source-inc/gents:v0.10.1 version
+docker pull ghcr.io/source-inc/gents:v0.11.0
+docker run --rm ghcr.io/source-inc/gents:v0.11.0 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.10.1 \
+  ghcr.io/source-inc/gents:v0.11.0 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.10.1 \
+  ghcr.io/source-inc/gents:v0.11.0 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -18,14 +18,14 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.10.1",
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-fleet": "0.10.1",
-        "@source-inc/gents-desktop-operations": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-chat": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-fleet": "0.11.0",
+        "@source-inc/gents-desktop-operations": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,17 +43,17 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.10.1",
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-fleet": "0.10.1",
-        "@source-inc/gents-desktop-operations": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-chat": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-fleet": "0.11.0",
+        "@source-inc/gents-desktop-operations": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -5088,12 +5088,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5103,9 +5103,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5115,7 +5115,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5127,16 +5127,16 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
         "jsqr": "^1.4.0"
       },
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5145,21 +5145,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5168,24 +5168,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.10.1",
-        "@source-inc/gents-desktop-tokens": "0.10.1",
-        "@source-inc/gents-desktop-ui": "0.10.1",
+        "@source-inc/gents-desktop-client": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-ui": "0.11.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5197,7 +5197,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.10.1",
+        "@source-inc/gents-desktop-tokens": "0.11.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1"
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1",
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,7 +15,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.10.1";
+export const PACKAGE_VERSION = "0.11.0";
 export const MINIMUM_BRIDGE_CONTRACT_VERSION = "0.7";
 
 export function assertCompatibleBridgeContract(

--- a/packages/gents-desktop-client/src/store.test.ts
+++ b/packages/gents-desktop-client/src/store.test.ts
@@ -36,7 +36,7 @@ describe("createDesktopStore", () => {
         },
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.10.1",
+          packageVersion: "0.11.0",
           events: [],
           eventReasons: [],
           errorCodes: [],
@@ -66,7 +66,7 @@ describe("createDesktopStore", () => {
         desktop_client_start: () => ({}),
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.10.1",
+          packageVersion: "0.11.0",
           events: [],
           eventReasons: [],
           errorCodes: [],

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "Reusable peer discovery, pairing, health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -40,14 +40,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1"
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1",
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "Reusable operations rail, liveness, health, lineage, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1"
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.10.1",
-    "@source-inc/gents-desktop-tokens": "0.10.1",
-    "@source-inc/gents-desktop-ui": "0.10.1",
+    "@source-inc/gents-desktop-client": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-ui": "0.11.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.10.1",
+    "@source-inc/gents-desktop-tokens": "0.11.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary
- advance Rust, npm, Tauri, Apple, fixture, and release-workflow versions to 0.11.0
- document the v0.11.0 runtime, desktop, formal-foundation, build, and DefraDB v0.18.0 changes
- keep desktop package manifests and lockfiles on the required lockstep release version

## Validation
- `RUST_MIN_STACK=16777216 cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `npm run check:package-boundaries`
- `npm run build:packages`
- `npm run test:packages`
- `git diff --check`

This is the final preparation PR for the v0.11.0 minor release. After merge, the merge commit will be tagged `v0.11.0`; tag workflows will publish Linux, signed/notarized macOS, npm package, build-metrics, checksum, debug-symbol, and container artifacts.