### PR TITLE
Redrive failed background completion wakes

### DIFF
--- a/crates/gents/proofs/Proofs/Background/CompletionContinuation.lean
+++ b/crates/gents/proofs/Proofs/Background/CompletionContinuation.lean
@@ -1,4 +1,5 @@
 import Proofs.Session.Properties.Executable
+import Proofs.Request
 import Proofs.ToolExecution.State
 import Proofs.Transcript.State
 
@@ -269,6 +270,116 @@ def canonicalWaitOrderingAccepted : Bool :=
 
 theorem canonical_wait_call_precedes_completion_notification :
     canonicalWaitOrderingAccepted = true := by
+  native_decide
+
+/-! ## Bounded failed-wake redrive
+
+Completion notifications remain durable when the scheduled continuation that
+was supposed to consume them fails.  The daemon may therefore create one
+fresh continuation attempt, but only for the canonical coalesced background
+queue shape and only while the persisted retry budget remains open.  This is a
+separate capability from the interactive client retry modeled by
+`SessionRecovery`: a generic scheduled request is not retryable merely because
+it was scheduled.
+-/
+
+structure FailedWake where
+  ctx : RequestContext
+  source : SessionQueue.QueueSource
+  policy : SessionQueue.QueuePolicy
+  queueKey : Option SessionId
+
+def CanRedriveWake (wake : FailedWake) : Prop :=
+  wake.ctx.state = .failed ∧
+    wake.ctx.admission = .released ∧
+    wake.ctx.origin = .scheduled ∧
+    wake.ctx.isLatest = true ∧
+    wake.ctx.retryCount < wake.ctx.maxRetries ∧
+    wake.source = .backgroundCompletion ∧
+    wake.policy = .coalesce ∧
+    wake.queueKey.isSome
+
+instance (wake : FailedWake) : Decidable (CanRedriveWake wake) := by
+  unfold CanRedriveWake
+  infer_instance
+
+def redrivenWakeContext (ctx : RequestContext) : RequestContext :=
+  { state := .pending
+  , origin := .scheduled
+  , backend := ctx.backend
+  , admission := .released
+  , deadline := ctx.currentTime + 1
+  , claimTime := ctx.currentTime
+  , currentTime := ctx.currentTime
+  , retryCount := ctx.retryCount + 1
+  , maxRetries := ctx.maxRetries
+  , progressSeq := 0
+  , messageSeq := 0
+  , isLatest := true
+  , persistence := .uncommitted
+  }
+
+def redriveWake? (wake : FailedWake) : Option RequestContext :=
+  if _h : CanRedriveWake wake then
+    some (redrivenWakeContext wake.ctx)
+  else
+    none
+
+theorem redriveWake?_bounded
+    {wake : FailedWake}
+    {post : RequestContext}
+    (h_redrive : redriveWake? wake = some post) :
+    post.state = .pending ∧
+      post.origin = .scheduled ∧
+      post.backend = wake.ctx.backend ∧
+      post.retryCount = wake.ctx.retryCount + 1 ∧
+      post.retryCount ≤ post.maxRetries := by
+  simp [redriveWake?] at h_redrive
+  rcases h_redrive with ⟨h_can, rfl⟩
+  rcases h_can with ⟨_, _, _, _, h_budget, _, _, _⟩
+  simp [redrivenWakeContext, Nat.succ_le_of_lt h_budget]
+
+def failedWakeFixture
+    (state : RequestState := .failed)
+    (origin : ExecutionOrigin := .scheduled)
+    (retryCount : Nat := 0)
+    (maxRetries : Nat := 3)
+    (isLatest : Bool := true)
+    (source : SessionQueue.QueueSource := .backgroundCompletion)
+    (policy : SessionQueue.QueuePolicy := .coalesce)
+    (queueKey : Option SessionId := some 900) : FailedWake :=
+  { ctx :=
+      { state := state
+      , origin := origin
+      , backend := { val := "background-wake-backend" }
+      , admission := .released
+      , deadline := 1
+      , claimTime := 0
+      , currentTime := 10
+      , retryCount := retryCount
+      , maxRetries := maxRetries
+      , progressSeq := 0
+      , messageSeq := 0
+      , isLatest := isLatest
+      , persistence := .committed
+      }
+  , source := source
+  , policy := policy
+  , queueKey := queueKey
+  }
+
+def canonicalFailedWakeRedriveAccepted : Bool :=
+  match redriveWake? (failedWakeFixture (retryCount := 1)) with
+  | none => false
+  | some post =>
+      decide
+        (post.state = .pending ∧
+         post.origin = .scheduled ∧
+         post.retryCount = 2 ∧
+         post.maxRetries = 3)
+
+theorem canonical_failed_wake_redrive_is_bounded :
+    canonicalFailedWakeRedriveAccepted = true := by
   native_decide
 
 end BackgroundCompletion

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/R6Background.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/R6Background.lean
@@ -151,6 +151,29 @@ def r6CompletionContinuationCase : R6BackgroundingCase :=
     (some wake.source.toDefraDB)
     (wake.queueKey.map fun key => wake.source.toDefraDB ++ ":" ++ toString key)
 
+def r6FailedWakeRedriveCase
+    (name : String)
+    (wake : BackgroundCompletion.FailedWake) : R6BackgroundingCase :=
+  let post := BackgroundCompletion.redriveWake? wake
+  let legal := post.isSome
+  { r6Case
+      name
+      "completion_redrive"
+      "redrive_failed_background_wake"
+      legal
+      1
+      wake.ctx.state.toDefraDB
+      (if legal then some "successor_created" else none)
+      (if legal then some "bounded_retry" else some "ineligible")
+      none
+      (some wake.source.toDefraDB)
+      (wake.queueKey.map fun key => wake.source.toDefraDB ++ ":" ++ toString key) with
+      retryCount := some wake.ctx.retryCount
+      maxRetries := some wake.ctx.maxRetries
+      postRetryCount := post.map (·.retryCount)
+      isLatest := some wake.ctx.isLatest
+  }
+
 def r6LegacyQueueAliasCase : R6BackgroundingCase :=
   let legacy := "subagent_completion"
   let parsed := SessionQueue.QueueSource.fromDefraDB? legacy
@@ -225,6 +248,18 @@ def r6BackgroundingCases : List R6BackgroundingCase :=
   , r6RestartCase
   , r6CompletionQueueCase
   , r6CompletionContinuationCase
+  , r6FailedWakeRedriveCase
+      "failed_background_wake_with_budget_redrives"
+      (BackgroundCompletion.failedWakeFixture (retryCount := 1))
+  , r6FailedWakeRedriveCase
+      "failed_background_wake_exhausted_budget_stops"
+      (BackgroundCompletion.failedWakeFixture (retryCount := 3))
+  , r6FailedWakeRedriveCase
+      "generic_scheduled_failure_is_not_background_redrive"
+      (BackgroundCompletion.failedWakeFixture (source := .user))
+  , r6FailedWakeRedriveCase
+      "non_latest_background_wake_does_not_redrive"
+      (BackgroundCompletion.failedWakeFixture (isLatest := false))
   , r6LegacyQueueAliasCase
   , r6ProcessControlCase
       "list_processes_same_requester_next_turn_authorized"
@@ -314,6 +349,17 @@ theorem r6BackgroundingCases_pinned :
           some "background_completion:900")
       , ("terminal_completion_message_precedes_claimed_continuation", true,
           "background", none, "completed", some "background_completion",
+          some "background_completion:900")
+      , ("failed_background_wake_with_budget_redrives", true,
+          "background", none, "failed", some "background_completion",
+          some "background_completion:900")
+      , ("failed_background_wake_exhausted_budget_stops", false,
+          "background", none, "failed", some "background_completion",
+          some "background_completion:900")
+      , ("generic_scheduled_failure_is_not_background_redrive", false,
+          "background", none, "failed", some "user", some "user:900")
+      , ("non_latest_background_wake_does_not_redrive", false,
+          "background", none, "failed", some "background_completion",
           some "background_completion:900")
       , ("legacy_subagent_completion_source_aliases_canonical_key", true,
           "background", none, "completed", some "subagent_completion",

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -387,6 +387,10 @@ structure R6BackgroundingCase where
   errorCode : Option String
   queueSource : Option String
   queueKey : Option String
+  retryCount : Option Nat := none
+  maxRetries : Option Nat := none
+  postRetryCount : Option Nat := none
+  isLatest : Option Bool := none
   deriving Repr
 
 structure R5CrossDeploymentCase where

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
@@ -317,7 +317,11 @@ def r6BackgroundingCaseJson (witness : R6BackgroundingCase) : String :=
     ++ "\"reason\":" ++ jsonOptionalString witness.reason ++ ","
     ++ "\"error_code\":" ++ jsonOptionalString witness.errorCode ++ ","
     ++ "\"queue_source\":" ++ jsonOptionalString witness.queueSource ++ ","
-    ++ "\"queue_key\":" ++ jsonOptionalString witness.queueKey
+    ++ "\"queue_key\":" ++ jsonOptionalString witness.queueKey ++ ","
+    ++ "\"retry_count\":" ++ jsonOptionalNat witness.retryCount ++ ","
+    ++ "\"max_retries\":" ++ jsonOptionalNat witness.maxRetries ++ ","
+    ++ "\"post_retry_count\":" ++ jsonOptionalNat witness.postRetryCount ++ ","
+    ++ "\"is_latest\":" ++ jsonOptionalBool witness.isLatest
     ++ "}"
 
 def r5CrossDeploymentCaseJson (witness : R5CrossDeploymentCase) : String :=

--- a/crates/gents/src/agent/runtime/startup.rs
+++ b/crates/gents/src/agent/runtime/startup.rs
@@ -715,6 +715,14 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
                     "recovered stuck requests"
                 );
             }
+            if report.background_wakes_redriven > 0 {
+                recovered_any = true;
+                tracing::info!(
+                    agent_did = %agent_did,
+                    count = report.background_wakes_redriven,
+                    "redrove failed background-completion wakes"
+                );
+            }
             if report.responses_recovered > 0 {
                 recovered_any = true;
                 tracing::info!(

--- a/crates/gents/src/background_completion/observer.rs
+++ b/crates/gents/src/background_completion/observer.rs
@@ -115,6 +115,22 @@ impl BackgroundCompletionObserver {
                 );
             }
         }
+        let wake_redrive = crate::RequestLifecycle::redrive_failed_background_wakeups(
+            self.node.as_ref(),
+            &self.local_did,
+        )
+        .await?;
+        if !wake_redrive.is_noop() {
+            tracing::debug!(
+                redriven = wake_redrive.redriven,
+                already_redriven = wake_redrive.already_redriven,
+                coalesced = wake_redrive.coalesced,
+                ineligible = wake_redrive.ineligible,
+                failed = wake_redrive.failed,
+                scanned = wake_redrive.scanned,
+                "redrove failed background-completion wakes"
+            );
+        }
         let unclaimed =
             reconcile_unclaimed_cross_deployment_spawns(self.node.clone(), &self.local_did).await?;
         if !unclaimed.is_empty() {

--- a/crates/gents/src/lean_vocab_test/background_transcript.rs
+++ b/crates/gents/src/lean_vocab_test/background_transcript.rs
@@ -165,6 +165,14 @@ pub(crate) struct LeanR6BackgroundingCase {
     pub(crate) error_code: Option<String>,
     pub(crate) queue_source: Option<String>,
     pub(crate) queue_key: Option<String>,
+    #[serde(default)]
+    pub(crate) retry_count: Option<usize>,
+    #[serde(default)]
+    pub(crate) max_retries: Option<usize>,
+    #[serde(default)]
+    pub(crate) post_retry_count: Option<usize>,
+    #[serde(default)]
+    pub(crate) is_latest: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -170,9 +170,9 @@ pub use identity::{
 pub use interrupt::{fetch_interrupt_requested_at, interrupt_request};
 pub use lifecycle::{
     task_run_conversation_title, write_manual_agent_request,
-    write_manual_agent_request_with_conversation_title, RecoveryReport, RequestLifecycle,
-    TerminalRedriveReport, TerminalRepairReport, TERMINAL_REDRIVE_BATCH_LIMIT,
-    TERMINAL_REDRIVE_CAP,
+    write_manual_agent_request_with_conversation_title, BackgroundWakeRedriveReport,
+    RecoveryReport, RequestLifecycle, TerminalRedriveReport, TerminalRepairReport,
+    TERMINAL_REDRIVE_BATCH_LIMIT, TERMINAL_REDRIVE_CAP,
 };
 pub use mcp_pool::McpPool;
 pub use meta_tools::build_meta_tools;

--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -7,6 +7,7 @@ use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::session;
 use crate::watcher::AgentRequest;
 
+mod background_wake_recovery;
 mod claim;
 mod lookup;
 pub mod manual;
@@ -283,6 +284,7 @@ impl RequestLifecycle {
 #[derive(Debug, Default)]
 pub struct RecoveryReport {
     pub requests_recovered: usize,
+    pub background_wakes_redriven: usize,
     pub responses_recovered: usize,
     pub conversations_recovered: usize,
     pub conversations_failed: usize,
@@ -295,6 +297,22 @@ pub struct TerminalRepairReport {
     pub repaired: usize,
     pub awaiting_outcome: usize,
     pub failed: usize,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BackgroundWakeRedriveReport {
+    pub scanned: usize,
+    pub redriven: usize,
+    pub already_redriven: usize,
+    pub coalesced: usize,
+    pub ineligible: usize,
+    pub failed: usize,
+}
+
+impl BackgroundWakeRedriveReport {
+    pub fn is_noop(&self) -> bool {
+        self.redriven == 0
+    }
 }
 
 impl TerminalRepairReport {

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -1,0 +1,449 @@
+use std::collections::BTreeSet;
+
+use anyhow::{Context, Result};
+use defra_node::EmbeddedNode;
+use serde::Deserialize;
+
+use crate::config_client::ConfigApplyTxn;
+use crate::graphql::escape_graphql_string;
+use crate::session;
+
+use super::queue::{parse_queue_hints, QueuePolicy, QueueSource};
+use super::{BackgroundWakeRedriveReport, RequestLifecycle};
+
+const BACKGROUND_WAKE_REDRIVE_BATCH_LIMIT: usize = 64;
+
+#[derive(Debug, Clone, Deserialize)]
+struct FailedWakeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    request_id: String,
+    agent_did: String,
+    requester_did: Option<String>,
+    behavior_id: String,
+    session_id: String,
+    retry_root_request: Option<String>,
+    content: String,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<i64>,
+    seed: Option<i64>,
+    max_tokens: Option<i64>,
+    max_total_tokens: Option<i64>,
+    metadata: Option<String>,
+    backend_id: Option<String>,
+    caused_by_parent_request_id: Option<String>,
+    caused_by_parent_request_doc_id: Option<String>,
+    subagent_depth: Option<u32>,
+    retry_count: i64,
+    max_retries: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SuccessorRow {
+    retry_parent_request_doc_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PendingWakeRow {
+    session_id: String,
+    metadata: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ConversationRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    latest_request_id: String,
+    updated_at: String,
+    title: String,
+    preview_text: String,
+}
+
+impl ConversationRow {
+    fn rank(&self) -> (String, usize, String) {
+        let richness = [
+            self.title.trim(),
+            self.preview_text.trim(),
+            self.latest_request_id.trim(),
+        ]
+        .iter()
+        .filter(|field| !field.is_empty())
+        .count();
+        (self.updated_at.clone(), richness, self.doc_id.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RedriveOutcome {
+    Created { request_id: String },
+    AlreadyCreated,
+    Coalesced,
+    Ineligible,
+}
+
+impl RequestLifecycle {
+    /// Create bounded retry successors for failed canonical background wakes.
+    ///
+    /// This is deliberately narrower than interactive request retry: the
+    /// source must be a failed scheduled request carrying the versioned,
+    /// coalesced `background_completion` queue metadata. The source must also
+    /// remain the conversation's latest request and have retry budget left.
+    /// A unique per-source `retry_key` plus a private transaction makes the
+    /// sweep idempotent across concurrent ticks and process restarts.
+    pub async fn redrive_failed_background_wakeups(
+        node: &EmbeddedNode,
+        agent_did: &str,
+    ) -> Result<BackgroundWakeRedriveReport> {
+        let (candidates, successors, pending) = load_candidates(node, agent_did).await?;
+        let mut report = BackgroundWakeRedriveReport {
+            scanned: candidates.len(),
+            ..Default::default()
+        };
+        let successor_parents = successors
+            .into_iter()
+            .filter_map(|row| clean(row.retry_parent_request_doc_id))
+            .collect::<BTreeSet<_>>();
+        let pending_keys = pending
+            .into_iter()
+            .filter_map(|row| {
+                let hints = parse_queue_hints(row.metadata.as_deref())?;
+                automated_queue_key(&hints).map(|key| (row.session_id, key))
+            })
+            .collect::<BTreeSet<_>>();
+
+        let mut eligible = Vec::new();
+        for candidate in candidates {
+            let Some(queue_key) = eligible_queue_key(&candidate) else {
+                report.ineligible += 1;
+                continue;
+            };
+            if successor_parents.contains(&candidate.doc_id) {
+                report.already_redriven += 1;
+                continue;
+            }
+            if pending_keys.contains(&(candidate.session_id.clone(), queue_key)) {
+                report.coalesced += 1;
+                continue;
+            }
+            eligible.push(candidate);
+        }
+
+        for candidate in eligible
+            .into_iter()
+            .take(BACKGROUND_WAKE_REDRIVE_BATCH_LIMIT)
+        {
+            match redrive_one(node, &candidate).await {
+                Ok(RedriveOutcome::Created { request_id }) => {
+                    report.redriven += 1;
+                    tracing::info!(
+                        source_request_id = %candidate.request_id,
+                        request_id,
+                        session_id = %candidate.session_id,
+                        retry_count = candidate.retry_count + 1,
+                        max_retries = candidate.max_retries,
+                        "redrove failed background-completion wake"
+                    );
+                }
+                Ok(RedriveOutcome::AlreadyCreated) => report.already_redriven += 1,
+                Ok(RedriveOutcome::Coalesced) => report.coalesced += 1,
+                Ok(RedriveOutcome::Ineligible) => report.ineligible += 1,
+                Err(error) => {
+                    report.failed += 1;
+                    tracing::warn!(
+                        request_id = %candidate.request_id,
+                        session_id = %candidate.session_id,
+                        error = %error,
+                        "failed to redrive background-completion wake"
+                    );
+                }
+            }
+        }
+        Ok(report)
+    }
+}
+
+async fn load_candidates(
+    node: &EmbeddedNode,
+    agent_did: &str,
+) -> Result<(Vec<FailedWakeRow>, Vec<SuccessorRow>, Vec<PendingWakeRow>)> {
+    let agent_did = escape_graphql_string(agent_did);
+    let response = node
+        .execute(&format!(
+            r#"{{
+                failed: AgentRequest(filter: {{
+                    agent_did: {{ _eq: "{agent_did}" }},
+                    status: {{ _eq: "error" }},
+                    lifecycle_state: {{ _eq: "failed" }},
+                    execution_origin: {{ _eq: "scheduled" }}
+                }}, order: [{{ terminalized_at: ASC }}, {{ request_id: ASC }}]) {{
+                    _docID request_id agent_did requester_did behavior_id session_id
+                    retry_root_request content temperature top_p top_k seed max_tokens
+                    max_total_tokens metadata backend_id caused_by_parent_request_id
+                    caused_by_parent_request_doc_id subagent_depth retry_count max_retries
+                }}
+                successors: AgentRequest(filter: {{
+                    agent_did: {{ _eq: "{agent_did}" }},
+                    retry_parent_request_doc_id: {{ _neq: null }}
+                }}) {{ retry_parent_request_doc_id }}
+                pending: AgentRequest(filter: {{
+                    agent_did: {{ _eq: "{agent_did}" }},
+                    status: {{ _eq: "pending" }},
+                    lifecycle_state: {{ _eq: "pending" }}
+                }}) {{ session_id metadata }}
+            }}"#
+        ))
+        .await;
+    if response.has_errors() {
+        anyhow::bail!("querying failed background wakes: {:?}", response.errors);
+    }
+    let data = response.data.context("background wake query has no data")?;
+    Ok((
+        serde_json::from_value(data["failed"].clone()).context("decoding failed wakes")?,
+        serde_json::from_value(data["successors"].clone()).context("decoding successors")?,
+        serde_json::from_value(data["pending"].clone()).context("decoding pending wakes")?,
+    ))
+}
+
+fn clean(value: Option<String>) -> Option<String> {
+    value.and_then(|value| (!value.trim().is_empty()).then_some(value))
+}
+
+fn automated_queue_key(hints: &super::queue::QueueHints) -> Option<String> {
+    (hints.source == QueueSource::BackgroundCompletion && hints.policy == QueuePolicy::Coalesce)
+        .then(|| clean(hints.key.clone()))
+        .flatten()
+}
+
+fn eligible_queue_key(candidate: &FailedWakeRow) -> Option<String> {
+    if candidate.retry_count < 0 || candidate.retry_count >= candidate.max_retries {
+        return None;
+    }
+    let hints = parse_queue_hints(candidate.metadata.as_deref())?;
+    if super::is_deprecated_background_completion_request(
+        Some("scheduled"),
+        candidate.metadata.as_deref(),
+    ) {
+        return None;
+    }
+    automated_queue_key(&hints)
+}
+
+async fn redrive_one(node: &EmbeddedNode, candidate: &FailedWakeRow) -> Result<RedriveOutcome> {
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let mut last_error = None;
+    for retry_index in 0..=crate::graphql::DEFRA_DB_CONFLICT_MAX_RETRIES {
+        let txn = ConfigApplyTxn::begin_local(node, None).await?;
+        let attempt = redrive_in_transaction(&txn, candidate, &request_id).await;
+        let result = match attempt {
+            Ok(outcome) => txn.commit().await.map(|()| outcome),
+            Err(error) => {
+                let _ = txn.discard().await;
+                Err(error)
+            }
+        };
+        match result {
+            Ok(outcome) => return Ok(outcome),
+            Err(error)
+                if retry_index < crate::graphql::DEFRA_DB_CONFLICT_MAX_RETRIES
+                    && retryable_transaction_error(&error) =>
+            {
+                let backoff = crate::graphql::defradb_conflict_retry_backoff(retry_index);
+                last_error = Some(error);
+                tokio::time::sleep(backoff).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("background wake redrive exhausted")))
+}
+
+fn retryable_transaction_error(error: &anyhow::Error) -> bool {
+    let text = error.to_string().to_ascii_lowercase();
+    crate::graphql::is_defradb_transaction_conflict_text(&text)
+        || text.contains("unique")
+        || text.contains("constraint")
+        || text.contains("database is locked")
+        || text.contains("compare-and-set lost")
+}
+
+async fn redrive_in_transaction(
+    txn: &ConfigApplyTxn<'_>,
+    candidate: &FailedWakeRow,
+    request_id: &str,
+) -> Result<RedriveOutcome> {
+    let retry_key = format!("retry:doc:{}", candidate.doc_id);
+    let response = txn
+        .execute(&precondition_query(candidate, &retry_key))
+        .await?;
+    let data = response.get("data").context("redrive query has no data")?;
+    if rows(data, "successor").is_some_and(|rows| !rows.is_empty()) {
+        return Ok(RedriveOutcome::AlreadyCreated);
+    }
+    if rows(data, "source").map_or(0, <[_]>::len) != 1 {
+        return Ok(RedriveOutcome::Ineligible);
+    }
+    let queue_key = eligible_queue_key(candidate).context("wake became ineligible")?;
+    if rows(data, "pending").into_iter().flatten().any(|row| {
+        parse_queue_hints(row.get("metadata").and_then(serde_json::Value::as_str))
+            .and_then(|hints| automated_queue_key(&hints))
+            .is_some_and(|key| key == queue_key)
+    }) {
+        return Ok(RedriveOutcome::Coalesced);
+    }
+
+    let mut conversations: Vec<ConversationRow> = serde_json::from_value(
+        data.get("conversations")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!([])),
+    )
+    .context("decoding background wake conversations")?;
+    conversations.sort_by(|left, right| right.rank().cmp(&left.rank()));
+    let Some(conversation) = conversations.first() else {
+        return Ok(RedriveOutcome::Ineligible);
+    };
+    if conversation.latest_request_id != candidate.request_id {
+        return Ok(RedriveOutcome::Ineligible);
+    }
+
+    let response = txn
+        .execute(&redrive_mutation(
+            candidate,
+            conversation,
+            request_id,
+            &retry_key,
+        ))
+        .await?;
+    let data = response
+        .get("data")
+        .context("redrive mutation has no data")?;
+    let created = data
+        .get("successor")
+        .is_some_and(crate::graphql::response_has_documents);
+    let updated = data
+        .get("conversation")
+        .is_some_and(crate::graphql::response_has_documents);
+    anyhow::ensure!(
+        created && updated,
+        "background wake redrive compare-and-set lost"
+    );
+    Ok(RedriveOutcome::Created {
+        request_id: request_id.to_string(),
+    })
+}
+
+fn rows<'a>(data: &'a serde_json::Value, name: &str) -> Option<&'a [serde_json::Value]> {
+    data.get(name)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice)
+}
+
+fn precondition_query(candidate: &FailedWakeRow, retry_key: &str) -> String {
+    let doc_id = escape_graphql_string(&candidate.doc_id);
+    let agent_did = escape_graphql_string(&candidate.agent_did);
+    let session_id = escape_graphql_string(&candidate.session_id);
+    let retry_key = escape_graphql_string(retry_key);
+    format!(
+        r#"{{
+            source: AgentRequest(filter: {{
+                _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{agent_did}" }},
+                status: {{ _eq: "error" }}, lifecycle_state: {{ _eq: "failed" }},
+                execution_origin: {{ _eq: "scheduled" }}
+            }}, limit: 1) {{ _docID }}
+            successor: AgentRequest(
+                filter: {{ retry_key: {{ _eq: "{retry_key}" }} }}, limit: 1
+            ) {{ _docID }}
+            pending: AgentRequest(filter: {{
+                session_id: {{ _eq: "{session_id}" }}, agent_did: {{ _eq: "{agent_did}" }},
+                status: {{ _eq: "pending" }}, lifecycle_state: {{ _eq: "pending" }}
+            }}) {{ metadata }}
+            conversations: AgentConversation(filter: {{
+                session_id: {{ _eq: "{session_id}" }}, agent_did: {{ _eq: "{agent_did}" }}
+            }}) {{ _docID latest_request_id updated_at title preview_text }}
+        }}"#
+    )
+}
+
+fn optional_field<T: std::fmt::Display>(name: &str, value: Option<T>) -> String {
+    value
+        .map(|value| format!("{name}: {value},"))
+        .unwrap_or_default()
+}
+
+fn optional_string_field(name: &str, value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(r#"{name}: "{}","#, escape_graphql_string(value)))
+        .unwrap_or_default()
+}
+
+fn redrive_mutation(
+    candidate: &FailedWakeRow,
+    conversation: &ConversationRow,
+    request_id: &str,
+    retry_key: &str,
+) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    let retry_root = candidate
+        .retry_root_request
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&candidate.request_id);
+    let requester_did = session::requester_did_create_field(candidate.requester_did.as_deref());
+    let parent_request_id = optional_string_field(
+        "caused_by_parent_request_id",
+        candidate.caused_by_parent_request_id.as_deref(),
+    );
+    let parent_request_doc_id = optional_string_field(
+        "caused_by_parent_request_doc_id",
+        candidate.caused_by_parent_request_doc_id.as_deref(),
+    );
+    format!(
+        r#"mutation {{
+            successor: create_AgentRequest(input: {{
+                request_id: "{request_id}", agent_did: "{agent_did}", {requester_did}
+                behavior_id: "{behavior_id}", session_id: "{session_id}",
+                retry_parent_request: "{source_id}",
+                retry_parent_request_doc_id: "{source_doc_id}",
+                retry_root_request: "{retry_root}", retry_key: "{retry_key}",
+                superseded_by_request: "", content: "{content}",
+                {temperature} {top_p} {top_k} {seed} {max_tokens} {max_total_tokens}
+                metadata: "{metadata}", status: "pending", lifecycle_state: "pending",
+                backend_id: "{backend_id}", execution_origin: "scheduled", failure_reason: "",
+                terminal_redrive_attempts: 0, created_at: "{created_at}",
+                retry_count: {retry_count}, max_retries: {max_retries},
+                subagent_depth: {subagent_depth}, {parent_request_id} {parent_request_doc_id}
+            }}) {{ _docID }}
+            conversation: update_AgentConversation(
+                filter: {{ _docID: {{ _eq: "{conversation_doc_id}" }},
+                    latest_request_id: {{ _eq: "{source_id}" }} }},
+                input: {{ latest_request_id: "{request_id}", preview_text: "{content}",
+                    status: "active", updated_at: "{created_at}" }}
+            ) {{ _docID }}
+        }}"#,
+        request_id = escape_graphql_string(request_id),
+        agent_did = escape_graphql_string(&candidate.agent_did),
+        behavior_id = escape_graphql_string(&candidate.behavior_id),
+        session_id = escape_graphql_string(&candidate.session_id),
+        source_id = escape_graphql_string(&candidate.request_id),
+        source_doc_id = escape_graphql_string(&candidate.doc_id),
+        retry_root = escape_graphql_string(retry_root),
+        retry_key = escape_graphql_string(retry_key),
+        content = escape_graphql_string(&candidate.content),
+        temperature = optional_field("temperature", candidate.temperature),
+        top_p = optional_field("top_p", candidate.top_p),
+        top_k = optional_field("top_k", candidate.top_k),
+        seed = optional_field("seed", candidate.seed),
+        max_tokens = optional_field("max_tokens", candidate.max_tokens),
+        max_total_tokens = optional_field("max_total_tokens", candidate.max_total_tokens),
+        metadata = escape_graphql_string(candidate.metadata.as_deref().unwrap_or("")),
+        backend_id = escape_graphql_string(candidate.backend_id.as_deref().unwrap_or("")),
+        created_at = escape_graphql_string(&now),
+        retry_count = candidate.retry_count + 1,
+        max_retries = candidate.max_retries,
+        subagent_depth = candidate.subagent_depth.unwrap_or_default(),
+        conversation_doc_id = escape_graphql_string(&conversation.doc_id),
+    )
+}

--- a/crates/gents/src/lifecycle/recovery.rs
+++ b/crates/gents/src/lifecycle/recovery.rs
@@ -13,11 +13,15 @@ impl RequestLifecycle {
         let requests_recovered = Self::repair_terminal_requests(node, agent_did)
             .await?
             .repaired;
+        let background_wakes_redriven = Self::redrive_failed_background_wakeups(node, agent_did)
+            .await?
+            .redriven;
         let conversations = recover_stuck_conversations(node, agent_did).await?;
 
         Ok(RecoveryReport {
             responses_recovered,
             requests_recovered,
+            background_wakes_redriven,
             conversations_recovered: conversations.recovered,
             conversations_failed: conversations.failed,
             duplicate_conversation_sessions: conversations.duplicate_sessions,

--- a/crates/gents/tests/conformance/background.rs
+++ b/crates/gents/tests/conformance/background.rs
@@ -532,7 +532,7 @@ async fn wait_for_background_theorem_child_lifecycle_state(
 
 pub(super) async fn generated_r6_backgrounding_cases_drive_tool_backgrounding_contract() {
     let cases = lean_r6_backgrounding_cases();
-    assert_eq!(cases.len(), 22);
+    assert_eq!(cases.len(), 26);
 
     let names = cases
         .iter()
@@ -549,6 +549,10 @@ pub(super) async fn generated_r6_backgrounding_cases_drive_tool_backgrounding_co
             "background_recovery_running_live_parent_to_cancelled",
             "background_completion_source_writes_canonical_key",
             "terminal_completion_message_precedes_claimed_continuation",
+            "failed_background_wake_with_budget_redrives",
+            "failed_background_wake_exhausted_budget_stops",
+            "generic_scheduled_failure_is_not_background_redrive",
+            "non_latest_background_wake_does_not_redrive",
             "legacy_subagent_completion_source_aliases_canonical_key",
             "list_processes_same_requester_next_turn_authorized",
             "read_process_same_requester_next_turn_authorized",
@@ -634,6 +638,28 @@ pub(super) async fn generated_r6_backgrounding_cases_drive_tool_backgrounding_co
         lean_r6_backgrounding_case("legacy_subagent_completion_source_aliases_canonical_key");
     assert_eq!(legacy.queue_source.as_deref(), Some("subagent_completion"));
     assert_eq!(legacy.queue_key.as_deref(), canonical.queue_key.as_deref());
+
+    let redrive = lean_r6_backgrounding_case("failed_background_wake_with_budget_redrives");
+    assert!(redrive.legal);
+    assert_eq!(redrive.group, "completion_redrive");
+    assert_eq!(redrive.action, "redrive_failed_background_wake");
+    assert_eq!(redrive.retry_count, Some(1));
+    assert_eq!(redrive.max_retries, Some(3));
+    assert_eq!(redrive.post_retry_count, Some(2));
+    assert_eq!(redrive.is_latest, Some(true));
+
+    let exhausted = lean_r6_backgrounding_case("failed_background_wake_exhausted_budget_stops");
+    assert!(!exhausted.legal);
+    assert_eq!(exhausted.retry_count, exhausted.max_retries);
+    assert_eq!(exhausted.post_retry_count, None);
+
+    let generic = lean_r6_backgrounding_case("generic_scheduled_failure_is_not_background_redrive");
+    assert!(!generic.legal);
+    assert_eq!(generic.queue_source.as_deref(), Some("user"));
+
+    let non_latest = lean_r6_backgrounding_case("non_latest_background_wake_does_not_redrive");
+    assert!(!non_latest.legal);
+    assert_eq!(non_latest.is_latest, Some(false));
 
     for case in cases.iter().filter(|case| case.group == "native_lifecycle") {
         drive_r6_native_lifecycle_case(case).await;

--- a/crates/gents/tests/e2e_lifecycle/lifecycle_recovery.rs
+++ b/crates/gents/tests/e2e_lifecycle/lifecycle_recovery.rs
@@ -37,6 +37,148 @@ struct NotificationDeliveryRow {
     completion_notification_delivered_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct BackgroundWakeRetryRow {
+    request_id: String,
+    status: String,
+    lifecycle_state: String,
+    execution_origin: String,
+    retry_parent_request: String,
+    retry_root_request: String,
+    retry_count: i64,
+    max_retries: i64,
+    metadata: String,
+    deadline: Option<String>,
+    valid_until: Option<String>,
+}
+
+#[tokio::test]
+async fn failed_background_wake_redrive_is_bounded_and_idempotent() {
+    let db = test_db("lifecycle-background-wake-redrive").await;
+    let metadata = serde_json::json!({
+        "queue": {
+            "source": "background_completion",
+            "policy": "coalesce",
+            "key": "background_completion:wake-redrive-session",
+            "queued_after_request_id": "foreground-parent"
+        },
+        "background_completion_wake_version": 1
+    })
+    .to_string();
+    let escaped_metadata = gents::graphql::escape_graphql_string(&metadata);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "failed-wake",
+                agent_did: "{AGENT_DID}",
+                behavior_id: "{AGENT_NAME}",
+                session_id: "wake-redrive-session",
+                retry_parent_request: "",
+                retry_root_request: "failed-wake",
+                superseded_by_request: "",
+                content: "continue after background completion",
+                metadata: "{escaped_metadata}",
+                status: "error",
+                lifecycle_state: "failed",
+                backend_id: "{BACKEND_ID}",
+                execution_origin: "scheduled",
+                failure_reason: "backend admission failed",
+                terminalized_at: "2026-08-12T00:00:00Z",
+                terminal_redrive_attempts: 0,
+                created_at: "2026-08-12T00:00:00Z",
+                deadline: "2026-08-12T00:00:01Z",
+                retry_count: 1,
+                max_retries: 3,
+                valid_until: "2026-08-12T00:00:01Z",
+                subagent_depth: 0
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = db.node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create failed wake: {:?}",
+        response.errors
+    );
+    upsert_conversation(
+        &db.node,
+        "wake-redrive-session",
+        "failed-wake",
+        "continue after background completion",
+        "active",
+    )
+    .await;
+
+    let (first, concurrent) = tokio::join!(
+        RequestLifecycle::redrive_failed_background_wakeups(&db.node, AGENT_DID),
+        RequestLifecycle::redrive_failed_background_wakeups(&db.node, AGENT_DID),
+    );
+    let first = first.expect("first concurrent redrive");
+    let concurrent = concurrent.expect("second concurrent redrive");
+    assert_eq!(first.scanned, 1);
+    assert_eq!(concurrent.scanned, 1);
+    assert_eq!(first.redriven + concurrent.redriven, 1);
+    assert_eq!(first.already_redriven + concurrent.already_redriven, 1);
+    assert_eq!(first.failed + concurrent.failed, 0);
+
+    let rows = background_wake_retry_rows(&db.node, "wake-redrive-session").await;
+    assert_eq!(rows.len(), 2);
+    let successor = rows
+        .iter()
+        .find(|row| row.request_id != "failed-wake")
+        .expect("retry successor");
+    assert_eq!(successor.status, "pending");
+    assert_eq!(successor.lifecycle_state, "pending");
+    assert_eq!(successor.execution_origin, "scheduled");
+    assert_eq!(successor.retry_parent_request, "failed-wake");
+    assert_eq!(successor.retry_root_request, "failed-wake");
+    assert_eq!(successor.retry_count, 2);
+    assert_eq!(successor.max_retries, 3);
+    assert_eq!(successor.metadata, metadata);
+    assert_eq!(successor.deadline, None);
+    assert_eq!(successor.valid_until, None);
+
+    let second = RequestLifecycle::redrive_failed_background_wakeups(&db.node, AGENT_DID)
+        .await
+        .expect("repeat redrive");
+    assert_eq!(second.redriven, 0);
+    assert_eq!(second.already_redriven, 1);
+    assert_eq!(
+        background_wake_retry_rows(&db.node, "wake-redrive-session")
+            .await
+            .len(),
+        2
+    );
+}
+
+async fn background_wake_retry_rows(
+    node: &gents::defra_node::EmbeddedNode,
+    session_id: &str,
+) -> Vec<BackgroundWakeRetryRow> {
+    let session_id = gents::graphql::escape_graphql_string(session_id);
+    let response = node
+        .execute(&format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ session_id: {{ _eq: "{session_id}" }} }},
+                    order: {{ created_at: ASC }}
+                ) {{
+                    request_id status lifecycle_state execution_origin
+                    retry_parent_request retry_root_request retry_count max_retries
+                    metadata deadline valid_until
+                }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !response.has_errors(),
+        "fetch background wake retries: {:?}",
+        response.errors
+    );
+    serde_json::from_value(response.data.expect("wake retry data")["AgentRequest"].clone())
+        .expect("decode wake retry rows")
+}
+
 async fn mark_request_interrupted(node: &gents::defra_node::EmbeddedNode, doc_id: &str) {
     let mutation = format!(
         r#"mutation {{


### PR DESCRIPTION
## Summary

- formalize the bounded redrive contract for failed background-completion wakes and add generated R6 conformance witnesses
- atomically create idempotent retry successors with preserved lineage, coalescing/latest guards, and a 64-item recovery batch
- run recovery during startup and live background reconciliation, with redrive counts in startup observability

## Validation

- `lake build Proofs.Conformance.Contracts:olean`
- `CARGO_INCREMENTAL=0 cargo test -p gents`
- `CARGO_INCREMENTAL=0 cargo check --workspace`
- `CARGO_INCREMENTAL=0 cargo test -p gents --test e2e_lifecycle failed_background_wake_redrive_is_bounded_and_idempotent`

Advances #1116. This PR covers automated redrive; the remaining admission fairness, acknowledgement, observability, and soak work stays tracked in the issue.
