### PR TITLE
fix(release): measure artifacts in container jobs

### DIFF
--- a/scripts/measure-gents-binary.sh
+++ b/scripts/measure-gents-binary.sh
@@ -67,10 +67,18 @@ sha256_file() {
   fi
 }
 
-git_sha=$(git rev-parse HEAD)
 git_dirty=false
-if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
-  git_dirty=true
+if [[ -n "${GITHUB_SHA:-}" ]]; then
+  # Actions checks out the immutable workflow SHA. Prefer that authoritative
+  # value because container jobs can intentionally have a different uid than
+  # the host-owned checkout, which makes Git reject repository inspection as
+  # dubious ownership even though the checked-out sources are valid.
+  git_sha=$GITHUB_SHA
+else
+  git_sha=$(git rev-parse HEAD)
+  if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+    git_dirty=true
+  fi
 fi
 cargo_lock_sha256=$(sha256_file Cargo.lock)
 rust_version=$(rustc --version)


### PR DESCRIPTION
## Summary
- use the authoritative GitHub Actions SHA when collecting release metrics
- avoid Git repository inspection inside container jobs where the host-owned checkout intentionally has a different uid
- preserve local commit and dirty-tree detection outside Actions

## Root cause
The v0.11.0 x86_64 Linux binary built, packaged, checksum-verified, and reported the correct version, but the post-build metrics step failed because Git rejected `/__w/gents/gents` as dubious ownership inside the release container.

## Validation
- `bash -n scripts/measure-gents-binary.sh`
- `shellcheck scripts/measure-gents-binary.sh`
- `GITHUB_SHA=f44a60aeda2d70c7f317a55f0c12ff32c313da53 MEASURE_MODE=graph scripts/measure-gents-binary.sh`
- `git diff --check`

After merge, the v0.11.0 Linux and macOS release workflows can be dispatched from `main` to attach the missing artifacts to the existing release tag.