### PR TITLE
Speed trusted macOS releases and fix graph metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,16 @@ jobs:
         env:
           MEASURE_MODE: graph
           OUTPUT_JSON: ${{ runner.temp }}/gents-build-graph-${{ github.sha }}.json
-        run: scripts/measure-gents-binary.sh
+        run: |
+          scripts/measure-gents-binary.sh
+          jq -e '
+            .schema_version == 2
+            and .dependencies.root_package == "gents-cli"
+            and .dependencies.target == .target_triple
+            and .dependencies.normal_packages > 0
+            and .dependencies.all_target_normal_packages >= .dependencies.normal_packages
+            and (.dependencies.duplicate_packages | length) == .dependencies.duplicate_package_names
+          ' "${OUTPUT_JSON}" >/dev/null
 
       - name: Upload Rust dependency graph metrics
         if: matrix.suite == 'support'

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -59,7 +59,13 @@ env:
 jobs:
   build-sign-package:
     name: Build, sign, and package macOS CLI
-    runs-on: [self-hosted, macOS, ARM64, studio]
+    # Release artifacts remain isolated under CARGO_RELEASE_TARGET_ROOT. Pin the
+    # job to the registration that owns the trusted release target tree so a
+    # normal source edit reuses prior release artifacts instead of randomly
+    # landing on one of three cold Studio registrations. SCCACHE_RECACHE stays
+    # enabled below: rustc invocations still cannot consume PR-populated cache
+    # objects.
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-2, ci-desktop]
     timeout-minutes: 120
 
     steps:

--- a/docs/build-measurements.md
+++ b/docs/build-measurements.md
@@ -115,22 +115,24 @@ without weakening the sccache boundary. Record cold, unchanged-source warm,
 and representative source-edit timings separately; the pin trades automatic
 runner failover for deterministic trusted-cache reuse.
 
-An unsigned workflow dispatch at commit `d0e1ca3b` measured the representative
-trusted-target rebuild after this change. Cargo rebuilt only `gents-cli`; all
-dependencies and the core `gents` runtime remained reusable. The changed Git
-revision still invalidated the final crate's compile/link, so this is not an
-unchanged-source no-op measurement:
+Two unsigned workflow dispatches at commit `d0e1ca3b` measured the
+representative trusted-target rebuild after this change. Cargo rebuilt only
+`gents-cli`; all dependencies and the core `gents` runtime remained reusable.
+Each clean checkout still invalidated the final crate's compile/link, so these
+are not unchanged-source no-op measurements:
 
 | Cache state | Cargo build | Raw binary | gzip -9 | Archive |
 |---|---:|---:|---:|---:|
 | v0.11.0 cold trusted target | 2,005s | 70,300,272 | 26,580,064 | 26,641,927 |
-| pinned trusted target, new revision | 524s | 70,299,648 | 26,577,430 | 26,639,171 |
+| pinned trusted target, clean checkout 1 | 524s | 70,299,648 | 26,577,430 | 26,639,171 |
+| pinned trusted target, clean checkout 2 | 426s | 70,299,648 | 26,577,430 | 26,639,171 |
 
-The representative new-revision build is 73.9% faster (3.83x) than the cold
-v0.11.0 release. The second row came from an unsigned dry run, so its size
+The representative clean-checkout builds are 73.9–78.8% faster (3.83–4.71x)
+than the cold v0.11.0 release. The dry runs were unsigned, so their size
 differences include the missing Developer ID signature and are not a claim of
-binary-size improvement. Raw workflow:
-https://github.com/source-inc/gents/actions/runs/31601223603.
+binary-size improvement. Raw workflows:
+https://github.com/source-inc/gents/actions/runs/31601223603 and
+https://github.com/source-inc/gents/actions/runs/31602179888.
 
 Useful next investigations are to rank duplicate packages by compiled size,
 map features that pull each duplicate version, split optional desktop/provider

--- a/docs/build-measurements.md
+++ b/docs/build-measurements.md
@@ -1,9 +1,10 @@
 # Build measurements
 
 The repository records release and dependency-graph measurements with
-`scripts/measure-gents-binary.sh`. Reports use a stable JSON schema and include
+`scripts/measure-gents-binary.sh`. Reports use a versioned JSON schema and include
 the commit, dirty state, `Cargo.lock` hash, Rust version, target triple, release
-profile, build time, binary and archive hashes/sizes, and dependency counts.
+profile, build time, binary and archive hashes/sizes, target-scoped dependency
+counts, and machine-readable duplicate-version identities.
 
 Use:
 
@@ -54,7 +55,8 @@ invalidated profile in 257 seconds and linked all three test executables.
 
 ## Dependency baseline
 
-The normal `gents-cli` graph currently contains:
+At the PR #1097 measurement commit, the normal macOS `gents-cli` graph
+contained:
 
 - 820 unique package/version entries
 - 69 package names resolved at more than one version or source
@@ -64,7 +66,73 @@ The earlier 1,142-package result counted Cargo tree's repeated `(*)` display
 rows as distinct entries. The measurement script strips that marker before
 deduplicating package/version identities.
 
+### v0.11.0 report reconciliation
+
+The published v0.11.0 reports showed 1,141 macOS packages and 1,129/1,131
+Linux packages even though the same lockfile resolves to 819, 813, and 815
+packages respectively. This was a measurement defect, not dependency growth
+from DefraDB v0.18.0. `dtolnay/rust-toolchain` sets
+`CARGO_TERM_COLOR=always` in Actions; Cargo then surrounds only the repeated
+`(*)` marker with ANSI escapes, so the script's plain-text suffix removal did
+not match. Reproducing the script locally with that environment produced the
+published 1,141 count exactly.
+
+Schema version 2 forces color off for Cargo tree data, passes the recorded
+target explicitly, records the target-independent `--target all` count, and
+includes each duplicated package name with its resolved identities. Current
+main (`b254258c`, lockfile SHA-256
+`72e775bf1cf70e186f1afa5d0ca314267973b68739995664fa8d0604ad5e1be6`)
+measures:
+
+| Target scope | Normal packages |
+|---|---:|
+| `aarch64-apple-darwin` | 819 |
+| `aarch64-unknown-linux-gnu` | 813 |
+| `x86_64-unknown-linux-gnu` | 815 |
+| all targets | 962 |
+
+Do not compare these target-scoped counts to `cargo tree --target all`, and do
+not establish a dependency budget until multiple schema-version-2 reports have
+established normal variance.
+
+## v0.11.0 macOS release latency
+
+The tagged release spent 2,005 seconds in Cargo; signing, notarization, dSYM
+generation, packaging, and upload together took about two additional minutes.
+Its log confirms `SCCACHE_RECACHE=1`, a cold release-only target tree, and a
+full compile ending in a roughly ten-minute `gents` compile/link tail. The
+209–214 second profile experiment also used a fresh target, but read from the
+host's warm shared sccache. Those are intentionally different trust/cache
+states: a signed release must not read compiler objects populated by public PR
+jobs.
+
+Release Cargo output is already isolated beneath
+`CARGO_RELEASE_TARGET_ROOT`, and forced recaching applies only when Cargo
+actually invokes rustc. The release workflow is therefore pinned to the
+`studio-2-2` (`studio-2`, `ci-desktop`) registration that owns the trusted
+release target tree. This makes prior signed-release artifacts reliably warm
+without weakening the sccache boundary. Record cold, unchanged-source warm,
+and representative source-edit timings separately; the pin trades automatic
+runner failover for deterministic trusted-cache reuse.
+
+An unsigned workflow dispatch at commit `d0e1ca3b` measured the representative
+trusted-target rebuild after this change. Cargo rebuilt only `gents-cli`; all
+dependencies and the core `gents` runtime remained reusable. The changed Git
+revision still invalidated the final crate's compile/link, so this is not an
+unchanged-source no-op measurement:
+
+| Cache state | Cargo build | Raw binary | gzip -9 | Archive |
+|---|---:|---:|---:|---:|
+| v0.11.0 cold trusted target | 2,005s | 70,300,272 | 26,580,064 | 26,641,927 |
+| pinned trusted target, new revision | 524s | 70,299,648 | 26,577,430 | 26,639,171 |
+
+The representative new-revision build is 73.9% faster (3.83x) than the cold
+v0.11.0 release. The second row came from an unsigned dry run, so its size
+differences include the missing Developer ID signature and are not a claim of
+binary-size improvement. Raw workflow:
+https://github.com/source-inc/gents/actions/runs/31601223603.
+
 Useful next investigations are to rank duplicate packages by compiled size,
 map features that pull each duplicate version, split optional desktop/provider
-surfaces from the runtime-critical CLI graph, and add explicit regression
-budgets only after several release reports establish normal variance.
+surfaces from the runtime-critical CLI graph, and pursue DefraDB feature
+boundaries for its internally enabled Wasmtime and libp2p graphs.

--- a/docs/ci-runner-operator-checklist.md
+++ b/docs/ci-runner-operator-checklist.md
@@ -150,12 +150,20 @@ If the daemon must be restarted for maintenance, first confirm that every
 runner on that host is idle in the GitHub API.
 
 The macOS release workflow uses a separate
-`/Users/admin/.cache/gents-cargo-target-release/<runner-name>` tree and sets
-`SCCACHE_RECACHE=1`. Release rustc invocations therefore bypass compiler
+`/Users/admin/.cache/gents-cargo-target-release/studio-2-2` tree and is pinned
+to the `studio-2` host's `ci-desktop` registration. It sets
+`SCCACHE_RECACHE=1`, so release rustc invocations bypass compiler
 objects populated by pull-request jobs and cannot reuse their linked target
 artifacts through normal Cargo operation. This is defense in depth against
 cache poisoning, not a substitute for ephemeral release hosts: PR code still
 runs without a strong isolation boundary on the same machines.
+
+Keep the `studio-2`, `ci-desktop`, and common Studio labels on that
+registration. Runner affinity trades failover for deterministic reuse of the
+trusted release target; if `studio-2-2` is offline, release jobs intentionally
+queue until an operator restores it or explicitly moves the `ci-desktop` label
+and its release target tree to another trusted registration. Never satisfy the
+label by pointing a release at a Cargo target tree populated by PR jobs.
 
 Mathlib is a separate cache surface. Runtime, desktop, and proof work each use a
 persistent Lake directory under `/Users/admin/.cache/gents-lean/<runner-name>`,

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -30,10 +30,11 @@ designated requirement, so keychain trust can survive binary updates.
 The macOS release workflow:
 
 - runs on a self-hosted Mac Studio runner labeled `self-hosted`, `macOS`,
-  `ARM64`, and `studio`;
+  `ARM64`, `studio`, `studio-2`, and `ci-desktop`;
 - caps Cargo build fan-out with `CARGO_BUILD_JOBS` and uses disk-backed
   `sccache`, forcing recache so release objects cannot come from PR jobs;
-- builds `gents-cli` in a release-only persistent Cargo target tree;
+- builds `gents-cli` in the `studio-2-2` release-only persistent Cargo target
+  tree, reusing only artifacts from prior trusted release builds;
 - unlocks the runner's persistent signing keychain;
 - makes that keychain visible to non-interactive `codesign` jobs;
 - smoke-signs a test binary before the Rust build starts;

--- a/scripts/measure-gents-binary.sh
+++ b/scripts/measure-gents-binary.sh
@@ -55,6 +55,21 @@ json_escape() {
   printf '%s' "$value"
 }
 
+json_array_from_lines() {
+  local first=1
+  local value
+  printf '['
+  while IFS= read -r value; do
+    [[ -n "$value" ]] || continue
+    if [[ "$first" == "0" ]]; then
+      printf ','
+    fi
+    printf '"%s"' "$(json_escape "$value")"
+    first=0
+  done
+  printf ']'
+}
+
 file_bytes() {
   wc -c < "$1" | tr -d '[:space:]'
 }
@@ -92,22 +107,53 @@ case "$release_lto" in
   false) release_lto=local-thin ;;
 esac
 
-# Cargo repeats already-rendered nodes with a trailing `(*)`. Strip that
-# presentation marker before counting package/version identities; otherwise a
-# package's position in the tree changes the metric.
+# GitHub's Rust setup action exports CARGO_TERM_COLOR=always. Override it for
+# machine-readable tree output: Cargo colors the `(*)` marker itself, so the
+# escape codes used to make the old normalization miss the marker and inflate
+# the v0.11.0 reports from 819 to 1,141 packages on macOS.
+#
+# Also select the recorded target explicitly. Without that, a report labelled
+# for a cross target can silently describe the host graph instead.
 package_lines=$(
-  cargo tree --locked -p gents-cli --edges normal --prefix none --format '{p}' \
+  CARGO_TERM_COLOR=never cargo tree --locked -p gents-cli --edges normal \
+    --target "$target_triple" --prefix none --format '{p}' \
     | sed 's/ (\*)$//' \
     | LC_ALL=C sort -u
 )
 resolved_packages=$(printf '%s\n' "$package_lines" | awk 'NF { count++ } END { print count + 0 }')
-duplicate_package_names=$(
+all_target_packages=$(
+  CARGO_TERM_COLOR=never cargo tree --locked -p gents-cli --edges normal \
+    --target all --prefix none --format '{p}' \
+    | sed 's/ (\*)$//' \
+    | LC_ALL=C sort -u
+)
+all_target_resolved_packages=$(
+  printf '%s\n' "$all_target_packages" | awk 'NF { count++ } END { print count + 0 }'
+)
+duplicate_names=$(
   printf '%s\n' "$package_lines" \
     | awk 'NF { print $1 }' \
     | LC_ALL=C sort \
-    | uniq -d \
-    | awk 'NF { count++ } END { print count + 0 }'
+    | uniq -d
 )
+duplicate_package_names=$(printf '%s\n' "$duplicate_names" | awk 'NF { count++ } END { print count + 0 }')
+duplicate_packages_json='['
+duplicate_separator=
+while IFS= read -r duplicate_name; do
+  [[ -n "$duplicate_name" ]] || continue
+  duplicate_identities_json=$(
+    printf '%s\n' "$package_lines" \
+      | awk -v name="$duplicate_name" '$1 == name' \
+      | json_array_from_lines
+  )
+  duplicate_packages_json+=$(printf \
+    '%s{"name":"%s","identities":%s}' \
+    "$duplicate_separator" \
+    "$(json_escape "$duplicate_name")" \
+    "$duplicate_identities_json")
+  duplicate_separator=,
+done <<< "$duplicate_names"
+duplicate_packages_json+=']'
 codex_packages=$(
   printf '%s\n' "$package_lines" \
     | sed -n 's/^\(codex-[^ ]*\).*/\1/p' \
@@ -184,7 +230,7 @@ fi
 
 report=$(printf '%s\n' \
   '{' \
-  '  "schema_version": 1,' \
+  '  "schema_version": 2,' \
   "  \"measurement_kind\": \"$(json_escape "$mode")\"," \
   "  \"git_sha\": \"$(json_escape "$git_sha")\"," \
   "  \"git_dirty\": $git_dirty," \
@@ -203,8 +249,14 @@ report=$(printf '%s\n' \
   "  \"binary\": $binary_json," \
   "  \"archive\": $archive_json," \
   '  "dependencies": {' \
+  '    "root_package": "gents-cli",' \
+  '    "edge_kinds": ["normal"],' \
+  '    "root_features": ["default"],' \
+  "    \"target\": \"$(json_escape "$target_triple")\"," \
   "    \"normal_packages\": $resolved_packages," \
+  "    \"all_target_normal_packages\": $all_target_resolved_packages," \
   "    \"duplicate_package_names\": $duplicate_package_names," \
+  "    \"duplicate_packages\": $duplicate_packages_json," \
   "    \"codex_packages\": $codex_packages" \
   '  }' \
   '}')
@@ -236,6 +288,7 @@ if [[ -n "$archive_path" ]]; then
   echo "archive_sha256: $archive_sha256"
 fi
 echo "resolved_packages: $resolved_packages"
+echo "all_target_resolved_packages: $all_target_resolved_packages"
 echo "duplicate_package_names: $duplicate_package_names"
 echo "codex_packages: $codex_packages"
 
@@ -243,6 +296,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     echo "measurement_kind=$mode"
     echo "normal_packages=$resolved_packages"
+    echo "all_target_normal_packages=$all_target_resolved_packages"
     echo "duplicate_package_names=$duplicate_package_names"
     echo "codex_packages=$codex_packages"
     [[ -z "$binary_bytes" ]] || echo "binary_bytes=$binary_bytes"
@@ -261,6 +315,7 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "| Target | \`$target_triple\` |"
     echo "| Release profile | LTO \`$release_lto\`, $release_codegen_units CGUs, strip \`$release_strip\` |"
     echo "| Normal dependency packages | $resolved_packages |"
+    echo "| Normal dependency packages (all targets) | $all_target_resolved_packages |"
     echo "| Duplicate package names | $duplicate_package_names |"
     echo "| Upstream Codex packages | $codex_packages |"
     [[ -z "$build_elapsed_seconds" ]] || echo "| Release build | ${build_elapsed_seconds}s |"


### PR DESCRIPTION
## Measured impact

The v0.11.0 macOS release spent **2,005s (33m25s)** inside Cargo on a cold release-only target tree. With this change, two clean-checkout runs took **524s and 426s (8m44s and 7m06s)**: **73.9–78.8% faster / 3.83–4.71x speedup**. Cargo rebuilt only `gents-cli`; dependencies and the core runtime stayed reusable.

The release workflow could land on any of four Studio registrations, but only `studio-2-2` currently owns the trusted 8.4 GB release target produced by v0.11.0. This change pins macOS releases to that registration so future releases deterministically reuse prior trusted Cargo artifacts.

The release still sets `SCCACHE_RECACHE=1`: any rustc invocation bypasses PR-populated sccache objects. This trades automatic runner failover for trusted warm-target reuse.

Raw runs:

- v0.11.0 cold trusted target: https://github.com/source-inc/gents/actions/runs/31554205416
- pinned trusted target, clean checkout 1: https://github.com/source-inc/gents/actions/runs/31601223603
- pinned trusted target, clean checkout 2: https://github.com/source-inc/gents/actions/runs/31602179888

| Cache state | Cargo build | Raw binary | gzip -9 | Archive |
|---|---:|---:|---:|---:|
| v0.11.0 cold trusted target | 2,005s | 70,300,272 | 26,580,064 | 26,641,927 |
| pinned trusted target, clean checkout 1 | 524s | 70,299,648 | 26,577,430 | 26,639,171 |
| pinned trusted target, clean checkout 2 | 426s | 70,299,648 | 26,577,430 | 26,639,171 |

The optimized measurements were unsigned dry runs, so their size differences include the missing Developer ID signature and are not a binary-size claim.

## Measurement correctness

The v0.11.0 reports' 1,129–1,141 normal-package counts were inflated by ANSI coloring, not DefraDB v0.18.0 or dependency growth. `dtolnay/rust-toolchain` exports `CARGO_TERM_COLOR=always`; Cargo colors the repeated `(*)` marker, so the old plain-text suffix removal failed.

Reproduction on the v0.11.0 lockfile:

| Target | Published schema v1 | Corrected schema v2 |
|---|---:|---:|
| macOS arm64 | 1,141 | 819 |
| Linux arm64 | 1,129 | 813 |
| Linux amd64 | 1,131 | 815 |
| all targets | — | 962 |

Schema v2 now:

- forces color off for Cargo tree data;
- selects the recorded target explicitly;
- records the comparable all-target count separately;
- emits machine-readable duplicate package/version identities.

Exact local command used for each target:

```sh
CARGO_TERM_COLOR=always TARGET_TRIPLE=<triple> \
  MEASURE_MODE=graph OUTPUT_JSON=/tmp/gents-graph-<triple>.json \
  scripts/measure-gents-binary.sh
```

Commit: `b254258c` base plus this tooling change. Cargo.lock SHA-256: `72e775bf1cf70e186f1afa5d0ca314267973b68739995664fa8d0604ad5e1be6`. Rust/Cargo: 1.97.1. Host: Apple M4 Max, arm64 macOS.

## Binary and archive impact

No Rust source, release profile, linker, signing, or packaging behavior changes. The unsigned measurement differed from v0.11.0 by -624 raw bytes, -2,634 gzip bytes, and -2,756 archive bytes; those small changes are not comparable to the signed baseline. Dependency resolution is unchanged; only reported counts are corrected and attributed.

## Root cause and boundaries

The 2,005s-versus-209–214s gap compared unlike cache states. The earlier experiment used a fresh target but read the host's warm shared sccache. The signed release used a cold release-only target and forced every compiler request to recache. Signing/notarization/package steps consumed only about two minutes outside Cargo.

DefraDB v0.18.0 no longer resolves the earlier ring 0.16 or old libp2p-version duplicates. Wasmtime and libp2p remain enabled below Gents' manifest boundary; Gents also uses native Lens execution. Removing those cleanly remains an upstream DefraDB feature-boundary task rather than a brittle local fork.

Issue #816 is stale with respect to its acceptance criteria: the checked-in launchd service now owns sccache from a persistent working directory and CI reuses that service.

## Validation

- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- Bash syntax and ShellCheck
- actionlint for CI and release workflows
- schema-v2 graph contract on macOS arm64, Linux arm64, and Linux amd64 under forced color
- `git diff --check`

## Roadmap

- measure a signed release and representative source-edit rebuild separately;
- rank compiled contributors and duplicate versions by size/time;
- pursue DefraDB feature boundaries for Wasmtime/libp2p and TLS-provider duplication;
- split optional provider/OAuth/MCP surfaces where runtime integrity permits;
- defer hard regression budgets until schema-v2 variance is established.
