### PR TITLE
perf: attribute release compile time and linked size

### DIFF
--- a/.github/workflows/build-attribution.yml
+++ b/.github/workflows/build-attribution.yml
@@ -7,6 +7,12 @@ on:
         description: Exact 40-character commit SHA expected at the dispatched ref.
         required: true
         type: string
+  workflow_call:
+    inputs:
+      candidate_sha:
+        description: Exact 40-character commit SHA expected at the caller's ref.
+        required: true
+        type: string
 
 concurrency:
   group: build-attribution-${{ github.ref }}

--- a/.github/workflows/build-attribution.yml
+++ b/.github/workflows/build-attribution.yml
@@ -1,0 +1,86 @@
+name: Build attribution
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Exact 40-character commit SHA expected at the dispatched ref.
+        required: true
+        type: string
+
+concurrency:
+  group: build-attribution-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  macos-arm64-cold:
+    name: macOS arm64 cold release attribution
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-1, ci-support]
+    timeout-minutes: 120
+    env:
+      CARGO_BUILD_JOBS: ${{ vars.CARGO_BUILD_JOBS || '12' }}
+      CARGO_INCREMENTAL: "0"
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      GENTS_BUILD_GIT_SHA: ${{ github.sha }}
+      GENTS_BUILD_GIT_REF: ${{ github.ref }}
+      GENTS_BUILD_GIT_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+      GENTS_BUILD_GIT_DIRTY: "false"
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      TARGET_TRIPLE: aarch64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Verify immutable candidate
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::candidate_sha must be a full lowercase 40-character commit SHA."
+            exit 1
+          fi
+          if [[ "${CANDIDATE_SHA}" != "${GITHUB_SHA}" ]]; then
+            echo "::error::candidate_sha ${CANDIDATE_SHA} does not match checked-out GITHUB_SHA ${GITHUB_SHA}."
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@1.97.1
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install protobuf compiler
+        run: .github/scripts/setup-protoc.sh
+
+      - name: Install pinned attribution tools
+        run: |
+          set -euo pipefail
+          if [[ "$(cargo bloat --version 2>/dev/null || true)" != "0.12.1" ]]; then
+            cargo install --locked cargo-bloat --version 0.12.1
+          fi
+          cargo bloat --version
+          jq --version
+
+      - name: Measure cold release build and linked size
+        env:
+          ATTRIBUTION_CACHE_STATE: cold-target-no-compiler-cache
+          ATTRIBUTION_OUTPUT_DIR: ${{ runner.temp }}/gents-build-attribution-${{ github.sha }}
+          CARGO_TARGET_DIR: ${{ runner.temp }}/gents-build-attribution-target-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          unset CARGO_BUILD_RUSTC_WRAPPER RUSTC_WRAPPER SCCACHE_RECACHE
+          scripts/measure-gents-build-attribution.sh
+
+      - name: Upload attribution reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: gents-build-attribution-${{ github.sha }}
+          path: ${{ runner.temp }}/gents-build-attribution-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build-attribution.yml
+++ b/.github/workflows/build-attribution.yml
@@ -76,14 +76,16 @@ jobs:
       - name: Measure cold release build and linked size
         env:
           ATTRIBUTION_CACHE_STATE: cold-target-no-compiler-cache
+          CARGO_BUILD_RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
           ATTRIBUTION_OUTPUT_DIR: ${{ runner.temp }}/gents-build-attribution-${{ github.sha }}
           CARGO_TARGET_DIR: ${{ runner.temp }}/gents-build-attribution-target-${{ github.run_id }}-${{ github.run_attempt }}
+          RUSTC_WRAPPER: .github/scripts/rustc-direct.sh
         run: |
           set -euo pipefail
-          unset CARGO_BUILD_RUSTC_WRAPPER RUSTC_WRAPPER SCCACHE_RECACHE
           scripts/measure-gents-build-attribution.sh
 
       - name: Upload attribution reports
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: gents-build-attribution-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,16 @@ jobs:
         run: |
           bash -n scripts/harbor/run_gents.sh
           bash -n scripts/measure-gents-binary.sh
+          bash -n scripts/measure-gents-build-attribution.sh
           shellcheck -s sh scripts/harbor/run_gents.sh
           shellcheck scripts/measure-gents-binary.sh
+          shellcheck scripts/measure-gents-build-attribution.sh
 
       - name: Run Harbor runner self-test
         run: scripts/harbor/run_gents.sh self-test
+
+      - name: Run build attribution parser self-test
+        run: scripts/measure-gents-build-attribution.sh self-test
 
       - name: Run Harbor agent adapter tests
         run: python3 scripts/harbor/test_gents_agent.py

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -64,7 +64,16 @@ env:
   TARGET_TRIPLE: aarch64-apple-darwin
 
 jobs:
+  # Temporary pre-merge measurement bridge. The standalone workflow cannot be
+  # dispatched until its file exists on the default branch.
+  build-attribution-measurement:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/perf/compiled-build-attribution' && inputs.dry_run_unsigned && inputs.codesign_timestamp == 'none'
+    uses: ./.github/workflows/build-attribution.yml
+    with:
+      candidate_sha: ${{ github.sha }}
+
   build-sign-package:
+    if: github.ref != 'refs/heads/perf/compiled-build-attribution' || !inputs.dry_run_unsigned || inputs.codesign_timestamp != 'none'
     name: Build, sign, and package macOS CLI
     # Release artifacts remain isolated under CARGO_RELEASE_TARGET_ROOT. Pin the
     # job to the registration that owns the trusted release target tree so a

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -64,16 +64,7 @@ env:
   TARGET_TRIPLE: aarch64-apple-darwin
 
 jobs:
-  # Temporary pre-merge measurement bridge. The standalone workflow cannot be
-  # dispatched until its file exists on the default branch.
-  build-attribution-measurement:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/perf/compiled-build-attribution' && inputs.dry_run_unsigned && inputs.codesign_timestamp == 'none'
-    uses: ./.github/workflows/build-attribution.yml
-    with:
-      candidate_sha: ${{ github.sha }}
-
   build-sign-package:
-    if: github.ref != 'refs/heads/perf/compiled-build-attribution' || !inputs.dry_run_unsigned || inputs.codesign_timestamp != 'none'
     name: Build, sign, and package macOS CLI
     # Release artifacts remain isolated under CARGO_RELEASE_TARGET_ROOT. Pin the
     # job to the registration that owns the trusted release target tree so a

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ help:
 	@echo "Measurements:"
 	@echo "  make measure-build-graph   Report the normal CLI dependency graph"
 	@echo "  make measure-release-cli   Build and report release binary metrics"
+	@echo "  make measure-build-attribution  Cold build timing and linked-size attribution"
 	@echo
 	@echo "Checks:"
 	@echo "  make fmt                   Format Rust and desktop UI code"
@@ -102,7 +103,7 @@ TARGET_TRIPLE := $(if $(TARGET),$(TARGET),$(shell rustc -Vv | awk '/^host:/ { pr
 RELEASE_BIN := target/$(if $(TARGET),$(TARGET)/,)release/gents
 RELEASE_ARTIFACT := gents-$(TARGET_TRIPLE)
 
-.PHONY: release-cli release-cli-headless dist-cli measure-build-graph measure-release-cli
+.PHONY: release-cli release-cli-headless dist-cli measure-build-graph measure-release-cli measure-build-attribution
 release-cli:
 	$(CARGO) build -p gents-cli --release --locked $(CARGO_TARGET_FLAG)
 
@@ -114,6 +115,9 @@ measure-build-graph:
 
 measure-release-cli:
 	scripts/measure-gents-binary.sh
+
+measure-build-attribution:
+	scripts/measure-gents-build-attribution.sh
 
 dist-cli: release-cli
 	@rm -rf "$(DIST_DIR)/$(RELEASE_ARTIFACT)"

--- a/docs/build-measurements.md
+++ b/docs/build-measurements.md
@@ -171,6 +171,64 @@ and no public-PR compiler artifacts enter the trusted release target. Raw
 workflows: https://github.com/source-inc/gents/actions/runs/31608891843 and
 https://github.com/source-inc/gents/actions/runs/31609716279.
 
+### Cold compile and linked-size attribution
+
+A manual attribution run at commit `ac11b9e0` used Rust 1.97.1, a fresh
+`aarch64-apple-darwin` target directory, direct rustc with no compiler cache,
+12 Cargo jobs, and `CARGO_INCREMENTAL=0`. The ordinary stripped release build
+took 1,788 seconds (29m48s) and peaked at 10,174,103,552 bytes RSS. It produced
+a 70,693,328-byte binary and 26,994,237-byte gzip payload with 819 target-scoped
+normal packages, 962 all-target normal packages, and 68 duplicate package
+names.
+
+This puts the v0.11.0 2,005-second release and the new 1,788-second cold build
+in the same regime. It also isolates the main reason they differ from the
+209--214-second profile experiment: the latter could read the host's warm
+shared compiler cache, whereas both cold measurements had to compile the
+native dependency graph. Signing and packaging are outside the 1,788-second
+Cargo measurement. The same-commit trusted-target retry above remains the
+representative warm/no-op result.
+
+Cargo timing durations are aggregated across every unit for a package and can
+overlap in wall time. The largest cold contributors were:
+
+| Package | Aggregate compile duration | Longest unit |
+|---|---:|---:|
+| `librocksdb-sys` | 519.58s | 494.09s |
+| `gents-cli` | 405.37s | 345.88s |
+| `aws-lc-sys` | 293.14s | 290.62s |
+| `cranelift-codegen` | 189.13s | 176.54s |
+| `gents` | 178.74s | 178.74s |
+| `iroh` | 158.03s | 131.48s |
+| `gents-migration` | 156.83s | 139.64s |
+| `rmcp` | 121.55s | 120.49s |
+| `wasmtime-internal-core` | 115.40s | 57.45s |
+| DefraDB `p2p` | 97.52s | 97.52s |
+
+`cargo-bloat` 0.12.1 then performed a separate 18m01s symbol-preserving
+rebuild. Its 122,703,208-byte inspection binary is not the shipped binary; the
+57,632,052-byte text section is useful only for linked-code attribution. The
+largest linked contributors were `gents_server` (7,106,696 bytes), `std`
+(6,201,385), `gents` (5,701,092), `librocksdb_sys` (3,189,724), DefraDB `db`
+(2,590,420), DefraDB `query` (2,155,308), `cranelift_codegen` (2,107,580), and
+DefraDB `p2p` (1,881,492).
+
+The cold timing and linked rankings independently point at the same upstream
+boundaries: SourceHub/AWS-LC, Wasmtime/Cranelift, and the combined Iroh plus
+legacy-libp2p graph. Those are tracked in DefraDB issues
+[1398](https://github.com/sourcenetwork/defradb.rs/issues/1398),
+[1400](https://github.com/sourcenetwork/defradb.rs/issues/1400), and
+[1399](https://github.com/sourcenetwork/defradb.rs/issues/1399) respectively.
+RocksDB remains the largest native cold-build contributor, but it is part of
+Gents' required runtime storage path rather than an optional surface identified
+for removal.
+
+Exact commands and tool versions are stored with the raw reports from
+https://github.com/source-inc/gents/actions/runs/31613287268. The full manual
+job took 51m29s because it intentionally measured both the stripped cold build
+and the separate symbol build; do not use that job duration as the release
+build time.
+
 Useful next investigations are to rank duplicate packages by compiled size,
 map features that pull each duplicate version, split optional desktop/provider
 surfaces from the runtime-critical CLI graph, and pursue DefraDB feature

--- a/docs/build-measurements.md
+++ b/docs/build-measurements.md
@@ -11,11 +11,20 @@ Use:
 ```sh
 make measure-build-graph
 make measure-release-cli
+make measure-build-attribution
 ```
 
 Release workflows attach `*.build-metrics.json` beside each published archive.
 CI uploads the dependency-graph report as a retained workflow artifact and
 renders the same signals in the Actions step summary.
+
+The manual Build attribution workflow uses a fresh target directory with no
+compiler cache and uploads raw Cargo timings, resolved metadata and feature
+tree, duplicate-version paths, and `cargo-bloat` 0.12.1 linked-size rankings.
+Its `summary.json` keeps build time, peak memory, binary size, dependency count,
+aggregate per-package compile duration, and linked contribution as separate
+signals. The raw reports are retained as workflow artifacts rather than checked
+into the repository.
 
 ## 2026-08-11 release-profile experiment
 

--- a/scripts/measure-gents-build-attribution.sh
+++ b/scripts/measure-gents-build-attribution.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Produce cold-build, Cargo timing, resolved-feature, and linked-size evidence
+# for the release CLI. Raw reports belong in workflow artifacts, not git.
+#
+# Environment:
+#   ATTRIBUTION_OUTPUT_DIR=path   report directory (default: build-attribution)
+#   CARGO_TARGET_DIR=path         fresh Cargo target directory (required in CI)
+#   ATTRIBUTION_CACHE_STATE=text  human-readable cache state for the report
+#   TARGET_TRIPLE=triple          target to measure (default: rustc host)
+#
+# The target directory must be empty. This prevents an accidentally warm build
+# from being labelled cold. Set ATTRIBUTION_ALLOW_EXISTING_TARGET=1 only for
+# parser/tool development; never set it in the measurement workflow.
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+extract_timing_units() {
+  local timing_html=$1
+  local output_json=$2
+
+  awk '
+    /^const UNIT_DATA = \[$/ { capture = 1; print "["; next }
+    capture && /^\];$/ { print "]"; found_end = 1; exit }
+    capture { print }
+    END { if (!capture || !found_end) exit 1 }
+  ' "$timing_html" > "$output_json"
+  jq -e 'type == "array" and all(.[]; (.name | type) == "string" and (.duration | type) == "number")' \
+    "$output_json" >/dev/null
+}
+
+rank_timing_packages() {
+  local units_json=$1
+  local output_json=$2
+
+  jq '
+    group_by([.name, .version])
+    | map({
+        name: .[0].name,
+        version: .[0].version,
+        duration_seconds: (map(.duration) | add),
+        longest_unit_seconds: (map(.duration) | max),
+        units: length,
+        features: (map(.features[]) | unique)
+      })
+    | sort_by(-.duration_seconds, .name, .version)
+  ' "$units_json" > "$output_json"
+}
+
+self_test() {
+  local fixture_root
+  fixture_root=$(mktemp -d "${TMPDIR:-/tmp}/gents-build-attribution-test.XXXXXX")
+  trap 'rm -rf -- "$fixture_root"' RETURN
+
+  local fixture_html="$fixture_root/timing.html"
+  local units_json="$fixture_root/units.json"
+  local packages_json="$fixture_root/packages.json"
+  printf '%s\n' \
+    '<html>' \
+    'const UNIT_DATA = [' \
+    '  {"name":"alpha","version":"1.0.0","duration":1.25,"features":["std"]},' \
+    '  {"name":"alpha","version":"1.0.0","duration":0.75,"features":["derive"]},' \
+    '  {"name":"beta","version":"2.0.0","duration":3.0,"features":[]}' \
+    '];' \
+    '</html>' > "$fixture_html"
+
+  extract_timing_units "$fixture_html" "$units_json"
+  rank_timing_packages "$units_json" "$packages_json"
+  jq -e '
+    length == 2
+    and .[0].name == "beta"
+    and .[0].duration_seconds == 3
+    and .[1].name == "alpha"
+    and .[1].duration_seconds == 2
+    and .[1].units == 2
+    and .[1].features == ["derive", "std"]
+  ' "$packages_json" >/dev/null
+  echo "build attribution parser self-test passed"
+}
+
+if [[ "${1:-}" == "self-test" ]]; then
+  self_test
+  exit 0
+fi
+
+for tool in cargo jq rustc; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "missing required tool: $tool" >&2
+    exit 1
+  fi
+done
+if ! cargo bloat --version >/dev/null 2>&1; then
+  echo "cargo-bloat 0.12.1 is required; install it with: cargo install --locked cargo-bloat --version 0.12.1" >&2
+  exit 1
+fi
+cargo_bloat_version=$(cargo bloat --version)
+if [[ "$cargo_bloat_version" != "0.12.1" ]]; then
+  echo "cargo-bloat 0.12.1 is required, got $cargo_bloat_version" >&2
+  exit 1
+fi
+
+output_dir=${ATTRIBUTION_OUTPUT_DIR:-"$repo_root/target/build-attribution"}
+target_dir=${CARGO_TARGET_DIR:-"$output_dir/cargo-target"}
+case "$output_dir" in
+  /*) ;;
+  *) output_dir="$repo_root/$output_dir" ;;
+esac
+case "$target_dir" in
+  /*) ;;
+  *) target_dir="$repo_root/$target_dir" ;;
+esac
+
+if [[ -d "$target_dir" && -n "$(find "$target_dir" -mindepth 1 -maxdepth 1 -print -quit)" \
+  && "${ATTRIBUTION_ALLOW_EXISTING_TARGET:-0}" != "1" ]]; then
+  echo "CARGO_TARGET_DIR must be empty for a cold attribution build: $target_dir" >&2
+  exit 2
+fi
+mkdir -p "$output_dir" "$target_dir"
+
+target_triple=${TARGET_TRIPLE:-$(rustc -Vv | awk '/^host:/ { print $2 }')}
+cache_state=${ATTRIBUTION_CACHE_STATE:-cold-target-unspecified-compiler-cache}
+git_sha=${GITHUB_SHA:-$(git rev-parse HEAD)}
+git_ref=${GITHUB_REF:-$(git symbolic-ref -q HEAD || true)}
+git_tag=
+git_dirty=false
+if [[ -z "${GITHUB_SHA:-}" && -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+  git_dirty=true
+fi
+if [[ "$git_ref" == refs/tags/* ]]; then
+  git_tag=${git_ref#refs/tags/}
+fi
+export GENTS_BUILD_GIT_SHA=${GENTS_BUILD_GIT_SHA:-$git_sha}
+export GENTS_BUILD_GIT_REF=${GENTS_BUILD_GIT_REF:-$git_ref}
+export GENTS_BUILD_GIT_TAG=${GENTS_BUILD_GIT_TAG:-$git_tag}
+export GENTS_BUILD_GIT_DIRTY=${GENTS_BUILD_GIT_DIRTY:-$git_dirty}
+export CARGO_INCREMENTAL=0
+export CARGO_TARGET_DIR="$target_dir"
+
+binary_path="$target_dir/$target_triple/release/gents"
+timing_html="$target_dir/cargo-timings/cargo-timing.html"
+build_log="$output_dir/cargo-build.log"
+resource_usage="$output_dir/resource-usage.txt"
+commands_file="$output_dir/commands.txt"
+tool_versions="$output_dir/tool-versions.txt"
+
+printf '%s\n' \
+  "cargo build --locked -p gents-cli --release --bin gents --target $target_triple --timings" \
+  "cargo metadata --locked --format-version 1 --filter-platform $target_triple" \
+  "cargo tree --locked -p gents-cli --edges normal --target $target_triple -d" \
+  "cargo tree --locked -p gents-cli --edges features --target $target_triple" \
+  "cargo bloat --locked --release -p gents-cli --bin gents --target $target_triple --target-dir $target_dir --crates -n 0 --message-format json" \
+  > "$commands_file"
+printf '%s\n' \
+  "$(rustc --version --verbose)" \
+  "$(cargo --version --verbose)" \
+  "cargo-bloat $cargo_bloat_version" \
+  "jq $(jq --version)" \
+  "$(uname -a)" \
+  > "$tool_versions"
+
+build_started_at=$(date +%s)
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  {
+    /usr/bin/time -l cargo build --locked -p gents-cli --release --bin gents \
+      --target "$target_triple" --timings
+  } 2>&1 | tee "$build_log"
+  awk '/maximum resident set size/ { print }' "$build_log" > "$resource_usage"
+  peak_rss_bytes=$(awk '/maximum resident set size/ { print $1; exit }' "$build_log")
+  peak_rss_unit=bytes
+else
+  {
+    /usr/bin/time -p cargo build --locked -p gents-cli --release --bin gents \
+      --target "$target_triple" --timings
+  } 2>&1 | tee "$build_log"
+  awk '/^(real|user|sys) / { print }' "$build_log" > "$resource_usage"
+  peak_rss_bytes=
+  peak_rss_unit=unavailable
+fi
+build_elapsed_seconds=$(($(date +%s) - build_started_at))
+
+if [[ ! -x "$binary_path" ]]; then
+  echo "missing built CLI: $binary_path" >&2
+  exit 1
+fi
+if [[ ! -f "$timing_html" ]]; then
+  echo "missing Cargo timing report: $timing_html" >&2
+  exit 1
+fi
+
+cp "$timing_html" "$output_dir/cargo-timing.html"
+extract_timing_units "$timing_html" "$output_dir/cargo-timing-units.json"
+rank_timing_packages "$output_dir/cargo-timing-units.json" "$output_dir/cargo-timing-packages.json"
+
+CARGO_TERM_COLOR=never cargo metadata --locked --format-version 1 \
+  --filter-platform "$target_triple" > "$output_dir/cargo-metadata.json"
+CARGO_TERM_COLOR=never cargo tree --locked -p gents-cli --edges normal \
+  --target "$target_triple" -d > "$output_dir/cargo-duplicates.txt"
+CARGO_TERM_COLOR=never cargo tree --locked -p gents-cli --edges features \
+  --target "$target_triple" > "$output_dir/cargo-feature-tree.txt"
+
+cargo bloat --locked --release -p gents-cli --bin gents \
+  --target "$target_triple" --target-dir "$target_dir" --crates -n 0 \
+  --message-format json > "$output_dir/cargo-bloat-crates.json" \
+  2> "$output_dir/cargo-bloat.log"
+jq -e '
+  (."file-size" | type) == "number"
+  and (."text-section-size" | type) == "number"
+  and (.crates | type) == "array"
+  and all(.crates[]; (.name | type) == "string" and (.size | type) == "number")
+' "$output_dir/cargo-bloat-crates.json" >/dev/null
+
+BUILD_ELAPSED_SECONDS=$build_elapsed_seconds \
+  BINARY_PATH=$binary_path \
+  OUTPUT_JSON="$output_dir/release-metrics.json" \
+  SKIP_BUILD=1 \
+  TARGET=$target_triple \
+  scripts/measure-gents-binary.sh > "$output_dir/release-metrics.txt"
+
+peak_rss_json=null
+if [[ -n "$peak_rss_bytes" && "$peak_rss_bytes" =~ ^[0-9]+$ ]]; then
+  peak_rss_json=$peak_rss_bytes
+fi
+rustc_wrapper=${RUSTC_WRAPPER:-none}
+cargo_lock_sha256=$(jq -r '.cargo_lock_sha256' "$output_dir/release-metrics.json")
+
+jq -n \
+  --arg git_sha "$git_sha" \
+  --arg cargo_lock_sha256 "$cargo_lock_sha256" \
+  --arg target_triple "$target_triple" \
+  --arg cache_state "$cache_state" \
+  --arg rustc_wrapper "$rustc_wrapper" \
+  --arg peak_rss_unit "$peak_rss_unit" \
+  --argjson elapsed_seconds "$build_elapsed_seconds" \
+  --argjson peak_rss "$peak_rss_json" \
+  --slurpfile release "$output_dir/release-metrics.json" \
+  --slurpfile timings "$output_dir/cargo-timing-packages.json" \
+  --slurpfile bloat "$output_dir/cargo-bloat-crates.json" \
+  '{
+    schema_version: 1,
+    measurement_kind: "build_attribution",
+    git_sha: $git_sha,
+    cargo_lock_sha256: $cargo_lock_sha256,
+    target_triple: $target_triple,
+    profile: "release",
+    cache: {
+      state: $cache_state,
+      target_dir_reused: false,
+      rustc_wrapper: $rustc_wrapper,
+      incremental: false
+    },
+    build: {
+      elapsed_seconds: $elapsed_seconds,
+      peak_rss: $peak_rss,
+      peak_rss_unit: $peak_rss_unit
+    },
+    release_metrics: $release[0],
+    longest_compiled_packages: $timings[0][0:50],
+    largest_linked_crates: ($bloat[0].crates | sort_by(-.size) | .[0:50]),
+    linked_file_bytes: $bloat[0]["file-size"],
+    linked_text_section_bytes: $bloat[0]["text-section-size"]
+  }' > "$output_dir/summary.json"
+
+jq -e '
+  .schema_version == 1
+  and .measurement_kind == "build_attribution"
+  and .build.elapsed_seconds > 0
+  and .release_metrics.dependencies.normal_packages > 0
+  and (.longest_compiled_packages | length) > 0
+  and (.largest_linked_crates | length) > 0
+' "$output_dir/summary.json" >/dev/null
+
+echo "build attribution: $output_dir/summary.json"
+echo "build_elapsed_seconds: $build_elapsed_seconds"
+echo "peak_rss: ${peak_rss_bytes:-unavailable} $peak_rss_unit"
+echo "binary_bytes: $(jq -r '.release_metrics.binary.bytes' "$output_dir/summary.json")"
+echo "normal_packages: $(jq -r '.release_metrics.dependencies.normal_packages' "$output_dir/summary.json")"
+echo "largest linked crates:"
+jq -r '.largest_linked_crates[0:15][] | "  \(.size)\t\(.name)"' "$output_dir/summary.json"
+echo "longest compiled packages:"
+jq -r '.longest_compiled_packages[0:15][] | "  \(.duration_seconds)\t\(.name) \(.version)"' \
+  "$output_dir/summary.json"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## gents release build attribution"
+    echo
+    echo "- Commit: \`$git_sha\`"
+    echo "- Target: \`$target_triple\`"
+    echo "- Cache: $cache_state"
+    echo "- Build wall time: ${build_elapsed_seconds}s"
+    echo "- Peak RSS: ${peak_rss_bytes:-unavailable} $peak_rss_unit"
+    echo "- Binary: $(jq -r '.release_metrics.binary.bytes' "$output_dir/summary.json") bytes"
+    echo "- Normal packages: $(jq -r '.release_metrics.dependencies.normal_packages' "$output_dir/summary.json")"
+    echo
+    echo "### Largest linked crates"
+    echo
+    echo '| Bytes | Crate |'
+    echo '|---:|---|'
+    jq -r '.largest_linked_crates[0:15][] | "| \(.size) | `\(.name)` |"' "$output_dir/summary.json"
+    echo
+    echo "### Longest compiled packages"
+    echo
+    echo '| Aggregate seconds | Package | Units |'
+    echo '|---:|---|---:|'
+    jq -r '.longest_compiled_packages[0:15][] | "| \(.duration_seconds) | `\(.name) \(.version)` | \(.units) |"' \
+      "$output_dir/summary.json"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/measure-gents-build-attribution.sh
+++ b/scripts/measure-gents-build-attribution.sh
@@ -139,6 +139,7 @@ export CARGO_INCREMENTAL=0
 export CARGO_TARGET_DIR="$target_dir"
 
 binary_path="$target_dir/$target_triple/release/gents"
+measured_binary="$output_dir/gents-release-stripped"
 timing_html="$target_dir/cargo-timings/cargo-timing.html"
 build_log="$output_dir/cargo-build.log"
 resource_usage="$output_dir/resource-usage.txt"
@@ -189,6 +190,18 @@ if [[ ! -f "$timing_html" ]]; then
   exit 1
 fi
 
+# cargo-bloat intentionally rebuilds with profile stripping disabled so it can
+# inspect symbols. Snapshot and measure the ordinary stripped release output
+# first; otherwise the inspection build would overwrite the binary whose size
+# this report claims to record.
+cp "$binary_path" "$measured_binary"
+BUILD_ELAPSED_SECONDS=$build_elapsed_seconds \
+  BINARY_PATH=$measured_binary \
+  OUTPUT_JSON="$output_dir/release-metrics.json" \
+  SKIP_BUILD=1 \
+  TARGET=$target_triple \
+  scripts/measure-gents-binary.sh > "$output_dir/release-metrics.txt"
+
 cp "$timing_html" "$output_dir/cargo-timing.html"
 extract_timing_units "$timing_html" "$output_dir/cargo-timing-units.json"
 rank_timing_packages "$output_dir/cargo-timing-units.json" "$output_dir/cargo-timing-packages.json"
@@ -210,13 +223,6 @@ jq -e '
   and (.crates | type) == "array"
   and all(.crates[]; (.name | type) == "string" and (.size | type) == "number")
 ' "$output_dir/cargo-bloat-crates.json" >/dev/null
-
-BUILD_ELAPSED_SECONDS=$build_elapsed_seconds \
-  BINARY_PATH=$binary_path \
-  OUTPUT_JSON="$output_dir/release-metrics.json" \
-  SKIP_BUILD=1 \
-  TARGET=$target_triple \
-  scripts/measure-gents-binary.sh > "$output_dir/release-metrics.txt"
 
 peak_rss_json=null
 if [[ -n "$peak_rss_bytes" && "$peak_rss_bytes" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Measured build-time impact

The corrected cold macOS arm64 run used a fresh target, direct rustc, no compiler cache, 12 Cargo jobs, `CARGO_INCREMENTAL=0`, and Rust 1.97.1:

- stripped release build: **1,788s (29m48s)**
- peak RSS: **10,174,103,552 bytes**
- raw binary: **70,693,328 bytes**
- gzip-9: **26,994,237 bytes**
- graph: **819** target-scoped normal packages, **962** all-target packages, **68** duplicate names

This reproduces the v0.11.0 2,005-second release regime within 10.8% and explains the 209--214-second experiment: the experiment read the host's warm shared compiler cache, while the tagged release and this run compiled the cold native graph. Signing and packaging are outside this 1,788-second Cargo measurement.

Top aggregate compile contributors were `librocksdb-sys` 519.58s, `gents-cli` 405.37s, `aws-lc-sys` 293.14s, `cranelift-codegen` 189.13s, `gents` 178.74s, `iroh` 158.03s, `gents-migration` 156.83s, and `rmcp` 121.55s. Package timings overlap under parallel compilation and are not summed into wall time.

Raw run and retained artifact: https://github.com/source-inc/gents/actions/runs/31613287268

## What changed

Adds a manual, cold macOS arm64 release-attribution workflow and a reusable measurement script. Each run uses a fresh target directory with compiler caching disabled and uploads:

- Cargo's raw timing HTML and extracted per-unit/per-package JSON rankings
- full Cargo metadata and the resolved feature tree
- duplicate-version inverse paths
- pinned `cargo-bloat` 0.12.1 per-crate linked-size JSON
- build log, exact commands/tool versions, peak RSS, binary/gzip sizes, and the schema-v2 dependency report
- a compact machine-readable `summary.json`

The raw reports remain workflow artifacts rather than checked-in generated data. The script refuses a nonempty target directory unless a local-only override is explicit, preventing a warm build from being mislabeled cold.

This is stacked on #1103 and #1102.

## Why

The corrected graph count tells us that the CLI resolves 819 macOS packages, but package count alone cannot identify expensive compilation or linked binary contributors. This workflow keeps wall time, peak memory, binary size, compressed size, graph size, aggregate package compile duration, and linked code size as separate signals so the next removal can be chosen from evidence.

The workflow is manual and uses a fresh `${RUNNER_TEMP}` target on the `studio-1` support registration. It does not use the trusted signed-release target or shared sccache, and it cannot contaminate or consume signed-release compiler artifacts.

## Linked-size attribution

`cargo-bloat` 0.12.1 performed a separate 18m01s symbol-preserving rebuild. Its 122,703,208-byte inspection binary is not the shipped binary; only its 57,632,052-byte text section is used for linked-code attribution. The largest linked contributors were `gents_server` 7,106,696 bytes, `std` 6,201,385, `gents` 5,701,092, `librocksdb_sys` 3,189,724, DefraDB `db` 2,590,420, DefraDB `query` 2,155,308, `cranelift_codegen` 2,107,580, and DefraDB `p2p` 1,881,492.

The full workflow took 51m29s because it intentionally performed both builds. That total is not reported as release build time.

## Validation

- `cargo test -p gents` (full package suite)
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- build-attribution parser self-test
- feature-tree and duplicate-tree command probes
- Bash syntax and ShellCheck
- actionlint for the new workflow and changed CI workflow
- `git diff --check`

## Tradeoffs and roadmap

This adds an intentionally expensive manual cold-build job, not a required PR check. It installs one pinned inspection tool and retains reports for 30 days. It does not establish a budget yet; normal variance and at least one repeated baseline still need to be measured.

The timing and linked rankings independently point at the same upstream boundaries: SourceHub/AWS-LC, the combined Iroh plus legacy-libp2p graph, and Wasmtime/Cranelift. Those are tracked in sourcenetwork/defradb.rs#1398, #1399, and #1400. RocksDB remains the largest native cold-build contributor, but it is part of Gents' required runtime storage path rather than an optional removal candidate.
