### PR TITLE
perf: add lean opt-in dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,17 @@ strip = false
 [profile.dev.package."*"]
 opt-level = 1
 
+# Agent and batch worktrees generally need actionable backtraces, not complete
+# dependency DWARF. Keep the default dev profile available for debugger-heavy
+# work while giving repeated build/link loops a smaller opt-in artifact set.
+[profile.fast-dev]
+inherits = "dev"
+debug = "line-tables-only"
+
+[profile.fast-dev.package."*"]
+opt-level = 1
+debug = 0
+
 [profile.test]
 # At opt-level 1 Cargo's implicit `lto = false` still performs local ThinLTO.
 # CI enables incremental compilation on persistent runner target trees; keeping

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ help:
 	@echo "  make build                 Build default Rust workspace members"
 	@echo "  make build-cli             Build the Gents CLI"
 	@echo "  make build-cli-headless    Build CLI without embedded Codex TUI"
+	@echo "  make fast-dev-cli          Build CLI with lean dev debug artifacts"
 	@echo "  make build-desktop         Build the Tauri Rust shell"
 	@echo "  make build-desktop-ui      Build the desktop frontend"
 	@echo
@@ -103,12 +104,15 @@ TARGET_TRIPLE := $(if $(TARGET),$(TARGET),$(shell rustc -Vv | awk '/^host:/ { pr
 RELEASE_BIN := target/$(if $(TARGET),$(TARGET)/,)release/gents
 RELEASE_ARTIFACT := gents-$(TARGET_TRIPLE)
 
-.PHONY: release-cli release-cli-headless dist-cli measure-build-graph measure-release-cli measure-build-attribution
+.PHONY: release-cli release-cli-headless fast-dev-cli dist-cli measure-build-graph measure-release-cli measure-build-attribution
 release-cli:
 	$(CARGO) build -p gents-cli --release --locked $(CARGO_TARGET_FLAG)
 
 release-cli-headless:
 	$(CARGO) build -p gents-cli --release --locked --no-default-features $(CARGO_TARGET_FLAG)
+
+fast-dev-cli:
+	$(CARGO) build -p gents-cli --profile fast-dev --locked $(CARGO_TARGET_FLAG)
 
 measure-build-graph:
 	MEASURE_MODE=graph scripts/measure-gents-binary.sh

--- a/docs/build-measurements.md
+++ b/docs/build-measurements.md
@@ -26,6 +26,48 @@ aggregate per-package compile duration, and linked contribution as separate
 signals. The raw reports are retained as workflow artifacts rather than checked
 into the repository.
 
+For local agent and batch worktrees, `make fast-dev-cli` uses the opt-in
+`fast-dev` profile. It retains line-table backtraces for workspace crates while
+omitting dependency debug info. The ordinary dev profile remains unchanged for
+debugger-heavy work. Do not compare `fast-dev` artifacts to release binaries;
+the profile addresses edit/build time and retained worktree disk space only.
+
+### Opt-in fast dev profile
+
+Host: Apple M4 Max (16 cores, 128 GB), macOS 26.6, Rust 1.97.1,
+`aarch64-apple-darwin`. Base commit: `69acf8b1`. `Cargo.lock` SHA-256:
+`72e775bf1cf70e186f1afa5d0ca314267973b68739995664fa8d0604ad5e1be6`.
+
+Both builds used all available CPUs, fresh target directories, direct rustc
+without sccache, and `CARGO_INCREMENTAL=0`. Rust sources and the lockfile were
+identical; only the candidate profile settings differed. Commands were:
+
+```sh
+CARGO_BUILD_RUSTC_WRAPPER=.github/scripts/rustc-direct.sh \
+  RUSTC_WRAPPER=.github/scripts/rustc-direct.sh CARGO_INCREMENTAL=0 \
+  /usr/bin/time -l cargo build -p gents-cli --locked --target-dir <fresh-target>
+CARGO_BUILD_RUSTC_WRAPPER=.github/scripts/rustc-direct.sh \
+  RUSTC_WRAPPER=.github/scripts/rustc-direct.sh CARGO_INCREMENTAL=0 \
+  /usr/bin/time -l cargo build -p gents-cli --profile fast-dev --locked \
+  --target-dir <fresh-target>
+```
+
+| Signal | Default dev | `fast-dev` | Delta |
+|---|---:|---:|---:|
+| Cold wall time | 212.10s | 177.11s | -16.5% |
+| Peak RSS | 4,506,910,720 | 3,967,090,688 | -12.0% |
+| Target size (KiB) | 11,669,916 | 5,144,180 | -55.9% |
+| `deps/` size (KiB) | 8,694,172 | 4,041,368 | -53.5% |
+| rlib size (KiB) | 4,546,124 | 2,006,892 | -55.9% |
+| loose object size (KiB) | 2,638,220 | 558,200 | -78.8% |
+| Unstripped dev CLI bytes | 328,694,312 | 312,358,584 | -5.0% |
+
+An identical one-line `gents-cli` source edit rebuilt and linked in 1.58s under
+default dev and 1.34s under `fast-dev` (-15.2%). These are dev artifacts, not
+release-size measurements. The default dev profile remains the debugger-rich
+escape hatch; `fast-dev` trades dependency DWARF for materially smaller agent
+worktrees while retaining workspace file-and-line backtraces.
+
 ## 2026-08-11 release-profile experiment
 
 Host: Apple M4 Max (16 cores, 128 GB), macOS 26.6, Rust 1.97.1,


### PR DESCRIPTION
## Measured build-time impact

This adds an opt-in `fast-dev` Cargo profile for agent and batch worktrees. On an Apple M4 Max with fresh target directories, all CPUs, direct rustc, sccache disabled, `CARGO_INCREMENTAL=0`, and identical Rust sources/Cargo.lock:

| Signal | Default dev | `fast-dev` | Delta |
|---|---:|---:|---:|
| Cold CLI build | 212.10s | 177.11s | **-16.5%** |
| Same one-line source edit | 1.58s | 1.34s | **-15.2%** |
| Peak RSS | 4,506,910,720 bytes | 3,967,090,688 bytes | **-12.0%** |

Exact commands, host/toolchain details, commit, lockfile hash, and the remaining measurements are recorded in `docs/build-measurements.md`.

## Disk and binary impact

This is a development-artifact optimization, not a release-binary change:

- target directory: 11,669,916 KiB -> 5,144,180 KiB (**-55.9%**)
- dependency rlibs: 4,546,124 KiB -> 2,006,892 KiB (**-55.9%**)
- loose objects: 2,638,220 KiB -> 558,200 KiB (**-78.8%**)
- unstripped dev CLI: 328,694,312 -> 312,358,584 bytes (**-5.0%**)
- release binary/archive/dependency graph: unchanged

## What changes

- Add an opt-in `fast-dev` profile.
- Keep line tables for workspace crates, while omitting dependency debug info.
- Add `make fast-dev-cli` as the explicit entry point.
- Leave the ordinary dev and release profiles unchanged.

The tradeoff is deliberate: `fast-dev` is not the profile for dependency-level debugger work. Developers retain the default dev profile as the debugger-rich escape hatch.

DefraDB PR [#1397](https://github.com/sourcenetwork/defradb.rs/pull/1397) prompted this lane, but Cargo profiles do not propagate from dependencies, so Gents needs its own opt-in profile. This uses the same general boundary while retaining workspace line tables and measuring Gents directly.

## Validation

- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `make -n fast-dev-cli`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
- fresh cold builds and representative identical source-edit rebuilds, as documented

## Stack and roadmap

- Base: #1104 (compiled build and linked-size attribution)
- Below that: #1103 (fast trusted release retries)
- DefraDB boundary follow-ups: sourcenetwork/defradb.rs#1398, #1399, and #1400

The next release-graph reductions should follow the measured attribution data and land at the upstream DefraDB feature boundaries instead of using a brittle local fork.
