### PR TITLE
fix(ci): restore main to green — LSP admit precondition, durable lineage seeding, DFS tree order

### DIFF
--- a/crates/gents-cli/src/commands/subagent.rs
+++ b/crates/gents-cli/src/commands/subagent.rs
@@ -682,10 +682,7 @@ async fn load_rooted_lineage(
         .await?
         .ok_or_else(|| anyhow::anyhow!("AgentRequest {root_request_id} not found"))?;
     let max_depth = max_depth.unwrap_or(usize::MAX);
-    let mut rows = vec![LineageNode {
-        row: root,
-        depth: 0,
-    }];
+    let mut descendants_by_parent = BTreeMap::<String, Vec<LineageNode>>::new();
     let mut after = None;
     loop {
         let page = gents::resolve_descendant_graph(
@@ -697,11 +694,15 @@ async fn load_rooted_lineage(
             },
         )
         .await?;
-        rows.extend(
-            page.edges
-                .into_iter()
-                .filter(|edge| edge.depth <= max_depth)
-                .map(|edge| LineageNode {
+        for edge in page.edges {
+            if edge.depth > max_depth {
+                continue;
+            }
+            let parent_request_id = edge.immediate_parent_request_id.clone();
+            descendants_by_parent
+                .entry(parent_request_id)
+                .or_default()
+                .push(LineageNode {
                     depth: edge.depth,
                     row: AgentRequestLineageRow {
                         request_id: edge.child_request_id,
@@ -713,12 +714,34 @@ async fn load_rooted_lineage(
                         claimed_at: None,
                         caused_by_parent_request_id: Some(edge.immediate_parent_request_id),
                     },
-                }),
-        );
+                });
+        }
         if !page.has_more {
             break;
         }
         after = page.next_cursor;
+    }
+
+    // The resolver pages breadth-first, but tree/table rendering assumes a
+    // child's subtree precedes later siblings; flatten depth-first (sibling
+    // order preserved from the resolver's started_at/tool_call_id ordering).
+    let mut rows = Vec::new();
+    let mut stack = vec![LineageNode {
+        row: root,
+        depth: 0,
+    }];
+    while let Some(node) = stack.pop() {
+        let request_id = node.row.request_id.clone();
+        rows.push(node);
+        if let Some(mut children) = descendants_by_parent.remove(&request_id) {
+            children.reverse();
+            stack.extend(children);
+        }
+    }
+    // A durable bridge can name a parent with no materialized row; keep such
+    // edges visible instead of silently dropping them.
+    for children in descendants_by_parent.into_values() {
+        rows.extend(children);
     }
 
     Ok(rows)

--- a/crates/gents-cli/tests/cli_subagent.rs
+++ b/crates/gents-cli/tests/cli_subagent.rs
@@ -40,7 +40,7 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
     let second_child_request_id = format!("child-b-{}", Uuid::new_v4().simple());
     let grandchild_request_id = format!("grandchild-{}", Uuid::new_v4().simple());
 
-    seed_request(
+    let root_doc_id = seed_request(
         &graphql,
         &test_agent_did,
         &root_request_id,
@@ -50,14 +50,37 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         "2026-05-20T12:00:00Z",
     )
     .await?;
-    seed_request(
+    let (first_tool_call_id, first_bridge_doc_id) = seed_spawn_bridge(
+        &graphql,
+        &test_agent_did,
+        &root_request_id,
+        &root_doc_id,
+        &first_child_request_id,
+        "2026-05-20T12:00:01Z",
+    )
+    .await?;
+    let first_child_doc_id = seed_request(
         &graphql,
         &test_agent_did,
         &first_child_request_id,
         "first-child-behavior",
-        Some(&root_request_id),
+        Some(&ParentLink {
+            parent_request_id: &root_request_id,
+            parent_doc_id: &root_doc_id,
+            tool_call_id: &first_tool_call_id,
+            tool_call_doc_id: &first_bridge_doc_id,
+        }),
         1,
         "2026-05-20T12:00:01Z",
+    )
+    .await?;
+    let (second_tool_call_id, second_bridge_doc_id) = seed_spawn_bridge(
+        &graphql,
+        &test_agent_did,
+        &root_request_id,
+        &root_doc_id,
+        &second_child_request_id,
+        "2026-05-20T12:00:02Z",
     )
     .await?;
     seed_request(
@@ -65,9 +88,23 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         &test_agent_did,
         &second_child_request_id,
         "second-child-behavior",
-        Some(&root_request_id),
+        Some(&ParentLink {
+            parent_request_id: &root_request_id,
+            parent_doc_id: &root_doc_id,
+            tool_call_id: &second_tool_call_id,
+            tool_call_doc_id: &second_bridge_doc_id,
+        }),
         1,
         "2026-05-20T12:00:02Z",
+    )
+    .await?;
+    let (grandchild_tool_call_id, grandchild_bridge_doc_id) = seed_spawn_bridge(
+        &graphql,
+        &test_agent_did,
+        &first_child_request_id,
+        &first_child_doc_id,
+        &grandchild_request_id,
+        "2026-05-20T12:00:03Z",
     )
     .await?;
     seed_request(
@@ -75,7 +112,12 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         &test_agent_did,
         &grandchild_request_id,
         "grandchild-behavior",
-        Some(&first_child_request_id),
+        Some(&ParentLink {
+            parent_request_id: &first_child_request_id,
+            parent_doc_id: &first_child_doc_id,
+            tool_call_id: &grandchild_tool_call_id,
+            tool_call_doc_id: &grandchild_bridge_doc_id,
+        }),
         2,
         "2026-05-20T12:00:03Z",
     )
@@ -293,32 +335,48 @@ fn assert_tree_node_id(node: &Value, request_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Full physical linkage from a child request back to the parent request and
+/// the spawn bridge, matching what the runtime stamps on real dispatches. The
+/// durable descendant graph fails closed on any missing or contradictory
+/// value (`child_corroborates` in `gents::descendant_graph`), so seeded
+/// lineage must carry all four references.
+struct ParentLink<'a> {
+    parent_request_id: &'a str,
+    parent_doc_id: &'a str,
+    tool_call_id: &'a str,
+    tool_call_doc_id: &'a str,
+}
+
 async fn seed_request(
     graphql: &str,
     agent_did: &str,
     request_id: &str,
     behavior_id: &str,
-    parent_request_id: Option<&str>,
+    parent: Option<&ParentLink<'_>>,
     subagent_depth: i64,
     created_at: &str,
-) -> Result<()> {
+) -> Result<String> {
     let session_id = format!("session-{request_id}");
-    let parent_fields = parent_request_id
-        .map(|parent| {
+    let parent_fields = parent
+        .map(|link| {
             format!(
                 r#"
                     ,
                     caused_by_parent_request_id: "{}",
-                    caused_by_parent_tool_call_id: "spawn-{}",
-                    caused_by_trigger_id: "spawn-{}",
+                    caused_by_parent_request_doc_id: "{}",
+                    caused_by_parent_tool_call_id: "{}",
+                    caused_by_parent_tool_call_doc_id: "{}",
+                    caused_by_trigger_id: "{}",
                     caused_by_trigger_kind: "subagent","#,
-                escape_graphql_string(parent),
-                escape_graphql_string(request_id),
-                escape_graphql_string(request_id),
+                escape_graphql_string(link.parent_request_id),
+                escape_graphql_string(link.parent_doc_id),
+                escape_graphql_string(link.tool_call_id),
+                escape_graphql_string(link.tool_call_doc_id),
+                escape_graphql_string(link.tool_call_id),
             )
         })
         .unwrap_or_default();
-    graphql_query(
+    let response = graphql_query(
         graphql,
         &format!(
             r#"mutation {{
@@ -350,7 +408,64 @@ async fn seed_request(
         ),
     )
     .await?;
-    Ok(())
+    doc_id_from_create(&response, "add_AgentRequest")
+}
+
+/// Seed the durable spawn bridge (`AgentToolCall` with `child_request_id`)
+/// that the descendant graph walks; `subagent list --root` discovers children
+/// exclusively through these since #1136. Returns `(tool_call_id, _docID)`
+/// for stamping the child's `caused_by_parent_tool_call*` fields.
+async fn seed_spawn_bridge(
+    graphql: &str,
+    agent_did: &str,
+    parent_request_id: &str,
+    parent_doc_id: &str,
+    child_request_id: &str,
+    started_at: &str,
+) -> Result<(String, String)> {
+    let tool_call_id = format!("spawn-{child_request_id}");
+    let session_id = format!("session-{parent_request_id}");
+    let response = graphql_query(
+        graphql,
+        &format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "bridge-{child_request_id}",
+                    request_id: "{parent_request_id}",
+                    request_doc_id: "{parent_doc_id}",
+                    session_id: "{session_id}",
+                    agent_did: "{agent_did}",
+                    tool_name: "task",
+                    tool_call_id: "{tool_call_id}",
+                    args: "{{}}",
+                    status: "pending",
+                    lifecycle_state: "pending",
+                    started_at: "{started_at}",
+                    await_mode: "foreground",
+                    child_request_id: "{child_request_id}",
+                    spawn_target_did: "{agent_did}"
+                }}) {{ _docID }}
+            }}"#,
+            child_request_id = escape_graphql_string(child_request_id),
+            parent_request_id = escape_graphql_string(parent_request_id),
+            parent_doc_id = escape_graphql_string(parent_doc_id),
+            session_id = escape_graphql_string(&session_id),
+            agent_did = escape_graphql_string(agent_did),
+            tool_call_id = escape_graphql_string(&tool_call_id),
+            started_at = escape_graphql_string(started_at),
+        ),
+    )
+    .await?;
+    let doc_id = doc_id_from_create(&response, "add_AgentToolCall")?;
+    Ok((tool_call_id, doc_id))
+}
+
+fn doc_id_from_create(response: &Value, field: &str) -> Result<String> {
+    response
+        .pointer(&format!("/data/{field}/0/_docID"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("missing _docID in {field} response: {response}"))
 }
 
 fn assert_lineage_row(

--- a/crates/gents/src/toolset/lsp/admit.rs
+++ b/crates/gents/src/toolset/lsp/admit.rs
@@ -59,8 +59,38 @@ mod tests {
         }
 
         let workspace = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        // rustup is the authority on whether the SELECTED toolchain actually
+        // carries the component; a shim on PATH proves nothing (rustup
+        // installs proxies for every known tool, and minimal profiles — this
+        // repo pins one — omit rust-analyzer). Executing rustup here is fine:
+        // the production constraint is only that ADMISSION never executes a
+        // helper.
+        let Ok(oracle) = std::process::Command::new(&proxy_target)
+            .args(["which", "rust-analyzer"])
+            .current_dir(&workspace)
+            .output()
+        else {
+            return;
+        };
+        if !oracle.status.success() {
+            // The selected toolchain has no rust-analyzer binary: the shim
+            // would fail at spawn, so admission must fail closed instead of
+            // resolving a nonexistent path.
+            let err = admit_command("rust-analyzer", &workspace)
+                .expect_err("missing toolchain component must deny, not resolve");
+            assert_eq!(err.to_contract(), "workspaceExecutable");
+            return;
+        }
+        let expected =
+            std::path::PathBuf::from(String::from_utf8_lossy(&oracle.stdout).trim().to_string());
+        let expected = std::fs::canonicalize(&expected).unwrap_or(expected);
+
         let admitted = admit_command("rust-analyzer", &workspace)
             .expect("installed rustup rust-analyzer proxy must resolve without executing a helper");
+        assert_eq!(
+            admitted, expected,
+            "admission's side-effect-free resolution must agree with `rustup which`"
+        );
         assert!(admitted.is_file(), "{}", admitted.display());
         assert_ne!(admitted, proxy_target);
         assert_eq!(


### PR DESCRIPTION
Main's CI has been red on every push since Aug 13. This PR restores it to green. Closes #1138, closes #1139.

## What was broken (full forensics in the two issues)

| Test | Red since | Cause |
|---|---|---|
| `rustup_proxy_admits_the_selected_toolchain_binary` (runtime) | `102ca829` (#1115, Aug 13) — never green on main | Test guard checks the rustup shim exists but not that the pinned toolchain (1.97.1, `profile = "minimal"`) has the rust-analyzer component. Admission correctly fails closed; the test blamed it. |
| `subagent_list_shows_two_level_dispatch_lineage` (cli) | `1911298c` (#1136, Aug 17) | `subagent list --root` moved onto `resolve_descendant_graph`, which discovers children exclusively via `AgentToolCall` spawn bridges; the test seeded bare `caused_by_*` links, no bridges. |
| `trace_project_graphql_enforces_acp_read_filter_with_real_cli` (cli) | `b4ca4328` (#1134) → healed by #1136 | Masked ever since: `cli_subagent` sorts before `cli_trace_export` under fail-fast. Passes on current main; re-enters coverage with this fix. |

Every PR stayed green throughout because these suites run only on main pushes.

## Changes

- **`admit.rs` test**: consult `rustup which rust-analyzer` as the oracle. Component absent (CI) → assert the fail-closed `WorkspaceExecutable` denial; component present → assert admission's side-effect-free resolution agrees exactly with rustup's answer. Strictly stronger than before in both environments. Deny branch verified locally via `RUSTUP_TOOLCHAIN=1.76.0`.
- **`cli_subagent.rs`**: seed the canonical durable shape — one spawn bridge per child plus fully corroborated `caused_by_parent_{request,tool_call}{,_doc}_id` links (the resolver's `child_corroborates` fails closed on any missing value, by design).
- **`subagent.rs` (`load_rooted_lineage`)**: real #1136 regression exposed by the fixed test — resolver pages are breadth-first, but tree/table rendering assumes a child's subtree precedes later siblings, so a grandchild rendered under the wrong sibling. Now DFS-flattened (sibling order preserved from the resolver's ordering), matching the forest path; orphaned-parent edges stay visible.

## Unauthenticated build (requested check — no changes needed)

Fresh `git clone` of this repo plus `cargo fetch` in a hard-isolated environment (empty `HOME`/`CARGO_HOME`, `GIT_TERMINAL_PROMPT=0`, no credential helper, `GIT_CONFIG_NOSYSTEM=1`) resolves everything: both git deps (`sourcenetwork/defradb.rs`, `sourcenetwork/rig`) are public, npm is registry-only, and the Lean toolchain pulls only public leanprover-community repos.

## Verification

- `cargo test -p gents --lib` with CI's `RUST_MIN_STACK`: **1618 passed, 0 failed**
- Full `cargo test -p gents-cli -- --test-threads=1` (CI mode): **0 failures across all binaries**
- `cargo check --workspace --all-targets`: clean; `rustfmt --check`: clean
- Admit test exercised on both branches; subagent test red→green with the exact CI assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)