### PR TITLE
Skip disabled P2P metrics polling

### DIFF
--- a/crates/gents-cli/src/http/router.rs
+++ b/crates/gents-cli/src/http/router.rs
@@ -134,6 +134,10 @@ async fn metrics_handler(State(state): State<RuntimeHttpState>) -> Response {
 }
 
 async fn load_p2p_metrics_for_scrape(state: &RuntimeHttpState) -> P2pMetricsSnapshot {
+    if state.p2p_admission.is_none() {
+        return p2p_metrics_admission_only(state, false);
+    }
+
     let cached = state
         .p2p_metrics_cache
         .lock()
@@ -613,6 +617,21 @@ mod tests {
         assert_eq!(sync.next_pending_retry_in_ms, Some(71));
         assert_eq!(sync.pending_dag_terminal_quarantined, 73);
         assert_eq!(sync.quarantined_pending_dags, 79);
+    }
+
+    #[tokio::test]
+    async fn disabled_p2p_metrics_skip_live_status_fetch() {
+        let mut state = state();
+        state.graphql = "http://127.0.0.1:9/api/v0/graphql".to_string();
+
+        let snapshot = load_p2p_metrics_for_scrape(&state).await;
+
+        assert!(!snapshot.enabled);
+        assert!(!snapshot.stale);
+        assert_eq!(snapshot.connected_peers, 0);
+        assert_eq!(snapshot.replicators, 0);
+        assert!(snapshot.admission.is_none());
+        assert!(snapshot.sync_status.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Skip live P2P status polling during `/metrics` collection when the runtime was started with P2P disabled.
- Emit a clean disabled snapshot (`enabled=0`, `stale=0`) instead of probing DefraDB endpoints that are expected to return 503.
- Add a regression test covering the disabled-P2P path.

## Root cause

Prometheus scrapes `/metrics` every 15 seconds. The handler unconditionally self-fetched DefraDB P2P endpoints, even for runtimes started with `--p2p-transport none`. DefraDB correctly returned `503 Service Unavailable`, and the HTTP trace layer logged every expected response as an error.

## Impact

Disabled-P2P runtimes no longer emit misleading 503 error logs on every metrics scrape. P2P-enabled metrics collection is unchanged.

## Validation

- `cargo fmt --check`
- `CARGO_INCREMENTAL=0 cargo test -p gents-cli disabled_p2p_metrics_skip_live_status_fetch`
- `CARGO_INCREMENTAL=0 cargo test -p gents`
- `CARGO_INCREMENTAL=0 cargo check --workspace --all-targets`