### PR TITLE
Bound terminal GraphQL persistence retries

### DIFF
--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -39,8 +39,20 @@ const GRAPHQL_RETRY_POLICY: ExecuteRetryPolicy = ExecuteRetryPolicy::new(
     Duration::from_millis(DEFRA_DB_CONFLICT_INITIAL_BACKOFF_MS),
     Duration::from_millis(800),
 );
+const GRAPHQL_SINGLE_ATTEMPT_POLICY: ExecuteRetryPolicy =
+    ExecuteRetryPolicy::new(0, Duration::ZERO, Duration::ZERO);
 
 type MutationWriteGate = Mutex<()>;
+
+pub(crate) trait GraphqlExecution: Sync {
+    async fn execute(&self, graphql: &str, retry_policy: ExecuteRetryPolicy) -> QueryResponse;
+}
+
+impl GraphqlExecution for EmbeddedNode {
+    async fn execute(&self, graphql: &str, retry_policy: ExecuteRetryPolicy) -> QueryResponse {
+        self.execute_with_retry(graphql, retry_policy).await
+    }
+}
 
 /// DefraDB commits auto-committed mutations at a database-wide revision
 /// boundary. Keep all ordinary writes for one embedded node on the same gate;
@@ -64,17 +76,17 @@ fn mutation_write_gate(node: &EmbeddedNode) -> Arc<MutationWriteGate> {
     gate
 }
 
-/// Execute GraphQL through the node's identity-aware retry path.
-///
-/// This is the low-level form for callers that intentionally inspect GraphQL
-/// errors. Most callers should use [`graphql_with_transaction_retry`].
-pub async fn graphql_response_with_transaction_retry(
-    node: &EmbeddedNode,
+async fn graphql_response_with_policy<E>(
+    executor: &E,
     graphql: &str,
     operation: &str,
-) -> QueryResponse {
+    retry_policy: ExecuteRetryPolicy,
+) -> QueryResponse
+where
+    E: GraphqlExecution + ?Sized,
+{
     let started = std::time::Instant::now();
-    let response = node.execute_with_retry(graphql, GRAPHQL_RETRY_POLICY).await;
+    let response = executor.execute(graphql, retry_policy).await;
     let elapsed = started.elapsed();
     if elapsed > Duration::from_secs(1) {
         tracing::warn!(
@@ -90,6 +102,18 @@ pub async fn graphql_response_with_transaction_retry(
         );
     }
     response
+}
+
+/// Execute GraphQL through the node's identity-aware retry path.
+///
+/// This is the low-level form for callers that intentionally inspect GraphQL
+/// errors. Most callers should use [`graphql_with_transaction_retry`].
+pub async fn graphql_response_with_transaction_retry(
+    node: &EmbeddedNode,
+    graphql: &str,
+    operation: &str,
+) -> QueryResponse {
+    graphql_response_with_policy(node, graphql, operation, GRAPHQL_RETRY_POLICY).await
 }
 
 /// Execute identity-aware GraphQL with transaction-conflict retry and fail on
@@ -113,9 +137,23 @@ pub async fn graphql_mutation_response_with_transaction_retry(
     graphql: &str,
     operation: &str,
 ) -> QueryResponse {
+    graphql_mutation_response_with_policy(node, node, graphql, operation, GRAPHQL_RETRY_POLICY)
+        .await
+}
+
+async fn graphql_mutation_response_with_policy<E>(
+    node: &EmbeddedNode,
+    executor: &E,
+    graphql: &str,
+    operation: &str,
+    retry_policy: ExecuteRetryPolicy,
+) -> QueryResponse
+where
+    E: GraphqlExecution + ?Sized,
+{
     let gate = mutation_write_gate(node);
     let _write_guard = gate.lock().await;
-    graphql_response_with_transaction_retry(node, graphql, operation).await
+    graphql_response_with_policy(executor, graphql, operation, retry_policy).await
 }
 
 /// Execute an auto-committed GraphQL mutation through the single node-scoped
@@ -126,9 +164,55 @@ pub async fn graphql_mutation_with_transaction_retry(
     graphql: &str,
     operation: &str,
 ) -> Result<QueryResponse> {
-    let response = graphql_mutation_response_with_transaction_retry(node, graphql, operation).await;
+    graphql_mutation_with_transaction_retry_using(node, node, graphql, operation).await
+}
+
+pub(crate) async fn graphql_mutation_with_transaction_retry_using<E>(
+    node: &EmbeddedNode,
+    executor: &E,
+    graphql: &str,
+    operation: &str,
+) -> Result<QueryResponse>
+where
+    E: GraphqlExecution + ?Sized,
+{
+    graphql_mutation_with_policy(node, executor, graphql, operation, GRAPHQL_RETRY_POLICY).await
+}
+
+async fn graphql_mutation_with_policy<E>(
+    node: &EmbeddedNode,
+    executor: &E,
+    graphql: &str,
+    operation: &str,
+    retry_policy: ExecuteRetryPolicy,
+) -> Result<QueryResponse>
+where
+    E: GraphqlExecution + ?Sized,
+{
+    let response =
+        graphql_mutation_response_with_policy(node, executor, graphql, operation, retry_policy)
+            .await;
     ensure_no_errors(&response, operation)?;
     Ok(response)
+}
+
+pub(crate) async fn graphql_mutation_once_with_executor<E>(
+    node: &EmbeddedNode,
+    executor: &E,
+    graphql: &str,
+    operation: &str,
+) -> Result<QueryResponse>
+where
+    E: GraphqlExecution + ?Sized,
+{
+    graphql_mutation_with_policy(
+        node,
+        executor,
+        graphql,
+        operation,
+        GRAPHQL_SINGLE_ATTEMPT_POLICY,
+    )
+    .await
 }
 
 pub fn ensure_no_errors(response: &QueryResponse, operation: &str) -> Result<()> {

--- a/crates/gents/src/retry.rs
+++ b/crates/gents/src/retry.rs
@@ -115,17 +115,33 @@ where
     }
 }
 
+/// Execute one initial terminal mutation plus at most
+/// [`TERMINAL_PERSISTENCE_MAX_RETRIES`] retries. Each attempt enters the shared
+/// node mutation gate once; terminal backoff happens after that guard is gone.
 pub(crate) async fn execute_graphql_with_terminal_persistence_retry(
     node: &EmbeddedNode,
     graphql: &str,
     operation: &str,
 ) -> anyhow::Result<QueryResponse> {
+    execute_graphql_with_terminal_persistence_retry_using(node, node, graphql, operation).await
+}
+
+async fn execute_graphql_with_terminal_persistence_retry_using<E>(
+    node: &EmbeddedNode,
+    executor: &E,
+    graphql: &str,
+    operation: &str,
+) -> anyhow::Result<QueryResponse>
+where
+    E: crate::graphql::GraphqlExecution + ?Sized,
+{
     retry_terminal_persistence_operation(
         operation,
         TERMINAL_PERSISTENCE_MAX_RETRIES,
         Duration::from_millis(TERMINAL_PERSISTENCE_INITIAL_BACKOFF_MS),
         || async {
-            crate::graphql::graphql_mutation_with_transaction_retry(node, graphql, operation).await
+            crate::graphql::graphql_mutation_once_with_executor(node, executor, graphql, operation)
+                .await
         },
     )
     .await

--- a/crates/gents/src/retry/tests.rs
+++ b/crates/gents/src/retry/tests.rs
@@ -1,4 +1,62 @@
 use super::*;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use defra_node::ExecuteRetryPolicy;
+
+#[derive(Clone, Copy)]
+enum ScriptedGraphqlResult {
+    Conflict(&'static str),
+    Error(&'static str),
+    Success,
+}
+
+struct ScriptedGraphqlExecution {
+    results: StdMutex<VecDeque<ScriptedGraphqlResult>>,
+    attempts: AtomicUsize,
+    policies: StdMutex<Vec<ExecuteRetryPolicy>>,
+}
+
+impl ScriptedGraphqlExecution {
+    fn new(results: impl IntoIterator<Item = ScriptedGraphqlResult>) -> Self {
+        Self {
+            results: StdMutex::new(results.into_iter().collect()),
+            attempts: AtomicUsize::new(0),
+            policies: StdMutex::new(Vec::new()),
+        }
+    }
+
+    fn attempts(&self) -> usize {
+        self.attempts.load(Ordering::SeqCst)
+    }
+
+    fn policies(&self) -> Vec<ExecuteRetryPolicy> {
+        self.policies.lock().unwrap().clone()
+    }
+}
+
+impl crate::graphql::GraphqlExecution for ScriptedGraphqlExecution {
+    async fn execute(&self, _graphql: &str, retry_policy: ExecuteRetryPolicy) -> QueryResponse {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        self.policies.lock().unwrap().push(retry_policy);
+        match self
+            .results
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("scripted GraphQL result")
+        {
+            ScriptedGraphqlResult::Conflict(message) => {
+                QueryResponse::transaction_conflict(message)
+            }
+            ScriptedGraphqlResult::Error(message) => QueryResponse::error(message),
+            ScriptedGraphqlResult::Success => {
+                QueryResponse::success(serde_json::json!({ "ok": true }))
+            }
+        }
+    }
+}
 
 #[test]
 fn default_policy() {
@@ -132,4 +190,163 @@ async fn terminal_lifecycle_persistence_exhaustion_is_bounded() {
 
     assert!(error.to_string().contains("storage remains unavailable"));
     assert_eq!(attempts, 4, "initial attempt plus three retries");
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_graphql_conflicts_have_one_total_attempt_budget() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let executor = ScriptedGraphqlExecution::new([
+        ScriptedGraphqlResult::Conflict("persistent conflict 1"),
+        ScriptedGraphqlResult::Conflict("persistent conflict 2"),
+        ScriptedGraphqlResult::Conflict("persistent conflict 3"),
+        ScriptedGraphqlResult::Conflict("persistent conflict 4"),
+    ]);
+
+    let error = execute_graphql_with_terminal_persistence_retry_using(
+        &node,
+        &executor,
+        "mutation { terminal }",
+        "persist terminal state",
+    )
+    .await
+    .expect_err("persistent conflicts must exhaust the terminal budget");
+
+    assert!(error.to_string().contains("persistent conflict 4"));
+    assert_eq!(
+        executor.attempts(),
+        (TERMINAL_PERSISTENCE_MAX_RETRIES + 1) as usize
+    );
+    assert!(
+        executor
+            .policies()
+            .iter()
+            .all(|policy| policy.max_retries == 0),
+        "each terminal attempt must disable DefraDB's nested retry budget"
+    );
+    node.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_graphql_retries_non_conflict_storage_errors_until_recovery() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let executor = ScriptedGraphqlExecution::new([
+        ScriptedGraphqlResult::Error("temporary disk unavailable"),
+        ScriptedGraphqlResult::Error("ambiguous commit acknowledgement"),
+        ScriptedGraphqlResult::Success,
+    ]);
+
+    let response = execute_graphql_with_terminal_persistence_retry_using(
+        &node,
+        &executor,
+        "mutation { terminal }",
+        "persist terminal state",
+    )
+    .await
+    .expect("ambiguous storage failure should recover");
+
+    assert!(!response.has_errors());
+    assert_eq!(executor.attempts(), 3);
+    node.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_graphql_exhaustion_returns_the_underlying_storage_error() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let executor = ScriptedGraphqlExecution::new([
+        ScriptedGraphqlResult::Error("storage failure 1"),
+        ScriptedGraphqlResult::Error("storage failure 2"),
+        ScriptedGraphqlResult::Error("storage failure 3"),
+        ScriptedGraphqlResult::Error("durable repair sentinel"),
+    ]);
+
+    let error = execute_graphql_with_terminal_persistence_retry_using(
+        &node,
+        &executor,
+        "mutation { terminal }",
+        "persist terminal state",
+    )
+    .await
+    .expect_err("terminal persistence must leave durable repair pending");
+
+    assert!(error.to_string().contains("durable repair sentinel"));
+    assert_eq!(executor.attempts(), 4);
+    node.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_backoff_releases_the_node_mutation_gate() {
+    let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+    let terminal_executor = Arc::new(ScriptedGraphqlExecution::new([
+        ScriptedGraphqlResult::Conflict("retry terminal mutation"),
+        ScriptedGraphqlResult::Success,
+    ]));
+    let terminal_task = {
+        let node = Arc::clone(&node);
+        let executor = Arc::clone(&terminal_executor);
+        tokio::spawn(async move {
+            execute_graphql_with_terminal_persistence_retry_using(
+                &node,
+                executor.as_ref(),
+                "mutation { terminal }",
+                "persist terminal state",
+            )
+            .await
+        })
+    };
+
+    while terminal_executor.attempts() == 0 {
+        tokio::task::yield_now().await;
+    }
+    tokio::task::yield_now().await;
+
+    let unrelated_executor = ScriptedGraphqlExecution::new([ScriptedGraphqlResult::Success]);
+    let before = tokio::time::Instant::now();
+    crate::graphql::graphql_mutation_once_with_executor(
+        &node,
+        &unrelated_executor,
+        "mutation { unrelated }",
+        "unrelated mutation",
+    )
+    .await
+    .expect("unrelated mutation should enter the gate during terminal backoff");
+
+    assert_eq!(
+        tokio::time::Instant::now(),
+        before,
+        "the unrelated mutation must not wait for terminal backoff"
+    );
+    assert_eq!(unrelated_executor.attempts(), 1);
+    tokio::time::advance(Duration::from_millis(
+        TERMINAL_PERSISTENCE_INITIAL_BACKOFF_MS,
+    ))
+    .await;
+    terminal_task
+        .await
+        .expect("terminal task panicked")
+        .expect("terminal retry should recover");
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn ordinary_mutations_keep_defradb_conflict_retry_policy() {
+    let node = EmbeddedNode::builder().build().await.unwrap();
+    let executor = ScriptedGraphqlExecution::new([ScriptedGraphqlResult::Success]);
+
+    crate::graphql::graphql_mutation_with_transaction_retry_using(
+        &node,
+        &executor,
+        "mutation { ordinary }",
+        "ordinary mutation",
+    )
+    .await
+    .unwrap();
+
+    let policies = executor.policies();
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0].max_retries, DEFRA_DB_CONFLICT_MAX_RETRIES);
+    assert_eq!(
+        policies[0].initial_backoff,
+        Duration::from_millis(DEFRA_DB_CONFLICT_INITIAL_BACKOFF_MS)
+    );
+    node.shutdown().await;
 }

--- a/demo/code-review/README.md
+++ b/demo/code-review/README.md
@@ -5,7 +5,7 @@ model-backed document graph:
 
 ```text
 ReviewJob -> GLM pre-scan + lens planning
-          -> N x ReviewArea -> N x DeepSeek V4 specialized scanners
+          -> N x ReviewArea -> N x GLM specialized scanners
                             -> CandidateFinding* + N x ScanResult
                             -> GLM adversarial verifier
                             -> N x FindingVerdict + VerificationSummary
@@ -50,15 +50,15 @@ candidate-to-verdict bijection and summary count balance, so a verifier that
 violates the write-last contract fails acceptance instead of publishing a
 plausible but incomplete review.
 
-The default uses `GLM-5.2` on workstation-2 for recon, verification, and final
-triage, with DeepSeek V4 Flash on workstation-1 for the parallel
-scanner swarm. Both endpoints are OpenAI-compatible vLLM services.
+The default uses `GLM-5.2` on workstation-2 for every review stage. The
+coordinator and parallel scanner backends remain separately configurable so
+their concurrency and serving endpoints can be tuned independently.
 
 ```bash
 export GENTS_REVIEW_COORDINATOR_ENDPOINT=http://100.87.27.25:8000/v1
 export GENTS_REVIEW_COORDINATOR_MODEL=GLM-5.2
-export GENTS_REVIEW_REVIEWER_ENDPOINT=http://100.73.235.38:8000/v1
-export GENTS_REVIEW_REVIEWER_MODEL=d4f
+export GENTS_REVIEW_REVIEWER_ENDPOINT=http://100.87.27.25:8000/v1
+export GENTS_REVIEW_REVIEWER_MODEL=GLM-5.2
 ```
 
 Review agents are configured as long-running workers: the one-million-turn

--- a/demo/code-review/agent-behaviors/review-scan/object.json
+++ b/demo/code-review/agent-behaviors/review-scan/object.json
@@ -7,7 +7,7 @@
   "system_prompt": "./system_prompt.md",
   "request_context_template": null,
   "backend_id": "review-reviewer-backend",
-  "model_name": "${GENTS_REVIEW_REVIEWER_MODEL:-d4f}",
+  "model_name": "${GENTS_REVIEW_REVIEWER_MODEL:-GLM-5.2}",
   "tool_selection_id": "review-scan-tools",
   "inference_profile_id": "review-scan-profile",
   "compaction_strategy": "StripThenSummarize",

--- a/demo/code-review/inference-backends/review-reviewer-backend/object.json
+++ b/demo/code-review/inference-backends/review-reviewer-backend/object.json
@@ -3,11 +3,11 @@
   "name": "Parallel reviewer backend",
   "provider_kind": "OpenAiCompatible",
   "openai_wire_api": "chat_completions",
-  "endpoint": "${GENTS_REVIEW_REVIEWER_ENDPOINT:-http://100.73.235.38:8000/v1}",
+  "endpoint": "${GENTS_REVIEW_REVIEWER_ENDPOINT:-http://100.87.27.25:8000/v1}",
   "api_key": null,
   "api_key_env_var": null,
   "max_concurrent": 8,
   "max_queue_depth": 100,
-  "models": ["${GENTS_REVIEW_REVIEWER_MODEL:-d4f}"],
+  "models": ["${GENTS_REVIEW_REVIEWER_MODEL:-GLM-5.2}"],
   "enabled": true
 }


### PR DESCRIPTION
## Summary

- give terminal GraphQL persistence one explicit four-attempt budget
- keep the node mutation gate around each auto-committed attempt while releasing it during terminal backoff
- preserve ordinary DefraDB conflict retries and all-error terminal durability semantics
- add deterministic composition and gate-ownership regression coverage
- default the code-review pack scanner and reviewer roles to GLM-5.2

## Root cause

Terminal persistence wrapped DefraDBs four-attempt transaction-conflict retry loop in another four-attempt durability loop, allowing persistent conflicts to multiply into sixteen GraphQL mutation attempts while holding the node-scoped mutation gate through inner backoffs.

## Validation

- cargo fmt --all -- --check
- cargo test -p gents
- cargo check --workspace --all-targets
- git diff --check
- make review using GLM-5.2 defaults: PASS, zero findings
- independent Claude and Grok reviews: no blocking findings

Closes #1131