### PR TITLE
Reuse same-commit release artifacts

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -22,6 +22,12 @@ permissions:
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  # Explicit provenance avoids checkout metadata invalidating the final CLI
+  # crate when a trusted release job retries the same commit.
+  GENTS_BUILD_GIT_SHA: ${{ github.sha }}
+  GENTS_BUILD_GIT_REF: ${{ github.ref }}
+  GENTS_BUILD_GIT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+  GENTS_BUILD_GIT_DIRTY: "false"
   # Keep the workspace's no-LTO/16-CGU release shape explicit on Linux. Cargo
   # parallelism remains per architecture: workstation-1 (x86_64) has ample
   # RAM, while the sparks (aarch64) serve a resident model and need a low cap.

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -39,6 +39,13 @@ env:
   CARGO_BUILD_JOBS: ${{ vars.CARGO_BUILD_JOBS || '12' }}
   CARGO_INCREMENTAL: "0"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  # Keep release provenance stable without making the CLI build script watch
+  # checkout-managed Git files. Re-running the same workflow commit can then
+  # reuse the trusted final-crate artifact as well as its dependencies.
+  GENTS_BUILD_GIT_SHA: ${{ github.sha }}
+  GENTS_BUILD_GIT_REF: ${{ github.ref }}
+  GENTS_BUILD_GIT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+  GENTS_BUILD_GIT_DIRTY: "false"
   # Do not reuse linked artifacts from the target trees populated by PR jobs.
   CARGO_TARGET_ROOT: ${{ vars.CARGO_RELEASE_TARGET_ROOT || '/Users/admin/.cache/gents-cargo-target-release' }}
   HOMEBREW_NO_AUTO_UPDATE: "1"

--- a/crates/gents-cli/build.rs
+++ b/crates/gents-cli/build.rs
@@ -6,50 +6,62 @@ fn main() {
     println!("cargo:rerun-if-env-changed=GENTS_BUILD_GIT_SHA");
     println!("cargo:rerun-if-env-changed=GENTS_BUILD_GIT_REF");
     println!("cargo:rerun-if-env-changed=GENTS_BUILD_GIT_TAG");
+    println!("cargo:rerun-if-env-changed=GENTS_BUILD_GIT_DIRTY");
 
-    if let Some(head_path) = git_path("HEAD") {
-        println!("cargo:rerun-if-changed={head_path}");
-    } else if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
-        let git_marker = Path::new(&manifest_dir).join("../../.git");
-        if git_marker.exists() {
-            println!("cargo:rerun-if-changed={}", git_marker.display());
+    // Release workflows provide immutable metadata explicitly. In that mode,
+    // do not watch Git's administrative files: actions/checkout rewrites them
+    // on every retry, which used to invalidate and relink gents-cli even when
+    // the source commit and trusted Cargo target were unchanged.
+    let explicit_git_metadata = nonempty_env("GENTS_BUILD_GIT_SHA").is_some();
+    if !explicit_git_metadata {
+        if let Some(head_path) = git_path("HEAD") {
+            println!("cargo:rerun-if-changed={head_path}");
+        } else if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+            let git_marker = Path::new(&manifest_dir).join("../../.git");
+            if git_marker.exists() {
+                println!("cargo:rerun-if-changed={}", git_marker.display());
+            }
+        }
+        if let Some(ref_name) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+            if let Some(ref_path) = git_path(&ref_name) {
+                println!("cargo:rerun-if-changed={ref_path}");
+            }
         }
     }
-    if let Some(ref_name) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
-        if let Some(ref_path) = git_path(&ref_name) {
-            println!("cargo:rerun-if-changed={ref_path}");
-        }
-    }
 
-    if let Some(value) = env::var("GENTS_BUILD_GIT_SHA")
-        .ok()
-        .filter(|value| !value.is_empty())
-        .or_else(|| git_output(&["rev-parse", "HEAD"]))
-    {
+    if let Some(value) = git_metadata(
+        "GENTS_BUILD_GIT_SHA",
+        explicit_git_metadata,
+        &["rev-parse", "HEAD"],
+    ) {
         println!("cargo:rustc-env=GENTS_BUILD_GIT_SHA={value}");
     }
 
-    if let Some(value) = env::var("GENTS_BUILD_GIT_REF")
-        .ok()
-        .filter(|value| !value.is_empty())
-        .or_else(|| git_output(&["rev-parse", "--abbrev-ref", "HEAD"]))
-    {
+    if let Some(value) = git_metadata(
+        "GENTS_BUILD_GIT_REF",
+        explicit_git_metadata,
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+    ) {
         println!("cargo:rustc-env=GENTS_BUILD_GIT_REF={value}");
     }
 
-    if let Some(value) = env::var("GENTS_BUILD_GIT_TAG")
-        .ok()
-        .filter(|value| !value.is_empty())
-        .or_else(|| git_output(&["describe", "--tags", "--exact-match", "HEAD"]))
-    {
+    if let Some(value) = git_metadata(
+        "GENTS_BUILD_GIT_TAG",
+        explicit_git_metadata,
+        &["describe", "--tags", "--exact-match", "HEAD"],
+    ) {
         println!("cargo:rustc-env=GENTS_BUILD_GIT_TAG={value}");
     }
 
-    if let Some(value) = git_output(&["status", "--porcelain", "--untracked-files=no"]) {
-        println!(
-            "cargo:rustc-env=GENTS_BUILD_GIT_DIRTY={}",
-            !value.is_empty()
-        );
+    if let Some(value) = nonempty_env("GENTS_BUILD_GIT_DIRTY") {
+        println!("cargo:rustc-env=GENTS_BUILD_GIT_DIRTY={value}");
+    } else if !explicit_git_metadata {
+        if let Some(value) = git_output(&["status", "--porcelain", "--untracked-files=no"]) {
+            println!(
+                "cargo:rustc-env=GENTS_BUILD_GIT_DIRTY={}",
+                !value.is_empty()
+            );
+        }
     }
 
     if let Ok(target) = env::var("TARGET") {
@@ -61,6 +73,14 @@ fn main() {
     if let Some(rustc) = command_output(Command::new("rustc").arg("--version")) {
         println!("cargo:rustc-env=GENTS_BUILD_RUSTC={rustc}");
     }
+}
+
+fn nonempty_env(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn git_metadata(name: &str, explicit: bool, fallback_args: &[&str]) -> Option<String> {
+    nonempty_env(name).or_else(|| (!explicit).then(|| git_output(fallback_args)).flatten())
 }
 
 fn git_output(args: &[&str]) -> Option<String> {

--- a/docs/build-measurements.md
+++ b/docs/build-measurements.md
@@ -134,6 +134,34 @@ binary-size improvement. Raw workflows:
 https://github.com/source-inc/gents/actions/runs/31601223603 and
 https://github.com/source-inc/gents/actions/runs/31602179888.
 
+### Same-commit release retries
+
+Cargo build-script fallback discovery watches the checkout's Git `HEAD` and
+resolved ref so local builds report accurate provenance. A release checkout is
+new on every workflow invocation, however, and those Git files receive new
+timestamps even when the source commit is unchanged. That invalidated
+`gents-cli` and its final link on every retry.
+
+Release workflows now pass the trusted GitHub event SHA, ref, tag, and clean
+state to the build script explicitly. The local discovery fallback is
+unchanged, while an explicit-metadata release no longer watches checkout-local
+Git files. Two unsigned dispatches of commit `ef1585af` on the same trusted
+target tree measured the creation and reuse of that artifact:
+
+| Cache state | Cargo build | Workflow job | Raw binary | gzip -9 | Archive |
+|---|---:|---:|---:|---:|---:|
+| first explicit-metadata artifact | 424s | 8m32s | 70,300,112 | 26,575,189 | 26,637,333 |
+| identical-SHA retry | 0.53s | 1m34s | 70,300,112 | 26,575,189 | 26,637,341 |
+
+The retry avoids 423 seconds (99.9%) of Cargo work and cuts the complete job by
+6m58s (81.6%). The eight-byte archive difference is packaging metadata; the raw
+binary and gzip payload sizes are identical. This optimization affects only
+exact same-commit retries. A source edit still requires the representative
+final-crate compile/link measured above. `SCCACHE_RECACHE=1` remains enabled,
+and no public-PR compiler artifacts enter the trusted release target. Raw
+workflows: https://github.com/source-inc/gents/actions/runs/31608891843 and
+https://github.com/source-inc/gents/actions/runs/31609716279.
+
 Useful next investigations are to rank duplicate packages by compiled size,
 map features that pull each duplicate version, split optional desktop/provider
 surfaces from the runtime-critical CLI graph, and pursue DefraDB feature


### PR DESCRIPTION
## What changed

Release workflows now provide immutable Git provenance explicitly to `gents-cli`'s build script. When an explicit commit SHA is present, the build script no longer watches Git administrative files that `actions/checkout` rewrites on every retry. Local builds retain the existing Git discovery and dirty-state behavior.

This is stacked on #1102 so it uses the trusted, runner-affine release target established there.

## Why

Two identical unsigned macOS dispatches on #1102 still rebuilt and linked `gents-cli`, taking 524s and 426s inside Cargo. The final crate remained dirty because checkout rewrote the watched `.git` HEAD/ref files even though source and commit were unchanged.

The release workflows continue to set `SCCACHE_RECACHE=1`; this change reuses the trusted Cargo artifact only and does not permit release builds to consume PR-populated sccache objects.

## Measurement

Two identical unsigned macOS dispatches of `ef1585af` on the same trusted target tree produced:

| Cache state | Cargo build | Workflow job | Raw binary | gzip -9 | Archive |
|---|---:|---:|---:|---:|---:|
| first explicit-metadata artifact | 424s | 8m32s | 70,300,112 | 26,575,189 | 26,637,333 |
| identical-SHA retry | 0.53s | 1m34s | 70,300,112 | 26,575,189 | 26,637,341 |

The retry avoids 423 seconds (99.9%) of Cargo work and cuts the complete job by 6m58s (81.6%). The raw binary and gzip payload sizes are identical; the eight-byte archive difference is packaging metadata. This is specifically an exact same-commit retry improvement—a source edit still requires the representative final-crate compile/link measured in #1102.

Raw runs: [first artifact](https://github.com/source-inc/gents/actions/runs/31608891843), [identical-SHA retry](https://github.com/source-inc/gents/actions/runs/31609716279).

## Validation

- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- focused explicit/fallback build-script output harness
- focused `gents-cli` version metadata unit test
- actionlint on both release workflows
- `git diff --check`
