### PR TITLE
Unify durable descendant graph authorization and projections

### DIFF
--- a/crates/gents-cli/src/commands/request.rs
+++ b/crates/gents-cli/src/commands/request.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use gents::{graphql::escape_graphql_string, tool_call_lifecycle::CancelCause};
+use gents::{
+    graphql::escape_graphql_string, tool_call_lifecycle::CancelCause, ConfigAccess,
+    DescendantGraphAccess, DescendantQuery, MAX_DESCENDANT_PAGE_LIMIT,
+};
 use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::time::Instant;
@@ -132,6 +135,7 @@ struct RequestShowSnapshot {
     backgrounded_tools: Vec<BackgroundedToolView>,
     native_executors_available: bool,
     native_executors: Vec<NativeExecutorView>,
+    descendant_edges: Vec<gents::DescendantEdge>,
     child_requests: Vec<ChildRequestView>,
 }
 
@@ -271,10 +275,26 @@ async fn load_request_show_snapshot(
         .with_context(|| format!("loading AgentToolCall rows for {request_id}"))?;
     let tool_rows = value_array(&tool_response, "/data/AgentToolCall");
 
-    let child_response = post_graphql(graphql, &request_show_child_requests_query(request_id))
+    let access = ConfigAccess::Graphql(graphql.to_string());
+    let mut descendant_edges = Vec::new();
+    let mut after = None;
+    loop {
+        let descendants = gents::resolve_descendant_graph(
+            DescendantGraphAccess::Config(&access),
+            &DescendantQuery {
+                after: after.clone(),
+                limit: MAX_DESCENDANT_PAGE_LIMIT,
+                ..DescendantQuery::direct(request_id)
+            },
+        )
         .await
-        .with_context(|| format!("loading child AgentRequest rows for {request_id}"))?;
-    let child_rows = value_array(&child_response, "/data/AgentRequest");
+        .with_context(|| format!("loading canonical descendants for {request_id}"))?;
+        descendant_edges.extend(descendants.edges);
+        if !descendants.has_more {
+            break;
+        }
+        after = descendants.next_cursor;
+    }
 
     let request_agent_did = string_field(&request_row, "agent_did").unwrap_or_default();
     let liveness = crate::commands::status::load_liveness_value(graphql, &request_agent_did).await;
@@ -347,7 +367,7 @@ async fn load_request_show_snapshot(
         terminal_cause.as_deref(),
     );
     let request = request_header_view(&request_row, terminal_cause, transition_history);
-    let child_requests = child_rows
+    let child_requests = descendant_edges
         .iter()
         .map(child_request_view)
         .collect::<Vec<_>>();
@@ -359,6 +379,7 @@ async fn load_request_show_snapshot(
         backgrounded_tools,
         native_executors_available,
         native_executors,
+        descendant_edges,
         child_requests,
     })
 }
@@ -475,26 +496,6 @@ fn request_show_tool_calls_query(request_id: &str, schema: &RequestShowSchema) -
                 order: {{ started_at: ASC }}
             ) {{
                 {fields}
-            }}
-        }}"#,
-        request_id = escape_graphql_string(request_id),
-    )
-}
-
-fn request_show_child_requests_query(request_id: &str) -> String {
-    format!(
-        r#"{{
-            AgentRequest(
-                filter: {{ caused_by_parent_request_id: {{ _eq: "{request_id}" }} }},
-                order: {{ created_at: ASC }}
-            ) {{
-                request_id
-                behavior_id
-                status
-                lifecycle_state
-                created_at
-                caused_by_parent_tool_call_id
-                caused_by_trigger_kind
             }}
         }}"#,
         request_id = escape_graphql_string(request_id),
@@ -785,17 +786,18 @@ fn backgrounded_tool_view(tool: &RequestToolCallView) -> BackgroundedToolView {
     }
 }
 
-fn child_request_view(row: &Value) -> ChildRequestView {
+fn child_request_view(edge: &gents::DescendantEdge) -> ChildRequestView {
     ChildRequestView {
-        request_id: string_field_or_unknown(row, "request_id"),
-        state: string_field(row, "lifecycle_state")
-            .or_else(|| string_field(row, "status"))
+        request_id: edge.child_request_id.clone(),
+        state: edge.lifecycle_state.clone(),
+        status: edge.lifecycle_state.clone(),
+        behavior_id: edge
+            .behavior_id
+            .clone()
             .unwrap_or_else(|| "unknown".to_string()),
-        status: string_field_or_unknown(row, "status"),
-        behavior_id: string_field_or_unknown(row, "behavior_id"),
-        created_at: string_field(row, "created_at"),
-        caused_by_parent_tool_call_id: string_field(row, "caused_by_parent_tool_call_id"),
-        caused_by_trigger_kind: string_field(row, "caused_by_trigger_kind"),
+        created_at: edge.created_at.clone(),
+        caused_by_parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
+        caused_by_trigger_kind: Some("subagent".to_string()),
     }
 }
 

--- a/crates/gents-cli/src/commands/subagent.rs
+++ b/crates/gents-cli/src/commands/subagent.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
 use gents::tool_call_lifecycle::{CancelCause, CascadeDispatch, ToolCallLifecycle};
+use gents::{DescendantGraphAccess, DescendantQuery, MAX_DESCENDANT_PAGE_LIMIT};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -681,24 +682,43 @@ async fn load_rooted_lineage(
         .await?
         .ok_or_else(|| anyhow::anyhow!("AgentRequest {root_request_id} not found"))?;
     let max_depth = max_depth.unwrap_or(usize::MAX);
-    let mut rows = Vec::new();
-    let mut seen = BTreeSet::new();
-    let mut stack = vec![(root, 0usize)];
-
-    while let Some((row, depth)) = stack.pop() {
-        let request_id = row.request_id.clone();
-        if !seen.insert(request_id.clone()) {
-            continue;
+    let mut rows = vec![LineageNode {
+        row: root,
+        depth: 0,
+    }];
+    let mut after = None;
+    loop {
+        let page = gents::resolve_descendant_graph(
+            DescendantGraphAccess::Config(access),
+            &DescendantQuery {
+                after: after.clone(),
+                limit: MAX_DESCENDANT_PAGE_LIMIT,
+                ..DescendantQuery::all(root_request_id)
+            },
+        )
+        .await?;
+        rows.extend(
+            page.edges
+                .into_iter()
+                .filter(|edge| edge.depth <= max_depth)
+                .map(|edge| LineageNode {
+                    depth: edge.depth,
+                    row: AgentRequestLineageRow {
+                        request_id: edge.child_request_id,
+                        agent_did: edge.principal_did,
+                        behavior_id: edge.behavior_id,
+                        status: Some(edge.lifecycle_state.clone()),
+                        lifecycle_state: Some(edge.lifecycle_state),
+                        created_at: edge.created_at,
+                        claimed_at: None,
+                        caused_by_parent_request_id: Some(edge.immediate_parent_request_id),
+                    },
+                }),
+        );
+        if !page.has_more {
+            break;
         }
-        rows.push(LineageNode { row, depth });
-        if depth >= max_depth {
-            continue;
-        }
-
-        let children = load_children(access, &request_id).await?;
-        for child in children.into_iter().rev() {
-            stack.push((child, depth + 1));
-        }
+        after = page.next_cursor;
     }
 
     Ok(rows)
@@ -837,24 +857,6 @@ async fn load_request_by_id(
     );
     let mut rows = load_request_rows(access, &query).await?;
     Ok(rows.pop())
-}
-
-async fn load_children(
-    access: &ConfigAccess,
-    parent_request_id: &str,
-) -> Result<Vec<AgentRequestLineageRow>> {
-    let escaped_parent_request_id = escape_graphql_string(parent_request_id);
-    let query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{ caused_by_parent_request_id: {{ _eq: "{escaped_parent_request_id}" }} }},
-                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
-            ) {{
-                {AGENT_REQUEST_FIELDS}
-            }}
-        }}"#
-    );
-    load_request_rows(access, &query).await
 }
 
 async fn load_all_requests(access: &ConfigAccess) -> Result<Vec<AgentRequestLineageRow>> {

--- a/crates/gents-cli/src/http/subagent_tree.rs
+++ b/crates/gents-cli/src/http/subagent_tree.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use axum::{
@@ -8,7 +8,10 @@ use axum::{
     Json,
 };
 use chrono::Utc;
-use gents::graphql::escape_graphql_string;
+use gents::{
+    graphql::escape_graphql_string, ConfigAccess, DescendantGraphAccess, DescendantQuery,
+    MAX_DESCENDANT_PAGE_LIMIT,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -20,6 +23,8 @@ const HARD_MAX_DEPTH: usize = 32;
 const TERMINAL_STATES: &[&str] = &[
     "completed",
     "failed",
+    "error",
+    "timedout",
     "cancelled",
     "interrupted",
     "superseded",
@@ -73,14 +78,6 @@ pub(crate) struct SubagentTreeQuery {
 }
 
 #[derive(Debug, Deserialize)]
-struct LevelQueryEnvelope {
-    #[serde(rename = "AgentRequest", default)]
-    requests: Vec<RequestRow>,
-    #[serde(rename = "AgentToolCall", default)]
-    bridges: Vec<BridgeRow>,
-}
-
-#[derive(Debug, Deserialize)]
 struct RootRequestEnvelope {
     #[serde(rename = "AgentRequest", default)]
     requests: Vec<RequestRow>,
@@ -106,32 +103,6 @@ struct RequestRow {
     caused_by_parent_request_id: Option<String>,
     #[serde(default)]
     caused_by_parent_tool_call_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct BridgeRow {
-    #[serde(default)]
-    request_id: String,
-    #[serde(default)]
-    tool_call_id: Option<String>,
-    #[serde(default)]
-    tool_name: Option<String>,
-    #[serde(default)]
-    args: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    lifecycle_state: Option<String>,
-    #[serde(default)]
-    child_request_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SpawnSubagentArgs {
-    #[serde(default)]
-    await_mode: Option<String>,
-    #[serde(default)]
-    cancel_policy: Option<String>,
 }
 
 pub(crate) async fn subagent_tree_handler(
@@ -180,74 +151,60 @@ pub(crate) async fn load_subagent_tree_snapshot(
     max_depth: usize,
 ) -> Result<SubagentTreeSnapshot> {
     let generated_at = Utc::now();
-
     let mut nodes: BTreeMap<String, SubagentTreeNode> = BTreeMap::new();
-    let mut edges: Vec<SubagentTreeEdge> = Vec::new();
-    let mut seen_edges: BTreeSet<(String, String)> = BTreeSet::new();
-
     if let Some(root) = fetch_root_request(graphql, root_request_id).await? {
         nodes.insert(root.request_id.clone(), request_row_into_node(root));
     }
-
-    let mut frontier: VecDeque<String> = VecDeque::new();
-    frontier.push_back(root_request_id.to_string());
-
-    let mut depth: usize = 0;
-    let mut truncated = false;
-
-    while !frontier.is_empty() && depth < max_depth {
-        let level: Vec<String> = frontier.drain(..).collect();
-        let envelope = fetch_level(graphql, &level).await?;
-
-        for request in envelope.requests {
-            if request.request_id.is_empty() {
-                continue;
-            }
-            let node = request_row_into_node(request);
-            nodes.entry(node.request_id.clone()).or_insert(node);
+    let access = ConfigAccess::Graphql(graphql.to_string());
+    let mut canonical_edges = Vec::new();
+    let mut after = None;
+    loop {
+        let page = gents::resolve_descendant_graph(
+            DescendantGraphAccess::Config(&access),
+            &DescendantQuery {
+                after: after.clone(),
+                limit: MAX_DESCENDANT_PAGE_LIMIT,
+                ..DescendantQuery::all(root_request_id)
+            },
+        )
+        .await?;
+        canonical_edges.extend(page.edges);
+        if !page.has_more {
+            break;
         }
-
-        let mut next_frontier: BTreeSet<String> = BTreeSet::new();
-        for bridge in envelope.bridges {
-            let parent_request_id = clean_string(&bridge.request_id);
-            let child_request_id = match clean_optional_string(bridge.child_request_id.as_deref()) {
-                Some(value) => value,
-                None => continue,
-            };
-            if parent_request_id.is_empty() {
-                continue;
-            }
-            if !seen_edges.insert((parent_request_id.clone(), child_request_id.clone())) {
-                continue;
-            }
-            let (await_mode, cancel_policy) = parse_spawn_args(bridge.args.as_deref());
-            let bridge_state = clean_optional_string(bridge.lifecycle_state.as_deref())
-                .or_else(|| clean_optional_string(bridge.status.as_deref()));
-            edges.push(SubagentTreeEdge {
-                parent_request_id,
-                child_request_id: child_request_id.clone(),
-                parent_tool_call_id: clean_optional_string(bridge.tool_call_id.as_deref()),
-                tool_name: clean_optional_string(bridge.tool_name.as_deref()),
-                await_mode,
-                cancel_policy,
-                lifecycle_state: bridge_state,
-            });
-            if !nodes.contains_key(&child_request_id) {
-                next_frontier.insert(child_request_id);
-            } else {
-                next_frontier.insert(child_request_id);
-            }
-        }
-
-        for child in next_frontier {
-            frontier.push_back(child);
-        }
-        depth += 1;
+        after = page.next_cursor;
     }
 
-    if !frontier.is_empty() {
-        truncated = true;
-    }
+    let truncated = canonical_edges.iter().any(|edge| edge.depth > max_depth);
+    canonical_edges.retain(|edge| edge.depth <= max_depth);
+    let mut edges = canonical_edges
+        .iter()
+        .map(|edge| {
+            nodes.insert(
+                edge.child_request_id.clone(),
+                SubagentTreeNode {
+                    request_id: edge.child_request_id.clone(),
+                    session_id: edge.child_session_id.clone(),
+                    agent_did: edge.principal_did.clone(),
+                    behavior_id: edge.behavior_id.clone(),
+                    lifecycle_state: Some(edge.lifecycle_state.clone()),
+                    status: Some(edge.lifecycle_state.clone()),
+                    subagent_depth: Some(edge.depth as i64),
+                    caused_by_parent_request_id: Some(edge.immediate_parent_request_id.clone()),
+                    caused_by_parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
+                },
+            );
+            SubagentTreeEdge {
+                parent_request_id: edge.immediate_parent_request_id.clone(),
+                child_request_id: edge.child_request_id.clone(),
+                parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
+                tool_name: Some("spawn_subagent".to_string()),
+                await_mode: Some(edge.await_mode.clone()),
+                cancel_policy: edge.cancel_policy.clone(),
+                lifecycle_state: Some(edge.lifecycle_state.clone()),
+            }
+        })
+        .collect::<Vec<_>>();
 
     if !include_terminal {
         prune_terminal_subtrees(&mut nodes, &mut edges, root_request_id);
@@ -319,52 +276,6 @@ async fn fetch_root_request(graphql: &str, root_request_id: &str) -> Result<Opti
     Ok(envelope.requests.into_iter().next())
 }
 
-async fn fetch_level(graphql: &str, parent_request_ids: &[String]) -> Result<LevelQueryEnvelope> {
-    let list = parent_request_ids
-        .iter()
-        .map(|value| format!("\"{}\"", escape_graphql_string(value)))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{ caused_by_parent_request_id: {{ _in: [{list}] }} }},
-                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
-            ) {{
-                request_id
-                session_id
-                agent_did
-                behavior_id
-                lifecycle_state
-                status
-                subagent_depth
-                caused_by_parent_request_id
-                caused_by_parent_tool_call_id
-            }}
-            AgentToolCall(
-                filter: {{
-                    _and: [
-                        {{ request_id: {{ _in: [{list}] }} }},
-                        {{ tool_name: {{ _eq: "spawn_subagent" }} }},
-                        {{ child_request_id: {{ _ne: "" }} }}
-                    ]
-                }},
-                order: [{{ started_at: ASC }}, {{ child_request_id: ASC }}]
-            ) {{
-                request_id
-                tool_call_id
-                tool_name
-                args
-                status
-                lifecycle_state
-                child_request_id
-            }}
-        }}"#
-    );
-    let response = post_graphql(graphql, &query).await?;
-    decode_data_object(response, "subagent tree level fetch")
-}
-
 fn decode_data_object<T: serde::de::DeserializeOwned>(response: Value, context: &str) -> Result<T> {
     let data = response
         .get("data")
@@ -372,24 +283,6 @@ fn decode_data_object<T: serde::de::DeserializeOwned>(response: Value, context: 
         .cloned()
         .with_context(|| format!("{context} response missing object data: {response}"))?;
     serde_json::from_value(data).with_context(|| format!("decoding {context}"))
-}
-
-fn parse_spawn_args(args: Option<&str>) -> (Option<String>, Option<String>) {
-    let args = match args {
-        Some(value) => value.trim(),
-        None => return (None, None),
-    };
-    if args.is_empty() {
-        return (None, None);
-    }
-    let parsed = match serde_json::from_str::<SpawnSubagentArgs>(args) {
-        Ok(parsed) => parsed,
-        Err(_) => return (None, None),
-    };
-    (
-        clean_optional_string(parsed.await_mode.as_deref()),
-        clean_optional_string(parsed.cancel_policy.as_deref()),
-    )
 }
 
 fn prune_terminal_subtrees(
@@ -552,55 +445,158 @@ mod tests {
         })
     }
 
-    fn level_one_response() -> Value {
+    fn canonical_root_response(
+        request_id: &str,
+        doc_id: &str,
+        session_id: &str,
+        agent_did: &str,
+        behavior_id: &str,
+        lifecycle_state: &str,
+        status: &str,
+    ) -> Value {
         json!({
-            "data": {
-                "AgentRequest": [
-                    {
-                        "request_id": "req-child",
-                        "session_id": "sess-child",
-                        "agent_did": "deployment-b",
-                        "behavior_id": "amy-code",
-                        "lifecycle_state": "Processing",
-                        "status": "processing",
-                        "subagent_depth": 1,
-                        "caused_by_parent_request_id": "req-root",
-                        "caused_by_parent_tool_call_id": "tc-bridge"
-                    }
-                ],
-                "AgentToolCall": [
-                    {
-                        "request_id": "req-root",
-                        "tool_call_id": "tc-bridge",
-                        "tool_name": "spawn_subagent",
-                        "args": "{\"await_mode\":\"background\",\"cancel_policy\":\"cascade\"}",
-                        "status": "running",
-                        "lifecycle_state": "running",
-                        "child_request_id": "req-child"
-                    }
-                ]
-            }
+            "data": { "AgentRequest": [{
+                "_docID": doc_id,
+                "request_id": request_id,
+                "agent_did": agent_did,
+                "requester_did": null,
+                "behavior_id": behavior_id,
+                "session_id": session_id,
+                "status": status,
+                "lifecycle_state": lifecycle_state,
+                "caused_by_parent_request_id": null,
+                "caused_by_parent_request_doc_id": null,
+                "caused_by_parent_tool_call_id": null,
+                "caused_by_parent_tool_call_doc_id": null
+            }]}
         })
     }
 
-    fn level_two_empty() -> Value {
+    #[allow(clippy::too_many_arguments)]
+    fn canonical_bridge_row(
+        doc_id: &str,
+        parent_request_id: &str,
+        parent_doc_id: &str,
+        parent_session_id: &str,
+        parent_agent_did: &str,
+        tool_call_id: &str,
+        child_request_id: &str,
+        await_mode: &str,
+        lifecycle_state: &str,
+    ) -> Value {
         json!({
-            "data": {
-                "AgentRequest": [],
-                "AgentToolCall": []
-            }
+            "_docID": doc_id,
+            "request_id": parent_request_id,
+            "request_doc_id": parent_doc_id,
+            "session_id": parent_session_id,
+            "agent_did": parent_agent_did,
+            "requester_did": null,
+            "tool_call_id": tool_call_id,
+            "args": format!(r#"{{"name":"{child_request_id}"}}"#),
+            "result": if lifecycle_state == "completed" { "done" } else { "" },
+            "status": lifecycle_state,
+            "lifecycle_state": lifecycle_state,
+            "started_at": "2026-08-01T00:00:00Z",
+            "completed_at": if lifecycle_state == "completed" {
+                Some("2026-08-01T00:00:01Z")
+            } else {
+                None
+            },
+            "await_mode": await_mode,
+            "cancel_policy": "cascade",
+            "child_request_id": child_request_id,
+            "spawn_target_did": null,
+            "workflow_group_id": null,
+            "workflow_role": null,
+            "unclaimed_deadline_at": null
         })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn canonical_child_row(
+        doc_id: &str,
+        request_id: &str,
+        session_id: &str,
+        agent_did: &str,
+        behavior_id: &str,
+        lifecycle_state: &str,
+        parent_request_id: &str,
+        parent_doc_id: &str,
+        parent_tool_call_id: &str,
+        parent_tool_doc_id: &str,
+    ) -> Value {
+        json!({
+            "_docID": doc_id,
+            "request_id": request_id,
+            "agent_did": agent_did,
+            "requester_did": null,
+            "behavior_id": behavior_id,
+            "session_id": session_id,
+            "status": lifecycle_state,
+            "lifecycle_state": lifecycle_state,
+            "caused_by_parent_request_id": parent_request_id,
+            "caused_by_parent_request_doc_id": parent_doc_id,
+            "caused_by_parent_tool_call_id": parent_tool_call_id,
+            "caused_by_parent_tool_call_doc_id": parent_tool_doc_id
+        })
+    }
+
+    fn canonical_bridges_response(rows: Vec<Value>) -> Value {
+        json!({ "data": { "AgentToolCall": rows } })
+    }
+
+    fn canonical_children_response(rows: Vec<Value>) -> Value {
+        json!({ "data": { "AgentRequest": rows } })
+    }
+
+    fn canonical_messages_empty() -> Value {
+        json!({ "data": { "AgentMessage": [] } })
+    }
+
+    fn canonical_standard_walk_responses() -> Vec<Value> {
+        vec![
+            root_response(),
+            canonical_root_response(
+                "req-root",
+                "doc-root",
+                "sess-root",
+                "deployment-a",
+                "amy-general",
+                "processing",
+                "processing",
+            ),
+            canonical_bridges_response(vec![canonical_bridge_row(
+                "doc-tc-bridge",
+                "req-root",
+                "doc-root",
+                "sess-root",
+                "deployment-a",
+                "tc-bridge",
+                "req-child",
+                "background",
+                "running",
+            )]),
+            canonical_children_response(vec![canonical_child_row(
+                "doc-child",
+                "req-child",
+                "sess-child",
+                "deployment-b",
+                "amy-code",
+                "processing",
+                "req-root",
+                "doc-root",
+                "tc-bridge",
+                "doc-tc-bridge",
+            )]),
+            canonical_bridges_response(Vec::new()),
+            canonical_messages_empty(),
+        ]
     }
 
     #[tokio::test]
     async fn tree_walks_cross_deployment_bridge_and_carries_await_mode_metadata(
     ) -> anyhow::Result<()> {
-        let (graphql, _queries) = spawn_mock_graphql(vec![
-            root_response(),
-            level_one_response(),
-            level_two_empty(),
-        ])
-        .await?;
+        let (graphql, _queries) = spawn_mock_graphql(canonical_standard_walk_responses()).await?;
         let snapshot = load_subagent_tree_snapshot(&graphql, "req-root", false, 4).await?;
 
         assert_eq!(snapshot.root_request_id, "req-root");
@@ -657,32 +653,72 @@ mod tests {
                 ]
             }
         });
-        let level_one = json!({
-            "data": {
-                "AgentRequest": [
-                    {
-                        "request_id": "req-a",
-                        "agent_did": "deployment-a",
-                        "lifecycle_state": "Processing",
-                        "status": "processing",
-                        "subagent_depth": 1,
-                        "caused_by_parent_request_id": "req-root",
-                        "caused_by_parent_tool_call_id": "tc-a"
-                    }
-                ],
-                "AgentToolCall": [
-                    {
-                        "request_id": "req-root",
-                        "tool_call_id": "tc-a",
-                        "tool_name": "spawn_subagent",
-                        "args": "{\"await_mode\":\"background\",\"cancel_policy\":\"cascade\"}",
-                        "lifecycle_state": "running",
-                        "child_request_id": "req-a"
-                    }
-                ]
-            }
-        });
-        let (graphql, _queries) = spawn_mock_graphql(vec![root, level_one]).await?;
+        let canonical_root = canonical_root_response(
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "amy-general",
+            "processing",
+            "processing",
+        );
+        let canonical_level_one = canonical_bridges_response(vec![canonical_bridge_row(
+            "doc-tc-a",
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "tc-a",
+            "req-a",
+            "background",
+            "running",
+        )]);
+        let canonical_child_a = canonical_children_response(vec![canonical_child_row(
+            "doc-a",
+            "req-a",
+            "sess-a",
+            "deployment-a",
+            "amy-code",
+            "processing",
+            "req-root",
+            "doc-root",
+            "tc-a",
+            "doc-tc-a",
+        )]);
+        let canonical_level_two = canonical_bridges_response(vec![canonical_bridge_row(
+            "doc-tc-b",
+            "req-a",
+            "doc-a",
+            "sess-a",
+            "deployment-a",
+            "tc-b",
+            "req-b",
+            "foreground",
+            "running",
+        )]);
+        let canonical_child_b = canonical_children_response(vec![canonical_child_row(
+            "doc-b",
+            "req-b",
+            "sess-b",
+            "deployment-a",
+            "amy-review",
+            "processing",
+            "req-a",
+            "doc-a",
+            "tc-b",
+            "doc-tc-b",
+        )]);
+        let (graphql, _queries) = spawn_mock_graphql(vec![
+            root,
+            canonical_root,
+            canonical_level_one,
+            canonical_child_a,
+            canonical_level_two,
+            canonical_child_b,
+            canonical_bridges_response(Vec::new()),
+            canonical_messages_empty(),
+        ])
+        .await?;
         let snapshot = load_subagent_tree_snapshot(&graphql, "req-root", true, 1).await?;
         assert!(snapshot.truncated, "max_depth=1 should set truncated");
         assert_eq!(snapshot.nodes.len(), 2);
@@ -692,12 +728,7 @@ mod tests {
 
     #[tokio::test]
     async fn tree_endpoint_routes_under_runtime_router() -> anyhow::Result<()> {
-        let (graphql, _queries) = spawn_mock_graphql(vec![
-            root_response(),
-            level_one_response(),
-            level_two_empty(),
-        ])
-        .await?;
+        let (graphql, _queries) = spawn_mock_graphql(canonical_standard_walk_responses()).await?;
         let runtime_addr = spawn_runtime_router(graphql).await?;
         let response = reqwest::Client::new()
             .get(format!(
@@ -747,54 +778,74 @@ mod tests {
                 ]
             }
         });
-        let level_one = json!({
-            "data": {
-                "AgentRequest": [
-                    {
-                        "request_id": "req-live",
-                        "agent_did": "deployment-a",
-                        "lifecycle_state": "Processing",
-                        "subagent_depth": 1,
-                        "caused_by_parent_request_id": "req-root",
-                        "caused_by_parent_tool_call_id": "tc-live"
-                    },
-                    {
-                        "request_id": "req-dead",
-                        "agent_did": "deployment-a",
-                        "lifecycle_state": "Completed",
-                        "subagent_depth": 1,
-                        "caused_by_parent_request_id": "req-root",
-                        "caused_by_parent_tool_call_id": "tc-dead"
-                    }
-                ],
-                "AgentToolCall": [
-                    {
-                        "request_id": "req-root",
-                        "tool_call_id": "tc-live",
-                        "tool_name": "spawn_subagent",
-                        "args": "{\"await_mode\":\"background\",\"cancel_policy\":\"cascade\"}",
-                        "lifecycle_state": "running",
-                        "child_request_id": "req-live"
-                    },
-                    {
-                        "request_id": "req-root",
-                        "tool_call_id": "tc-dead",
-                        "tool_name": "spawn_subagent",
-                        "args": "{\"await_mode\":\"foreground\",\"cancel_policy\":\"cascade\"}",
-                        "lifecycle_state": "completed",
-                        "child_request_id": "req-dead"
-                    }
-                ]
-            }
-        });
-        let level_two_empty = json!({
-            "data": {
-                "AgentRequest": [],
-                "AgentToolCall": []
-            }
-        });
-        let (graphql, _queries) =
-            spawn_mock_graphql(vec![root, level_one, level_two_empty]).await?;
+        let canonical_root = canonical_root_response(
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "amy-general",
+            "processing",
+            "processing",
+        );
+        let bridges = canonical_bridges_response(vec![
+            canonical_bridge_row(
+                "doc-tc-live",
+                "req-root",
+                "doc-root",
+                "sess-root",
+                "deployment-a",
+                "tc-live",
+                "req-live",
+                "background",
+                "running",
+            ),
+            canonical_bridge_row(
+                "doc-tc-dead",
+                "req-root",
+                "doc-root",
+                "sess-root",
+                "deployment-a",
+                "tc-dead",
+                "req-dead",
+                "foreground",
+                "completed",
+            ),
+        ]);
+        let children = canonical_children_response(vec![
+            canonical_child_row(
+                "doc-live",
+                "req-live",
+                "sess-live",
+                "deployment-a",
+                "amy-code",
+                "processing",
+                "req-root",
+                "doc-root",
+                "tc-live",
+                "doc-tc-live",
+            ),
+            canonical_child_row(
+                "doc-dead",
+                "req-dead",
+                "sess-dead",
+                "deployment-a",
+                "amy-code",
+                "completed",
+                "req-root",
+                "doc-root",
+                "tc-dead",
+                "doc-tc-dead",
+            ),
+        ]);
+        let (graphql, _queries) = spawn_mock_graphql(vec![
+            root,
+            canonical_root,
+            bridges,
+            children,
+            canonical_bridges_response(Vec::new()),
+            canonical_messages_empty(),
+        ])
+        .await?;
         let snapshot = load_subagent_tree_snapshot(&graphql, "req-root", false, 4).await?;
         let request_ids = snapshot
             .nodes

--- a/crates/gents-desktop-bridge/src/snapshot/subagent_tree.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/subagent_tree.rs
@@ -1,10 +1,13 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
+use gents::{
+    ConfigAccess, DescendantEdge, DescendantGraphAccess, DescendantQuery, MAX_DESCENDANT_PAGE_LIMIT,
+};
 use gents_protocol::graphql::{execute_graphql_async, GraphqlRequestOptions};
 use serde::Deserialize;
 use serde_json::Value;
@@ -17,19 +20,13 @@ pub const HARD_SUBAGENT_TREE_MAX_DEPTH: usize = 32;
 const TERMINAL_STATES: &[&str] = &[
     "completed",
     "failed",
+    "error",
+    "timedout",
     "cancelled",
     "interrupted",
     "superseded",
     "dead",
 ];
-
-#[derive(Debug, Deserialize)]
-struct LevelQueryEnvelope {
-    #[serde(rename = "AgentRequest", default)]
-    requests: Vec<RequestRow>,
-    #[serde(rename = "AgentToolCall", default)]
-    bridges: Vec<BridgeRow>,
-}
 
 #[derive(Debug, Deserialize)]
 struct RootRequestEnvelope {
@@ -59,32 +56,6 @@ struct RequestRow {
     caused_by_parent_tool_call_id: Option<String>,
     #[serde(default)]
     backend_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct BridgeRow {
-    #[serde(default)]
-    request_id: String,
-    #[serde(default)]
-    tool_call_id: Option<String>,
-    #[serde(default)]
-    tool_name: Option<String>,
-    #[serde(default)]
-    args: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    lifecycle_state: Option<String>,
-    #[serde(default)]
-    child_request_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SpawnSubagentArgs {
-    #[serde(default)]
-    await_mode: Option<String>,
-    #[serde(default)]
-    cancel_policy: Option<String>,
 }
 
 pub fn effective_subagent_tree_max_depth(max_depth: Option<u32>) -> usize {
@@ -154,8 +125,6 @@ pub async fn build_subagent_tree(
     max_depth: usize,
 ) -> Result<SubagentTreeView> {
     let mut nodes: BTreeMap<String, SubagentNodeView> = BTreeMap::new();
-    let mut edges: Vec<SubagentEdgeView> = Vec::new();
-    let mut seen_edges: BTreeSet<(String, String)> = BTreeSet::new();
     let mut partial_errors: Vec<String> = Vec::new();
     let mut dead_accesses: BTreeSet<usize> = BTreeSet::new();
 
@@ -179,25 +148,29 @@ pub async fn build_subagent_tree(
         }
     }
 
-    let mut frontier: VecDeque<String> = VecDeque::from([root_request_id.to_string()]);
-    let mut depth = 0;
-    let mut truncated = false;
-
-    while !frontier.is_empty() && depth < max_depth {
-        let level = frontier.drain(..).collect::<Vec<_>>();
-        let mut level_requests = Vec::new();
-        let mut level_bridges = Vec::new();
-        for (index, entry) in accesses.iter().enumerate() {
-            if dead_accesses.contains(&index) {
-                continue;
-            }
-            match fetch_level(&entry.access, &level).await {
-                Ok(envelope) => {
-                    for request in envelope.requests {
-                        level_requests.push((entry.label.clone(), request));
-                    }
-                    level_bridges.extend(envelope.bridges);
-                }
+    let mut canonical =
+        BTreeMap::<(String, String, String), (Option<String>, DescendantEdge)>::new();
+    for (index, entry) in accesses.iter().enumerate() {
+        if dead_accesses.contains(&index) {
+            continue;
+        }
+        let access = match &entry.access {
+            TreeQueryAccess::Local(node) => ConfigAccess::Local(node.clone()),
+            TreeQueryAccess::Graphql(endpoint) => ConfigAccess::Graphql(endpoint.clone()),
+        };
+        let mut after = None;
+        loop {
+            let page = match gents::resolve_descendant_graph(
+                DescendantGraphAccess::Config(&access),
+                &DescendantQuery {
+                    after: after.clone(),
+                    limit: MAX_DESCENDANT_PAGE_LIMIT,
+                    ..DescendantQuery::all(root_request_id)
+                },
+            )
+            .await
+            {
+                Ok(page) => page,
                 Err(error) => {
                     record_dead_access(
                         &mut partial_errors,
@@ -206,59 +179,60 @@ pub async fn build_subagent_tree(
                         entry,
                         &error,
                     );
+                    break;
+                }
+            };
+            for edge in page.edges {
+                let key = (
+                    edge.immediate_parent_request_id.clone(),
+                    edge.immediate_parent_tool_call_id.clone(),
+                    edge.child_request_id.clone(),
+                );
+                match canonical.get(&key) {
+                    Some((_, existing)) if existing.readable() || !edge.readable() => {}
+                    _ => {
+                        canonical.insert(key, (entry.label.clone(), edge));
+                    }
                 }
             }
-        }
-
-        for (label, request) in level_requests {
-            if request.request_id.trim().is_empty() {
-                continue;
+            if !page.has_more {
+                break;
             }
-            let mut node = request_row_into_node(request);
-            node.resolved_via = label;
-            nodes.entry(node.request_id.clone()).or_insert(node);
+            after = page.next_cursor;
         }
-
-        let envelope = LevelQueryEnvelope {
-            requests: Vec::new(),
-            bridges: level_bridges,
-        };
-
-        let mut next_frontier: BTreeSet<String> = BTreeSet::new();
-        for bridge in envelope.bridges {
-            let parent_request_id = clean_string(&bridge.request_id);
-            let child_request_id = match clean_optional_string(bridge.child_request_id.as_deref()) {
-                Some(value) => value,
-                None => continue,
-            };
-            if parent_request_id.is_empty() {
-                continue;
-            }
-            if !seen_edges.insert((parent_request_id.clone(), child_request_id.clone())) {
-                continue;
-            }
-
-            let (await_mode, cancel_policy) = parse_spawn_args(bridge.args.as_deref());
-            let bridge_state = clean_optional_string(bridge.lifecycle_state.as_deref())
-                .or_else(|| clean_optional_string(bridge.status.as_deref()));
-            edges.push(SubagentEdgeView {
-                parent_request_id,
-                child_request_id: child_request_id.clone(),
-                parent_tool_call_id: clean_optional_string(bridge.tool_call_id.as_deref()),
-                tool_name: clean_optional_string(bridge.tool_name.as_deref()),
-                await_mode,
-                cancel_policy,
-                lifecycle_state: bridge_state,
-            });
-            next_frontier.insert(child_request_id);
-        }
-
-        frontier.extend(next_frontier);
-        depth += 1;
     }
 
-    if !frontier.is_empty() {
-        truncated = true;
+    let truncated = canonical.values().any(|(_, edge)| edge.depth > max_depth);
+    let mut edges = Vec::new();
+    for (resolved_via, edge) in canonical
+        .into_values()
+        .filter(|(_, edge)| edge.depth <= max_depth)
+    {
+        nodes.insert(
+            edge.child_request_id.clone(),
+            SubagentNodeView {
+                request_id: edge.child_request_id.clone(),
+                resolved_via,
+                session_id: edge.child_session_id.clone(),
+                agent_did: edge.principal_did.clone(),
+                behavior_id: edge.behavior_id.clone(),
+                lifecycle_state: Some(edge.lifecycle_state.clone()),
+                status: Some(edge.lifecycle_state.clone()),
+                subagent_depth: Some(edge.depth as i64),
+                caused_by_parent_request_id: Some(edge.immediate_parent_request_id.clone()),
+                caused_by_parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
+                backend_id: None,
+            },
+        );
+        edges.push(SubagentEdgeView {
+            parent_request_id: edge.immediate_parent_request_id,
+            child_request_id: edge.child_request_id,
+            parent_tool_call_id: Some(edge.immediate_parent_tool_call_id),
+            tool_name: Some("spawn_subagent".to_string()),
+            await_mode: Some(edge.await_mode),
+            cancel_policy: edge.cancel_policy,
+            lifecycle_state: Some(edge.lifecycle_state),
+        });
     }
 
     if !include_terminal {
@@ -347,55 +321,6 @@ async fn fetch_root_request(
     Ok(envelope.requests.into_iter().next())
 }
 
-async fn fetch_level(
-    access: &TreeQueryAccess,
-    parent_request_ids: &[String],
-) -> Result<LevelQueryEnvelope> {
-    let list = parent_request_ids
-        .iter()
-        .map(|value| format!("\"{}\"", escape_graphql_string(value)))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{ caused_by_parent_request_id: {{ _in: [{list}] }} }},
-                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
-            ) {{
-                request_id
-                session_id
-                agent_did
-                behavior_id
-                lifecycle_state
-                status
-                subagent_depth
-                caused_by_parent_request_id
-                caused_by_parent_tool_call_id
-                backend_id
-            }}
-            AgentToolCall(
-                filter: {{
-                    _and: [
-                        {{ request_id: {{ _in: [{list}] }} }},
-                        {{ tool_name: {{ _eq: "spawn_subagent" }} }},
-                        {{ child_request_id: {{ _ne: "" }} }}
-                    ]
-                }},
-                order: [{{ started_at: ASC }}, {{ child_request_id: ASC }}]
-            ) {{
-                request_id
-                tool_call_id
-                tool_name
-                args
-                status
-                lifecycle_state
-                child_request_id
-            }}
-        }}"#
-    );
-    execute_access_query(access, &query, "subagent tree level fetch").await
-}
-
 async fn execute_access_query<T: serde::de::DeserializeOwned>(
     access: &TreeQueryAccess,
     query: &str,
@@ -410,24 +335,6 @@ async fn execute_access_query<T: serde::de::DeserializeOwned>(
         .cloned()
         .with_context(|| format!("{context} response missing object data"))?;
     serde_json::from_value(data).with_context(|| format!("decoding {context}"))
-}
-
-fn parse_spawn_args(args: Option<&str>) -> (Option<String>, Option<String>) {
-    let args = match args {
-        Some(value) => value.trim(),
-        None => return (None, None),
-    };
-    if args.is_empty() {
-        return (None, None);
-    }
-    let parsed = match serde_json::from_str::<SpawnSubagentArgs>(args) {
-        Ok(parsed) => parsed,
-        Err(_) => return (None, None),
-    };
-    (
-        clean_optional_string(parsed.await_mode.as_deref()),
-        clean_optional_string(parsed.cancel_policy.as_deref()),
-    )
 }
 
 fn prune_terminal_subtrees(

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/DescendantGraph.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/DescendantGraph.lean
@@ -19,6 +19,7 @@ structure DescendantGraphCase where
   retryable : Bool
   listedByDefault : Bool
   controllable : Bool
+  cursorAnchorSurvivesTerminal : Bool
   deriving Repr
 
 def viewer : Viewer :=
@@ -86,7 +87,11 @@ def descendantCase (name : String) (edge : Edge) : DescendantGraphCase :=
   , readable := DescendantGraph.readable viewer edge
   , retryable := DescendantGraph.retryable viewer edge
   , listedByDefault := DescendantGraph.listedByDefault viewer edge
-  , controllable := DescendantGraph.controllable viewer edge }
+  , controllable := DescendantGraph.controllable viewer edge
+  , cursorAnchorSurvivesTerminal :=
+      (DescendantGraph.afterCursor
+        (DescendantGraph.cursor edge)
+        [{ edge with lifecycle := .completed }, baseEdge]).isSome }
 
 def descendantGraphCases : List DescendantGraphCase :=
   [ descendantCase "background_direct" baseEdge

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/DescendantGraph.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/DescendantGraph.lean
@@ -1,0 +1,130 @@
+import Proofs.DescendantGraph
+
+namespace Conformance.ContractCases
+
+open DescendantGraph
+
+structure DescendantGraphCase where
+  name : String
+  rootRequestId : Nat
+  parentRequestId : Nat
+  childRequestId : Nat
+  awaitMode : String
+  materialization : String
+  lifecycle : String
+  workflowRole : String
+  direct : Bool
+  visible : Bool
+  readable : Bool
+  retryable : Bool
+  listedByDefault : Bool
+  controllable : Bool
+  deriving Repr
+
+def viewer : Viewer :=
+  { rootRequestId := 1
+  , rootPrincipal := 10
+  , rootSessionId := 100
+  , lineageId := 1000 }
+
+def baseEdge : Edge :=
+  { rootRequestId := 1
+  , rootSessionId := 100
+  , parentRequestId := 1
+  , parentToolCallId := 20
+  , childRequestId := 2
+  , childSessionId := some 200
+  , ownerPrincipal := 10
+  , controlPrincipal := 10
+  , childPrincipal := 11
+  , behaviorId := 30
+  , deploymentId := 40
+  , lineageId := 1000
+  , awaitMode := .background
+  , materialization := .local
+  , lifecycle := .running
+  , workflowGroup := none
+  , workflowRole := .plain
+  , bridgeDurable := true
+  , physicalCorroborated := true
+  , directFromRoot := true }
+
+def awaitModeString : AwaitMode → String
+  | .foreground => "foreground"
+  | .background => "background"
+
+def materializationString : Materialization → String
+  | .pending => "pending"
+  | .local => "local"
+  | .replicated => "replicated"
+
+def lifecycleString : Lifecycle → String
+  | .pending => "pending"
+  | .running => "running"
+  | .completed => "completed"
+  | .failed => "failed"
+  | .cancelled => "cancelled"
+
+def workflowRoleString : WorkflowRole → String
+  | .plain => "plain"
+  | .fanOut => "fan_out_child"
+  | .synthesis => "synthesis"
+  | .reviewer => "reviewer"
+  | .futureRole => "future_role"
+
+def descendantCase (name : String) (edge : Edge) : DescendantGraphCase :=
+  { name
+  , rootRequestId := edge.rootRequestId
+  , parentRequestId := edge.parentRequestId
+  , childRequestId := edge.childRequestId
+  , awaitMode := awaitModeString edge.awaitMode
+  , materialization := materializationString edge.materialization
+  , lifecycle := lifecycleString edge.lifecycle
+  , workflowRole := workflowRoleString edge.workflowRole
+  , direct := edge.directFromRoot
+  , visible := DescendantGraph.visible viewer edge
+  , readable := DescendantGraph.readable viewer edge
+  , retryable := DescendantGraph.retryable viewer edge
+  , listedByDefault := DescendantGraph.listedByDefault viewer edge
+  , controllable := DescendantGraph.controllable viewer edge }
+
+def descendantGraphCases : List DescendantGraphCase :=
+  [ descendantCase "background_direct" baseEdge
+  , descendantCase "foreground_direct"
+      { { baseEdge with awaitMode := .foreground } with childRequestId := 3 }
+  , descendantCase "workflow_fan_out"
+      { { { baseEdge with workflowGroup := some 50 } with
+          workflowRole := .fanOut } with childRequestId := 4 }
+  , descendantCase "workflow_synthesis_foreground"
+      { { { { baseEdge with workflowGroup := some 50 } with
+          workflowRole := .synthesis } with awaitMode := .foreground } with
+          childRequestId := 5 }
+  , descendantCase "nested_reviewer_visible_not_controllable"
+      { { { { { { baseEdge with parentRequestId := 5 } with
+          parentToolCallId := 21 } with childRequestId := 6 } with
+          workflowRole := .reviewer } with directFromRoot := false } with
+          controlPrincipal := 11 }
+  , descendantCase "unmaterialized_remote_bridge"
+      { { { { { baseEdge with childRequestId := 7 } with childSessionId := none } with
+          materialization := .pending } with physicalCorroborated := false } with
+          deploymentId := 41 }
+  , descendantCase "terminal_unmaterialized_remote_bridge"
+      { { { { { baseEdge with childRequestId := 14 } with childSessionId := none } with
+          materialization := .pending } with physicalCorroborated := false } with
+          lifecycle := .failed }
+  , descendantCase "terminal_result_edge"
+      { { baseEdge with childRequestId := 8 } with lifecycle := .completed }
+  , descendantCase "replicated_remote_materialization"
+      { { { baseEdge with childRequestId := 9 } with
+          materialization := .replicated } with deploymentId := 42 }
+  , descendantCase "unauthorized_principal"
+      { { baseEdge with childRequestId := 10 } with ownerPrincipal := 99 }
+  , descendantCase "unauthorized_session"
+      { { baseEdge with childRequestId := 11 } with rootSessionId := 999 }
+  , descendantCase "unauthorized_lineage"
+      { { baseEdge with childRequestId := 12 } with lineageId := 9999 }
+  , descendantCase "uncorroborated_materialized"
+      { { baseEdge with childRequestId := 13 } with physicalCorroborated := false }
+  ]
+
+end Conformance.ContractCases

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/DescendantGraph.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/DescendantGraph.lean
@@ -20,7 +20,9 @@ def descendantGraphCaseJson (value : DescendantGraphCase) : String :=
     ++ "\"readable\":" ++ boolString value.readable ++ ","
     ++ "\"retryable\":" ++ boolString value.retryable ++ ","
     ++ "\"listed_by_default\":" ++ boolString value.listedByDefault ++ ","
-    ++ "\"controllable\":" ++ boolString value.controllable
+    ++ "\"controllable\":" ++ boolString value.controllable ++ ","
+    ++ "\"cursor_anchor_survives_terminal\":"
+      ++ boolString value.cursorAnchorSurvivesTerminal
     ++ "}"
 
 def descendantGraphCasesJson : String :=

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/DescendantGraph.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/DescendantGraph.lean
@@ -1,0 +1,29 @@
+import Proofs.Conformance.Contracts.Json.Helpers
+import Proofs.Conformance.ContractCases.DescendantGraph
+
+namespace Conformance.Contracts
+
+open Conformance.ContractCases
+
+def descendantGraphCaseJson (value : DescendantGraphCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString value.name ++ ","
+    ++ "\"root_request_id\":" ++ toString value.rootRequestId ++ ","
+    ++ "\"parent_request_id\":" ++ toString value.parentRequestId ++ ","
+    ++ "\"child_request_id\":" ++ toString value.childRequestId ++ ","
+    ++ "\"await_mode\":" ++ jsonString value.awaitMode ++ ","
+    ++ "\"materialization\":" ++ jsonString value.materialization ++ ","
+    ++ "\"lifecycle\":" ++ jsonString value.lifecycle ++ ","
+    ++ "\"workflow_role\":" ++ jsonString value.workflowRole ++ ","
+    ++ "\"direct\":" ++ boolString value.direct ++ ","
+    ++ "\"visible\":" ++ boolString value.visible ++ ","
+    ++ "\"readable\":" ++ boolString value.readable ++ ","
+    ++ "\"retryable\":" ++ boolString value.retryable ++ ","
+    ++ "\"listed_by_default\":" ++ boolString value.listedByDefault ++ ","
+    ++ "\"controllable\":" ++ boolString value.controllable
+    ++ "}"
+
+def descendantGraphCasesJson : String :=
+  jsonArray (descendantGraphCases.map descendantGraphCaseJson)
+
+end Conformance.Contracts

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -7,6 +7,7 @@ import Proofs.Conformance.Contracts.Json.ToolPolicy
 import Proofs.Conformance.Contracts.Json.Lsp
 import Proofs.Conformance.Contracts.Json.ClientRuntime
 import Proofs.Conformance.Contracts.Json.BackgroundWork
+import Proofs.Conformance.Contracts.Json.DescendantGraph
 import Proofs.Conformance.Contracts.Json.ComposedInvariants
 import Proofs.Conformance.Contracts.Json.CodexShim
 import Proofs.Conformance.Contracts.Json.Workflow
@@ -187,6 +188,8 @@ def snapshotJson : String :=
     ++ "\"r6_backgrounding_cases\":"
       ++ jsonArray
         (r6BackgroundingCases.map r6BackgroundingCaseJson) ++ ","
+    ++ "\"descendant_graph_cases\":"
+      ++ descendantGraphCasesJson ++ ","
     ++ "\"r5_cross_deployment_cases\":"
       ++ jsonArray
         (r5CrossDeploymentCases.map r5CrossDeploymentCaseJson) ++ ","

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -149,6 +149,10 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
         [ (Surface.operatorCli, "#268")
         ]
     }
+  , { feature := "descendant-graph"
+    , required := [Surface.agentFacing, Surface.runtimeInternal, Surface.operatorUi]
+    , deferred := []
+    }
   , { feature := "subagents-cross-deployment"
     , required := [Surface.agentFacing, Surface.api, Surface.operatorUi]
     , deferred := []
@@ -737,6 +741,11 @@ def caseCoverage : List CoverageEntry :=
       "SubagentDelegationGraphCases"
       "conformance::generated_subagent_delegation_graph_cases_pin_gap2_contract")
       "background-tools" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "descendant_graph_cases"
+      "DescendantGraphCases"
+      "descendant_graph::tests::generated_descendant_graph_cases_fence_visibility_and_control")
+      "descendant-graph" [Surface.agentFacing, Surface.runtimeInternal, Surface.operatorUi]
   , tagged (consumerCoverage
       "r4c_background_work_cases"
       "R4cBackgroundWorkCases"

--- a/crates/gents/proofs/Proofs/DescendantGraph.lean
+++ b/crates/gents/proofs/Proofs/DescendantGraph.lean
@@ -1,0 +1,270 @@
+import Proofs.Basic
+
+/-!
+# Canonical descendant graph
+
+`AgentToolCall` is the parent-authored durable edge receipt.  A child request
+may materialize later (and on another deployment), so visibility is defined
+from the receipt and the root ownership tuple.  Once a child is materialized,
+the logical and physical request/tool-call links must corroborate the receipt.
+
+Visibility and control are intentionally separate.  An ancestor can inspect a
+verified descendant edge without thereby acquiring the direct parent's
+steer/cancel authority.
+-/
+
+namespace DescendantGraph
+
+abbrev PrincipalId := Nat
+abbrev DeploymentId := Nat
+abbrev ToolCallId := Nat
+abbrev LineageId := Nat
+abbrev WorkflowGroupId := Nat
+
+inductive AwaitMode where
+  | foreground
+  | background
+  deriving DecidableEq, Repr
+
+inductive Materialization where
+  | pending
+  | local
+  | replicated
+  deriving DecidableEq, Repr
+
+inductive Lifecycle where
+  | pending
+  | running
+  | completed
+  | failed
+  | cancelled
+  deriving DecidableEq, Repr
+
+inductive WorkflowRole where
+  | plain
+  | fanOut
+  | synthesis
+  | reviewer
+  | futureRole
+  deriving DecidableEq, Repr
+
+inductive Scope where
+  | direct
+  | descendants
+  | workflowGroup
+  deriving DecidableEq, Repr
+
+structure Viewer where
+  rootRequestId : RequestId
+  rootPrincipal : PrincipalId
+  rootSessionId : SessionId
+  lineageId : LineageId
+  deriving DecidableEq, Repr
+
+structure Edge where
+  rootRequestId : RequestId
+  rootSessionId : SessionId
+  parentRequestId : RequestId
+  parentToolCallId : ToolCallId
+  childRequestId : RequestId
+  childSessionId : Option SessionId
+  ownerPrincipal : PrincipalId
+  controlPrincipal : PrincipalId
+  childPrincipal : PrincipalId
+  behaviorId : BehaviorId
+  deploymentId : DeploymentId
+  lineageId : LineageId
+  awaitMode : AwaitMode
+  materialization : Materialization
+  lifecycle : Lifecycle
+  workflowGroup : Option WorkflowGroupId
+  workflowRole : WorkflowRole
+  bridgeDurable : Bool
+  physicalCorroborated : Bool
+  directFromRoot : Bool
+  deriving DecidableEq, Repr
+
+def materializationAuthorized (edge : Edge) : Bool :=
+  match edge.materialization with
+  | .pending => true
+  | .local | .replicated => edge.physicalCorroborated
+
+/- The durable bridge receipt is enumerable by its owning lineage even when a
+   materialized child fails physical corroboration. That diagnostic visibility
+   never grants access to the child document itself. -/
+def visible (viewer : Viewer) (edge : Edge) : Bool :=
+  edge.bridgeDurable &&
+    edge.rootRequestId == viewer.rootRequestId &&
+    edge.ownerPrincipal == viewer.rootPrincipal &&
+    edge.rootSessionId == viewer.rootSessionId &&
+    edge.lineageId == viewer.lineageId
+
+def readable (viewer : Viewer) (edge : Edge) : Bool :=
+  visible viewer edge &&
+    materializationAuthorized edge &&
+    edge.materialization != .pending
+
+def terminal : Lifecycle → Bool
+  | .pending | .running => false
+  | .completed | .failed | .cancelled => true
+
+/-- Only an absent child can converge through retry. A child that exists but
+    rejects the bridge's physical lineage is a permanent authorization result.
+    A terminal bridge cannot converge further even if no child materialized. -/
+def retryable (viewer : Viewer) (edge : Edge) : Bool :=
+  visible viewer edge && edge.materialization == .pending && !terminal edge.lifecycle
+
+/-- The ordinary active-child view retains every owned, nonterminal bridge,
+    including a rejected child diagnostic. -/
+def listedByDefault (viewer : Viewer) (edge : Edge) : Bool :=
+  visible viewer edge && !terminal edge.lifecycle
+
+/-- Control is narrower than visibility: only the direct owning principal may
+    steer/cancel through this edge. -/
+def controllable (viewer : Viewer) (edge : Edge) : Bool :=
+  readable viewer edge &&
+    edge.directFromRoot &&
+    edge.controlPrincipal == viewer.rootPrincipal
+
+def inScope (scope : Scope) (group : Option WorkflowGroupId) (edge : Edge) : Bool :=
+  match scope with
+  | .direct => edge.directFromRoot
+  | .descendants => true
+  | .workflowGroup => edge.workflowGroup == group && group.isSome
+
+theorem behavior_change_preserves_visibility
+    (viewer : Viewer) (edge : Edge) (behavior : BehaviorId) :
+    visible viewer { edge with behaviorId := behavior } = visible viewer edge := by
+  rfl
+
+theorem deployment_change_preserves_visibility
+    (viewer : Viewer) (edge : Edge) (deployment : DeploymentId) :
+    visible viewer { edge with deploymentId := deployment } = visible viewer edge := by
+  rfl
+
+theorem await_change_preserves_visibility
+    (viewer : Viewer) (edge : Edge) (mode : AwaitMode) :
+    visible viewer { edge with awaitMode := mode } = visible viewer edge := by
+  rfl
+
+theorem workflow_role_change_preserves_visibility
+    (viewer : Viewer) (edge : Edge) (role : WorkflowRole) :
+    visible viewer { edge with workflowRole := role } = visible viewer edge := by
+  rfl
+
+theorem pending_bridge_visible_without_child
+    (viewer : Viewer) (edge : Edge)
+    (hBridge : edge.bridgeDurable = true)
+    (hRoot : edge.rootRequestId = viewer.rootRequestId)
+    (hOwner : edge.ownerPrincipal = viewer.rootPrincipal)
+    (hSession : edge.rootSessionId = viewer.rootSessionId)
+    (hLineage : edge.lineageId = viewer.lineageId) :
+    visible viewer { edge with
+      materialization := .pending
+      physicalCorroborated := false } = true := by
+  simp [visible, materializationAuthorized, hBridge, hRoot, hOwner, hSession, hLineage]
+
+theorem unrelated_principal_cannot_see
+    (viewer : Viewer) (edge : Edge)
+    (h : edge.ownerPrincipal ≠ viewer.rootPrincipal) :
+    visible viewer edge = false := by
+  simp [visible, h]
+
+theorem unrelated_principal_cannot_read
+    (viewer : Viewer) (edge : Edge)
+    (h : edge.ownerPrincipal ≠ viewer.rootPrincipal) :
+    readable viewer edge = false := by
+  simp [readable, unrelated_principal_cannot_see viewer edge h]
+
+theorem unrelated_root_request_cannot_see
+    (viewer : Viewer) (edge : Edge)
+    (h : edge.rootRequestId ≠ viewer.rootRequestId) :
+    visible viewer edge = false := by
+  simp [visible, h]
+
+theorem unrelated_session_cannot_see
+    (viewer : Viewer) (edge : Edge)
+    (h : edge.rootSessionId ≠ viewer.rootSessionId) :
+    visible viewer edge = false := by
+  simp [visible, h]
+
+theorem unrelated_lineage_cannot_see
+    (viewer : Viewer) (edge : Edge)
+    (h : edge.lineageId ≠ viewer.lineageId) :
+    visible viewer edge = false := by
+  simp [visible, h]
+
+theorem uncorroborated_materialized_edge_is_visible_but_unreadable
+    (viewer : Viewer) (edge : Edge)
+    (hBridge : edge.bridgeDurable = true)
+    (hRoot : edge.rootRequestId = viewer.rootRequestId)
+    (hOwner : edge.ownerPrincipal = viewer.rootPrincipal)
+    (hSession : edge.rootSessionId = viewer.rootSessionId)
+    (hLineage : edge.lineageId = viewer.lineageId)
+    (h : edge.materialization ≠ .pending)
+    (hPhysical : edge.physicalCorroborated = false) :
+    visible viewer edge = true ∧ readable viewer edge = false := by
+  have hMaterialization : materializationAuthorized edge = false := by
+    generalize hKind : edge.materialization = kind at h ⊢
+    cases kind <;> simp_all [materializationAuthorized, hPhysical]
+  constructor
+  · simp [visible, hBridge, hRoot, hOwner, hSession, hLineage]
+  · simp [readable, hMaterialization]
+
+theorem rejected_materialization_is_not_retryable
+    (viewer : Viewer) (edge : Edge)
+    (h : edge.materialization ≠ .pending) :
+    retryable viewer edge = false := by
+  simp [retryable, h]
+
+theorem terminal_pending_bridge_is_not_retryable
+    (viewer : Viewer) (edge : Edge)
+    (hTerminal : terminal edge.lifecycle = true) :
+    retryable viewer { edge with materialization := .pending } = false := by
+  simp [retryable, hTerminal]
+
+theorem owned_running_rejection_remains_listed
+    (viewer : Viewer) (edge : Edge)
+    (hBridge : edge.bridgeDurable = true)
+    (hRoot : edge.rootRequestId = viewer.rootRequestId)
+    (hOwner : edge.ownerPrincipal = viewer.rootPrincipal)
+    (hSession : edge.rootSessionId = viewer.rootSessionId)
+    (hLineage : edge.lineageId = viewer.lineageId)
+    (hRunning : edge.lifecycle = .running) :
+    listedByDefault viewer edge = true := by
+  simp [listedByDefault, terminal, visible, hBridge, hRoot, hOwner, hSession, hLineage,
+    hRunning]
+
+theorem replicated_materialization_preserves_authorization
+    (viewer : Viewer) (edge : Edge) :
+    visible viewer { edge with materialization := .replicated } =
+      visible viewer { edge with materialization := .local } := by
+  rfl
+
+theorem visibility_does_not_grant_ancestor_control
+    (viewer : Viewer) (edge : Edge)
+    (_hVisible : visible viewer edge = true)
+    (hNested : edge.directFromRoot = false) :
+    controllable viewer edge = false := by
+  simp [controllable, hNested]
+
+theorem control_implies_visibility
+    (viewer : Viewer) (edge : Edge)
+    (hControl : controllable viewer edge = true) :
+    visible viewer edge = true := by
+  simp [controllable] at hControl
+  have hReadable := hControl.1
+  unfold readable at hReadable
+  simp at hReadable
+  exact hReadable.1.1.1
+
+theorem direct_scope_excludes_nested
+    (edge : Edge) (hNested : edge.directFromRoot = false) :
+    inScope .direct none edge = false := by
+  simp [inScope, hNested]
+
+theorem descendants_scope_includes_every_edge (edge : Edge) :
+    inScope .descendants none edge = true := by
+  rfl
+
+end DescendantGraph

--- a/crates/gents/proofs/Proofs/DescendantGraph.lean
+++ b/crates/gents/proofs/Proofs/DescendantGraph.lean
@@ -20,6 +20,7 @@ abbrev DeploymentId := Nat
 abbrev ToolCallId := Nat
 abbrev LineageId := Nat
 abbrev WorkflowGroupId := Nat
+abbrev Cursor := ToolCallId × RequestId
 
 inductive AwaitMode where
   | foreground
@@ -132,6 +133,18 @@ def inScope (scope : Scope) (group : Option WorkflowGroupId) (edge : Edge) : Boo
   | .descendants => true
   | .workflowGroup => edge.workflowGroup == group && group.isSome
 
+/-- A page cursor is derived only from durable edge identity, never from the
+    edge's mutable lifecycle/materialization projection. -/
+def cursor (edge : Edge) : Cursor :=
+  (edge.parentToolCallId, edge.childRequestId)
+
+/-- Cursor lookup runs over the stable scoped edge sequence. Volatile filters
+    such as `includeTerminal` are applied only to the returned suffix. -/
+def afterCursor (target : Cursor) : List Edge → Option (List Edge)
+  | [] => none
+  | edge :: rest =>
+      if cursor edge == target then some rest else afterCursor target rest
+
 theorem behavior_change_preserves_visibility
     (viewer : Viewer) (edge : Edge) (behavior : BehaviorId) :
     visible viewer { edge with behaviorId := behavior } = visible viewer edge := by
@@ -151,6 +164,17 @@ theorem workflow_role_change_preserves_visibility
     (viewer : Viewer) (edge : Edge) (role : WorkflowRole) :
     visible viewer { edge with workflowRole := role } = visible viewer edge := by
   rfl
+
+theorem lifecycle_change_preserves_cursor
+    (edge : Edge) (lifecycle : Lifecycle) :
+    cursor { edge with lifecycle := lifecycle } = cursor edge := by
+  rfl
+
+theorem terminal_transition_preserves_cursor_anchor
+    (edge next : Edge) :
+    afterCursor (cursor edge) [{ edge with lifecycle := .completed }, next] =
+      some [next] := by
+  simp [afterCursor, lifecycle_change_preserves_cursor]
 
 theorem pending_bridge_visible_without_child
     (viewer : Viewer) (edge : Edge)

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -24,6 +24,8 @@ The proofs are strongest where the runtime is a state machine:
 - command/tool execution policy for bash argv, network, sandbox, and shell env
 - MCP/tool execution preflight and retry eligibility boundaries
 - managed native executor deadline/cancel liveness and tool composition
+- canonical descendant visibility, materialization authorization, and
+  direct-parent control authority (`DescendantGraph`, #836)
 - provider-input narrowing and prompt-layer assembly (`PromptAssembly`,
   #448 / #992): soundness/fixpoint/idempotence/split-stability over the
   permissive transcript, loop-threading validity (the `run_loop_stream`
@@ -85,7 +87,7 @@ lake env lean --run Proofs/Conformance/Contracts.lean
 
 ## What Is Proven
 
-The current proof suite covers sixteen practical areas:
+The current proof suite covers seventeen practical areas:
 
 1. Request/process/persistence state transitions
 2. Daemon storage-observation assumptions that refine persistence
@@ -110,6 +112,13 @@ The current proof suite covers sixteen practical areas:
 15. Provider-input and token-budget enforcement: prompt assembly and
     sanitization, per-turn context clamps, and the request-wide aggregate
     ledger across tool turns and retracted attempts
+16. Canonical descendant graphs: durable pending bridge visibility,
+    logical-plus-physical materialization authorization, behavior/deployment/
+    await/workflow-role independence, replicated authorization equivalence,
+    and the separation between ancestor visibility and direct-parent control
+17. Agent self-configuration writes: per-collection writable/protected field
+    partitions, patch-merge identity immutability and containment,
+    transactional accept/reject totality, and no-lockout recoverability
 
 Separately, **obligation models** (no Rust refinement tests yet):
 
@@ -130,9 +139,6 @@ The proof boundary matters:
 - External assumptions such as "DefraDB eventually makes an acked mutation
   visible" or "provider streamed bytes" are not proven here.
 
-16. Agent self-configuration writes: per-collection writable/protected field
-    partitions, patch-merge identity immutability and containment,
-    transactional accept/reject totality, and no-lockout recoverability
 ## Cross-node TLA+ specs
 
 The `tla/` sibling directory contains TLA+ specifications for cross-node properties beyond per-node Lean coverage. See `tla/README.md`.
@@ -168,6 +174,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | File | Contents |
 |------|----------|
 | `Proofs/Basic.lean` | Shared opaque ids, `Time`, and terminal-state helpers |
+| `Proofs/DescendantGraph.lean` | Canonical descendant-edge visibility/read/control authorization, materialization and scope properties (#836) |
 | `Proofs/Process.lean` | Process lifecycle model plus executable `Action`, `step?`, and `replay?` |
 | `Proofs/Request.lean` | Barrel for request state, transitions, executable semantics, and local properties |
 | `Proofs/InferenceCall.lean` | Barrel for inference-call state, transitions, slot accounting, cancellation properties, and in-memory controller bookkeeping (#1001) |

--- a/crates/gents/src/adapter_projection.rs
+++ b/crates/gents/src/adapter_projection.rs
@@ -1922,7 +1922,16 @@ fn build_openai_codex_run_trace(
             .clone()
             .or(timeline.request.status.clone()),
         items,
-        child_run_ids: timeline.child_request_ids.clone(),
+        child_run_ids: if timeline.descendant_edges.is_empty() {
+            timeline.child_request_ids.clone()
+        } else {
+            timeline
+                .descendant_edges
+                .iter()
+                .filter(|edge| edge.is_direct() && edge.readable())
+                .map(|edge| edge.child_request_id.clone())
+                .collect()
+        },
     }
 }
 
@@ -1947,7 +1956,16 @@ fn build_langgraph_state_history(
         ),
         (
             "child_request_ids".to_string(),
-            json!(timeline.child_request_ids),
+            json!(if timeline.descendant_edges.is_empty() {
+                timeline.child_request_ids.clone()
+            } else {
+                timeline
+                    .descendant_edges
+                    .iter()
+                    .filter(|edge| edge.readable())
+                    .map(|edge| edge.child_request_id.clone())
+                    .collect::<Vec<_>>()
+            }),
         ),
     ]);
 
@@ -2103,6 +2121,48 @@ fn build_langgraph_state_history(
         }
     }
 
+    for descendant in timeline
+        .descendant_edges
+        .iter()
+        .filter(|edge| edge.readable())
+    {
+        let node_id = format!("request:{}", descendant.child_request_id);
+        if seen_nodes.insert(node_id.clone()) {
+            nodes.push(LangGraphNode {
+                id: node_id.clone(),
+                kind: "request".to_string(),
+                request_id: Some(descendant.child_request_id.clone()),
+                agent_did: descendant.principal_did.clone(),
+                behavior_id: descendant.behavior_id.clone(),
+                parent_request_id: Some(descendant.immediate_parent_request_id.clone()),
+                parent_tool_call_id: Some(descendant.immediate_parent_tool_call_id.clone()),
+                status: Some(descendant.lifecycle_state.clone()),
+                content: None,
+                reasoning: None,
+            });
+        }
+        let lineage_edge = LangGraphEdge {
+            from: format!("request:{}", descendant.immediate_parent_request_id),
+            to: node_id,
+            kind: "child_request".to_string(),
+        };
+        if !edges.contains(&lineage_edge) {
+            edges.push(lineage_edge);
+        }
+        if !tasks
+            .iter()
+            .any(|task| task.id == descendant.immediate_parent_tool_call_id)
+        {
+            tasks.push(LangGraphTask {
+                id: descendant.immediate_parent_tool_call_id.clone(),
+                request_id: Some(descendant.immediate_parent_request_id.clone()),
+                name: "spawn_subagent".to_string(),
+                status: descendant.lifecycle_state.clone(),
+                child_request_id: Some(descendant.child_request_id.clone()),
+            });
+        }
+    }
+
     if let Some(output) = root_final_output(timeline) {
         values.insert(
             "final_output".to_string(),
@@ -2163,6 +2223,31 @@ fn build_multi_agent_task(
     let mut delegations = Vec::new();
     let mut tool_events = Vec::new();
 
+    for edge in timeline
+        .descendant_edges
+        .iter()
+        .filter(|edge| edge.readable())
+    {
+        push_participant(
+            &mut participants,
+            edge.principal_did.clone(),
+            edge.behavior_id.clone(),
+            edge.workflow_role.as_deref().unwrap_or("delegate"),
+        );
+        delegations.push(MultiAgentDelegation {
+            parent_request_id: edge.immediate_parent_request_id.clone(),
+            child_request_id: edge.child_request_id.clone(),
+            parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
+            agent_did: edge.principal_did.clone(),
+            behavior_id: edge.behavior_id.clone(),
+            status: Some(edge.lifecycle_state.clone()),
+            // Descendant transcripts are deliberately not injected into
+            // projections. The durable result remains addressable by the
+            // canonical edge's terminal_result_ref.
+            input: None,
+        });
+    }
+
     for event in &timeline.events {
         match event {
             RunTimelineEvent::Request(request) => {
@@ -2186,16 +2271,18 @@ fn build_multi_agent_task(
                             }),
                     );
                 }
-                if let Some(parent_request_id) = request.parent_request_id.as_deref() {
-                    delegations.push(MultiAgentDelegation {
-                        parent_request_id: parent_request_id.to_string(),
-                        child_request_id: request.request_id.clone(),
-                        parent_tool_call_id: request.parent_tool_call_id.clone(),
-                        agent_did: request.agent_did.clone(),
-                        behavior_id: request.behavior_id.clone(),
-                        status: request.lifecycle_state.clone().or(request.status.clone()),
-                        input: redact_option(request.content.as_deref(), context),
-                    });
+                if timeline.descendant_edges.is_empty() {
+                    if let Some(parent_request_id) = request.parent_request_id.as_deref() {
+                        delegations.push(MultiAgentDelegation {
+                            parent_request_id: parent_request_id.to_string(),
+                            child_request_id: request.request_id.clone(),
+                            parent_tool_call_id: request.parent_tool_call_id.clone(),
+                            agent_did: request.agent_did.clone(),
+                            behavior_id: request.behavior_id.clone(),
+                            status: request.lifecycle_state.clone().or(request.status.clone()),
+                            input: redact_option(request.content.as_deref(), context),
+                        });
+                    }
                 }
             }
             // Captures ride the envelope's `rendered_captures`; the

--- a/crates/gents/src/adapter_projection/tests.rs
+++ b/crates/gents/src/adapter_projection/tests.rs
@@ -179,6 +179,123 @@ fn open_extension_surfaces_carry_capture_metadata() {
     assert_eq!(captures[1]["provenance_status"], "unsupported_manifest");
 }
 
+fn projection_descendant_edge(
+    child_request_id: &str,
+    materialization_state: crate::DescendantMaterializationState,
+    authorization_state: crate::DescendantAuthorizationState,
+    control_authority: crate::DescendantControlAuthority,
+) -> crate::DescendantEdge {
+    crate::DescendantEdge {
+        cursor: format!("cursor-{child_request_id}"),
+        root_request_id: "req-root".to_string(),
+        immediate_parent_request_id: "req-root".to_string(),
+        immediate_parent_session_id: "session-root".to_string(),
+        immediate_parent_tool_call_id: format!("tool-{child_request_id}"),
+        child_request_id: child_request_id.to_string(),
+        child_session_id: Some(format!("session-{child_request_id}")),
+        principal_did: Some(format!("did:test:{child_request_id}")),
+        behavior_id: Some(format!("behavior-{child_request_id}")),
+        deployment_id: Some(format!("deployment-{child_request_id}")),
+        target: Some(format!("target-{child_request_id}")),
+        await_mode: "background".to_string(),
+        cancel_policy: Some("cascade".to_string()),
+        lifecycle_state: "running".to_string(),
+        materialization_state,
+        workflow_group_id: None,
+        workflow_task_id: None,
+        workflow_role: Some("worker".to_string()),
+        terminal_result_ref: None,
+        transcript_cursor: 0,
+        authorization_state,
+        control_authority,
+        diagnostic: None,
+        depth: 1,
+        created_at: Some("2026-08-16T00:00:00Z".to_string()),
+        updated_at: Some("2026-08-16T00:00:01Z".to_string()),
+    }
+}
+
+#[test]
+fn external_descendant_projections_only_promote_readable_edges() {
+    let mut timeline = build_run_timeline(RunTimelineRows {
+        request: TimelineRequestRow {
+            doc_id: Some("doc-root".to_string()),
+            request_id: "req-root".to_string(),
+            agent_did: Some("did:test:root".to_string()),
+            behavior_id: Some("root".to_string()),
+            session_id: Some("session-root".to_string()),
+            status: Some("running".to_string()),
+            lifecycle_state: Some("running".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    timeline.descendant_edges = vec![
+        projection_descendant_edge(
+            "child-readable",
+            crate::DescendantMaterializationState::MaterializedRemote,
+            crate::DescendantAuthorizationState::Authorized,
+            crate::DescendantControlAuthority::Authorized,
+        ),
+        projection_descendant_edge(
+            "child-pending-private",
+            crate::DescendantMaterializationState::AwaitingChild,
+            crate::DescendantAuthorizationState::PendingMaterialization,
+            crate::DescendantControlAuthority::PendingMaterialization,
+        ),
+        projection_descendant_edge(
+            "child-rejected-private",
+            crate::DescendantMaterializationState::AuthorizationPending,
+            crate::DescendantAuthorizationState::RejectedPhysicalLineage,
+            crate::DescendantControlAuthority::RejectedPhysicalLineage,
+        ),
+    ];
+
+    let context = ProjectionContext::default();
+    let codex = build_adapter_projection(
+        AdapterProjectionKind::OpenAiCodexRunTrace,
+        &timeline,
+        &context,
+    );
+    let AdapterProjection::OpenAiCodexRunTrace(codex) = codex.output else {
+        panic!("Codex projection");
+    };
+    assert_eq!(codex.child_run_ids, vec!["child-readable"]);
+
+    let langgraph = build_adapter_projection(
+        AdapterProjectionKind::LangGraphStateHistory,
+        &timeline,
+        &context,
+    );
+    let AdapterProjection::LangGraphStateHistory(langgraph) = langgraph.output else {
+        panic!("LangGraph projection");
+    };
+    assert_eq!(
+        langgraph.values.get("child_request_ids"),
+        Some(&json!(["child-readable"]))
+    );
+    assert!(langgraph
+        .nodes
+        .iter()
+        .any(|node| node.request_id.as_deref() == Some("child-readable")));
+    assert!(langgraph
+        .tasks
+        .iter()
+        .any(|task| { task.child_request_id.as_deref() == Some("child-readable") }));
+
+    let multi =
+        build_adapter_projection(AdapterProjectionKind::MultiAgentTask, &timeline, &context);
+    let AdapterProjection::MultiAgentTask(multi) = multi.output else {
+        panic!("multi-agent projection");
+    };
+    assert_eq!(multi.delegations.len(), 1);
+    assert_eq!(multi.delegations[0].child_request_id, "child-readable");
+
+    let serialized = serde_json::to_string(&(codex, langgraph, multi)).unwrap();
+    assert!(!serialized.contains("child-pending-private"));
+    assert!(!serialized.contains("child-rejected-private"));
+}
+
 fn workspace_root() -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/crates/gents/src/background_tools.rs
+++ b/crates/gents/src/background_tools.rs
@@ -418,6 +418,7 @@ pub enum SteerSubagentTarget {
     /// explains the bridge state instead of collapsing into not-authorized.
     AwaitingMaterialization {
         message: String,
+        retryable: bool,
     },
     Terminal(String),
 }
@@ -1099,6 +1100,7 @@ pub async fn load_steer_subagent_target(
     }
     if !canonical.readable() {
         return Ok(SteerSubagentTarget::AwaitingMaterialization {
+            retryable: canonical.retryable(),
             message: canonical
                 .diagnostic
                 .unwrap_or_else(|| format!("child request {child_request_id} is not materialized")),

--- a/crates/gents/src/background_tools.rs
+++ b/crates/gents/src/background_tools.rs
@@ -7,13 +7,18 @@ mod transcript_render;
 use std::collections::{HashMap, HashSet};
 
 use crate::llm::message::{AssistantContent, Message, Text, UserContent};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use defra_node::EmbeddedNode;
 use gents_protocol::transcript::{decode_persisted_message, present_persisted_message};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::descendant_graph::{
+    resolve_descendant_edge, resolve_descendant_graph, resolve_descendant_root_request_id,
+    DescendantGraphAccess, DescendantQuery,
+};
+pub use crate::descendant_graph::{AWAITING_CHILD_MATERIALIZATION, PENDING_CHILD_AUTHORIZATION};
 use crate::document_config::SubagentTarget;
 use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::lifecycle::queue::{
@@ -35,16 +40,6 @@ use self::r4c_args::{
 use self::transcript_render::{
     render_transcript, MessageKindView, MessageRoleView, MessageView, RenderOptions,
 };
-
-/// #593: projected status served by `list_subagents`/`read_subagent` for a
-/// background spawn bridge whose child `AgentRequest` has not materialized
-/// yet (spawn convergence #377 creates the child asynchronously via
-/// `SubagentSource`; a cross-deployment child appears only after the owning
-/// peer claims and replicates it). This is a read-side projection of
-/// (bridge `await_mode = background` ∧ bridge non-terminal ∧ child row
-/// absent) — it is never persisted as a bridge `lifecycle_state`. Pinned by
-/// the Lean witness `r4c.list_subagents.unmaterialized_child_visible`.
-pub const AWAITING_CHILD_MATERIALIZATION: &str = "awaiting_child_materialization";
 
 /// Immutable identity boundary used by `list_processes`, `read_process`,
 /// `wait_process`, and `cancel_process`. A handle is usable on a later request
@@ -280,6 +275,8 @@ pub(crate) fn subagent_spawn_denial(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChildEdge {
+    pub parent_request_id: String,
+    pub parent_session_id: String,
     pub parent_tool_call_id: String,
     pub child_request_id: String,
     pub child_session_id: String,
@@ -290,6 +287,26 @@ pub struct ChildEdge {
     pub behavior_id: String,
     pub await_mode: AwaitMode,
     pub lifecycle_state: String,
+}
+
+impl ChildEdge {
+    pub(crate) fn from_descendant(edge: &crate::DescendantEdge) -> Option<Self> {
+        if !edge.readable() {
+            return None;
+        }
+        Some(Self {
+            parent_request_id: edge.immediate_parent_request_id.clone(),
+            parent_session_id: edge.immediate_parent_session_id.clone(),
+            parent_tool_call_id: edge.immediate_parent_tool_call_id.clone(),
+            child_request_id: edge.child_request_id.clone(),
+            child_session_id: edge.child_session_id.clone()?,
+            child_agent_did: edge.principal_did.clone()?,
+            behavior_id: edge.behavior_id.clone()?,
+            await_mode: AwaitMode::from_persisted(&edge.await_mode)
+                .unwrap_or(AwaitMode::Foreground),
+            lifecycle_state: edge.lifecycle_state.clone(),
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -326,28 +343,6 @@ struct ToolSelectionTargetsRow {
 }
 
 pub(crate) const DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS: i64 = 60;
-
-#[derive(Debug, Deserialize)]
-struct ListSubagentBridgeRow {
-    tool_call_id: String,
-    child_request_id: Option<String>,
-    lifecycle_state: Option<String>,
-    await_mode: Option<String>,
-    started_at: Option<String>,
-    completed_at: Option<String>,
-    unclaimed_deadline_at: Option<String>,
-    /// Raw JSON bridge args — we extract the `name` field here.
-    args: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ListSubagentChildRow {
-    request_id: String,
-    session_id: String,
-    behavior_id: Option<String>,
-    created_at: String,
-    subagent_depth: Option<u32>,
-}
 
 #[derive(Debug, Deserialize)]
 struct ListBackgroundToolRow {
@@ -434,174 +429,69 @@ pub async fn handle_list_subagents(
     args: ListSubagentsArgs,
 ) -> Result<ListSubagentsResponse> {
     let limit = args.validated_limit() as usize;
-    let escaped_caller = escape_graphql_string(caller_request_id);
-    let escaped_spawn_tool = escape_graphql_string("spawn_subagent");
-    let bridge_query = format!(
-        r#"{{
-            AgentToolCall(
-                filter: {{
-                    request_id: {{ _eq: "{escaped_caller}" }},
-                    tool_name: {{ _eq: "{escaped_spawn_tool}" }}
-                }},
-                order: {{ started_at: ASC }}
-            ) {{
-                tool_call_id
-                child_request_id
-                lifecycle_state
-                await_mode
-                started_at
-                completed_at
-                unclaimed_deadline_at
-                args
-            }}
-        }}"#
-    );
-    let bridge_response = node.execute(&bridge_query).await;
-    if bridge_response.has_errors() {
-        anyhow::bail!(
-            "list_subagents bridge query failed: {:?}",
-            bridge_response.errors
-        );
-    }
-    let bridges: Vec<ListSubagentBridgeRow> = rows(bridge_response.data.as_ref(), "AgentToolCall")?;
-
-    let child_query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{
-                    caused_by_parent_request_id: {{ _eq: "{escaped_caller}" }}
-                }},
-                order: {{ created_at: ASC }}
-            ) {{
-                request_id
-                session_id
-                behavior_id
-                created_at
-                subagent_depth
-            }}
-        }}"#
-    );
-    let child_response = node.execute(&child_query).await;
-    if child_response.has_errors() {
-        anyhow::bail!(
-            "list_subagents child query failed: {:?}",
-            child_response.errors
-        );
-    }
-    let children_by_request =
-        rows::<ListSubagentChildRow>(child_response.data.as_ref(), "AgentRequest")?
-            .into_iter()
-            .map(|row| (row.request_id.clone(), row))
-            .collect::<HashMap<_, _>>();
-
-    let mut entries = Vec::new();
-    for bridge in bridges {
-        if bridge.await_mode.as_deref() != Some("background") {
-            continue;
-        }
-        let Some(child_request_id) = non_empty_string(bridge.child_request_id.as_deref()) else {
-            continue;
-        };
-        let bridge_status = bridge
-            .lifecycle_state
-            .as_deref()
-            .filter(|state| !state.trim().is_empty())
-            .unwrap_or("running");
-
-        // Extract the model-facing `name` (and, for a bridge-level entry, the
-        // resolved `behavior_id`) from the bridge args JSON. The named-target
-        // redesign (#377) always writes both into the bridge args payload;
-        // older or malformed records fall back to empty string.
-        let bridge_args = bridge
-            .args
-            .as_deref()
-            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
-        let bridge_arg = |key: &str| {
-            bridge_args
-                .as_ref()
-                .and_then(|v| v.get(key).and_then(serde_json::Value::as_str))
-                .and_then(|s| non_empty_string(Some(s)))
-                .unwrap_or_default()
-        };
-
-        let entry = match children_by_request.get(&child_request_id) {
-            Some(child) => {
-                if !list_subagent_status_matches(args.status, bridge_status) {
-                    continue;
-                }
-                let created_at = parse_rfc3339(Some(&child.created_at)).ok_or_else(|| {
-                    anyhow!("child AgentRequest {child_request_id} has invalid created_at")
-                })?;
-                let last_update = parse_rfc3339(bridge.completed_at.as_deref())
-                    .or_else(|| parse_rfc3339(bridge.started_at.as_deref()))
-                    .unwrap_or(created_at);
-                ListSubagentsEntry {
-                    child_request_id,
-                    child_session_id: child.session_id.clone(),
-                    name: bridge_arg("name"),
-                    behavior_id: non_empty_string(child.behavior_id.as_deref()).unwrap_or_default(),
-                    deployment_id: local_deployment_id.to_string(),
-                    await_mode: "background".to_string(),
-                    status: bridge_status.to_string(),
-                    created_at,
-                    last_update,
-                    depth: child.subagent_depth.unwrap_or_default(),
-                    diagnostic: None,
-                }
+    let root_request_id =
+        resolve_descendant_root_request_id(DescendantGraphAccess::Local(node), caller_request_id)
+            .await?;
+    let page = resolve_descendant_graph(
+        DescendantGraphAccess::Local(node),
+        &DescendantQuery {
+            root_request_id,
+            scope: args.scope,
+            workflow_group_id: args.workflow_group_id.clone(),
+            after: args.after.clone(),
+            limit: crate::descendant_graph::MAX_DESCENDANT_PAGE_LIMIT,
+            include_terminal: args.status != ListStatusFilter::Running,
+        },
+    )
+    .await?;
+    let mut entries = page
+        .edges
+        .into_iter()
+        .filter(|edge| list_subagent_status_matches(args.status, &edge.lifecycle_state))
+        .map(|edge| {
+            let created_at = parse_rfc3339(edge.created_at.as_deref()).unwrap_or_else(Utc::now);
+            let last_update = parse_rfc3339(edge.updated_at.as_deref()).unwrap_or(created_at);
+            ListSubagentsEntry {
+                root_request_id: edge.root_request_id,
+                immediate_parent_request_id: edge.immediate_parent_request_id,
+                parent_tool_call_id: edge.immediate_parent_tool_call_id,
+                child_request_id: edge.child_request_id,
+                child_session_id: edge.child_session_id.unwrap_or_default(),
+                name: edge.target.unwrap_or_default(),
+                principal_did: edge.principal_did.unwrap_or_default(),
+                behavior_id: edge.behavior_id.unwrap_or_default(),
+                deployment_id: edge
+                    .deployment_id
+                    .unwrap_or_else(|| local_deployment_id.to_string()),
+                await_mode: edge.await_mode,
+                cancel_policy: edge.cancel_policy,
+                status: edge.lifecycle_state,
+                created_at,
+                last_update,
+                depth: u32::try_from(edge.depth).unwrap_or(u32::MAX),
+                materialization_state: edge.materialization_state,
+                workflow_group_id: edge.workflow_group_id,
+                workflow_task_id: edge.workflow_task_id,
+                workflow_role: edge.workflow_role,
+                terminal_result_ref: edge.terminal_result_ref,
+                transcript_cursor: edge.transcript_cursor,
+                authorization_state: edge.authorization_state,
+                control_authority: edge.control_authority,
+                cursor: edge.cursor,
+                diagnostic: edge.diagnostic,
             }
-            None => {
-                // #593: the child `AgentRequest` has not materialized (it is
-                // created asynchronously by the claiming deployment; a
-                // cross-deployment child appears only after replication). A
-                // returned background child id must never disappear from the
-                // control plane, so surface the bridge-level handle with a
-                // projected status instead of dropping it.
-                let status = if bridge_state_is_terminal(bridge_status) {
-                    bridge_status.to_string()
-                } else {
-                    AWAITING_CHILD_MATERIALIZATION.to_string()
-                };
-                if !list_subagent_status_matches(args.status, &status) {
-                    continue;
-                }
-                let created_at = parse_rfc3339(bridge.started_at.as_deref())
-                    .or_else(|| parse_rfc3339(bridge.completed_at.as_deref()))
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "bridge AgentToolCall {} has invalid started_at",
-                            bridge.tool_call_id
-                        )
-                    })?;
-                let last_update =
-                    parse_rfc3339(bridge.completed_at.as_deref()).unwrap_or(created_at);
-                let diagnostic = unmaterialized_child_diagnostic(
-                    &bridge.tool_call_id,
-                    bridge_status,
-                    bridge.unclaimed_deadline_at.as_deref(),
-                );
-                ListSubagentsEntry {
-                    child_request_id,
-                    child_session_id: String::new(),
-                    name: bridge_arg("name"),
-                    behavior_id: bridge_arg("behavior_id"),
-                    deployment_id: local_deployment_id.to_string(),
-                    await_mode: "background".to_string(),
-                    status,
-                    created_at,
-                    last_update,
-                    depth: 0,
-                    diagnostic: Some(diagnostic),
-                }
-            }
-        };
-        entries.push(entry);
-    }
-
-    let truncated = entries.len() > limit;
+        })
+        .collect::<Vec<_>>();
+    let truncated = page.has_more || entries.len() > limit;
     entries.truncate(limit);
+    let next_cursor = truncated
+        .then(|| entries.last().map(|entry| entry.cursor.clone()))
+        .flatten()
+        .or(page.next_cursor);
     Ok(ListSubagentsResponse {
         read_at: Utc::now(),
         truncated,
+        next_cursor,
         entries,
     })
 }
@@ -722,44 +612,35 @@ pub async fn handle_read_subagent(
     args: ReadSubagentArgs,
 ) -> Result<Option<ReadSubagentResponse>> {
     let child_request_id = args.child_request_id.trim();
-    let Some(edge) =
-        load_readable_background_child_edge(node, caller_request_id, child_request_id).await?
+    let root_request_id =
+        resolve_descendant_root_request_id(DescendantGraphAccess::Local(node), caller_request_id)
+            .await?;
+    let Some(canonical_edge) = resolve_descendant_edge(
+        DescendantGraphAccess::Local(node),
+        &root_request_id,
+        child_request_id,
+    )
+    .await?
     else {
-        // #593: distinguish "no such child edge for this caller" from "the
-        // caller owns a background spawn bridge whose child has not
-        // materialized". The bridge-level handle stays readable: an empty
-        // transcript with the projected (never faked-terminal) state.
-        let Some(bridge) = load_spawn_bridge_row(node, caller_request_id, child_request_id).await?
-        else {
-            return Ok(None);
-        };
-        if !bridge.is_background() {
-            return Ok(None);
-        }
-        let terminal = bridge.is_terminal();
-        let lifecycle_state = if terminal {
-            bridge.status().to_string()
-        } else {
-            AWAITING_CHILD_MATERIALIZATION.to_string()
-        };
-        let diagnostic = unmaterialized_child_diagnostic(
-            &bridge.tool_call_id,
-            bridge.status(),
-            bridge.unclaimed_deadline_at.as_deref(),
-        );
+        return Ok(None);
+    };
+    if !canonical_edge.readable() {
         return Ok(Some(ReadSubagentResponse {
-            child_request_id: child_request_id.to_string(),
-            child_session_id: String::new(),
+            edge: canonical_edge.clone(),
+            child_request_id: canonical_edge.child_request_id.clone(),
+            child_session_id: canonical_edge.child_session_id.clone().unwrap_or_default(),
             from_sequence: 0,
             through_sequence: 0,
             next_sequence: 0,
             has_more: false,
-            terminal,
-            lifecycle_state,
-            diagnostic: Some(diagnostic),
+            terminal: canonical_edge.is_terminal(),
+            lifecycle_state: canonical_edge.lifecycle_state.clone(),
+            diagnostic: canonical_edge.diagnostic.clone(),
             transcript: String::new(),
         }));
-    };
+    }
+    let edge = ChildEdge::from_descendant(&canonical_edge)
+        .context("authorized descendant edge lacks materialized child identity")?;
 
     // Project the child's terminal status so the model knows whether to keep
     // polling once it has drained the transcript.
@@ -839,6 +720,7 @@ pub async fn handle_read_subagent(
     );
 
     Ok(Some(ReadSubagentResponse {
+        edge: canonical_edge,
         child_request_id: edge.child_request_id,
         child_session_id: edge.child_session_id,
         from_sequence: rendered.from_sequence,
@@ -850,25 +732,6 @@ pub async fn handle_read_subagent(
         diagnostic: None,
         transcript: rendered.transcript,
     }))
-}
-
-async fn load_readable_background_child_edge(
-    node: &EmbeddedNode,
-    caller_request_id: &str,
-    child_request_id: &str,
-) -> Result<Option<ChildEdge>> {
-    if child_request_id.is_empty() {
-        return Ok(None);
-    }
-    let parent_context = load_parent_subagent_context(node, caller_request_id).await?;
-    match load_authorized_child_edge(node, &parent_context, child_request_id).await {
-        Ok(edge) if edge.await_mode == AwaitMode::Background => Ok(Some(edge)),
-        Ok(_) => Ok(None),
-        Err(error) if authorization_lookup_error(&error, caller_request_id, child_request_id) => {
-            Ok(None)
-        }
-        Err(error) => Err(error),
-    }
 }
 
 /// True for the error class where the child edge could not be RESOLVED for
@@ -1207,31 +1070,45 @@ pub async fn load_steer_subagent_target(
     if child_request_id.trim().is_empty() {
         return Ok(SteerSubagentTarget::NotAuthorized);
     }
-    let parent_context = load_parent_subagent_context(node, caller_request_id).await?;
-    let edge = match load_authorized_child_edge(node, &parent_context, child_request_id).await {
-        Ok(edge) => edge,
-        Err(error) if authorization_lookup_error(&error, caller_request_id, child_request_id) => {
-            // #593: if the caller owns a spawn bridge for this child, the id
-            // is real — report the bridge state instead of not-authorized.
-            let Some(bridge) =
-                load_spawn_bridge_row(node, caller_request_id, child_request_id).await?
-            else {
-                return Ok(SteerSubagentTarget::NotAuthorized);
-            };
-            if !bridge.is_background() {
-                return Ok(SteerSubagentTarget::NotBackgrounded);
-            }
-            if bridge.is_terminal() {
-                return Ok(SteerSubagentTarget::Terminal(bridge.status().to_string()));
-            }
-            let (message, _retryable) = bridge.unmaterialized_child_explanation(child_request_id);
-            return Ok(SteerSubagentTarget::AwaitingMaterialization { message });
-        }
-        Err(error) => return Err(error),
+    let root_request_id =
+        resolve_descendant_root_request_id(DescendantGraphAccess::Local(node), caller_request_id)
+            .await?;
+    let Some(canonical) = resolve_descendant_edge(
+        DescendantGraphAccess::Local(node),
+        &root_request_id,
+        child_request_id,
+    )
+    .await?
+    else {
+        return Ok(SteerSubagentTarget::NotAuthorized);
     };
-    if edge.await_mode != AwaitMode::Background {
+    // Only the immediate owning parent may steer. Keep this structural check
+    // separate from materialization: pending direct edges intentionally do
+    // not have control_authority yet, but still need an accurate bridge-level
+    // diagnostic below.
+    if !canonical.is_direct() {
+        return Ok(SteerSubagentTarget::NotAuthorized);
+    }
+    if canonical.await_mode != AwaitMode::Background.as_str() {
         return Ok(SteerSubagentTarget::NotBackgrounded);
     }
+    if canonical.is_terminal() {
+        return Ok(SteerSubagentTarget::Terminal(
+            canonical.lifecycle_state.clone(),
+        ));
+    }
+    if !canonical.readable() {
+        return Ok(SteerSubagentTarget::AwaitingMaterialization {
+            message: canonical
+                .diagnostic
+                .unwrap_or_else(|| format!("child request {child_request_id} is not materialized")),
+        });
+    }
+    if !canonical.controllable() {
+        return Ok(SteerSubagentTarget::NotAuthorized);
+    }
+    let edge = ChildEdge::from_descendant(&canonical)
+        .context("authorized descendant edge lacks materialized child identity")?;
     let Some(terminal_row) = load_child_terminal_row(node, &edge.child_request_id).await? else {
         return Ok(SteerSubagentTarget::NotAuthorized);
     };
@@ -1257,17 +1134,17 @@ pub(crate) async fn append_steering_request(
         crate::request_binding::load_agent_request(node, &edge.child_request_id)
             .await?
             .ok_or_else(|| anyhow!("child AgentRequest {} not found", edge.child_request_id))?;
-    let caller_request_doc_id =
-        crate::request_binding::require_request_doc_id(node, caller_request_id).await?;
-    if child_request.caused_by_parent_request_id.as_deref() != Some(caller_request_id)
-        || child_request.caused_by_parent_request_doc_id.as_deref()
-            != Some(caller_request_doc_id.as_str())
+    if child_request.caused_by_parent_request_id.as_deref() != Some(edge.parent_request_id.as_str())
     {
         anyhow::bail!(
-            "child AgentRequest {} no longer links to caller request {caller_request_id}",
-            edge.child_request_id
+            "child AgentRequest {} no longer links to owning parent request {}",
+            edge.child_request_id,
+            edge.parent_request_id
         );
     }
+
+    let caller_request_doc_id =
+        crate::request_binding::require_request_doc_id(node, caller_request_id).await?;
 
     child_request.caused_by_parent_request_id = Some(caller_request_id.to_string());
     child_request.caused_by_parent_request_doc_id = Some(caller_request_doc_id);
@@ -1459,10 +1336,14 @@ fn persisted_stream_body(value: &str) -> String {
 
 fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {
     match filter {
-        // #593: the awaiting-materialization projection is non-terminal, so
-        // the default `running` filter must show the handle.
+        // #593: both pending materialization and rejected physical lineage
+        // are owned, nonterminal bridge diagnostics. Keep their handles in
+        // the default view without granting child readability or control.
         ListStatusFilter::Running => {
-            status == "running" || status == AWAITING_CHILD_MATERIALIZATION
+            matches!(
+                status,
+                "running" | AWAITING_CHILD_MATERIALIZATION | PENDING_CHILD_AUTHORIZATION
+            )
         }
         _ => list_status_matches(filter, status),
     }
@@ -1479,35 +1360,16 @@ fn list_status_matches(filter: ListStatusFilter, status: &str) -> bool {
 fn bridge_state_is_terminal(status: &str) -> bool {
     matches!(
         status,
-        "completed" | "failed" | "timedOut" | "cancelled" | "dead" | "interrupted" | "superseded"
+        "completed"
+            | "complete"
+            | "failed"
+            | "error"
+            | "timedOut"
+            | "cancelled"
+            | "dead"
+            | "interrupted"
+            | "superseded"
     )
-}
-
-/// #593: parent-facing explanation for a background spawn bridge whose child
-/// `AgentRequest` row is absent.
-fn unmaterialized_child_diagnostic(
-    tool_call_id: &str,
-    bridge_status: &str,
-    unclaimed_deadline_at: Option<&str>,
-) -> String {
-    if bridge_state_is_terminal(bridge_status) {
-        format!(
-            "spawn bridge {tool_call_id} reached terminal state '{bridge_status}' without a \
-             materialized child request (e.g. no paired deployment claimed the spawn)"
-        )
-    } else {
-        let deadline_clause = unclaimed_deadline_at
-            .filter(|value| !value.trim().is_empty())
-            .map(|deadline| {
-                format!("; the spawn fails as no_peer_claimed_spawn if unclaimed by {deadline}")
-            })
-            .unwrap_or_default();
-        format!(
-            "spawn bridge {tool_call_id} is running but the child request has not materialized \
-             yet (it is created asynchronously by the claiming deployment; a cross-deployment \
-             child appears only after peer replication){deadline_clause}"
-        )
-    }
 }
 
 pub(crate) async fn load_parent_subagent_context(
@@ -1928,32 +1790,6 @@ mod cross_deployment_timeout_tests {
     }
 
     #[test]
-    fn unmaterialized_explanation_is_retryable_until_bridge_terminal() {
-        let running = SpawnBridgeRow {
-            tool_call_id: "tc-running".to_string(),
-            lifecycle_state: Some("running".to_string()),
-            await_mode: Some("background".to_string()),
-            unclaimed_deadline_at: Some("2026-07-01T00:01:00Z".to_string()),
-        };
-        let (message, retryable) = running.unmaterialized_child_explanation("child-1");
-        assert!(retryable, "non-terminal bridge must be retryable");
-        assert!(message.contains("child-1"));
-        assert!(message.contains("tc-running"));
-        assert!(message.contains("no_peer_claimed_spawn"));
-        assert!(message.contains("2026-07-01T00:01:00Z"));
-
-        let failed = SpawnBridgeRow {
-            tool_call_id: "tc-failed".to_string(),
-            lifecycle_state: Some("failed".to_string()),
-            await_mode: Some("background".to_string()),
-            unclaimed_deadline_at: None,
-        };
-        let (message, retryable) = failed.unmaterialized_child_explanation("child-1");
-        assert!(!retryable, "terminal bridge must not be retryable");
-        assert!(message.contains("'failed'"));
-    }
-
-    #[test]
     fn authorization_lookup_error_excludes_child_present_corruption() {
         // Resolution failures (child absent / unlinked) are probe-eligible…
         assert!(authorization_lookup_error(
@@ -1994,6 +1830,18 @@ mod cross_deployment_timeout_tests {
             ListStatusFilter::Terminal,
             AWAITING_CHILD_MATERIALIZATION
         ));
+        assert!(list_subagent_status_matches(
+            ListStatusFilter::Running,
+            PENDING_CHILD_AUTHORIZATION
+        ));
+        assert!(list_subagent_status_matches(
+            ListStatusFilter::All,
+            PENDING_CHILD_AUTHORIZATION
+        ));
+        assert!(!list_subagent_status_matches(
+            ListStatusFilter::Terminal,
+            PENDING_CHILD_AUTHORIZATION
+        ));
         // Unchanged: plain running and terminal bridge states.
         assert!(list_subagent_status_matches(
             ListStatusFilter::Running,
@@ -2010,39 +1858,13 @@ mod cross_deployment_timeout_tests {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct ChildRequestEdgeRow {
-    #[serde(rename = "_docID")]
-    doc_id: String,
-    request_id: String,
-    session_id: String,
-    agent_did: Option<String>,
-    behavior_id: Option<String>,
-    caused_by_parent_request_id: Option<String>,
-    caused_by_parent_request_doc_id: Option<String>,
-    caused_by_parent_tool_call_id: Option<String>,
-    caused_by_parent_tool_call_doc_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ParentToolCallEdgeRow {
-    #[serde(rename = "_docID")]
-    doc_id: String,
-    tool_call_id: String,
-    request_id: Option<String>,
-    request_doc_id: Option<String>,
-    lifecycle_state: Option<String>,
-    await_mode: Option<String>,
-    child_request_id: Option<String>,
-}
-
 /// Tolerant variant of [`load_authorized_child_edge`] used by the foreground
 /// subagent wait loop. After the spawn convergence (#377) the child
 /// `AgentRequest` is materialized asynchronously by `SubagentSource` rather than
 /// synchronously by the hook, so the foreground poller can observe the bridge
 /// before the child row exists. This returns `Ok(None)` for the "child not yet
 /// materialized" / not-yet-linked cases (using the same `authorization_lookup_error`
-/// predicate as `load_readable_background_child_edge`) so the caller can back off
+/// authorization lookup predicate) so the caller can back off
 /// and keep polling; all other errors propagate.
 pub(crate) async fn try_load_authorized_child_edge(
     node: &EmbeddedNode,
@@ -2060,232 +1882,39 @@ pub(crate) async fn try_load_authorized_child_edge(
     }
 }
 
-/// #593: the caller-owned spawn bridge pointing at a child request id,
-/// loadable regardless of whether the child `AgentRequest` exists. This is
-/// the durable receipt behind a background spawn: when the child row is
-/// absent, the bridge is what keeps the returned `child_request_id`
-/// observable on the parent control plane.
-#[derive(Debug, Deserialize)]
-pub(crate) struct SpawnBridgeRow {
-    pub(crate) tool_call_id: String,
-    pub(crate) lifecycle_state: Option<String>,
-    pub(crate) await_mode: Option<String>,
-    pub(crate) unclaimed_deadline_at: Option<String>,
-}
-
-impl SpawnBridgeRow {
-    pub(crate) fn status(&self) -> &str {
-        self.lifecycle_state
-            .as_deref()
-            .filter(|state| !state.trim().is_empty())
-            .unwrap_or("running")
-    }
-
-    pub(crate) fn is_terminal(&self) -> bool {
-        bridge_state_is_terminal(self.status())
-    }
-
-    pub(crate) fn is_background(&self) -> bool {
-        self.await_mode.as_deref().map(str::trim) == Some("background")
-    }
-
-    /// Explanation served by `wait_subagent`/`cancel_subagent` for a child
-    /// that has not materialized: `(message, retryable)`. Retryable while the
-    /// bridge is non-terminal (the child may still materialize or the
-    /// unclaimed projection will fail the bridge); not retryable once the
-    /// bridge is terminal.
-    pub(crate) fn unmaterialized_child_explanation(
-        &self,
-        child_request_id: &str,
-    ) -> (String, bool) {
-        let diagnostic = unmaterialized_child_diagnostic(
-            &self.tool_call_id,
-            self.status(),
-            self.unclaimed_deadline_at.as_deref(),
-        );
-        (
-            format!("child request {child_request_id} has no materialized row yet: {diagnostic}"),
-            !self.is_terminal(),
-        )
-    }
-}
-
-/// Load the caller-owned `spawn_subagent` bridge whose `child_request_id`
-/// matches, independent of child materialization. Ownership is enforced by
-/// filtering on the caller's `request_id`, so a caller can never observe a
-/// sibling's bridge through this path.
-pub(crate) async fn load_spawn_bridge_row(
-    node: &EmbeddedNode,
-    caller_request_id: &str,
-    child_request_id: &str,
-) -> Result<Option<SpawnBridgeRow>> {
-    if child_request_id.trim().is_empty() {
-        return Ok(None);
-    }
-    let escaped_caller = escape_graphql_string(caller_request_id);
-    let escaped_child = escape_graphql_string(child_request_id);
-    let query = format!(
-        r#"{{
-            AgentToolCall(
-                filter: {{
-                    request_id: {{ _eq: "{escaped_caller}" }},
-                    child_request_id: {{ _eq: "{escaped_child}" }}
-                }},
-                limit: 1
-            ) {{
-                tool_call_id
-                lifecycle_state
-                await_mode
-                unclaimed_deadline_at
-            }}
-        }}"#
-    );
-    let response = node.execute(&query).await;
-    if response.has_errors() {
-        anyhow::bail!(
-            "query spawn bridge for child {child_request_id} failed: {:?}",
-            response.errors
-        );
-    }
-    Ok(first_row(response.data.as_ref(), "AgentToolCall"))
-}
-
 pub(crate) async fn load_authorized_child_edge(
     node: &EmbeddedNode,
     parent_context: &ParentSubagentContext,
     child_request_id: &str,
 ) -> Result<ChildEdge> {
-    let Some(child_request_doc_id) =
-        crate::request_binding::resolve_request_doc_id(node, child_request_id).await?
+    let Some(edge) = resolve_descendant_edge(
+        DescendantGraphAccess::Local(node),
+        &parent_context.request_id,
+        child_request_id,
+    )
+    .await?
     else {
-        anyhow::bail!("child AgentRequest {child_request_id} not found");
-    };
-    let escaped_child_request_doc_id = escape_graphql_string(&child_request_doc_id);
-    let child_query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{ _docID: {{ _eq: "{escaped_child_request_doc_id}" }} }},
-                limit: 1
-            ) {{
-                _docID
-                request_id
-                session_id
-                agent_did
-                behavior_id
-                caused_by_parent_request_id
-                caused_by_parent_request_doc_id
-                caused_by_parent_tool_call_id
-                caused_by_parent_tool_call_doc_id
-            }}
-        }}"#
-    );
-    let child_response = node.execute(&child_query).await;
-    if child_response.has_errors() {
         anyhow::bail!(
-            "query child AgentRequest {child_request_id} failed: {:?}",
-            child_response.errors
+            "child AgentRequest {child_request_id} is not linked to parent request {}",
+            parent_context.request_id
         );
-    }
-    let child: ChildRequestEdgeRow = first_row(child_response.data.as_ref(), "AgentRequest")
-        .ok_or_else(|| anyhow!("child AgentRequest {child_request_id} not found"))?;
-    if child.request_id != child_request_id || child.doc_id != child_request_doc_id {
-        anyhow::bail!("child AgentRequest binding changed while loading {child_request_id}");
-    }
-    if child.caused_by_parent_request_id.as_deref() != Some(parent_context.request_id.as_str()) {
+    };
+    if edge.immediate_parent_request_id != parent_context.request_id || !edge.is_direct() {
         anyhow::bail!(
             "child AgentRequest {child_request_id} is not linked to parent request {}",
             parent_context.request_id
         );
     }
-    let behavior_id = child
-        .behavior_id
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| anyhow!("child AgentRequest {child_request_id} has no behavior_id"))?;
-    let child_agent_did = child
-        .agent_did
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| anyhow!("child AgentRequest {child_request_id} has no agent_did"))?;
-    if child.caused_by_parent_request_doc_id.as_deref()
-        != Some(parent_context.request_doc_id.as_str())
-    {
+    if !edge.readable() {
+        if edge.authorization_state == crate::DescendantAuthorizationState::PendingMaterialization {
+            anyhow::bail!("child AgentRequest {child_request_id} not found");
+        }
         anyhow::bail!(
-            "child AgentRequest {child_request_id} has incoherent physical parent request provenance"
+            "child AgentRequest {child_request_id} has incoherent physical parent provenance"
         );
     }
-    let parent_tool_call_id = child
-        .caused_by_parent_tool_call_id
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| {
-            anyhow!("child AgentRequest {child_request_id} has no parent tool-call link")
-        })?;
-    let parent_tool_call_doc_id = child
-        .caused_by_parent_tool_call_doc_id
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| {
-            anyhow!("child AgentRequest {child_request_id} has no parent tool-call document link")
-        })?;
-    let escaped_parent_tool_call_doc_id = escape_graphql_string(&parent_tool_call_doc_id);
-    let tool_call_query = format!(
-        r#"{{
-            AgentToolCall(
-                filter: {{ _docID: {{ _eq: "{escaped_parent_tool_call_doc_id}" }} }},
-                limit: 1
-            ) {{
-                _docID
-                tool_call_id
-                request_id
-                request_doc_id
-                lifecycle_state
-                await_mode
-                child_request_id
-            }}
-        }}"#
-    );
-    let tool_call_response = node.execute(&tool_call_query).await;
-    if tool_call_response.has_errors() {
-        anyhow::bail!(
-            "query parent AgentToolCall {parent_tool_call_id} failed: {:?}",
-            tool_call_response.errors
-        );
-    }
-    let tool_call: ParentToolCallEdgeRow =
-        first_row(tool_call_response.data.as_ref(), "AgentToolCall").ok_or_else(|| {
-            anyhow!(
-                "parent AgentToolCall {parent_tool_call_id} not found for child {child_request_id}"
-            )
-        })?;
-    if tool_call.doc_id != parent_tool_call_doc_id
-        || tool_call.tool_call_id != parent_tool_call_id
-        || tool_call.request_id.as_deref() != Some(parent_context.request_id.as_str())
-        || tool_call.request_doc_id.as_deref() != Some(parent_context.request_doc_id.as_str())
-    {
-        anyhow::bail!(
-            "parent AgentToolCall {parent_tool_call_id} is not linked to parent request {}",
-            parent_context.request_id
-        );
-    }
-    if tool_call.child_request_id.as_deref() != Some(child.request_id.as_str()) {
-        anyhow::bail!(
-            "parent AgentToolCall {parent_tool_call_id} does not point at child {child_request_id}"
-        );
-    }
-    let await_mode = tool_call
-        .await_mode
-        .as_deref()
-        .and_then(AwaitMode::from_persisted)
-        .unwrap_or(AwaitMode::Foreground);
-
-    Ok(ChildEdge {
-        parent_tool_call_id: tool_call.tool_call_id,
-        child_request_id: child.request_id,
-        child_session_id: child.session_id,
-        child_agent_did,
-        behavior_id,
-        await_mode,
-        lifecycle_state: tool_call
-            .lifecycle_state
-            .unwrap_or_else(|| "running".to_string()),
-    })
+    ChildEdge::from_descendant(&edge)
+        .context("authorized descendant edge lacks materialized child identity")
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/gents/src/background_tools/r4c_args.rs
+++ b/crates/gents/src/background_tools/r4c_args.rs
@@ -3,6 +3,11 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::descendant_graph::{
+    DescendantAuthorizationState, DescendantControlAuthority, DescendantEdge,
+    DescendantMaterializationState, DescendantScope,
+};
+
 const DEFAULT_LIST_LIMIT: u32 = 20;
 const MAX_LIST_LIMIT: u32 = 50;
 const MAX_TRANSCRIPT_LIMIT: u32 = 100;
@@ -38,6 +43,12 @@ pub struct ListSubagentsArgs {
     pub(crate) status: ListStatusFilter,
     #[serde(default = "default_list_limit")]
     pub(crate) limit: u32,
+    #[serde(default)]
+    pub(crate) scope: DescendantScope,
+    #[serde(default)]
+    pub(crate) workflow_group_id: Option<String>,
+    #[serde(default)]
+    pub(crate) after: Option<String>,
 }
 
 fn default_list_limit() -> u32 {
@@ -49,6 +60,9 @@ impl Default for ListSubagentsArgs {
         Self {
             status: ListStatusFilter::default(),
             limit: DEFAULT_LIST_LIMIT,
+            scope: DescendantScope::DirectChildren,
+            workflow_group_id: None,
+            after: None,
         }
     }
 }
@@ -155,19 +169,37 @@ pub(crate) struct SteerSubagentArgs {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ListSubagentsEntry {
+    pub root_request_id: String,
+    pub immediate_parent_request_id: String,
+    pub parent_tool_call_id: String,
     pub child_request_id: String,
     pub child_session_id: String,
     /// Friendly model-facing name of the subagent target (from the spawn args).
     /// Matches the `name` passed to `spawn_subagent`. Empty string if the
     /// bridge args did not carry a name (legacy or malformed record).
     pub name: String,
+    pub principal_did: String,
     pub behavior_id: String,
     pub deployment_id: String,
     pub await_mode: String,
+    pub cancel_policy: Option<String>,
     pub status: String,
     pub created_at: DateTime<Utc>,
     pub last_update: DateTime<Utc>,
     pub depth: u32,
+    pub materialization_state: DescendantMaterializationState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_group_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_result_ref: Option<String>,
+    pub transcript_cursor: u64,
+    pub authorization_state: DescendantAuthorizationState,
+    pub control_authority: DescendantControlAuthority,
+    pub cursor: String,
     /// #593: present only on a bridge-level entry whose child `AgentRequest`
     /// has not materialized (status `awaiting_child_materialization`) or
     /// whose bridge went terminal without one; explains the bridge state.
@@ -181,6 +213,8 @@ pub struct ListSubagentsEntry {
 pub struct ListSubagentsResponse {
     pub read_at: DateTime<Utc>,
     pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
     pub entries: Vec<ListSubagentsEntry>,
 }
 
@@ -206,6 +240,7 @@ pub(crate) struct ListBackgroundToolsResponse {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ReadSubagentResponse {
+    pub edge: DescendantEdge,
     pub child_request_id: String,
     pub child_session_id: String,
     pub from_sequence: u64,

--- a/crates/gents/src/descendant_graph.rs
+++ b/crates/gents/src/descendant_graph.rs
@@ -1,0 +1,1121 @@
+//! Canonical, authorization-safe descendant graph projection (#836).
+//!
+//! The parent-authored `AgentToolCall` document is the durable edge receipt.
+//! A materialized child is readable/control-eligible only after both logical
+//! identifiers and immutable DefraDB document identifiers corroborate that
+//! receipt. Consumers must not rebuild lineage from `AgentRequest` labels.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use anyhow::{Context, Result};
+use defra_node::EmbeddedNode;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::config_client::ConfigAccess;
+use crate::graphql::escape_graphql_string;
+
+pub const DEFAULT_DESCENDANT_PAGE_LIMIT: usize = 20;
+pub const MAX_DESCENDANT_PAGE_LIMIT: usize = 100;
+pub const MAX_DESCENDANT_DEPTH: usize = 32;
+pub const AWAITING_CHILD_MATERIALIZATION: &str = "awaiting_child_materialization";
+pub const PENDING_CHILD_AUTHORIZATION: &str = "pending_child_authorization";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DescendantScope {
+    #[default]
+    DirectChildren,
+    AllDescendants,
+    WorkflowGroup,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DescendantQuery {
+    pub root_request_id: String,
+    pub scope: DescendantScope,
+    pub workflow_group_id: Option<String>,
+    pub after: Option<String>,
+    pub limit: usize,
+    pub include_terminal: bool,
+}
+
+impl DescendantQuery {
+    pub fn direct(root_request_id: impl Into<String>) -> Self {
+        Self {
+            root_request_id: root_request_id.into(),
+            scope: DescendantScope::DirectChildren,
+            workflow_group_id: None,
+            after: None,
+            limit: DEFAULT_DESCENDANT_PAGE_LIMIT,
+            include_terminal: true,
+        }
+    }
+
+    pub fn all(root_request_id: impl Into<String>) -> Self {
+        Self {
+            scope: DescendantScope::AllDescendants,
+            ..Self::direct(root_request_id)
+        }
+    }
+
+    fn validated_limit(&self) -> usize {
+        self.limit.clamp(1, MAX_DESCENDANT_PAGE_LIMIT)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DescendantMaterializationState {
+    AwaitingChild,
+    AuthorizationPending,
+    MaterializedLocal,
+    MaterializedRemote,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DescendantAuthorizationState {
+    Authorized,
+    PendingMaterialization,
+    RejectedPhysicalLineage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DescendantControlAuthority {
+    Authorized,
+    VisibilityOnly,
+    PendingMaterialization,
+    RejectedPhysicalLineage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DescendantEdge {
+    pub cursor: String,
+    pub root_request_id: String,
+    pub immediate_parent_request_id: String,
+    pub immediate_parent_session_id: String,
+    pub immediate_parent_tool_call_id: String,
+    pub child_request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub child_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub behavior_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    pub await_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_policy: Option<String>,
+    pub lifecycle_state: String,
+    pub materialization_state: DescendantMaterializationState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_group_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_result_ref: Option<String>,
+    pub transcript_cursor: u64,
+    pub authorization_state: DescendantAuthorizationState,
+    pub control_authority: DescendantControlAuthority,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+    pub depth: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+impl DescendantEdge {
+    pub fn is_direct(&self) -> bool {
+        self.depth == 1
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        lifecycle_is_terminal(&self.lifecycle_state)
+    }
+
+    pub fn readable(&self) -> bool {
+        self.authorization_state == DescendantAuthorizationState::Authorized
+            && matches!(
+                self.materialization_state,
+                DescendantMaterializationState::MaterializedLocal
+                    | DescendantMaterializationState::MaterializedRemote
+            )
+    }
+
+    pub fn controllable(&self) -> bool {
+        self.control_authority == DescendantControlAuthority::Authorized
+    }
+
+    /// Only a bridge whose child has not materialized can converge through a
+    /// retry. A present child with rejected physical lineage is permanent.
+    pub fn retryable(&self) -> bool {
+        self.authorization_state == DescendantAuthorizationState::PendingMaterialization
+            && !self.is_terminal()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DescendantPage {
+    pub root_request_id: String,
+    pub scope: DescendantScope,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_group_id: Option<String>,
+    pub edges: Vec<DescendantEdge>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+pub enum DescendantGraphAccess<'a> {
+    Local(&'a EmbeddedNode),
+    Config(&'a ConfigAccess),
+}
+
+impl DescendantGraphAccess<'_> {
+    async fn execute(&self, query: &str) -> Result<Value> {
+        match self {
+            Self::Config(access) => access.execute(query).await,
+            Self::Local(node) => {
+                let response = node.execute(query).await;
+                if response.has_errors() {
+                    let errors = response
+                        .errors
+                        .iter()
+                        .map(|error| error.message.as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    anyhow::bail!("descendant graph GraphQL returned errors: {errors}");
+                }
+                Ok(serde_json::json!({
+                    "data": response.data.unwrap_or(Value::Null),
+                }))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequestRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    request_id: String,
+    agent_did: Option<String>,
+    requester_did: Option<String>,
+    behavior_id: Option<String>,
+    session_id: String,
+    caused_by_parent_request_id: Option<String>,
+    caused_by_parent_request_doc_id: Option<String>,
+    caused_by_parent_tool_call_id: Option<String>,
+    caused_by_parent_tool_call_doc_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BridgeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    request_id: String,
+    request_doc_id: Option<String>,
+    session_id: Option<String>,
+    agent_did: Option<String>,
+    requester_did: Option<String>,
+    tool_call_id: String,
+    args: Option<String>,
+    result: Option<String>,
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+    await_mode: Option<String>,
+    cancel_policy: Option<String>,
+    child_request_id: Option<String>,
+    spawn_target_did: Option<String>,
+    workflow_group_id: Option<String>,
+    workflow_role: Option<String>,
+    unclaimed_deadline_at: Option<String>,
+}
+
+const BRIDGE_FIELDS: &str = r#"
+    _docID
+    request_id
+    request_doc_id
+    session_id
+    agent_did
+    requester_did
+    tool_call_id
+    args
+    result
+    status
+    lifecycle_state
+    started_at
+    completed_at
+    await_mode
+    cancel_policy
+    child_request_id
+    spawn_target_did
+    workflow_group_id
+    workflow_role
+    unclaimed_deadline_at
+"#;
+
+#[derive(Debug, Deserialize)]
+struct MessageCursorRow {
+    session_id: String,
+    sequence: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BridgeArgs {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    workflow_task_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParentNode {
+    row: RequestRow,
+    depth: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RootContext {
+    request_id: String,
+    doc_id: String,
+    agent_did: Option<String>,
+    requester_did: Option<String>,
+}
+
+impl RootContext {
+    fn from_request(row: &RequestRow) -> Self {
+        Self {
+            request_id: row.request_id.clone(),
+            doc_id: row.doc_id.clone(),
+            agent_did: clean(row.agent_did.as_deref()),
+            requester_did: clean(row.requester_did.as_deref()),
+        }
+    }
+}
+
+struct ProjectedEdge {
+    edge: DescendantEdge,
+    child: Option<RequestRow>,
+}
+
+pub async fn resolve_descendant_graph(
+    access: DescendantGraphAccess<'_>,
+    query: &DescendantQuery,
+) -> Result<DescendantPage> {
+    let root_id = nonempty(Some(query.root_request_id.as_str()))
+        .context("descendant graph root_request_id is required")?;
+    if query.scope == DescendantScope::WorkflowGroup
+        && nonempty(query.workflow_group_id.as_deref()).is_none()
+    {
+        anyhow::bail!("workflow_group scope requires workflow_group_id");
+    }
+
+    let root = load_unique_request(&access, root_id)
+        .await?
+        .with_context(|| format!("root AgentRequest {root_id} not found"))?;
+    let root_context = RootContext::from_request(&root);
+
+    let mut frontier = VecDeque::from([ParentNode {
+        row: root,
+        depth: 0,
+    }]);
+    let mut visited_parents = BTreeSet::new();
+    let mut seen_children = BTreeSet::new();
+    let mut edges = Vec::new();
+
+    while !frontier.is_empty() {
+        let mut level = Vec::new();
+        while let Some(parent) = frontier.pop_front() {
+            if parent.depth >= MAX_DESCENDANT_DEPTH
+                || !visited_parents.insert(parent.row.doc_id.clone())
+            {
+                continue;
+            }
+            level.push(parent);
+        }
+        if level.is_empty() {
+            break;
+        }
+
+        let parent_ids = level
+            .iter()
+            .map(|parent| parent.row.request_id.clone())
+            .collect::<Vec<_>>();
+        let bridges = load_bridges(&access, &parent_ids).await?;
+        let child_ids = bridges
+            .iter()
+            .filter_map(|bridge| clean(bridge.child_request_id.as_deref()))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let children = load_requests(&access, &child_ids).await?;
+        let mut children_by_id = BTreeMap::<String, Vec<RequestRow>>::new();
+        for child in children {
+            children_by_id
+                .entry(child.request_id.clone())
+                .or_default()
+                .push(child);
+        }
+        let parents_by_id = level
+            .iter()
+            .map(|parent| (parent.row.request_id.clone(), parent))
+            .collect::<BTreeMap<_, _>>();
+
+        for bridge in bridges {
+            let Some(parent) = parents_by_id.get(&bridge.request_id) else {
+                continue;
+            };
+            let Some(child_request_id) = clean(bridge.child_request_id.as_deref()) else {
+                continue;
+            };
+            let candidate_rows = children_by_id
+                .get(&child_request_id)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let Some(projected) =
+                project_descendant_edge(&root_context, parent, &bridge, candidate_rows)?
+            else {
+                continue;
+            };
+            if !seen_children.insert(projected.edge.child_request_id.clone()) {
+                anyhow::bail!(
+                    "descendant child {child_request_id} is referenced by more than one canonical bridge"
+                );
+            }
+
+            if query.scope != DescendantScope::DirectChildren {
+                if let Some(child) = projected.child.clone() {
+                    frontier.push_back(ParentNode {
+                        row: child,
+                        depth: projected.edge.depth,
+                    });
+                }
+            }
+            edges.push(projected.edge);
+        }
+
+        if query.scope == DescendantScope::DirectChildren {
+            break;
+        }
+    }
+
+    populate_transcript_cursors(&access, &mut edges).await?;
+    edges.retain(|edge| match query.scope {
+        DescendantScope::DirectChildren => edge.is_direct(),
+        DescendantScope::AllDescendants => true,
+        DescendantScope::WorkflowGroup => {
+            edge.workflow_group_id.as_deref() == nonempty(query.workflow_group_id.as_deref())
+        }
+    });
+    if !query.include_terminal {
+        edges.retain(|edge| !edge.is_terminal());
+    }
+    edges.sort_by(|left, right| left.cursor.cmp(&right.cursor));
+
+    let start = match query
+        .after
+        .as_deref()
+        .and_then(|value| nonempty(Some(value)))
+    {
+        None => 0,
+        Some(after) => edges
+            .iter()
+            .position(|edge| edge.cursor == after)
+            .map(|index| index + 1)
+            .with_context(|| format!("descendant cursor {after:?} is not in this graph scope"))?,
+    };
+    let limit = query.validated_limit();
+    let has_more = start.saturating_add(limit) < edges.len();
+    let page_edges = edges
+        .into_iter()
+        .skip(start)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let next_cursor = has_more
+        .then(|| page_edges.last().map(|edge| edge.cursor.clone()))
+        .flatten();
+
+    Ok(DescendantPage {
+        root_request_id: root_id.to_string(),
+        scope: query.scope,
+        workflow_group_id: clean(query.workflow_group_id.as_deref()),
+        edges: page_edges,
+        next_cursor,
+        has_more,
+    })
+}
+
+fn project_descendant_edge(
+    root: &RootContext,
+    parent: &ParentNode,
+    bridge: &BridgeRow,
+    candidate_rows: &[RequestRow],
+) -> Result<Option<ProjectedEdge>> {
+    // Older durable bridge rows predate the physical request binding. The
+    // unique parent request_id remains safe, so omitted legacy metadata is
+    // accepted while every contradictory value fails closed.
+    if !bridge_corroborates_parent(parent, bridge) {
+        return Ok(None);
+    }
+    let Some(child_request_id) = clean(bridge.child_request_id.as_deref()) else {
+        return Ok(None);
+    };
+    let matching = candidate_rows
+        .iter()
+        .filter(|child| child_corroborates(parent, bridge, child))
+        .collect::<Vec<_>>();
+    if matching.len() > 1 {
+        anyhow::bail!(
+            "descendant child {child_request_id} is ambiguous across physically corroborated documents"
+        );
+    }
+    let child = matching.first().copied().cloned();
+    let rejected_physical_lineage = child.is_none() && !candidate_rows.is_empty();
+    let depth = parent.depth + 1;
+    let args = parse_bridge_args(bridge.args.as_deref());
+    let bridge_state = lifecycle(&bridge.lifecycle_state, &bridge.status, "running");
+    // The parent-authored bridge owns edge lifecycle. Child request state is
+    // intentionally not substituted: continuations can make one request
+    // terminal while the bridge itself is still converging.
+    let lifecycle_state = if child.is_some() || bridge_state_is_terminal(&bridge_state) {
+        bridge_state.clone()
+    } else if rejected_physical_lineage {
+        PENDING_CHILD_AUTHORIZATION.to_string()
+    } else {
+        AWAITING_CHILD_MATERIALIZATION.to_string()
+    };
+    let materialization_state = match child.as_ref() {
+        Some(child) if clean(child.agent_did.as_deref()) == root.agent_did => {
+            DescendantMaterializationState::MaterializedLocal
+        }
+        Some(_) => DescendantMaterializationState::MaterializedRemote,
+        None if rejected_physical_lineage => DescendantMaterializationState::AuthorizationPending,
+        None => DescendantMaterializationState::AwaitingChild,
+    };
+    let authorization_state = match child {
+        Some(_) => DescendantAuthorizationState::Authorized,
+        None if rejected_physical_lineage => DescendantAuthorizationState::RejectedPhysicalLineage,
+        None => DescendantAuthorizationState::PendingMaterialization,
+    };
+    let direct = depth == 1;
+    let parent_principal_matches_root = clean(parent.row.agent_did.as_deref()) == root.agent_did
+        && (parent.row.doc_id == root.doc_id
+            || clean(parent.row.requester_did.as_deref()) == root.requester_did);
+    let control_authority = match authorization_state {
+        DescendantAuthorizationState::Authorized if direct && parent_principal_matches_root => {
+            DescendantControlAuthority::Authorized
+        }
+        DescendantAuthorizationState::Authorized => DescendantControlAuthority::VisibilityOnly,
+        DescendantAuthorizationState::PendingMaterialization => {
+            DescendantControlAuthority::PendingMaterialization
+        }
+        DescendantAuthorizationState::RejectedPhysicalLineage => {
+            DescendantControlAuthority::RejectedPhysicalLineage
+        }
+    };
+    let terminal_result_ref = bridge_state_is_terminal(&lifecycle_state)
+        .then(|| clean(bridge.result.as_deref()))
+        .flatten()
+        .map(|_| format!("AgentToolCall:{}", bridge.doc_id));
+    let diagnostic = match authorization_state {
+        DescendantAuthorizationState::Authorized => None,
+        DescendantAuthorizationState::PendingMaterialization => Some(format!(
+            "bridge {} is durable; child {} has no materialized row yet{}",
+            bridge.tool_call_id,
+            child_request_id,
+            bridge
+                .unclaimed_deadline_at
+                .as_deref()
+                .map(|deadline| format!(" (unclaimed deadline {deadline})"))
+                .unwrap_or_default()
+        )),
+        DescendantAuthorizationState::RejectedPhysicalLineage => Some(format!(
+            "child {child_request_id} exists but does not corroborate bridge {} physical provenance",
+            bridge.tool_call_id
+        )),
+    };
+    let created_at = clean(bridge.started_at.as_deref());
+    let updated_at = clean(bridge.completed_at.as_deref()).or_else(|| created_at.clone());
+    let cursor = edge_cursor(
+        depth,
+        created_at.as_deref(),
+        &bridge.request_id,
+        &bridge.tool_call_id,
+        &child_request_id,
+    );
+    let principal_did = child
+        .as_ref()
+        .and_then(|row| clean(row.agent_did.as_deref()))
+        .or_else(|| clean(bridge.spawn_target_did.as_deref()))
+        .or_else(|| clean(args.agent_did.as_deref()));
+    let behavior_id = child
+        .as_ref()
+        .and_then(|row| clean(row.behavior_id.as_deref()))
+        .or_else(|| clean(args.behavior_id.as_deref()));
+
+    Ok(Some(ProjectedEdge {
+        edge: DescendantEdge {
+            cursor,
+            root_request_id: root.request_id.clone(),
+            immediate_parent_request_id: bridge.request_id.clone(),
+            immediate_parent_session_id: parent.row.session_id.clone(),
+            immediate_parent_tool_call_id: bridge.tool_call_id.clone(),
+            child_request_id,
+            child_session_id: child.as_ref().map(|row| row.session_id.clone()),
+            principal_did: principal_did.clone(),
+            behavior_id,
+            deployment_id: principal_did,
+            target: clean(args.name.as_deref()),
+            await_mode: clean(bridge.await_mode.as_deref())
+                .unwrap_or_else(|| "foreground".to_string()),
+            cancel_policy: clean(bridge.cancel_policy.as_deref()),
+            lifecycle_state,
+            materialization_state,
+            workflow_group_id: clean(bridge.workflow_group_id.as_deref()),
+            workflow_task_id: clean(args.workflow_task_id.as_deref()),
+            workflow_role: clean(bridge.workflow_role.as_deref()),
+            terminal_result_ref,
+            transcript_cursor: 0,
+            authorization_state,
+            control_authority,
+            diagnostic,
+            depth,
+            created_at,
+            updated_at,
+        },
+        child,
+    }))
+}
+
+pub async fn resolve_descendant_edge(
+    access: DescendantGraphAccess<'_>,
+    root_request_id: &str,
+    child_request_id: &str,
+) -> Result<Option<DescendantEdge>> {
+    let Some(root_request_id) = nonempty(Some(root_request_id)) else {
+        anyhow::bail!("descendant graph root_request_id is required");
+    };
+    let Some(child_request_id) = nonempty(Some(child_request_id)) else {
+        return Ok(None);
+    };
+
+    let root = load_unique_request(&access, root_request_id)
+        .await?
+        .with_context(|| format!("root AgentRequest {root_request_id} not found"))?;
+    let root_context = RootContext::from_request(&root);
+    let bridges = load_bridges_by_child(&access, child_request_id).await?;
+    if bridges.is_empty() {
+        return Ok(None);
+    }
+    let candidate_rows = load_requests(&access, &[child_request_id.to_string()]).await?;
+    let mut matches = Vec::new();
+
+    for bridge in bridges {
+        let parent = if bridge.request_id == root.request_id {
+            root.clone()
+        } else {
+            let Some(parent) = load_unique_request(&access, &bridge.request_id).await? else {
+                continue;
+            };
+            parent
+        };
+        let Some(parent_depth) = trace_parent_to_root(&access, &root, &parent).await? else {
+            continue;
+        };
+        let parent = ParentNode {
+            row: parent,
+            depth: parent_depth,
+        };
+        let Some(projected) =
+            project_descendant_edge(&root_context, &parent, &bridge, &candidate_rows)?
+        else {
+            continue;
+        };
+        matches.push(projected.edge);
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => {
+            populate_transcript_cursors(&access, &mut matches).await?;
+            Ok(matches.pop())
+        }
+        count => anyhow::bail!(
+            "descendant child {child_request_id} is referenced by {count} canonical bridges in root {root_request_id}"
+        ),
+    }
+}
+
+/// Walk only the immutable physical parent joins needed to prove that one
+/// immediate parent belongs to `root`. This keeps exact-handle resolution
+/// O(depth), independent of fan-out size and page count.
+async fn trace_parent_to_root(
+    access: &DescendantGraphAccess<'_>,
+    root: &RequestRow,
+    candidate_parent: &RequestRow,
+) -> Result<Option<usize>> {
+    let mut current = candidate_parent.clone();
+    let mut depth = 0usize;
+    let mut seen = BTreeSet::new();
+
+    loop {
+        if current.doc_id == root.doc_id {
+            return Ok((current.request_id == root.request_id).then_some(depth));
+        }
+        if depth >= MAX_DESCENDANT_DEPTH || !seen.insert(current.doc_id.clone()) {
+            return Ok(None);
+        }
+        let (
+            Some(parent_request_id),
+            Some(parent_request_doc_id),
+            Some(parent_tool_call_id),
+            Some(parent_tool_call_doc_id),
+        ) = (
+            clean(current.caused_by_parent_request_id.as_deref()),
+            clean(current.caused_by_parent_request_doc_id.as_deref()),
+            clean(current.caused_by_parent_tool_call_id.as_deref()),
+            clean(current.caused_by_parent_tool_call_doc_id.as_deref()),
+        )
+        else {
+            return Ok(None);
+        };
+        let Some(parent) = load_unique_request(access, &parent_request_id).await? else {
+            return Ok(None);
+        };
+        if parent.doc_id != parent_request_doc_id {
+            return Ok(None);
+        }
+        let Some(parent_bridge) =
+            load_unique_bridge_by_doc_id(access, &parent_tool_call_doc_id).await?
+        else {
+            return Ok(None);
+        };
+        let parent_node = ParentNode {
+            row: parent.clone(),
+            depth: 0,
+        };
+        if parent_bridge.tool_call_id != parent_tool_call_id
+            || parent_bridge.request_id != parent.request_id
+            || !bridge_corroborates_parent(&parent_node, &parent_bridge)
+            || !child_corroborates(&parent_node, &parent_bridge, &current)
+        {
+            return Ok(None);
+        }
+        current = parent;
+        depth += 1;
+    }
+}
+
+/// Resolve request-only control continuations (steering/background-completion
+/// wakes) back to the request that owns the descendant bridges. A subagent
+/// spawn edge is never crossed because it has an immediate parent tool-call.
+pub async fn resolve_descendant_root_request_id(
+    access: DescendantGraphAccess<'_>,
+    caller_request_id: &str,
+) -> Result<String> {
+    let mut current = load_unique_request(&access, caller_request_id)
+        .await?
+        .with_context(|| format!("caller AgentRequest {caller_request_id} not found"))?;
+    let mut seen = BTreeSet::from([current.doc_id.clone()]);
+    loop {
+        let parent_request_id = clean(current.caused_by_parent_request_id.as_deref());
+        let parent_request_doc_id = clean(current.caused_by_parent_request_doc_id.as_deref());
+        let has_tool_edge = clean(current.caused_by_parent_tool_call_id.as_deref()).is_some()
+            || clean(current.caused_by_parent_tool_call_doc_id.as_deref()).is_some();
+        let (Some(parent_request_id), Some(parent_request_doc_id)) =
+            (parent_request_id, parent_request_doc_id)
+        else {
+            return Ok(current.request_id);
+        };
+        if has_tool_edge {
+            return Ok(current.request_id);
+        }
+        let parent = load_unique_request(&access, &parent_request_id)
+            .await?
+            .with_context(|| {
+                format!(
+                    "request-only continuation {} points to missing parent {parent_request_id}",
+                    current.request_id
+                )
+            })?;
+        if parent.doc_id != parent_request_doc_id
+            || parent.session_id != current.session_id
+            || clean(parent.agent_did.as_deref()) != clean(current.agent_did.as_deref())
+            || clean(parent.requester_did.as_deref()) != clean(current.requester_did.as_deref())
+        {
+            anyhow::bail!(
+                "request-only continuation {} crosses its principal/session/physical lineage boundary",
+                current.request_id
+            );
+        }
+        if !seen.insert(parent.doc_id.clone()) {
+            anyhow::bail!("request-only continuation lineage contains a cycle");
+        }
+        current = parent;
+    }
+}
+
+fn child_corroborates(parent: &ParentNode, bridge: &BridgeRow, child: &RequestRow) -> bool {
+    clean(child.caused_by_parent_request_id.as_deref()).as_deref()
+        == Some(parent.row.request_id.as_str())
+        && clean(child.caused_by_parent_request_doc_id.as_deref()).as_deref()
+            == Some(parent.row.doc_id.as_str())
+        && clean(child.caused_by_parent_tool_call_id.as_deref()).as_deref()
+            == Some(bridge.tool_call_id.as_str())
+        && clean(child.caused_by_parent_tool_call_doc_id.as_deref()).as_deref()
+            == Some(bridge.doc_id.as_str())
+        && clean(bridge.child_request_id.as_deref()).as_deref() == Some(child.request_id.as_str())
+}
+
+fn bridge_corroborates_parent(parent: &ParentNode, bridge: &BridgeRow) -> bool {
+    !contradicts(
+        bridge.request_doc_id.as_deref(),
+        Some(parent.row.doc_id.as_str()),
+    ) && !contradicts(
+        bridge.session_id.as_deref(),
+        Some(parent.row.session_id.as_str()),
+    ) && !contradicts(bridge.agent_did.as_deref(), parent.row.agent_did.as_deref())
+        && !contradicts(
+            bridge.requester_did.as_deref(),
+            parent.row.requester_did.as_deref(),
+        )
+}
+
+async fn load_unique_request(
+    access: &DescendantGraphAccess<'_>,
+    request_id: &str,
+) -> Result<Option<RequestRow>> {
+    let rows = load_requests(access, &[request_id.to_string()]).await?;
+    match rows.len() {
+        0 => Ok(None),
+        1 => Ok(rows.into_iter().next()),
+        count => anyhow::bail!(
+            "request_id {request_id} is ambiguous across {count} AgentRequest documents"
+        ),
+    }
+}
+
+async fn load_requests(
+    access: &DescendantGraphAccess<'_>,
+    request_ids: &[String],
+) -> Result<Vec<RequestRow>> {
+    if request_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let list = graphql_string_list(request_ids);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _in: [{list}] }} }},
+                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
+            ) {{
+                _docID
+                request_id
+                agent_did
+                requester_did
+                behavior_id
+                session_id
+                caused_by_parent_request_id
+                caused_by_parent_request_doc_id
+                caused_by_parent_tool_call_id
+                caused_by_parent_tool_call_doc_id
+            }}
+        }}"#
+    );
+    load_rows(access, "AgentRequest", &query).await
+}
+
+async fn load_bridges(
+    access: &DescendantGraphAccess<'_>,
+    parent_request_ids: &[String],
+) -> Result<Vec<BridgeRow>> {
+    if parent_request_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let list = graphql_string_list(parent_request_ids);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    request_id: {{ _in: [{list}] }},
+                    child_request_id: {{ _ne: "" }}
+                }},
+                order: [{{ started_at: ASC }}, {{ tool_call_id: ASC }}]
+            ) {{ {BRIDGE_FIELDS} }}
+        }}"#
+    );
+    load_rows(access, "AgentToolCall", &query).await
+}
+
+async fn load_bridges_by_child(
+    access: &DescendantGraphAccess<'_>,
+    child_request_id: &str,
+) -> Result<Vec<BridgeRow>> {
+    let child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{ child_request_id: {{ _eq: "{child_request_id}" }} }},
+                order: [{{ started_at: ASC }}, {{ tool_call_id: ASC }}]
+            ) {{ {BRIDGE_FIELDS} }}
+        }}"#
+    );
+    load_rows(access, "AgentToolCall", &query).await
+}
+
+async fn load_unique_bridge_by_doc_id(
+    access: &DescendantGraphAccess<'_>,
+    doc_id: &str,
+) -> Result<Option<BridgeRow>> {
+    let doc_id = escape_graphql_string(doc_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                limit: 2
+            ) {{ {BRIDGE_FIELDS} }}
+        }}"#
+    );
+    let rows: Vec<BridgeRow> = load_rows(access, "AgentToolCall", &query).await?;
+    match rows.len() {
+        0 => Ok(None),
+        1 => Ok(rows.into_iter().next()),
+        count => anyhow::bail!("AgentToolCall document {doc_id} resolved to {count} rows"),
+    }
+}
+
+async fn populate_transcript_cursors(
+    access: &DescendantGraphAccess<'_>,
+    edges: &mut [DescendantEdge],
+) -> Result<()> {
+    let session_ids = edges
+        .iter()
+        .filter(|edge| edge.readable())
+        .filter_map(|edge| edge.child_session_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if session_ids.is_empty() {
+        return Ok(());
+    }
+    let list = graphql_string_list(&session_ids);
+    let query = format!(
+        r#"{{
+            AgentMessage(
+                filter: {{ session_id: {{ _in: [{list}] }} }},
+                order: [{{ session_id: ASC }}, {{ sequence: ASC }}]
+            ) {{ session_id sequence }}
+        }}"#
+    );
+    let rows: Vec<MessageCursorRow> = load_rows(access, "AgentMessage", &query).await?;
+    let mut cursors = BTreeMap::<String, u64>::new();
+    for row in rows {
+        let next = row.sequence.unwrap_or_default().saturating_add(1);
+        cursors
+            .entry(row.session_id)
+            .and_modify(|cursor| *cursor = (*cursor).max(next))
+            .or_insert(next);
+    }
+    for edge in edges {
+        edge.transcript_cursor = edge
+            .child_session_id
+            .as_ref()
+            .and_then(|session_id| cursors.get(session_id))
+            .copied()
+            .unwrap_or_default();
+    }
+    Ok(())
+}
+
+async fn load_rows<T: for<'de> Deserialize<'de>>(
+    access: &DescendantGraphAccess<'_>,
+    collection: &str,
+    query: &str,
+) -> Result<Vec<T>> {
+    let response = access.execute(query).await?;
+    let value = response
+        .pointer(&format!("/data/{collection}"))
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    serde_json::from_value(value)
+        .with_context(|| format!("decoding canonical descendant {collection} rows"))
+}
+
+fn parse_bridge_args(value: Option<&str>) -> BridgeArgs {
+    value
+        .and_then(|value| serde_json::from_str(value).ok())
+        .unwrap_or_default()
+}
+
+fn graphql_string_list(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!("\"{}\"", escape_graphql_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn lifecycle(primary: &Option<String>, fallback: &Option<String>, default: &str) -> String {
+    clean(primary.as_deref())
+        .or_else(|| clean(fallback.as_deref()))
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn edge_cursor(
+    depth: usize,
+    created_at: Option<&str>,
+    parent_request_id: &str,
+    tool_call_id: &str,
+    child_request_id: &str,
+) -> String {
+    // Fixed-width depth plus immutable identifiers gives every consumer the
+    // same total order. The cursor is intentionally the sort key itself.
+    format!(
+        "{depth:08}\u{1f}{}\u{1f}{parent_request_id}\u{1f}{tool_call_id}\u{1f}{child_request_id}",
+        created_at.unwrap_or_default()
+    )
+}
+
+fn bridge_state_is_terminal(value: &str) -> bool {
+    matches!(
+        value.trim(),
+        "completed"
+            | "complete"
+            | "failed"
+            | "error"
+            | "timedOut"
+            | "cancelled"
+            | "interrupted"
+            | "superseded"
+            | "dead"
+    )
+}
+
+fn lifecycle_is_terminal(value: &str) -> bool {
+    bridge_state_is_terminal(value)
+}
+
+fn nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn clean(value: Option<&str>) -> Option<String> {
+    nonempty(value).map(ToOwned::to_owned)
+}
+
+fn contradicts(observed: Option<&str>, expected: Option<&str>) -> bool {
+    match nonempty(observed) {
+        None => false,
+        Some(observed) => nonempty(expected) != Some(observed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lean_vocab_test::lean_descendant_graph_cases;
+
+    #[test]
+    fn cursor_order_is_total_and_depth_first() {
+        let direct = edge_cursor(1, Some("2026-01-01T00:00:00Z"), "p", "t", "c");
+        let nested = edge_cursor(2, Some("2025-01-01T00:00:00Z"), "p2", "t2", "c2");
+        assert!(direct < nested);
+        assert_eq!(
+            direct,
+            edge_cursor(1, Some("2026-01-01T00:00:00Z"), "p", "t", "c")
+        );
+    }
+
+    #[test]
+    fn terminal_vocabulary_covers_request_and_bridge_spellings() {
+        for value in [
+            "completed",
+            "failed",
+            "timedOut",
+            "cancelled",
+            "interrupted",
+            "superseded",
+            "dead",
+        ] {
+            assert!(lifecycle_is_terminal(value), "{value}");
+        }
+        assert!(!lifecycle_is_terminal(AWAITING_CHILD_MATERIALIZATION));
+        assert!(!lifecycle_is_terminal(PENDING_CHILD_AUTHORIZATION));
+    }
+
+    #[test]
+    fn generated_descendant_graph_cases_fence_visibility_and_control() {
+        let cases = lean_descendant_graph_cases();
+        assert_eq!(cases.len(), 13);
+        for case in cases {
+            assert!(case.root_request_id > 0, "{}", case.name);
+            assert!(case.parent_request_id > 0, "{}", case.name);
+            assert!(case.child_request_id > 0, "{}", case.name);
+            assert!(
+                matches!(case.await_mode.as_str(), "foreground" | "background"),
+                "{}",
+                case.name
+            );
+            if !case.visible {
+                assert!(!case.controllable, "{}", case.name);
+                assert!(!case.readable, "{}", case.name);
+                assert!(!case.listed_by_default, "{}", case.name);
+            }
+            if !case.direct || case.materialization == "pending" {
+                assert!(!case.controllable, "{}", case.name);
+            }
+            assert_eq!(
+                case.retryable,
+                case.visible
+                    && case.materialization == "pending"
+                    && !matches!(
+                        case.lifecycle.as_str(),
+                        "completed" | "failed" | "cancelled"
+                    ),
+                "{}",
+                case.name
+            );
+            if case.name == "workflow_synthesis_foreground" {
+                assert!(case.visible);
+                assert_eq!(case.workflow_role, "synthesis");
+            }
+            if case.name == "nested_reviewer_visible_not_controllable" {
+                assert!(case.visible);
+                assert!(!case.controllable);
+            }
+            if case.name.starts_with("unauthorized_") {
+                assert!(!case.visible, "{}", case.name);
+            }
+            if case.name == "uncorroborated_materialized" {
+                assert!(case.visible);
+                assert!(!case.readable);
+                assert!(!case.retryable);
+                assert!(case.listed_by_default);
+                assert!(!case.controllable);
+            }
+            if case.name == "terminal_unmaterialized_remote_bridge" {
+                assert!(case.visible);
+                assert!(!case.readable);
+                assert!(!case.retryable);
+                assert!(!case.listed_by_default);
+                assert!(!case.controllable);
+            }
+        }
+    }
+}

--- a/crates/gents/src/descendant_graph.rs
+++ b/crates/gents/src/descendant_graph.rs
@@ -423,11 +423,11 @@ pub async fn resolve_descendant_graph(
             edge.workflow_group_id.as_deref() == nonempty(query.workflow_group_id.as_deref())
         }
     });
-    if !query.include_terminal {
-        edges.retain(|edge| !edge.is_terminal());
-    }
     edges.sort_by(|left, right| left.cursor.cmp(&right.cursor));
 
+    // Resolve the cursor against the stable scoped edge set before applying
+    // lifecycle filters. Otherwise an edge that becomes terminal between
+    // pages disappears along with the client's valid pagination anchor.
     let start = match query
         .after
         .as_deref()
@@ -441,12 +441,13 @@ pub async fn resolve_descendant_graph(
             .with_context(|| format!("descendant cursor {after:?} is not in this graph scope"))?,
     };
     let limit = query.validated_limit();
-    let has_more = start.saturating_add(limit) < edges.len();
-    let page_edges = edges
+    let eligible_edges = edges
         .into_iter()
         .skip(start)
-        .take(limit)
+        .filter(|edge| query.include_terminal || !edge.is_terminal())
         .collect::<Vec<_>>();
+    let has_more = eligible_edges.len() > limit;
+    let page_edges = eligible_edges.into_iter().take(limit).collect::<Vec<_>>();
     let next_cursor = has_more
         .then(|| page_edges.last().map(|edge| edge.cursor.clone()))
         .flatten();
@@ -1080,6 +1081,7 @@ mod tests {
             if !case.direct || case.materialization == "pending" {
                 assert!(!case.controllable, "{}", case.name);
             }
+            assert!(case.cursor_anchor_survives_terminal, "{}", case.name);
             assert_eq!(
                 case.retryable,
                 case.visible

--- a/crates/gents/src/hook/persistence/mod.rs
+++ b/crates/gents/src/hook/persistence/mod.rs
@@ -11,18 +11,21 @@ use crate::background_tools::r4c_args::{
     SteerSubagentArgs,
 };
 use crate::background_tools::{
-    active_session_request_id, append_steering_request, authorization_lookup_error,
-    child_request_completed, context_allowed_target_names, drain_automated_wakeups_returning_ids,
+    active_session_request_id, append_steering_request, child_request_completed,
+    context_allowed_target_names, drain_automated_wakeups_returning_ids,
     effective_context_cross_deployment_spawn_timeout_seconds, handle_list_background_tools,
     handle_list_subagents, handle_read_subagent, handle_read_tool_output,
     load_authorized_child_edge, load_child_final_response, load_child_terminal_row,
-    load_parent_subagent_context, load_spawn_bridge_row, load_steer_subagent_target,
-    pending_automated_wakeup_request_ids, project_child_terminal, resolve_context_target,
-    try_load_authorized_child_edge, BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs,
-    ParentSubagentContext, ProcessControlScope, ReadToolOutputOutcome, SpawnSubagentArgs,
-    SteerSubagentTarget, WaitSubagentArgs, WaitToolArgs,
+    load_parent_subagent_context, load_steer_subagent_target, pending_automated_wakeup_request_ids,
+    project_child_terminal, resolve_context_target, try_load_authorized_child_edge,
+    BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, ChildEdge, ParentSubagentContext,
+    ProcessControlScope, ReadToolOutputOutcome, SpawnSubagentArgs, SteerSubagentTarget,
+    WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
+use crate::descendant_graph::{
+    resolve_descendant_edge, resolve_descendant_root_request_id, DescendantGraphAccess,
+};
 use crate::document_config::{load_agent_behavior, SubagentTarget};
 use crate::session;
 use crate::tool_call_lifecycle::query::load_tool_call_result;

--- a/crates/gents/src/hook/persistence/orchestration.rs
+++ b/crates/gents/src/hook/persistence/orchestration.rs
@@ -736,6 +736,7 @@ impl DefraSessionHook {
             "name": spec.target_name,
             "agent_did": target_agent_did.clone(),
             "behavior_id": spec.behavior_id,
+            "workflow_task_id": spec.task_id.clone(),
             "prompt": spec.prompt,
             "deadline": serde_json::Value::Null,
             "parent_subagent_depth": parent_context.subagent_depth,

--- a/crates/gents/src/hook/persistence/subagent_tools.rs
+++ b/crates/gents/src/hook/persistence/subagent_tools.rs
@@ -286,12 +286,12 @@ impl DefraSessionHook {
                     ),
                 ));
             }
-            SteerSubagentTarget::AwaitingMaterialization { message } => {
+            SteerSubagentTarget::AwaitingMaterialization { message, retryable } => {
                 let result = service_unavailable_payload(
                     STEER_SUBAGENT_TOOL_NAME,
                     "/child_request_id",
                     message,
-                    true,
+                    retryable,
                 );
                 return Ok(self.skip_tool_result(STEER_SUBAGENT_TOOL_NAME, result));
             }

--- a/crates/gents/src/hook/persistence/subagent_tools.rs
+++ b/crates/gents/src/hook/persistence/subagent_tools.rs
@@ -40,43 +40,52 @@ impl DefraSessionHook {
             ));
         }
 
-        let parent_context = load_parent_subagent_context(&self.node, &request_id).await?;
-        let edge =
-            match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
-                Ok(edge) => edge,
-                Err(error) => {
-                    // #593: if the edge failed to RESOLVE (child absent or
-                    // unlinked) and the caller owns a spawn bridge for this
-                    // child, the id is real — explain the bridge state
-                    // (retryable while non-terminal). Child-present
-                    // corruption and query failures keep the original error;
-                    // a probe failure falls through to the generic payload.
-                    if authorization_lookup_error(&error, &request_id, child_request_id) {
-                        if let Ok(Some(bridge)) =
-                            load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
-                        {
-                            let (message, retryable) =
-                                bridge.unmaterialized_child_explanation(child_request_id);
-                            let result = service_unavailable_payload(
-                                WAIT_SUBAGENT_TOOL_NAME,
-                                "/child_request_id",
-                                message,
-                                retryable,
-                            );
-                            return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
-                        }
-                    }
-                    let result = service_unavailable_payload(
-                        WAIT_SUBAGENT_TOOL_NAME,
-                        "/child_request_id",
-                        format!(
-                        "child subagent request is not available to this parent request: {error}"
-                    ),
-                        false,
-                    );
-                    return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
-                }
-            };
+        let root_request_id = resolve_descendant_root_request_id(
+            DescendantGraphAccess::Local(&self.node),
+            &request_id,
+        )
+        .await?;
+        let Some(canonical) = resolve_descendant_edge(
+            DescendantGraphAccess::Local(&self.node),
+            &root_request_id,
+            child_request_id,
+        )
+        .await?
+        else {
+            let result = service_unavailable_payload(
+                WAIT_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                "child subagent request is not available to this parent request",
+                false,
+            );
+            return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
+        };
+        if !canonical.readable() {
+            let result = service_unavailable_payload(
+                WAIT_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                canonical.diagnostic.clone().unwrap_or_else(|| {
+                    format!("child request {child_request_id} is not materialized")
+                }),
+                canonical.retryable(),
+            );
+            return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
+        }
+        if !canonical.controllable() {
+            let result = tool_not_allowed_payload(
+                WAIT_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                child_request_id,
+                "descendant is visible but control belongs to its immediate parent",
+                Vec::new(),
+            );
+            return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
+        }
+        let edge = ChildEdge::from_descendant(&canonical).ok_or_else(|| {
+            anyhow::anyhow!("authorized descendant edge lacks materialized child identity")
+        })?;
+        let parent_context =
+            load_parent_subagent_context(&self.node, &edge.parent_request_id).await?;
 
         if edge.lifecycle_state == "running" {
             if edge.await_mode == AwaitMode::Background {
@@ -397,37 +406,50 @@ impl DefraSessionHook {
             ));
         }
 
-        let parent_context = load_parent_subagent_context(&self.node, &request_id).await?;
-        let edge =
-            match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
-                Ok(edge) => edge,
-                Err(error) => {
-                    if authorization_lookup_error(&error, &request_id, child_request_id) {
-                        if let Ok(Some(bridge)) =
-                            load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
-                        {
-                            let (message, retryable) =
-                                bridge.unmaterialized_child_explanation(child_request_id);
-                            let result = service_unavailable_payload(
-                                CANCEL_SUBAGENT_TOOL_NAME,
-                                "/child_request_id",
-                                message,
-                                retryable,
-                            );
-                            return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
-                        }
-                    }
-                    let result = service_unavailable_payload(
-                        CANCEL_SUBAGENT_TOOL_NAME,
-                        "/child_request_id",
-                        format!(
-                        "child subagent request is not available to this parent request: {error}"
-                    ),
-                        false,
-                    );
-                    return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
-                }
-            };
+        let root_request_id = resolve_descendant_root_request_id(
+            DescendantGraphAccess::Local(&self.node),
+            &request_id,
+        )
+        .await?;
+        let Some(canonical) = resolve_descendant_edge(
+            DescendantGraphAccess::Local(&self.node),
+            &root_request_id,
+            child_request_id,
+        )
+        .await?
+        else {
+            let result = service_unavailable_payload(
+                CANCEL_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                "child subagent request is not available to this parent request",
+                false,
+            );
+            return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
+        };
+        if !canonical.readable() {
+            let result = service_unavailable_payload(
+                CANCEL_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                canonical.diagnostic.clone().unwrap_or_else(|| {
+                    format!("child request {child_request_id} is not materialized")
+                }),
+                canonical.retryable(),
+            );
+            return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
+        }
+        if !canonical.controllable() {
+            let result = tool_not_allowed_payload(
+                CANCEL_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                child_request_id,
+                "descendant is visible but control belongs to its immediate parent",
+                Vec::new(),
+            );
+            return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
+        }
+        let edge = ChildEdge::from_descendant(&canonical).ok_or_else(|| {
+            anyhow::anyhow!("authorized descendant edge lacks materialized child identity")
+        })?;
 
         let reason = parsed
             .reason
@@ -444,7 +466,7 @@ impl DefraSessionHook {
         )
         .await?;
         self.cancel_running_subagent_bridge(
-            &parent_context.session_id,
+            &edge.parent_session_id,
             &edge.parent_tool_call_id,
             "root",
             CancelCause::UserCancelled,

--- a/crates/gents/src/lean_vocab_test/descendant_graph.rs
+++ b/crates/gents/src/lean_vocab_test/descendant_graph.rs
@@ -16,4 +16,5 @@ pub(crate) struct LeanDescendantGraphCase {
     pub(crate) retryable: bool,
     pub(crate) listed_by_default: bool,
     pub(crate) controllable: bool,
+    pub(crate) cursor_anchor_survives_terminal: bool,
 }

--- a/crates/gents/src/lean_vocab_test/descendant_graph.rs
+++ b/crates/gents/src/lean_vocab_test/descendant_graph.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanDescendantGraphCase {
+    pub(crate) name: String,
+    pub(crate) root_request_id: usize,
+    pub(crate) parent_request_id: usize,
+    pub(crate) child_request_id: usize,
+    pub(crate) await_mode: String,
+    pub(crate) materialization: String,
+    pub(crate) lifecycle: String,
+    pub(crate) workflow_role: String,
+    pub(crate) direct: bool,
+    pub(crate) visible: bool,
+    pub(crate) readable: bool,
+    pub(crate) retryable: bool,
+    pub(crate) listed_by_default: bool,
+    pub(crate) controllable: bool,
+}

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -128,6 +128,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) codex_shim_binding_cases: Vec<LeanCodexShimBindingCase>,
     pub(crate) r6_backgrounding_cases: Vec<LeanR6BackgroundingCase>,
     #[serde(default)]
+    pub(crate) descendant_graph_cases: Vec<LeanDescendantGraphCase>,
+    #[serde(default)]
     pub(crate) r5_cross_deployment_cases: Vec<LeanR5CrossDeploymentCase>,
     #[serde(default)]
     pub(crate) composed_invariant_witnesses: Vec<LeanComposedInvariantWitness>,
@@ -377,6 +379,8 @@ mod codex_shim;
 mod command_identity_queue;
 #[path = "composed_invariants.rs"]
 mod composed_invariants;
+#[path = "descendant_graph.rs"]
+mod descendant_graph;
 #[path = "durable_reduction.rs"]
 mod durable_reduction;
 #[path = "event_delivery.rs"]
@@ -399,6 +403,7 @@ pub(crate) use client_session::*;
 pub(crate) use codex_shim::*;
 pub(crate) use command_identity_queue::*;
 pub(crate) use composed_invariants::*;
+pub(crate) use descendant_graph::*;
 pub(crate) use durable_reduction::*;
 pub(crate) use event_delivery::*;
 pub(crate) use prompt_assembly::*;
@@ -763,6 +768,10 @@ pub(crate) fn lean_codex_shim_binding_cases() -> &'static [LeanCodexShimBindingC
 
 pub(crate) fn lean_r6_backgrounding_cases() -> &'static [LeanR6BackgroundingCase] {
     &lean_contract_snapshot().r6_backgrounding_cases
+}
+
+pub(crate) fn lean_descendant_graph_cases() -> &'static [LeanDescendantGraphCase] {
+    &lean_contract_snapshot().descendant_graph_cases
 }
 
 pub(crate) fn lean_r6_backgrounding_case(name: &str) -> &'static LeanR6BackgroundingCase {

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -23,6 +23,7 @@ pub mod config;
 pub mod config_client;
 pub mod defra_query;
 pub mod defra_write;
+pub mod descendant_graph;
 pub mod desired_fields;
 pub mod document_config;
 pub mod error;
@@ -144,7 +145,14 @@ pub use config::{
     DEFAULT_MAX_TURNS, DEFAULT_MODEL_NAME, DEFAULT_STREAM_BATCH_MS,
     DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS,
 };
+pub use config_client::ConfigAccess;
 pub use defra_node;
+pub use descendant_graph::{
+    resolve_descendant_edge, resolve_descendant_graph, resolve_descendant_root_request_id,
+    DescendantAuthorizationState, DescendantControlAuthority, DescendantEdge,
+    DescendantGraphAccess, DescendantMaterializationState, DescendantPage, DescendantQuery,
+    DescendantScope, MAX_DESCENDANT_PAGE_LIMIT,
+};
 pub use desired_fields::{DesiredFields, LiveFields};
 pub use document_config::{
     default_behavior_id_for_agent, default_inference_profile_id_for_behavior,

--- a/crates/gents/src/lifecycle/queue/tests/background_completion.rs
+++ b/crates/gents/src/lifecycle/queue/tests/background_completion.rs
@@ -10,6 +10,47 @@ fn root_parent(session_id: &str) -> AgentRequest {
     parent
 }
 
+async fn persist_completed_root_parent(node: &EmbeddedNode, parent: &mut AgentRequest) {
+    let request_id = escape_graphql_string(&parent.request_id);
+    let session_id = escape_graphql_string(&parent.session_id);
+    let created_at = escape_graphql_string(&parent.created_at);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{TEST_AGENT_DID}",
+                behavior_id: "{TEST_BEHAVIOR_ID}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "completed parent",
+                metadata: "",
+                status: "completed",
+                lifecycle_state: "completed",
+                backend_id: "",
+                execution_origin: "interactive",
+                failure_reason: "",
+                created_at: "{created_at}",
+                retry_count: 0,
+                max_retries: {max_retries},
+                subagent_depth: 0
+            }}) {{ _docID }}
+        }}"#,
+        max_retries = DEFAULT_REQUEST_MAX_RETRIES,
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "persist completed root parent: {:?}",
+        response.errors
+    );
+    parent.doc_id = lookup_request_doc_id_optional(node, &parent.request_id)
+        .await
+        .unwrap()
+        .expect("persisted root parent document id");
+}
+
 fn background_hints(parent: &AgentRequest) -> QueueHints {
     QueueHints {
         source: QueueSource::BackgroundCompletion,
@@ -398,7 +439,8 @@ async fn persisted_response_repair_makes_acknowledgement_restart_atomic() {
 async fn successor_acknowledges_input_left_by_a_failed_active_wake() {
     let TestDb { node, _tempdir } = test_db("background-successor-ack").await;
     let node = std::sync::Arc::new(node);
-    let parent = root_parent("background-successor-ack-session");
+    let mut parent = root_parent("background-successor-ack-session");
+    persist_completed_root_parent(node.as_ref(), &mut parent).await;
     let hints = background_hints(&parent);
     let first = enqueue_background_completion_with_message(
         node.as_ref(),

--- a/crates/gents/src/lifecycle/queue/tests/background_completion.rs
+++ b/crates/gents/src/lifecycle/queue/tests/background_completion.rs
@@ -10,47 +10,6 @@ fn root_parent(session_id: &str) -> AgentRequest {
     parent
 }
 
-async fn persist_completed_root_parent(node: &EmbeddedNode, parent: &mut AgentRequest) {
-    let request_id = escape_graphql_string(&parent.request_id);
-    let session_id = escape_graphql_string(&parent.session_id);
-    let created_at = escape_graphql_string(&parent.created_at);
-    let mutation = format!(
-        r#"mutation {{
-            create_AgentRequest(input: {{
-                request_id: "{request_id}",
-                agent_did: "{TEST_AGENT_DID}",
-                behavior_id: "{TEST_BEHAVIOR_ID}",
-                session_id: "{session_id}",
-                retry_parent_request: "",
-                retry_root_request: "{request_id}",
-                superseded_by_request: "",
-                content: "completed parent",
-                metadata: "",
-                status: "completed",
-                lifecycle_state: "completed",
-                backend_id: "",
-                execution_origin: "interactive",
-                failure_reason: "",
-                created_at: "{created_at}",
-                retry_count: 0,
-                max_retries: {max_retries},
-                subagent_depth: 0
-            }}) {{ _docID }}
-        }}"#,
-        max_retries = DEFAULT_REQUEST_MAX_RETRIES,
-    );
-    let response = node.execute(&mutation).await;
-    assert!(
-        !response.has_errors(),
-        "persist completed root parent: {:?}",
-        response.errors
-    );
-    parent.doc_id = lookup_request_doc_id_optional(node, &parent.request_id)
-        .await
-        .unwrap()
-        .expect("persisted root parent document id");
-}
-
 fn background_hints(parent: &AgentRequest) -> QueueHints {
     QueueHints {
         source: QueueSource::BackgroundCompletion,
@@ -439,8 +398,7 @@ async fn persisted_response_repair_makes_acknowledgement_restart_atomic() {
 async fn successor_acknowledges_input_left_by_a_failed_active_wake() {
     let TestDb { node, _tempdir } = test_db("background-successor-ack").await;
     let node = std::sync::Arc::new(node);
-    let mut parent = root_parent("background-successor-ack-session");
-    persist_completed_root_parent(node.as_ref(), &mut parent).await;
+    let parent = root_parent("background-successor-ack-session");
     let hints = background_hints(&parent);
     let first = enqueue_background_completion_with_message(
         node.as_ref(),
@@ -528,4 +486,9 @@ async fn successor_acknowledges_input_left_by_a_failed_active_wake() {
         .unwrap();
     assert_eq!(timeline.background_completions.len(), 2);
     assert!(timeline.background_completion_diagnostics_error.is_none());
+    assert!(timeline.descendant_edges.is_empty());
+    assert!(timeline
+        .descendant_graph_diagnostics_error
+        .as_deref()
+        .is_some_and(|error| error.contains("points to missing parent")));
 }

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -52,6 +52,8 @@ pub struct RunTimeline {
     pub child_request_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub descendant_edges: Vec<crate::DescendantEdge>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub descendant_graph_diagnostics_error: Option<String>,
     #[serde(default)]
     pub inference_calls: Vec<TimelineInferenceCallRow>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -916,6 +918,7 @@ pub fn build_run_timeline(mut rows: RunTimelineRows) -> RunTimeline {
         conversation: rows.conversation,
         child_request_ids,
         descendant_edges: Vec::new(),
+        descendant_graph_diagnostics_error: None,
         inference_calls,
         rendered_request_refs: rows.rendered_request_refs,
         background_completions: Vec::new(),

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -50,6 +50,8 @@ pub struct RunTimeline {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conversation: Option<TimelineConversationRow>,
     pub child_request_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub descendant_edges: Vec<crate::DescendantEdge>,
     #[serde(default)]
     pub inference_calls: Vec<TimelineInferenceCallRow>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -913,6 +915,7 @@ pub fn build_run_timeline(mut rows: RunTimelineRows) -> RunTimeline {
         session: rows.session,
         conversation: rows.conversation,
         child_request_ids,
+        descendant_edges: Vec::new(),
         inference_calls,
         rendered_request_refs: rows.rendered_request_refs,
         background_completions: Vec::new(),

--- a/crates/gents/src/run_timeline_fetch.rs
+++ b/crates/gents/src/run_timeline_fetch.rs
@@ -25,25 +25,11 @@ use gents_protocol::graphql::graphql_rows_from_response;
 
 pub async fn load_run_timeline(access: &ConfigAccess, request_id: &str) -> Result<RunTimeline> {
     let mut timeline = build_run_timeline(load_run_timeline_rows(access, request_id).await?);
-    let descendant_root =
-        resolve_descendant_root_request_id(DescendantGraphAccess::Config(access), request_id)
-            .await?;
-    let mut after = None;
-    loop {
-        let page = resolve_descendant_graph(
-            DescendantGraphAccess::Config(access),
-            &DescendantQuery {
-                after: after.clone(),
-                limit: MAX_DESCENDANT_PAGE_LIMIT,
-                ..DescendantQuery::all(&descendant_root)
-            },
-        )
-        .await?;
-        timeline.descendant_edges.extend(page.edges);
-        if !page.has_more {
-            break;
+    match load_timeline_descendant_edges(access, request_id).await {
+        Ok(edges) => timeline.descendant_edges = edges,
+        Err(error) => {
+            timeline.descendant_graph_diagnostics_error = Some(error.to_string());
         }
-        after = page.next_cursor;
     }
     if let Some(agent_did) = timeline.agent_did.as_deref() {
         match crate::load_background_completion_diagnostics(access, agent_did).await {
@@ -67,6 +53,34 @@ pub async fn load_run_timeline(access: &ConfigAccess, request_id: &str) -> Resul
         }
     }
     Ok(timeline)
+}
+
+async fn load_timeline_descendant_edges(
+    access: &ConfigAccess,
+    request_id: &str,
+) -> Result<Vec<crate::DescendantEdge>> {
+    let descendant_root =
+        resolve_descendant_root_request_id(DescendantGraphAccess::Config(access), request_id)
+            .await?;
+    let mut after = None;
+    let mut edges = Vec::new();
+    loop {
+        let page = resolve_descendant_graph(
+            DescendantGraphAccess::Config(access),
+            &DescendantQuery {
+                after: after.clone(),
+                limit: MAX_DESCENDANT_PAGE_LIMIT,
+                ..DescendantQuery::all(&descendant_root)
+            },
+        )
+        .await?;
+        edges.extend(page.edges);
+        if !page.has_more {
+            break;
+        }
+        after = page.next_cursor;
+    }
+    Ok(edges)
 }
 
 pub async fn load_run_timeline_rows(

--- a/crates/gents/src/run_timeline_fetch.rs
+++ b/crates/gents/src/run_timeline_fetch.rs
@@ -10,6 +10,10 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::config_client::ConfigAccess;
+use crate::descendant_graph::{
+    resolve_descendant_graph, resolve_descendant_root_request_id, DescendantGraphAccess,
+    DescendantQuery, MAX_DESCENDANT_PAGE_LIMIT,
+};
 use crate::graphql::escape_graphql_string;
 use crate::run_timeline::{
     build_run_timeline, RunTimeline, RunTimelineRows, TimelineCompactionRow,
@@ -21,6 +25,26 @@ use gents_protocol::graphql::graphql_rows_from_response;
 
 pub async fn load_run_timeline(access: &ConfigAccess, request_id: &str) -> Result<RunTimeline> {
     let mut timeline = build_run_timeline(load_run_timeline_rows(access, request_id).await?);
+    let descendant_root =
+        resolve_descendant_root_request_id(DescendantGraphAccess::Config(access), request_id)
+            .await?;
+    let mut after = None;
+    loop {
+        let page = resolve_descendant_graph(
+            DescendantGraphAccess::Config(access),
+            &DescendantQuery {
+                after: after.clone(),
+                limit: MAX_DESCENDANT_PAGE_LIMIT,
+                ..DescendantQuery::all(&descendant_root)
+            },
+        )
+        .await?;
+        timeline.descendant_edges.extend(page.edges);
+        if !page.has_more {
+            break;
+        }
+        after = page.next_cursor;
+    }
     if let Some(agent_did) = timeline.agent_did.as_deref() {
         match crate::load_background_completion_diagnostics(access, agent_did).await {
             Ok(diagnostics) => {

--- a/crates/gents/src/toolset/subagent.rs
+++ b/crates/gents/src/toolset/subagent.rs
@@ -286,10 +286,9 @@ impl Tool for ListSubagentsTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "List this parent request's visible background child subagents. \
-A background child spawned by this request stays listed even before its child request \
-materializes: such an entry has status `awaiting_child_materialization` (matched by the \
-`running` and `all` filters) and a `diagnostic` explaining the bridge state."
+            description: "List the canonical descendant graph owned by this parent lineage. \
+Foreground, background, workflow, cross-behavior, and pending remote children use the same edge \
+shape. Use `scope=all_descendants` for nested children or `scope=workflow_group` with a group id."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -306,6 +305,20 @@ materializes: such an entry has status `awaiting_child_materialization` (matched
                         "maximum": 50,
                         "default": 20,
                         "description": "Maximum entries to return."
+                    },
+                    "scope": {
+                        "type": "string",
+                        "enum": ["direct_children", "all_descendants", "workflow_group"],
+                        "default": "direct_children",
+                        "description": "Graph scope to enumerate."
+                    },
+                    "workflow_group_id": {
+                        "type": "string",
+                        "description": "Required when scope is workflow_group."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Opaque cursor returned as next_cursor by a previous page."
                     }
                 }
             }),
@@ -329,7 +342,7 @@ impl Tool for ReadSubagentTool {
         ToolDefinition {
             name: Self::NAME.to_string(),
             description:
-                "Read an incremental transcript slice from a visible background subagent. \
+                "Read an incremental transcript slice from any visible canonical descendant. \
 Paging is cursor-based and content-honest: pass `since_sequence` to resume, and the response \
 returns `next_sequence` (the exact cursor to pass next), `has_more` (true when the token budget \
 capped the read and more messages remain past `next_sequence`), and `terminal`/`lifecycle_state` \

--- a/crates/gents/tests/conformance.rs
+++ b/crates/gents/tests/conformance.rs
@@ -51,7 +51,7 @@ use lean_vocab_test::{
     lean_codex_shim_thread_status_cases, lean_codex_shim_tool_metadata_cases,
     lean_codex_shim_turn_lifecycle_cases, lean_command_env_case, lean_command_policy_case,
     lean_command_sandbox_case, lean_compaction_reducer_cases, lean_composed_invariant_witnesses,
-    lean_contract_snapshot, lean_event_delivery_convergence_traces,
+    lean_contract_snapshot, lean_descendant_graph_cases, lean_event_delivery_convergence_traces,
     lean_event_delivery_source_instances, lean_event_delivery_transition_cases,
     lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case,
     lean_inference_slot_accounting_cases, lean_managed_exec_liveness_cases,

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -1012,6 +1012,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "SubagentDelegationGraphCases".to_string(),
         ));
     }
+    if !lean_descendant_graph_cases().is_empty() {
+        emitted.insert((
+            "descendant_graph_cases".to_string(),
+            "DescendantGraphCases".to_string(),
+        ));
+    }
     if !lean_goal_decision_cases().is_empty() {
         emitted.insert((
             "goal_decision_cases".to_string(),
@@ -1097,6 +1103,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "cancel_propagation_cases",
         "r6_background_theorem_witnesses",
         "subagent_delegation_graph_cases",
+        "descendant_graph_cases",
         "goal_decision_cases",
         "goal_transition_cases",
         "follow_up_hook",

--- a/crates/gents/tests/conformance/structure.rs
+++ b/crates/gents/tests/conformance/structure.rs
@@ -32,6 +32,7 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
             Module("conformance/composed_invariants.rs"),
         ),
         ("DurableLineage", Module("conformance/background.rs")),
+        ("DescendantGraph", Module("descendant_graph.rs")),
         ("EditMatch", Module("conformance/edit_match.rs")),
         ("EventDelivery", Module("conformance/event_delivery.rs")),
         ("Fleet", Module("conformance/fleet.rs")),

--- a/crates/gents/tests/descendant_graph.rs
+++ b/crates/gents/tests/descendant_graph.rs
@@ -327,3 +327,93 @@ async fn canonical_graph_preserves_pending_remote_terminal_nested_and_paging_edg
     .unwrap();
     assert_eq!(second.edges[0].child_request_id, "request-reviewer");
 }
+
+#[tokio::test]
+async fn running_page_cursor_survives_anchor_becoming_terminal() {
+    let db = support::test_db("descendant-running-cursor-terminal-transition").await;
+    let root_id = "cursor-root";
+    let root_session = "cursor-root-session";
+    let root_did = "did:test:cursor-root";
+    let root_doc =
+        create_request(db.node.as_ref(), root_id, root_session, root_did, "default").await;
+    let deadline = Utc::now() + Duration::minutes(5);
+
+    let mut first = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        root_id.to_string(),
+        root_session.to_string(),
+        root_did.to_string(),
+        "cursor-call-a".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        r#"{"name":"worker-a","behavior_id":"worker-a"}"#.to_string(),
+        deadline,
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        "cursor-child-a".to_string(),
+        root_did.to_string(),
+    )
+    .with_request_doc_id(Some(root_doc.clone()));
+    first.start_running().await.unwrap();
+
+    let mut second = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        root_id.to_string(),
+        root_session.to_string(),
+        root_did.to_string(),
+        "cursor-call-b".to_string(),
+        2,
+        "spawn_subagent".to_string(),
+        r#"{"name":"worker-b","behavior_id":"worker-b"}"#.to_string(),
+        deadline,
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        "cursor-child-b".to_string(),
+        root_did.to_string(),
+    )
+    .with_request_doc_id(Some(root_doc));
+    second.start_running().await.unwrap();
+
+    let first_page = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery {
+            limit: 1,
+            include_terminal: false,
+            ..DescendantQuery::direct(root_id)
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(first_page.edges.len(), 1);
+    assert!(first_page.has_more);
+    let anchor_child = first_page.edges[0].child_request_id.clone();
+    let after = first_page.next_cursor.expect("running page cursor");
+
+    let terminalized = match anchor_child.as_str() {
+        "cursor-child-a" => first
+            .bridge_complete("worker a complete".to_string())
+            .await
+            .unwrap(),
+        "cursor-child-b" => second
+            .bridge_complete("worker b complete".to_string())
+            .await
+            .unwrap(),
+        other => panic!("unexpected cursor anchor {other}"),
+    };
+    assert!(terminalized);
+
+    let second_page = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery {
+            after: Some(after),
+            limit: 1,
+            include_terminal: false,
+            ..DescendantQuery::direct(root_id)
+        },
+    )
+    .await
+    .expect("terminal transition must not invalidate the stable cursor anchor");
+    assert_eq!(second_page.edges.len(), 1);
+    assert_ne!(second_page.edges[0].child_request_id, anchor_child);
+    assert!(!second_page.has_more);
+}

--- a/crates/gents/tests/descendant_graph.rs
+++ b/crates/gents/tests/descendant_graph.rs
@@ -1,0 +1,329 @@
+mod support;
+
+use chrono::{Duration, Utc};
+use gents::graphql::escape_graphql_string;
+use gents::tool_call_lifecycle::{
+    create_subagent_request_with_request_id,
+    create_subagent_request_with_trusted_parent_request_id, AwaitMode, CancelPolicy,
+    ToolCallLifecycle,
+};
+use gents::{
+    resolve_descendant_edge, resolve_descendant_graph, DescendantControlAuthority,
+    DescendantGraphAccess, DescendantMaterializationState, DescendantQuery, DescendantScope,
+};
+
+async fn create_request(
+    node: &gents::defra_node::EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+) -> String {
+    let request_id = escape_graphql_string(request_id);
+    let session_id = escape_graphql_string(session_id);
+    let agent_did = escape_graphql_string(agent_did);
+    let behavior_id = escape_graphql_string(behavior_id);
+    let now = Utc::now().to_rfc3339();
+    let response = node
+        .execute(&format!(
+            r#"mutation {{
+                create_AgentRequest(input: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    session_id: "{session_id}",
+                    retry_parent_request: "",
+                    retry_root_request: "{request_id}",
+                    superseded_by_request: "",
+                    content: "descendant graph root",
+                    status: "processing",
+                    lifecycle_state: "processing",
+                    backend_id: "",
+                    execution_origin: "interactive",
+                    metadata: "",
+                    failure_reason: "",
+                    created_at: "{now}",
+                    retry_count: 0,
+                    max_retries: 3,
+                    subagent_depth: 0
+                }}) {{ _docID }}
+            }}"#
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    support::exact_request_doc_id(node, &request_id).await
+}
+
+async fn create_nested_bridge(
+    node: &gents::defra_node::EmbeddedNode,
+    parent_request_doc_id: &str,
+    parent_session_id: &str,
+    requester_did: &str,
+) -> String {
+    let args = escape_graphql_string(
+        r#"{"name":"reviewer","behavior_id":"reviewer","workflow_task_id":"review"}"#,
+    );
+    let now = Utc::now().to_rfc3339();
+    let deadline = (Utc::now() + Duration::minutes(5)).to_rfc3339();
+    let response = node
+        .execute(&format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "{parent_session_id}:call-reviewer",
+                    request_id: "request-worker",
+                    request_doc_id: "{parent_request_doc_id}",
+                    session_id: "{parent_session_id}",
+                    agent_did: "did:test:worker-host",
+                    requester_did: "{requester_did}",
+                    message_sequence: 1,
+                    tool_name: "spawn_subagent",
+                    tool_call_id: "call-reviewer",
+                    args: "{args}",
+                    result: "",
+                    status: "called",
+                    lifecycle_state: "running",
+                    started_at: "{now}",
+                    deadline_at: "{deadline}",
+                    child_request_id: "request-reviewer",
+                    spawn_target_did: "did:test:worker-host",
+                    await_mode: "foreground",
+                    cancel_policy: "cascade",
+                    workflow_group_id: "workflow-1",
+                    workflow_role: "reviewer",
+                    selected_service_id: null,
+                    selected_tool_name: null,
+                    tool_failure_class: null,
+                    latency_ms: null
+                }}) {{ _docID }}
+            }}"#,
+            parent_request_doc_id = escape_graphql_string(parent_request_doc_id),
+            parent_session_id = escape_graphql_string(parent_session_id),
+            requester_did = escape_graphql_string(requester_did),
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let response = node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "call-reviewer" } }, limit: 1) { _docID } }"#,
+        )
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    response.data.expect("bridge query data")["AgentToolCall"][0]["_docID"]
+        .as_str()
+        .expect("reviewer bridge doc")
+        .to_string()
+}
+
+#[tokio::test]
+async fn canonical_graph_preserves_pending_remote_terminal_nested_and_paging_edges() {
+    let db = support::test_db("canonical-descendant-graph").await;
+    let root_id = "graph-root";
+    let root_session = "graph-root-session";
+    let root_did = "did:test:coordinator";
+    let root_doc =
+        create_request(db.node.as_ref(), root_id, root_session, root_did, "default").await;
+
+    let deadline = Utc::now() + Duration::minutes(5);
+    let mut worker_bridge = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        root_id.to_string(),
+        root_session.to_string(),
+        root_did.to_string(),
+        "call-worker".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        r#"{"name":"fast-worker","behavior_id":"fast-worker"}"#.to_string(),
+        deadline,
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        "request-worker".to_string(),
+        "did:test:worker-host".to_string(),
+    )
+    .with_request_doc_id(Some(root_doc.clone()));
+    worker_bridge.start_running().await.unwrap();
+    let worker_bridge_doc = worker_bridge.doc_id().unwrap().to_string();
+
+    let pending = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery::direct(root_id),
+    )
+    .await
+    .unwrap();
+    assert_eq!(pending.edges.len(), 1);
+    assert_eq!(
+        pending.edges[0].materialization_state,
+        DescendantMaterializationState::AwaitingChild
+    );
+    assert_eq!(pending.edges[0].child_request_id, "request-worker");
+    let pending_exact = resolve_descendant_edge(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        root_id,
+        "request-worker",
+    )
+    .await
+    .unwrap()
+    .expect("pending exact edge");
+    assert_eq!(pending_exact.depth, 1);
+    assert!(!pending_exact.readable());
+    assert!(pending_exact.retryable());
+    let pending_cursor = pending.edges[0].cursor.clone();
+
+    create_subagent_request_with_trusted_parent_request_id(
+        db.node.as_ref(),
+        "request-worker".to_string(),
+        root_id.to_string(),
+        root_doc.clone(),
+        "call-worker".to_string(),
+        worker_bridge_doc.clone(),
+        0,
+        "did:test:worker-host".to_string(),
+        "fast-worker".to_string(),
+        "work".to_string(),
+        Some(deadline),
+        root_did.to_string(),
+    )
+    .await
+    .unwrap();
+    let worker_doc = support::exact_request_doc_id(db.node.as_ref(), "request-worker").await;
+
+    let materialized = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery::direct(root_id),
+    )
+    .await
+    .unwrap();
+    assert_eq!(materialized.edges[0].cursor, pending_cursor);
+    assert!(materialized.edges[0].readable());
+    assert_eq!(
+        materialized.edges[0].behavior_id.as_deref(),
+        Some("fast-worker")
+    );
+    assert_eq!(
+        materialized.edges[0].materialization_state,
+        DescendantMaterializationState::MaterializedRemote
+    );
+
+    let worker_session = materialized.edges[0]
+        .child_session_id
+        .clone()
+        .expect("worker session");
+    let reviewer_bridge_doc =
+        create_nested_bridge(db.node.as_ref(), &worker_doc, &worker_session, root_did).await;
+    create_subagent_request_with_request_id(
+        db.node.as_ref(),
+        "request-reviewer".to_string(),
+        "request-worker".to_string(),
+        worker_doc,
+        "call-reviewer".to_string(),
+        reviewer_bridge_doc,
+        1,
+        "did:test:worker-host".to_string(),
+        "reviewer".to_string(),
+        "review".to_string(),
+        Some(deadline),
+    )
+    .await
+    .unwrap();
+
+    worker_bridge
+        .bridge_complete("durable worker result".to_string())
+        .await
+        .unwrap();
+
+    let all = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery::all(root_id),
+    )
+    .await
+    .unwrap();
+    assert_eq!(all.edges.len(), 2);
+    assert!(all.edges[0].terminal_result_ref.is_some());
+    assert_eq!(all.edges[1].depth, 2);
+    assert_eq!(
+        all.edges[1].control_authority,
+        DescendantControlAuthority::VisibilityOnly
+    );
+    assert_eq!(all.edges[1].workflow_role.as_deref(), Some("reviewer"));
+
+    let direct_exact = resolve_descendant_edge(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        root_id,
+        "request-worker",
+    )
+    .await
+    .unwrap()
+    .expect("direct exact edge");
+    assert_eq!(direct_exact.depth, 1);
+    assert!(direct_exact.readable());
+    let nested_exact = resolve_descendant_edge(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        root_id,
+        "request-reviewer",
+    )
+    .await
+    .unwrap()
+    .expect("nested exact edge");
+    assert_eq!(nested_exact.depth, 2);
+    assert!(nested_exact.readable());
+    assert_eq!(
+        nested_exact.control_authority,
+        DescendantControlAuthority::VisibilityOnly
+    );
+    assert!(resolve_descendant_edge(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        root_id,
+        "unrelated-child",
+    )
+    .await
+    .unwrap()
+    .is_none());
+    assert!(
+        resolve_descendant_edge(
+            DescendantGraphAccess::Local(db.node.as_ref()),
+            "request-reviewer",
+            "request-worker",
+        )
+        .await
+        .unwrap()
+        .is_none(),
+        "a descendant root cannot enumerate an ancestor edge"
+    );
+
+    let workflow = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery {
+            root_request_id: root_id.to_string(),
+            scope: DescendantScope::WorkflowGroup,
+            workflow_group_id: Some("workflow-1".to_string()),
+            after: None,
+            limit: 20,
+            include_terminal: true,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(workflow.edges.len(), 1);
+    assert_eq!(workflow.edges[0].child_request_id, "request-reviewer");
+
+    let first = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery {
+            limit: 1,
+            ..DescendantQuery::all(root_id)
+        },
+    )
+    .await
+    .unwrap();
+    assert!(first.has_more);
+    let second = resolve_descendant_graph(
+        DescendantGraphAccess::Local(db.node.as_ref()),
+        &DescendantQuery {
+            after: first.next_cursor,
+            limit: 1,
+            ..DescendantQuery::all(root_id)
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(second.edges[0].child_request_id, "request-reviewer");
+}

--- a/crates/gents/tests/e2e_live/subagent_delegation_live.rs
+++ b/crates/gents/tests/e2e_live/subagent_delegation_live.rs
@@ -30,9 +30,12 @@
 //!
 //! ## Cross-node delegation (Test 3)
 //!
-//! `live_cross_node_subagent_delegation` exercises orchestrator-on-A delegating
-//! to a behavior hosted on B over REAL in-process P2P replication installed by
-//! declarative `PeerPairingDesired` rows — no test "pump".
+//! `live_cross_node_subagent_delegation` exercises default-on-A delegating to
+//! fast-worker-on-B, which delegates again to reviewer-on-B, over REAL
+//! in-process P2P replication installed by declarative `PeerPairingDesired`
+//! rows — no test "pump". It then restarts both runtimes so the pairing
+//! reconcilers reconnect and proves the canonical graph converges without
+//! duplicate edges.
 //!
 //! Subagent targets are named `(agent_did, behavior_id)` pairs. The orchestrator
 //! on A writes a targeted bridge; B's SubagentSource materializes the child
@@ -52,8 +55,10 @@ use gents::graphql::escape_graphql_string;
 use gents::{
     agent::p2p_reconcile::resolve_template, default_behavior_id_for_agent,
     default_inference_profile_id_for_behavior, ensure_agent_principal, load_agent_behavior,
-    upsert_agent_behavior, upsert_tool_selection, AgentBehaviorDocument, AgentIdentity,
-    DocumentRuntimeOptions, Gents, SubagentTarget, ToolCeiling, ToolSelectionDocument,
+    resolve_descendant_graph, upsert_agent_behavior, upsert_tool_selection, AgentBehaviorDocument,
+    AgentIdentity, DescendantGraphAccess, DescendantMaterializationState, DescendantPage,
+    DescendantQuery, DocumentRuntimeOptions, Gents, SubagentTarget, ToolCeiling,
+    ToolSelectionDocument,
 };
 use serde::Deserialize;
 
@@ -66,9 +71,13 @@ const DEFAULT_LIVE_MODEL: &str = "d4f";
 const DEFAULT_BACKGROUNDING_MODEL: &str = "GLM-5.2";
 const LIVE_BACKEND_ID: &str = "backend-live-subagent";
 const RESEARCHER_BEHAVIOR_ID: &str = "live-researcher";
+const FAST_WORKER_BEHAVIOR_ID: &str = "live-fast-worker";
+const REVIEWER_BEHAVIOR_ID: &str = "live-reviewer";
 const BACKGROUND_WORKER_BEHAVIOR_ID: &str = "live-background-worker";
 /// Friendly, model-facing subagent target name (the model never sees behavior ids).
 const RESEARCHER_TARGET_NAME: &str = "researcher";
+const FAST_WORKER_TARGET_NAME: &str = "fast-worker";
+const REVIEWER_TARGET_NAME: &str = "reviewer";
 const BACKGROUND_WORKER_TARGET_NAME: &str = "background-worker";
 
 fn live_enabled() -> bool {
@@ -904,7 +913,7 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
     let did_b = identity_b.did().to_string();
     let orchestrator_behavior_id = default_behavior_id_for_agent(&did_a);
 
-    // --- Node B: host the researcher behavior owned by DID-B. ---
+    // --- Node B: host the fast-worker and reviewer behaviors owned by DID-B. ---
     ensure_agent_principal(db_b.node.as_ref(), &did_b)
         .await
         .expect("ensure principal B");
@@ -913,12 +922,37 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
     upsert_live_backend(db_b.node.as_ref(), &endpoint, &model).await;
     configure_behavior(
         db_b.node.as_ref(),
-        RESEARCHER_BEHAVIOR_ID,
+        FAST_WORKER_BEHAVIOR_ID,
         &did_b,
         &model,
         &profile_b,
-        "You answer the user's question concisely and factually in one short sentence.",
-        Some("Researches factual questions and returns a concise factual answer."),
+        CROSS_NODE_FAST_WORKER_SYSTEM_PROMPT,
+        Some("Delegates its draft to the reviewer before returning it."),
+    )
+    .await;
+    configure_behavior(
+        db_b.node.as_ref(),
+        REVIEWER_BEHAVIOR_ID,
+        &did_b,
+        &model,
+        &profile_b,
+        "When asked to review the capital of France, reply exactly REVIEWER_OK: Paris is the capital of France.",
+        Some("Reviews the fast worker's factual answer."),
+    )
+    .await;
+    authorize_subagents(
+        db_b.node.as_ref(),
+        &did_b,
+        FAST_WORKER_BEHAVIOR_ID,
+        vec![SubagentTarget {
+            name: REVIEWER_TARGET_NAME.to_string(),
+            agent_did: did_b.clone(),
+            behavior_id: REVIEWER_BEHAVIOR_ID.to_string(),
+            description: Some("Reviews the fast worker's answer.".to_string()),
+        }],
+        /* spawn */ true,
+        /* background */ true,
+        /* allow_cross_deployment */ false,
     )
     .await;
 
@@ -934,7 +968,7 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
         &did_a,
         &model,
         &profile_a,
-        CROSS_NODE_ORCHESTRATOR_SYSTEM_PROMPT,
+        CROSS_NODE_NESTED_ORCHESTRATOR_SYSTEM_PROMPT,
         None,
     )
     .await;
@@ -948,10 +982,10 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
         &did_a,
         &orchestrator_behavior_id,
         vec![SubagentTarget {
-            name: RESEARCHER_TARGET_NAME.to_string(),
+            name: FAST_WORKER_TARGET_NAME.to_string(),
             agent_did: did_b.clone(),
-            behavior_id: RESEARCHER_BEHAVIOR_ID.to_string(),
-            description: Some("Researches factual questions.".to_string()),
+            behavior_id: FAST_WORKER_BEHAVIOR_ID.to_string(),
+            description: Some("Produces a reviewed factual answer.".to_string()),
         }],
         /* spawn */ true,
         /* background */ true,
@@ -990,8 +1024,8 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
 
     // Boot full agents on both nodes. B owns DID-B: its daemon + SubagentSource
     // claim and run the replicated child request against the live model.
-    let agent_b = boot_document_agent(&db_b, identity_b).await?;
-    let agent_a = boot_document_agent(&db_a, identity_a).await?;
+    let agent_b = boot_document_agent(&db_b, identity_b.clone()).await?;
+    let agent_a = boot_document_agent(&db_a, identity_a.clone()).await?;
     wait_for_replicator_installed(db_a.node.as_ref(), "peer-b", Duration::from_secs(120)).await;
     wait_for_replicator_installed(db_b.node.as_ref(), "peer-a", Duration::from_secs(120)).await;
 
@@ -1003,7 +1037,7 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
         &orchestrator_behavior_id,
         request_id,
         session_id,
-        "Use your research subagent to find the capital of France, then tell me the answer.",
+        "Run the nested review workflow for the capital of France.",
     )
     .await;
 
@@ -1059,7 +1093,40 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
         Some(did_a.as_str()),
         "child request must route only to its DID-A coordinator"
     );
-    assert_eq!(child_on_b.behavior_id, RESEARCHER_BEHAVIOR_ID);
+    assert_eq!(child_on_b.behavior_id, FAST_WORKER_BEHAVIOR_ID);
+
+    // The live fast-worker must itself delegate to reviewer. This is a local
+    // child on B, but requester_did remains DID-A so its bridge and result are
+    // part of the same authorization-safe return projection.
+    let reviewer_on_b = wait_for_child_of_parent(
+        db_b.node.as_ref(),
+        &child_request_id,
+        Duration::from_secs(120),
+    )
+    .await
+    .expect("fast-worker must materialize its reviewer child on node B");
+    assert_eq!(reviewer_on_b.behavior_id, REVIEWER_BEHAVIOR_ID);
+    assert_eq!(
+        reviewer_on_b.caused_by_parent_request_id.as_deref(),
+        Some(child_request_id.as_str())
+    );
+    let reviewer_terminal_b = wait_for_request_terminal(
+        db_b.node.as_ref(),
+        &reviewer_on_b.request_id,
+        Duration::from_secs(150),
+    )
+    .await;
+    assert_eq!(reviewer_terminal_b, "completed");
+    let reviewer_answer_b = wait_for_assistant_answer(
+        db_b.node.as_ref(),
+        &reviewer_on_b.request_id,
+        Duration::from_secs(30),
+    )
+    .await;
+    assert!(
+        reviewer_answer_b.contains("REVIEWER_OK"),
+        "reviewer did not produce its live completion marker: {reviewer_answer_b:?}"
+    );
 
     // B runs the child to completion with a non-empty live response.
     let child_terminal_b = wait_for_request_terminal(
@@ -1116,8 +1183,64 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
         "orchestrator request on A must terminalize; got {parent_terminal_a}"
     );
 
+    // #836: the model-facing and operator projections consume this same edge.
+    // Its identity survives remote materialization and completion without a
+    // second lineage reconstruction from child request labels.
+    let graph =
+        wait_for_descendant_graph(db_a.node.as_ref(), request_id, 2, Duration::from_secs(120))
+            .await;
+    assert_eq!(graph.edges.len(), 2, "both remote edges must converge once");
+    let edge = &graph.edges[0];
+    assert_eq!(edge.child_request_id, child_request_id);
+    assert_eq!(edge.principal_did.as_deref(), Some(did_b.as_str()));
+    assert_eq!(edge.behavior_id.as_deref(), Some(FAST_WORKER_BEHAVIOR_ID));
+    assert_eq!(
+        edge.materialization_state,
+        DescendantMaterializationState::MaterializedRemote
+    );
+    assert!(edge.readable());
+    assert!(edge.is_terminal());
+    assert!(edge.terminal_result_ref.is_some());
+    let reviewer_edge = &graph.edges[1];
+    assert_eq!(reviewer_edge.child_request_id, reviewer_on_b.request_id);
+    assert_eq!(reviewer_edge.immediate_parent_request_id, child_request_id);
+    assert_eq!(
+        reviewer_edge.behavior_id.as_deref(),
+        Some(REVIEWER_BEHAVIOR_ID)
+    );
+    assert_eq!(reviewer_edge.depth, 2);
+    assert!(reviewer_edge.readable());
+    assert!(!reviewer_edge.controllable());
+    assert!(reviewer_edge.is_terminal());
+
+    // Stop and restart both runtimes. Their pairing reconcilers reconnect to
+    // the already-running P2P nodes and re-project the same durable facts.
+    // The graph must remain exactly-once after restart/replay convergence.
     agent_a.shutdown().await;
     agent_b.shutdown().await;
+    let restarted_b = boot_document_agent(&db_b, identity_b).await?;
+    let restarted_a = boot_document_agent(&db_a, identity_a).await?;
+    wait_for_replicator_installed(db_a.node.as_ref(), "peer-b", Duration::from_secs(120)).await;
+    wait_for_replicator_installed(db_b.node.as_ref(), "peer-a", Duration::from_secs(120)).await;
+    let reconnected_graph =
+        wait_for_descendant_graph(db_a.node.as_ref(), request_id, 2, Duration::from_secs(120))
+            .await;
+    let reconnected_ids = reconnected_graph
+        .edges
+        .iter()
+        .map(|edge| edge.child_request_id.as_str())
+        .collect::<HashSet<_>>();
+    assert_eq!(reconnected_graph.edges.len(), 2);
+    assert_eq!(
+        reconnected_ids.len(),
+        2,
+        "reconnect must not duplicate edges"
+    );
+    assert!(reconnected_ids.contains(child_request_id.as_str()));
+    assert!(reconnected_ids.contains(reviewer_on_b.request_id.as_str()));
+
+    restarted_a.shutdown().await;
+    restarted_b.shutdown().await;
     // BootedAgent only stops Gents::run; P2P belongs to the embedded node.
     db_a.node.shutdown().await;
     db_b.node.shutdown().await;
@@ -1134,12 +1257,18 @@ MUST delegate it by calling the `spawn_subagent` tool with name exactly \"resear
 `prompt` describing the question. Do not answer factual questions yourself; always delegate them. After \
 the subagent returns its answer, relay that answer to the user.";
 
-const CROSS_NODE_ORCHESTRATOR_SYSTEM_PROMPT: &str = "You are an orchestrator agent. You have a remote \
-research subagent available named `researcher`. For ANY research or factual lookup the \
-user asks for, you MUST delegate it by calling the `spawn_subagent` tool with name exactly \
-\"researcher\", await_mode exactly \"background\", and a `prompt` describing the question. The \
-subagent runs on a different node, so you MUST use await_mode=\"background\" (foreground is rejected). Do \
-not answer factual questions yourself; always delegate them.";
+const CROSS_NODE_NESTED_ORCHESTRATOR_SYSTEM_PROMPT: &str = "You are the root of a deterministic nested \
+delegation test. When asked to run the nested review workflow, call `spawn_subagent` exactly once with \
+name exactly \"fast-worker\", await_mode exactly \"background\", and prompt exactly \
+\"RESEARCH_AND_REVIEW_FRANCE\". The worker is remote, so foreground is rejected. Do not answer the \
+question yourself. After its completion notification arrives, report its reviewed answer without spawning \
+another worker.";
+
+const CROSS_NODE_FAST_WORKER_SYSTEM_PROMPT: &str = "You are the fast worker in a deterministic nested \
+delegation test. When the request is exactly RESEARCH_AND_REVIEW_FRANCE, call `spawn_subagent` exactly \
+once with name exactly \"reviewer\", await_mode exactly \"foreground\", and prompt exactly \
+\"Review this claim: Paris is the capital of France.\" After the reviewer returns, reply with its answer. \
+Do not answer before the reviewer completes.";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -1610,6 +1739,37 @@ async fn wait_for_child_of_parent(
         if tokio::time::Instant::now() >= deadline {
             return None;
         }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+async fn wait_for_descendant_graph(
+    node: &EmbeddedNode,
+    root_request_id: &str,
+    expected_edges: usize,
+    timeout: Duration,
+) -> DescendantPage {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Ok(graph) = resolve_descendant_graph(
+            DescendantGraphAccess::Local(node),
+            &DescendantQuery::all(root_request_id),
+        )
+        .await
+        {
+            let unique = graph
+                .edges
+                .iter()
+                .map(|edge| edge.child_request_id.as_str())
+                .collect::<HashSet<_>>();
+            if graph.edges.len() == expected_edges && unique.len() == expected_edges {
+                return graph;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {expected_edges} unique canonical descendant edges under {root_request_id}"
+        );
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 }

--- a/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
+++ b/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
@@ -447,6 +447,26 @@ async fn corrupt_materialized_child_is_nonretryable_and_remains_listed() {
         .as_str()
         .is_some_and(|message| message.contains("does not corroborate")));
 
+    let steer_action = hook
+        .on_tool_call(
+            "steer_subagent",
+            Some("model-call-steer-corrupt".to_string()),
+            "internal-steer-corrupt",
+            &json!({
+                "child_request_id": child_request_id,
+                "message": "do not retry rejected lineage"
+            })
+            .to_string(),
+        )
+        .await;
+    let steer_error = skip_reason_json(steer_action);
+    assert_eq!(steer_error["ok"], false);
+    assert_eq!(steer_error["failure_class"], "service_unavailable");
+    assert_eq!(steer_error["retryable"], false);
+    assert!(steer_error["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("does not corroborate")));
+
     let list_action = hook
         .on_tool_call(
             "list_subagents",

--- a/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
+++ b/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
@@ -341,7 +341,7 @@ async fn wait_subagent_explains_unmaterialized_child_bridge() {
 }
 
 #[tokio::test]
-async fn wait_subagent_preserves_error_for_corrupt_materialized_child() {
+async fn corrupt_materialized_child_is_nonretryable_and_remains_listed() {
     let fixture = setup_spawn_fixture(
         "wait_subagent_corrupt_child",
         vec![CHILD_BEHAVIOR_ID],
@@ -423,13 +423,43 @@ async fn wait_subagent_preserves_error_for_corrupt_materialized_child() {
     assert_eq!(error["retryable"], false);
     let message = error["message"].as_str().expect("message");
     assert!(
-        message.contains("has no behavior_id"),
-        "preserves the original error: {message}"
+        message.contains("does not corroborate") && message.contains(bridge_tool_call_id),
+        "rejects corrupt physical provenance: {message}"
     );
     assert!(
         !message.contains("has no materialized row yet"),
         "must not be masked as materialization lag: {message}"
     );
+
+    let cancel_action = hook
+        .on_tool_call(
+            "cancel_subagent",
+            Some("model-call-cancel-corrupt".to_string()),
+            "internal-cancel-corrupt",
+            &json!({ "child_request_id": child_request_id }).to_string(),
+        )
+        .await;
+    let cancel_error = skip_reason_json(cancel_action);
+    assert_eq!(cancel_error["ok"], false);
+    assert_eq!(cancel_error["failure_class"], "service_unavailable");
+    assert_eq!(cancel_error["retryable"], false);
+    assert!(cancel_error["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("does not corroborate")));
+
+    let list_action = hook
+        .on_tool_call(
+            "list_subagents",
+            Some("model-call-list-corrupt".to_string()),
+            "internal-list-corrupt",
+            "{}",
+        )
+        .await;
+    let list_result = skip_reason_json(list_action);
+    let entries = list_result["entries"].as_array().expect("list entries");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["child_request_id"], child_request_id);
+    assert_eq!(entries[0]["status"], "pending_child_authorization");
 }
 
 #[tokio::test]

--- a/crates/gents/tests/e2e_subagent/subagent_convergence.rs
+++ b/crates/gents/tests/e2e_subagent/subagent_convergence.rs
@@ -7,7 +7,9 @@ use gents::__test_internals::{
 };
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
-use gents::tool_call_lifecycle::{AwaitMode, CancelPolicy, ToolCallLifecycle};
+use gents::tool_call_lifecycle::{
+    AwaitMode, CancelPolicy, ChildTerminal, FailureClass, ToolCallLifecycle,
+};
 use gents::{
     default_behavior_id_for_agent, load_agent_behavior, upsert_agent_behavior,
     upsert_tool_selection, AgentBehaviorDocument, AgentIdentity, DocumentRuntimeOptions, Gents,
@@ -247,7 +249,7 @@ async fn local_background_spawn_materializes_child_with_lineage_and_lists() {
         db.node.clone(),
         parent_request_id.to_string(),
         parent_session_id.to_string(),
-        "did:test:test".to_string(),
+        running.booted.agent_did.clone(),
         parent_tool_call_id.to_string(),
         1,
         "spawn_subagent".to_string(),
@@ -350,7 +352,7 @@ async fn unmaterialized_background_child_stays_observable_in_list() {
         db.node.clone(),
         parent_request_id.to_string(),
         parent_session_id.to_string(),
-        "did:test:test".to_string(),
+        agent_did.clone(),
         parent_tool_call_id.to_string(),
         1,
         "spawn_subagent".to_string(),
@@ -451,6 +453,60 @@ async fn unmaterialized_background_child_stays_observable_in_list() {
         }
         other => panic!("expected AwaitingMaterialization, got {other:?}"),
     }
+
+    assert!(lifecycle
+        .bridge_failure(ChildTerminal::Failed {
+            reason: "remote child never materialized".to_string(),
+            failure_class: FailureClass::ServiceUnavailable,
+        })
+        .await
+        .expect("terminalize the unmaterialized bridge"));
+    match load_steer_subagent_target(db.node.as_ref(), parent_request_id, child_request_id)
+        .await
+        .expect("load terminal steer target")
+    {
+        SteerSubagentTarget::Terminal(state) => assert_eq!(state, "failed"),
+        other => panic!("expected Terminal(failed), got {other:?}"),
+    }
+
+    let foreground_child_request_id = "unmat-fg-child";
+    let foreground_args = serde_json::json!({
+        "name": "remote-foreground-coder",
+        "agent_did": "did:key:z6MkUnclaimedRemoteTarget",
+        "behavior_id": "remote-coder-behavior",
+        "prompt": "cross-deployment foreground child work",
+        "await_mode": "foreground"
+    })
+    .to_string();
+    let mut foreground_lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        parent_request_id.to_string(),
+        parent_session_id.to_string(),
+        agent_did.clone(),
+        "unmat-fg-tc".to_string(),
+        2,
+        "spawn_subagent".to_string(),
+        foreground_args,
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        foreground_child_request_id.to_string(),
+        "did:key:z6MkUnclaimedRemoteTarget".to_string(),
+    )
+    .with_request_doc_id(Some(
+        crate::support::exact_request_doc_id(db.node.as_ref(), parent_request_id).await,
+    ));
+    foreground_lifecycle.start_running().await.unwrap();
+    assert!(matches!(
+        load_steer_subagent_target(
+            db.node.as_ref(),
+            parent_request_id,
+            foreground_child_request_id,
+        )
+        .await
+        .expect("load foreground steer target"),
+        SteerSubagentTarget::NotBackgrounded
+    ));
 
     let stranger = handle_read_subagent(
         db.node.as_ref(),

--- a/crates/gents/tests/e2e_subagent/subagent_convergence.rs
+++ b/crates/gents/tests/e2e_subagent/subagent_convergence.rs
@@ -445,7 +445,8 @@ async fn unmaterialized_background_child_stays_observable_in_list() {
         .await
         .expect("load_steer_subagent_target must not error")
     {
-        SteerSubagentTarget::AwaitingMaterialization { message } => {
+        SteerSubagentTarget::AwaitingMaterialization { message, retryable } => {
+            assert!(retryable);
             assert!(
                 message.contains(child_request_id),
                 "steer explanation names the child: {message}"

--- a/crates/gents/tests/e2e_subagent/subagent_enablement_e2e.rs
+++ b/crates/gents/tests/e2e_subagent/subagent_enablement_e2e.rs
@@ -174,7 +174,7 @@ async fn enabled_agent_spawns_local_child_and_list_reflects_it() {
         db.node.clone(),
         parent_request_id.to_string(),
         parent_session_id.to_string(),
-        "did:test:test".to_string(),
+        running.booted.agent_did.clone(),
         parent_tool_call_id.to_string(),
         1,
         "spawn_subagent".to_string(),

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -568,6 +568,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_subagent_delegation_graph_cases_pin_gap2_contract",
         },
         ConformanceConsumer::RustTest {
+            id: "descendant_graph::tests::generated_descendant_graph_cases_fence_visibility_and_control",
+            package: "gents",
+            source_path: "crates/gents/src/descendant_graph.rs",
+            module_path: "descendant_graph::tests",
+            function: "generated_descendant_graph_cases_fence_visibility_and_control",
+        },
+        ConformanceConsumer::RustTest {
             id: "conformance::generated_r4c_background_work_cases_pin_observable_shapes",
             package: "gents",
             source_path: "crates/gents/tests/conformance.rs",


### PR DESCRIPTION
Closes #836.

## What changed

- Adds one canonical durable descendant-edge resolver and stable edge vocabulary shared by agent tools, request inspection, timelines, adapter projections, CLI trees, and desktop trees.
- Separates bridge visibility, child readability, retryability, default listing, and direct-parent control authority.
- Supports deterministic direct-child, all-descendant, and workflow-group scopes with stable cursor paging.
- Preserves unmaterialized remote bridge handles and terminal result references while failing closed across principal, session, and lineage boundaries.
- Reconciles duplicated CLI, desktop, workflow, and background-tool lineage reconstruction onto the canonical projection.
- Adds the Lean descendant graph model first, generated conformance cases, integration coverage, subagent E2Es, and a live multi-behavior/deployment nesting scenario.

## Why

Behavior identity, deployment placement, await mode, and workflow role must not sever a parent-owned descendant edge. The previous split implementations could disagree on visibility, lifecycle state, and authorization. This change makes durable bridge ownership the enumeration boundary while retaining physical lineage corroboration for reads and direct-parent authority for control.

## Review follow-ups included

Three GLM-5.2 review rounds were addressed:

- Terminal and foreground unmaterialized diagnostics now remain authorization-safe, and external projections do not promote unreadable pending or rejected edges.
- Exact edge lookup uses direct document joins plus O(lineage depth) ancestry validation instead of repeated full-graph traversal.
- Rejected physical lineage is nonretryable, pending authorization remains in the default running view, and the Lean retryable predicate now includes the terminal-state guard with an explicit pending-plus-terminal contract case.

## Validation

- `cd crates/gents/proofs && lake build`
- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`