### PR TITLE
Eagerly sync the mobile session index

### DIFF
--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -50,7 +50,6 @@ impl ClientCore {
         gents::storage_backend::reject_legacy_rocksdb_store(paths.node_data_dir())?;
 
         let principal = PrincipalIdentity::load_or_create(&paths).await?;
-        let bootstrap_errors = Vec::new();
         let node = Arc::new(
             NodeBuilder::default()
                 .data_path(paths.node_data_dir())
@@ -97,7 +96,7 @@ impl ClientCore {
             .await
             .context("reading desktop P2P listen addresses")?;
 
-        let (peer_statuses, _peer_errors) = {
+        let (peer_statuses, bootstrap_errors) = {
             let records = peer_directory.read().await.records().to_vec();
             bootstrap_saved_peers(node.as_ref(), &p2p, &records, &options, &principal).await
         };
@@ -256,25 +255,6 @@ pub(super) async fn bootstrap_saved_peers(
         }
 
         statuses.push(status);
-    }
-
-    if options.install_replicators_on_bootstrap
-        && statuses.iter().any(|status| status.dial_succeeded)
-    {
-        match sync_index_collections_with_retry(node, p2p, BOOTSTRAP_OPERATION_TIMEOUT).await {
-            Ok(synced) => {
-                tracing::info!(
-                    target: "gents_desktop_core::peer",
-                    synced_collections = ?synced,
-                    "session index sync complete"
-                );
-            }
-            Err(error) => {
-                let message = format!("session index sync failed: {error}");
-                tracing::warn!(target: "gents_desktop_core::peer", %message);
-                errors.push(message);
-            }
-        }
     }
 
     (statuses, errors)
@@ -509,12 +489,14 @@ pub(super) async fn add_replicator_with_retry_until(
     }
 }
 
-pub(super) async fn sync_index_collections_with_retry(
+pub(super) async fn request_index_sync(
     node: &EmbeddedNode,
     p2p: &Arc<dyn P2POps>,
-    timeout: Duration,
 ) -> Result<Vec<String>> {
-    let deadline = Instant::now() + timeout;
+    if p2p_connected_peers(p2p).await?.is_empty() {
+        anyhow::bail!("no connected peers available for session index request");
+    }
+
     let [conversation_name, session_name] = index_collection_names();
     let resolve_id = |collection_name| -> Result<String> {
         let collection = node
@@ -529,33 +511,14 @@ pub(super) async fn sync_index_collections_with_retry(
     let session_id = resolve_id(session_name)?;
 
     tokio::try_join!(
-        sync_index_collection_with_retry(p2p, conversation_name, &conversation_id, deadline),
-        sync_index_collection_with_retry(p2p, session_name, &session_id, deadline),
+        p2p_sync_branchable_collection(p2p, &conversation_id),
+        p2p_sync_branchable_collection(p2p, &session_id),
     )?;
 
     Ok(vec![
         conversation_name.to_string(),
         session_name.to_string(),
     ])
-}
-
-async fn sync_index_collection_with_retry(
-    p2p: &Arc<dyn P2POps>,
-    collection_name: &str,
-    collection_id: &str,
-    deadline: Instant,
-) -> Result<()> {
-    loop {
-        match p2p_sync_branchable_collection(p2p, collection_id).await {
-            Ok(()) => return Ok(()),
-            Err(error) => {
-                if Instant::now() >= deadline {
-                    anyhow::bail!("timed out syncing index collection {collection_name}: {error}");
-                }
-                sleep(BOOTSTRAP_OPERATION_BACKOFF).await;
-            }
-        }
-    }
 }
 
 pub(super) async fn is_connected_peer(p2p: &Arc<dyn P2POps>, peer_id: &str) -> Result<bool> {

--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -14,7 +14,7 @@ use super::super::peer_directory::{PeerDirectory, PeerRecord};
 use super::super::principal_identity::PrincipalIdentity;
 use super::super::query::load_full_snapshot_with_peer_records;
 use super::super::schema::{
-    branchable_collection_names, ensure_runtime_schemas, subscribe_all_collections,
+    ensure_runtime_schemas, index_collection_names, subscribe_all_collections,
     subscribed_collection_names,
 };
 use super::bearer_pairing::{
@@ -31,7 +31,6 @@ use super::{
     ClientCore, ClientCoreOptions, ClientPeerStatus, P2PHealth, BOOTSTRAP_OPERATION_BACKOFF,
     BOOTSTRAP_OPERATION_TIMEOUT,
 };
-pub(super) const BRANCHABLE_PAIR_SYNC_ENV: &str = "GENTS_DESKTOP_SYNC_BRANCHABLE_ON_PAIR";
 
 impl ClientCore {
     pub async fn start() -> Result<Self> {
@@ -237,42 +236,7 @@ pub(super) async fn bootstrap_saved_peers(
 
                 if options.install_replicators_on_bootstrap && !is_bearer_peer(record) {
                     match configure_local_runtime_pairing(node, p2p, actor, record).await {
-                        Ok(()) => {
-                            if branchable_pair_sync_enabled() {
-                                match sync_branchable_collections_with_retry(
-                                    node,
-                                    p2p,
-                                    &record.label,
-                                    BOOTSTRAP_OPERATION_TIMEOUT,
-                                )
-                                .await
-                                {
-                                    Ok(synced) => {
-                                        tracing::info!(
-                                            target: "gents_desktop_core::peer",
-                                            label = %record.label,
-                                            synced_collections = ?synced,
-                                            "desktop requested branchable collection sync after pairing"
-                                        );
-                                    }
-                                    Err(error) => {
-                                        let message = format!(
-                                            "peer {} branchable sync failed: {}",
-                                            record.label, error
-                                        );
-                                        status.last_error = Some(message.clone());
-                                        errors.push(message);
-                                    }
-                                }
-                            } else {
-                                tracing::debug!(
-                                    target: "gents_desktop_core::peer",
-                                    label = %record.label,
-                                    env = BRANCHABLE_PAIR_SYNC_ENV,
-                                    "skipping opt-in branchable collection sync after pairing"
-                                );
-                            }
-                        }
+                        Ok(()) => {}
                         Err(error) => {
                             let message = format!(
                                 "peer {} local runtime pairing failed: {}",
@@ -292,6 +256,25 @@ pub(super) async fn bootstrap_saved_peers(
         }
 
         statuses.push(status);
+    }
+
+    if options.install_replicators_on_bootstrap
+        && statuses.iter().any(|status| status.dial_succeeded)
+    {
+        match sync_index_collections_with_retry(node, p2p, BOOTSTRAP_OPERATION_TIMEOUT).await {
+            Ok(synced) => {
+                tracing::info!(
+                    target: "gents_desktop_core::peer",
+                    synced_collections = ?synced,
+                    "session index sync complete"
+                );
+            }
+            Err(error) => {
+                let message = format!("session index sync failed: {error}");
+                tracing::warn!(target: "gents_desktop_core::peer", %message);
+                errors.push(message);
+            }
+        }
     }
 
     (statuses, errors)
@@ -315,6 +298,7 @@ pub(super) async fn write_peer_pairing_desired(
     requester_did: &str,
     requester_addr: &str,
 ) -> Result<()> {
+    use gents::agent::p2p_reconcile::templates::MACHINE_TEMPLATE;
     use gents_protocol::graphql::escape_graphql_string;
 
     let peer_id = escape_graphql_string(&record.peer_id);
@@ -322,11 +306,7 @@ pub(super) async fn write_peer_pairing_desired(
     // replicator address therefore describe this requester, not the remote
     // deployment represented by `record`.
     let agent_did = escape_graphql_string(requester_did);
-    let collections = subscribed_collection_names()
-        .iter()
-        .map(|s| format!(r#""{}""#, escape_graphql_string(s)))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let template = escape_graphql_string(MACHINE_TEMPLATE);
     let replicator_addr = escape_graphql_string(requester_addr);
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let now = escape_graphql_string(&now);
@@ -364,7 +344,8 @@ pub(super) async fn write_peer_pairing_desired(
             r#"mutation {{ update_PeerPairingDesired(
                 filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
                 input: {{
-                    collections: [{collections}],
+                    collections: null,
+                    template: "{template}",
                     replicator_addresses: ["{replicator_addr}"],
                     agent_did: "{agent_did}",
                     created_at: "{created_at}",
@@ -378,7 +359,8 @@ pub(super) async fn write_peer_pairing_desired(
             r#"mutation {{ create_PeerPairingDesired(input: {{
                 peer_id: "{peer_id}",
                 agent_did: "{agent_did}",
-                collections: [{collections}],
+                collections: null,
+                template: "{template}",
                 replicator_addresses: ["{replicator_addr}"],
                 profiles: null,
                 created_at: "{now}",
@@ -527,61 +509,53 @@ pub(super) async fn add_replicator_with_retry_until(
     }
 }
 
-pub(super) async fn sync_branchable_collections_with_retry(
+pub(super) async fn sync_index_collections_with_retry(
     node: &EmbeddedNode,
     p2p: &Arc<dyn P2POps>,
-    label: &str,
     timeout: Duration,
 ) -> Result<Vec<String>> {
     let deadline = Instant::now() + timeout;
-    let mut synced = Vec::new();
-    for collection_name in branchable_collection_names() {
-        let collection_id = node
+    let [conversation_name, session_name] = index_collection_names();
+    let resolve_id = |collection_name| -> Result<String> {
+        let collection = node
             .get_collection(collection_name)
             .map_err(|error| {
                 anyhow::anyhow!("loading collection id for {collection_name}: {error}")
             })?
-            .ok_or_else(|| anyhow::anyhow!("collection {collection_name} not found"))?
-            .collection_id;
+            .ok_or_else(|| anyhow::anyhow!("collection {collection_name} not found"))?;
+        Ok(collection.collection_id)
+    };
+    let conversation_id = resolve_id(conversation_name)?;
+    let session_id = resolve_id(session_name)?;
 
-        loop {
-            match p2p_sync_branchable_collection(p2p, &collection_id).await {
-                Ok(()) => {
-                    synced.push(collection_name.to_string());
-                    break;
+    tokio::try_join!(
+        sync_index_collection_with_retry(p2p, conversation_name, &conversation_id, deadline),
+        sync_index_collection_with_retry(p2p, session_name, &session_id, deadline),
+    )?;
+
+    Ok(vec![
+        conversation_name.to_string(),
+        session_name.to_string(),
+    ])
+}
+
+async fn sync_index_collection_with_retry(
+    p2p: &Arc<dyn P2POps>,
+    collection_name: &str,
+    collection_id: &str,
+    deadline: Instant,
+) -> Result<()> {
+    loop {
+        match p2p_sync_branchable_collection(p2p, collection_id).await {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                if Instant::now() >= deadline {
+                    anyhow::bail!("timed out syncing index collection {collection_name}: {error}");
                 }
-                Err(error) => {
-                    if Instant::now() >= deadline {
-                        anyhow::bail!(
-                            "timed out syncing branchable collection {collection_name} for peer {label}: {error}"
-                        );
-                    }
-                    sleep(BOOTSTRAP_OPERATION_BACKOFF).await;
-                }
+                sleep(BOOTSTRAP_OPERATION_BACKOFF).await;
             }
         }
     }
-    Ok(synced)
-}
-
-pub(super) fn branchable_pair_sync_enabled() -> bool {
-    env_flag_enabled(BRANCHABLE_PAIR_SYNC_ENV)
-}
-
-fn env_flag_enabled(name: &str) -> bool {
-    let Ok(value) = std::env::var(name) else {
-        return false;
-    };
-    env_flag_value(Some(&value)).unwrap_or(false)
-}
-
-fn env_flag_value(value: Option<&str>) -> Option<bool> {
-    let value = value?;
-    let value = value.trim().to_ascii_lowercase();
-    if value.is_empty() {
-        return None;
-    }
-    Some(matches!(value.as_str(), "1" | "true" | "yes" | "on"))
 }
 
 pub(super) async fn is_connected_peer(p2p: &Arc<dyn P2POps>, peer_id: &str) -> Result<bool> {

--- a/crates/gents-desktop-core/src/client/core/supervisor.rs
+++ b/crates/gents-desktop-core/src/client/core/supervisor.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::RwLock as StdRwLock;
 use std::time::SystemTime;
@@ -24,7 +25,7 @@ use super::bearer_pairing::{
 };
 use super::bootstrap::{
     add_replicator_with_retry, connect_peer_with_retry, force_connect_peer_with_retry,
-    is_connected_peer,
+    is_connected_peer, request_index_sync,
 };
 use super::p2p_ops::{
     p2p_connected_peers, p2p_get_replicators, p2p_listen_addresses, p2p_local_peer_id,
@@ -52,6 +53,7 @@ pub(super) fn spawn_p2p_supervisor_task(
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
         let endpoint_refresh_interval = endpoint_interval();
         let mut last_endpoint_refresh = Instant::now() - endpoint_refresh_interval;
+        let mut index_requests = BTreeSet::new();
 
         loop {
             let manual_repair = tokio::select! {
@@ -88,6 +90,7 @@ pub(super) fn spawn_p2p_supervisor_task(
                 &remote_admin_actor,
                 install_replicators_on_bootstrap,
                 manual_repair,
+                &mut index_requests,
             )
             .await;
 
@@ -153,9 +156,16 @@ async fn run_saved_peer_repair_cycle(
     remote_admin_actor: &Arc<PrincipalIdentity>,
     install_replicators_on_bootstrap: bool,
     force_repair: bool,
+    index_requests: &mut BTreeSet<String>,
 ) {
     let records = peer_directory.read().await.records().to_vec();
-    for record in records {
+    let saved_peer_ids = records
+        .iter()
+        .map(|record| record.peer_id.clone())
+        .collect::<BTreeSet<_>>();
+    index_requests.retain(|peer_id| saved_peer_ids.contains(peer_id));
+
+    for record in &records {
         let current_status = peer_statuses
             .read()
             .expect("peer status lock poisoned")
@@ -164,7 +174,7 @@ async fn run_saved_peer_repair_cycle(
             .cloned();
 
         let needs_repair =
-            force_repair || saved_peer_needs_repair(p2p, &record, current_status.as_ref()).await;
+            force_repair || saved_peer_needs_repair(p2p, record, current_status.as_ref()).await;
 
         let mut still_saved = peer_directory
             .read()
@@ -173,9 +183,10 @@ async fn run_saved_peer_repair_cycle(
             .iter()
             .any(|candidate| candidate.peer_id == record.peer_id);
         if needs_repair {
+            index_requests.remove(&record.peer_id);
             let updated = repair_saved_peer(
                 p2p,
-                &record,
+                record,
                 current_status,
                 remote_admin_actor.did(),
                 install_replicators_on_bootstrap,
@@ -193,14 +204,14 @@ async fn run_saved_peer_repair_cycle(
             }
         }
 
-        if still_saved && is_bearer_peer(&record) {
+        if still_saved && is_bearer_peer(record) {
             revalidate_bearer_pairing_readiness(
                 node,
                 p2p,
                 peer_directory,
                 peer_statuses,
                 remote_admin_actor,
-                &record,
+                record,
             )
             .await;
         }
@@ -208,11 +219,66 @@ async fn run_saved_peer_repair_cycle(
         if still_saved {
             run_pairing_reconcile_for_peer(
                 node,
-                &record,
+                record,
                 peer_statuses,
                 Arc::clone(remote_admin_actor),
             )
             .await;
+        }
+    }
+
+    if install_replicators_on_bootstrap {
+        request_index_for_ready_peers(node, p2p, peer_statuses, &saved_peer_ids, index_requests)
+            .await;
+    }
+}
+
+pub(super) async fn request_index_for_ready_peers(
+    node: &Arc<EmbeddedNode>,
+    p2p: &Arc<dyn P2POps>,
+    peer_statuses: &Arc<StdRwLock<Vec<ClientPeerStatus>>>,
+    saved_peer_ids: &BTreeSet<String>,
+    requested_for: &mut BTreeSet<String>,
+) {
+    let pending = peer_statuses
+        .read()
+        .expect("peer status lock poisoned")
+        .iter()
+        .filter(|status| {
+            saved_peer_ids.contains(&status.peer_id)
+                && status.dial_succeeded
+                && status.last_error.is_none()
+                && !requested_for.contains(&status.peer_id)
+        })
+        .map(|status| status.peer_id.clone())
+        .collect::<BTreeSet<_>>();
+    if pending.is_empty() {
+        return;
+    }
+
+    match request_index_sync(node.as_ref(), p2p).await {
+        Ok(collections) => {
+            requested_for.extend(pending);
+            tracing::info!(
+                target: "gents_desktop_core::peer_maintenance",
+                requested_collections = ?collections,
+                "session index sync request dispatched; merges continue asynchronously"
+            );
+        }
+        Err(error) => {
+            let message = format!("session index sync request failed: {error}");
+            let mut statuses = peer_statuses.write().expect("peer status lock poisoned");
+            for status in statuses
+                .iter_mut()
+                .filter(|status| pending.contains(&status.peer_id))
+            {
+                status.last_error = Some(message.clone());
+            }
+            tracing::warn!(
+                target: "gents_desktop_core::peer_maintenance",
+                error = %error,
+                "session index sync request failed; supervisor will retry after repair"
+            );
         }
     }
 }

--- a/crates/gents-desktop-core/src/client/core/tests.rs
+++ b/crates/gents-desktop-core/src/client/core/tests.rs
@@ -27,6 +27,7 @@ struct RecordingP2P {
     connected_peers_error: StdRwLock<Option<String>>,
     connect_calls: StdRwLock<Vec<String>>,
     add_replicator_calls: StdRwLock<Vec<String>>,
+    sync_branchable_calls: StdRwLock<Vec<String>>,
     cleanup_calls: StdRwLock<Vec<String>>,
     replicators: StdRwLock<Vec<ReplicatorInfo>>,
     replicators_error: StdRwLock<Option<String>>,
@@ -91,6 +92,13 @@ impl RecordingP2P {
         self.add_replicator_calls
             .read()
             .expect("add replicator calls lock poisoned")
+            .clone()
+    }
+
+    fn sync_branchable_calls(&self) -> Vec<String> {
+        self.sync_branchable_calls
+            .read()
+            .expect("sync branchable calls lock poisoned")
             .clone()
     }
 
@@ -266,13 +274,58 @@ impl P2POps for RecordingP2P {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, _collection_id: &str) -> P2PResult<()> {
+    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
+        self.sync_branchable_calls
+            .write()
+            .expect("sync branchable calls lock poisoned")
+            .push(collection_id.to_string());
         Ok(())
     }
 
     async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> P2PResult<()> {
         Ok(())
     }
+}
+
+#[tokio::test]
+async fn index_sync_requests_exactly_the_session_index() {
+    use crate::client::paths::DesktopPaths;
+
+    let tmp = tempfile::TempDir::new().expect("tmpdir");
+    let core = ClientCore::start_with_paths_and_options(
+        DesktopPaths::from_root(tmp.path().to_path_buf()),
+        ClientCoreOptions::local_only(),
+    )
+    .await
+    .expect("client core");
+    let recording = Arc::new(RecordingP2P::default());
+    let p2p: Arc<dyn P2POps> = recording.clone();
+
+    let synced = super::bootstrap::sync_index_collections_with_retry(
+        core.node(),
+        &p2p,
+        Duration::from_secs(1),
+    )
+    .await
+    .expect("sync index");
+    assert_eq!(synced, ["AgentConversation", "AgentSession"]);
+
+    let mut expected = crate::client::schema::index_collection_names()
+        .into_iter()
+        .map(|name| {
+            core.node()
+                .get_collection(name)
+                .expect("get collection")
+                .expect("collection exists")
+                .collection_id
+        })
+        .collect::<Vec<_>>();
+    let mut actual = recording.sync_branchable_calls();
+    expected.sort();
+    actual.sort();
+    assert_eq!(actual, expected);
+
+    core.shutdown().await.expect("shutdown");
 }
 
 #[tokio::test]
@@ -328,6 +381,14 @@ async fn remove_peer_retains_saved_deployment_when_p2p_cleanup_fails() {
     )
     .await
     .expect("save pairing desired fixture");
+    super::bootstrap::write_peer_pairing_desired(
+        core.node(),
+        &record,
+        "did:key:desktop-requester",
+        "endpoint-requester-ticket-updated",
+    )
+    .await
+    .expect("update pairing desired fixture");
 
     let error = core
         .remove_peer(&record.peer_id)
@@ -352,17 +413,18 @@ async fn remove_peer_retains_saved_deployment_when_p2p_cleanup_fails() {
     let response = core
         .node()
         .execute(&format!(
-            r#"query {{ PeerPairingDesired(filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}) {{ _docID agent_did replicator_addresses }} }}"#
+            r#"query {{ PeerPairingDesired(filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}) {{ _docID agent_did collections template replicator_addresses }} }}"#
         ))
         .await;
     assert!(!response.has_errors());
-    let row = response
+    let rows = response
         .data
         .as_ref()
         .and_then(|data| data.get("PeerPairingDesired"))
         .and_then(|rows| rows.as_array())
-        .and_then(|rows| rows.first())
-        .expect("saved pairing desired row");
+        .expect("saved pairing desired rows");
+    assert_eq!(rows.len(), 1, "writer must update the existing row");
+    let row = rows.first().expect("saved pairing desired row");
     assert_eq!(
         row.get("agent_did").and_then(serde_json::Value::as_str),
         Some("did:key:desktop-requester")
@@ -372,7 +434,14 @@ async fn remove_peer_retains_saved_deployment_when_p2p_cleanup_fails() {
             .and_then(serde_json::Value::as_array)
             .and_then(|addresses| addresses.first())
             .and_then(serde_json::Value::as_str),
-        Some("endpoint-requester-ticket")
+        Some("endpoint-requester-ticket-updated")
+    );
+    assert!(row
+        .get("collections")
+        .is_some_and(serde_json::Value::is_null));
+    assert_eq!(
+        row.get("template").and_then(serde_json::Value::as_str),
+        Some("machine")
     );
 
     core.shutdown().await.expect("shutdown");

--- a/crates/gents-desktop-core/src/client/core/tests.rs
+++ b/crates/gents-desktop-core/src/client/core/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::RwLock as StdRwLock;
@@ -11,7 +11,8 @@ use defra_p2p_adapter::{
 };
 
 use super::supervisor::{
-    p2p_health_materially_changed, probe_p2p_health, repair_saved_peer, saved_peer_needs_repair,
+    p2p_health_materially_changed, probe_p2p_health, repair_saved_peer,
+    request_index_for_ready_peers, saved_peer_needs_repair,
 };
 use super::writes::cleanup_saved_peer_p2p;
 use super::*;
@@ -288,7 +289,7 @@ impl P2POps for RecordingP2P {
 }
 
 #[tokio::test]
-async fn index_sync_requests_exactly_the_session_index() {
+async fn index_sync_request_targets_exactly_the_session_index() {
     use crate::client::paths::DesktopPaths;
 
     let tmp = tempfile::TempDir::new().expect("tmpdir");
@@ -299,16 +300,13 @@ async fn index_sync_requests_exactly_the_session_index() {
     .await
     .expect("client core");
     let recording = Arc::new(RecordingP2P::default());
+    recording.set_connected_peers(vec!["peer-alpha".to_string()]);
     let p2p: Arc<dyn P2POps> = recording.clone();
 
-    let synced = super::bootstrap::sync_index_collections_with_retry(
-        core.node(),
-        &p2p,
-        Duration::from_secs(1),
-    )
-    .await
-    .expect("sync index");
-    assert_eq!(synced, ["AgentConversation", "AgentSession"]);
+    let requested = super::bootstrap::request_index_sync(core.node(), &p2p)
+        .await
+        .expect("request index sync");
+    assert_eq!(requested, ["AgentConversation", "AgentSession"]);
 
     let mut expected = crate::client::schema::index_collection_names()
         .into_iter()
@@ -324,6 +322,75 @@ async fn index_sync_requests_exactly_the_session_index() {
     expected.sort();
     actual.sort();
     assert_eq!(actual, expected);
+
+    core.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn supervisor_requests_index_for_new_and_reconnected_peers_and_surfaces_failures() {
+    use crate::client::paths::DesktopPaths;
+
+    let tmp = tempfile::TempDir::new().expect("tmpdir");
+    let core = ClientCore::start_with_paths_and_options(
+        DesktopPaths::from_root(tmp.path().to_path_buf()),
+        ClientCoreOptions::local_only(),
+    )
+    .await
+    .expect("client core");
+    let recording = Arc::new(RecordingP2P::default());
+    recording.set_connected_peers(vec!["peer-alpha".to_string()]);
+    let p2p: Arc<dyn P2POps> = recording.clone();
+    let node = core.node_arc();
+    let statuses = Arc::new(StdRwLock::new(vec![ClientPeerStatus {
+        peer_id: "saved-alpha".to_string(),
+        label: "Alpha".to_string(),
+        agent_did: "did:key:alpha".to_string(),
+        addr: "peer-alpha".to_string(),
+        dial_succeeded: true,
+        last_error: None,
+        pairing: Vec::new(),
+    }]));
+    let mut saved = BTreeSet::from(["saved-alpha".to_string()]);
+    let mut requested_for = BTreeSet::new();
+
+    request_index_for_ready_peers(&node, &p2p, &statuses, &saved, &mut requested_for).await;
+    assert_eq!(recording.sync_branchable_calls().len(), 2);
+    assert_eq!(requested_for, saved);
+
+    request_index_for_ready_peers(&node, &p2p, &statuses, &saved, &mut requested_for).await;
+    assert_eq!(recording.sync_branchable_calls().len(), 2);
+
+    statuses
+        .write()
+        .expect("peer statuses lock poisoned")
+        .push(ClientPeerStatus {
+            peer_id: "saved-beta".to_string(),
+            label: "Beta".to_string(),
+            agent_did: "did:key:beta".to_string(),
+            addr: "peer-beta".to_string(),
+            dial_succeeded: true,
+            last_error: None,
+            pairing: Vec::new(),
+        });
+    saved.insert("saved-beta".to_string());
+    request_index_for_ready_peers(&node, &p2p, &statuses, &saved, &mut requested_for).await;
+    assert_eq!(recording.sync_branchable_calls().len(), 4);
+    assert_eq!(requested_for, saved);
+
+    requested_for.remove("saved-alpha");
+    request_index_for_ready_peers(&node, &p2p, &statuses, &saved, &mut requested_for).await;
+    assert_eq!(recording.sync_branchable_calls().len(), 6);
+
+    requested_for.remove("saved-alpha");
+    recording.set_connected_peers(Vec::new());
+    request_index_for_ready_peers(&node, &p2p, &statuses, &saved, &mut requested_for).await;
+    let statuses = statuses.read().expect("peer statuses lock poisoned");
+    assert!(statuses
+        .iter()
+        .find(|status| status.peer_id == "saved-alpha")
+        .and_then(|status| status.last_error.as_deref())
+        .is_some_and(|error| error.contains("no connected peers")));
+    assert!(!requested_for.contains("saved-alpha"));
 
     core.shutdown().await.expect("shutdown");
 }

--- a/crates/gents-desktop-core/src/client/core/writes.rs
+++ b/crates/gents-desktop-core/src/client/core/writes.rs
@@ -21,7 +21,7 @@ use super::super::schema::subscribed_collection_names;
 use super::super::store::{ClientStore, ClientStoreRows};
 use super::bootstrap::{
     add_replicator_with_retry_until, connect_peer_with_retry_until, is_connected_peer,
-    normalize_required, sync_index_collections_with_retry,
+    normalize_required,
 };
 use super::p2p_ops;
 use super::p2p_ops::{p2p_disconnect_peer, p2p_remove_replicator};
@@ -1255,7 +1255,7 @@ impl ClientCore {
             }
         };
 
-        match super::bootstrap::configure_local_runtime_pairing(
+        if let Err(error) = super::bootstrap::configure_local_runtime_pairing(
             self.node.as_ref(),
             &self.p2p,
             &self.principal,
@@ -1263,44 +1263,15 @@ impl ClientCore {
         )
         .await
         {
-            Ok(()) => {
-                if connected {
-                    match sync_index_collections_with_retry(
-                        self.node.as_ref(),
-                        &self.p2p,
-                        PEER_ADD_OPERATION_TIMEOUT,
-                    )
-                    .await
-                    {
-                        Ok(synced) => {
-                            tracing::info!(
-                                target: "gents_desktop_core::peer",
-                                peer_id = %record.peer_id,
-                                label = %record.label,
-                                synced_collections = ?synced,
-                                "session index sync complete after peer add"
-                            );
-                        }
-                        Err(error) => {
-                            append_warning(
-                                &mut warning,
-                                format!("deployment paired but session index sync failed: {error}"),
-                            );
-                        }
-                    }
-                }
-            }
-            Err(error) => {
-                let prefix = if connected {
-                    "deployment connected"
-                } else {
-                    "deployment saved"
-                };
-                append_warning(
-                    &mut warning,
-                    format!("{prefix} but reverse pairing failed: {error}"),
-                );
-            }
+            let prefix = if connected {
+                "deployment connected"
+            } else {
+                "deployment saved"
+            };
+            append_warning(
+                &mut warning,
+                format!("{prefix} but reverse pairing failed: {error}"),
+            );
         }
         if let Err(error) = self.refresh_agent(&record.agent_did).await {
             append_warning(

--- a/crates/gents-desktop-core/src/client/core/writes.rs
+++ b/crates/gents-desktop-core/src/client/core/writes.rs
@@ -20,9 +20,8 @@ use super::super::query::load_chat_patch;
 use super::super::schema::subscribed_collection_names;
 use super::super::store::{ClientStore, ClientStoreRows};
 use super::bootstrap::{
-    add_replicator_with_retry_until, branchable_pair_sync_enabled, connect_peer_with_retry_until,
-    is_connected_peer, normalize_required, sync_branchable_collections_with_retry,
-    BRANCHABLE_PAIR_SYNC_ENV,
+    add_replicator_with_retry_until, connect_peer_with_retry_until, is_connected_peer,
+    normalize_required, sync_index_collections_with_retry,
 };
 use super::p2p_ops;
 use super::p2p_ops::{p2p_disconnect_peer, p2p_remove_replicator};
@@ -1265,11 +1264,10 @@ impl ClientCore {
         .await
         {
             Ok(()) => {
-                if branchable_pair_sync_enabled() {
-                    match sync_branchable_collections_with_retry(
+                if connected {
+                    match sync_index_collections_with_retry(
                         self.node.as_ref(),
                         &self.p2p,
-                        &record.label,
                         PEER_ADD_OPERATION_TIMEOUT,
                     )
                     .await
@@ -1280,26 +1278,16 @@ impl ClientCore {
                                 peer_id = %record.peer_id,
                                 label = %record.label,
                                 synced_collections = ?synced,
-                                "desktop requested branchable collection sync after peer add"
+                                "session index sync complete after peer add"
                             );
                         }
                         Err(error) => {
                             append_warning(
                                 &mut warning,
-                                format!(
-                                    "deployment paired but existing branchable sync failed: {error}"
-                                ),
+                                format!("deployment paired but session index sync failed: {error}"),
                             );
                         }
                     }
-                } else {
-                    tracing::debug!(
-                        target: "gents_desktop_core::peer",
-                        peer_id = %record.peer_id,
-                        label = %record.label,
-                        env = BRANCHABLE_PAIR_SYNC_ENV,
-                        "skipping opt-in branchable collection sync after peer add"
-                    );
                 }
             }
             Err(error) => {

--- a/crates/gents-desktop-core/src/client/schema.rs
+++ b/crates/gents-desktop-core/src/client/schema.rs
@@ -1,8 +1,6 @@
 use anyhow::{Context, Result};
 use defra_node::EmbeddedNode;
-use gents_protocol::schemas::{
-    ALL_COLLECTION_NAMES, BRANCHABLE_COLLECTION_NAMES, RUNTIME_COLLECTION_NAMES,
-};
+use gents_protocol::schemas::{ALL_COLLECTION_NAMES, RUNTIME_COLLECTION_NAMES};
 
 pub async fn ensure_runtime_schemas(node: &EmbeddedNode) -> Result<()> {
     gents_migration::ensure_migrations(node)
@@ -58,8 +56,9 @@ pub fn subscribed_collection_names() -> Vec<&'static str> {
         .collect()
 }
 
-pub fn branchable_collection_names() -> Vec<&'static str> {
-    BRANCHABLE_COLLECTION_NAMES.to_vec()
+/// The lightweight session index eagerly hydrated by paired clients.
+pub fn index_collection_names() -> [&'static str; 2] {
+    ["AgentConversation", "AgentSession"]
 }
 
 #[cfg(test)]
@@ -82,5 +81,17 @@ mod tests {
             names.iter().any(|name| *name == "AgentRequest"),
             "the exclusion must not have emptied the set: {names:?}"
         );
+    }
+
+    #[test]
+    fn index_collections_are_the_session_index_and_are_branchable() {
+        let index = super::index_collection_names();
+        assert_eq!(index, ["AgentConversation", "AgentSession"]);
+        for name in index {
+            assert!(
+                gents_protocol::schemas::BRANCHABLE_COLLECTION_NAMES.contains(&name),
+                "{name} must be branchable for DAG sync"
+            );
+        }
     }
 }

--- a/crates/gents-desktop-core/src/client/schema.rs
+++ b/crates/gents-desktop-core/src/client/schema.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use defra_node::EmbeddedNode;
+use gents::agent::p2p_reconcile::templates::CLIENT_INDEX_COLLECTIONS;
 use gents_protocol::schemas::{ALL_COLLECTION_NAMES, RUNTIME_COLLECTION_NAMES};
 
 pub async fn ensure_runtime_schemas(node: &EmbeddedNode) -> Result<()> {
@@ -58,7 +59,7 @@ pub fn subscribed_collection_names() -> Vec<&'static str> {
 
 /// The lightweight session index eagerly hydrated by paired clients.
 pub fn index_collection_names() -> [&'static str; 2] {
-    ["AgentConversation", "AgentSession"]
+    CLIENT_INDEX_COLLECTIONS
 }
 
 #[cfg(test)]

--- a/crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
+++ b/crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
@@ -155,15 +155,19 @@ theorem conversation_readiness_crossing_is_claimant_scoped (peerDid localDid : D
 theorem machine_filter_eq (peerDid homeDid : Did) :
     scopeFilter machineTemplate.scope [] peerDid homeDid =
       scopeFilter conversationTemplate.scope [] peerDid homeDid ++
-        [ { collection := "AgentDirectoryEntry"
+        [ { collection := "PersonaConfigRequest"
+          , field := "requester_did"
+          , value := peerDid }
+        , { collection := "AgentDirectoryEntry"
           , field := "source_did"
           , value := homeDid } ] := by
   simp [scopeFilter, machineTemplate, machineRules, conversationTemplate]
 
-theorem machine_filters_transcript_and_directory (peerDid homeDid : Did) :
+theorem machine_filters_transcript_persona_and_directory (peerDid homeDid : Did) :
     ((scopeFilter machineTemplate.scope [] peerDid homeDid).map
         (fun k => k.collection)).toFinset
-      = (conversationTranscriptCollections ++ ["AgentDirectoryEntry"]).toFinset := by
+      = (conversationTranscriptCollections ++
+          ["PersonaConfigRequest", "AgentDirectoryEntry"]).toFinset := by
   simp [scopeFilter, machineTemplate, machineRules, machineCollections,
     conversationRules, conversationCollections, conversationTranscriptCollections]
 
@@ -243,6 +247,24 @@ theorem appCollections_collections_empty :
 
 theorem appCollections_unscoped_no_filter (collections : List String) (peerDid localDid : Did) :
     scopeFilter appCollectionsTemplate.scope collections peerDid localDid = [] := rfl
+
+theorem clientIndex_in_catalog :
+    resolveTemplate builtinCatalog "client-index" = some clientIndexTemplate := by
+  decide
+
+theorem clientIndex_filter_eq (peerDid localDid : Did) :
+    scopeFilter (.perCollection clientIndexRules) [] peerDid localDid
+      = [ { collection := "AgentConversation", field := "requester_did", value := peerDid }
+        , { collection := "AgentSession",      field := "requester_did", value := peerDid } ] := by
+  simp [scopeFilter, clientIndexRules]
+
+theorem clientIndex_filters_requester_lineage (peerDid localDid : Did) :
+    (scopeFilter clientIndexTemplate.scope [] peerDid localDid).all
+      (fun k => k.value = peerDid ∧ k.field = "requester_did") = true := by
+  simp [scopeFilter, clientIndexTemplate, clientIndexRules]
+
+theorem clientIndex_covers_exactly_index_collections :
+    clientIndexTemplate.collections = clientIndexCollections.toFinset := rfl
 
 theorem subagent_filter_values_local_or_peer
     (rules : List CollectionRule) (peerDid localDid : Did)

--- a/crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
+++ b/crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
@@ -263,8 +263,10 @@ theorem clientIndex_filters_requester_lineage (peerDid localDid : Did) :
       (fun k => k.value = peerDid ∧ k.field = "requester_did") = true := by
   simp [scopeFilter, clientIndexTemplate, clientIndexRules]
 
-theorem clientIndex_covers_exactly_index_collections :
-    clientIndexTemplate.collections = clientIndexCollections.toFinset := rfl
+theorem clientIndex_covers_exactly_literal_index_collections :
+    clientIndexTemplate.collections =
+      ["AgentConversation", "AgentSession"].toFinset := by
+  decide
 
 theorem subagent_filter_values_local_or_peer
     (rules : List CollectionRule) (peerDid localDid : Did)

--- a/crates/gents/proofs/Proofs/ScopeTemplates/State.lean
+++ b/crates/gents/proofs/Proofs/ScopeTemplates/State.lean
@@ -57,24 +57,27 @@ def conversationTranscriptCollections : List String :=
 
 def agentConfigCollections : List String :=
   ["AgentBehavior", "ToolSelection", "InferenceBackend", "InferenceProfile",
-   "ToolServiceRegistry", "Skill"]
+   "ToolServiceRegistry", "Skill", "DatastoreToolSurface"]
 
 def conversationCollections : List String :=
   conversationTranscriptCollections ++ agentConfigCollections
 
 def machineCollections : List String :=
-  conversationCollections ++ ["AgentDirectoryEntry"]
+  conversationCollections ++ ["PersonaConfigRequest", "AgentDirectoryEntry"]
 
 def discoveryCollections : List String :=
   ["AgentNetwork", "NetworkMembership", "PeerEndpoint", "NetworkJoinRequest",
    "AgentBehavior", "ToolSelection", "InferenceBackend", "InferenceProfile",
-   "ToolServiceRegistry", "Skill"]
+   "ToolServiceRegistry", "Skill", "DatastoreToolSurface"]
 
 def networkControlCollections : List String :=
   ["AgentNetwork", "NetworkMembership", "PeerEndpoint", "NetworkJoinRequest"]
 
 def subagentHostCollections : List String :=
   ["AgentRequest", "AgentResponse", "AgentMessage", "AgentToolCall"]
+
+def clientIndexCollections : List String :=
+  ["AgentConversation", "AgentSession"]
 
 def conversationRules : List CollectionRule :=
   [ { collection := "AgentRequest",      field := "requester_did", source := .peerDid }
@@ -89,7 +92,8 @@ def conversationRules : List CollectionRule :=
 
 def machineRules : List CollectionRule :=
   conversationRules ++
-    [ { collection := "AgentDirectoryEntry", field := "source_did", source := .homeDid } ]
+    [ { collection := "PersonaConfigRequest", field := "requester_did", source := .peerDid }
+    , { collection := "AgentDirectoryEntry", field := "source_did", source := .homeDid } ]
 
 def subagentCoordinatorRules : List CollectionRule :=
   [ { collection := "AgentToolCall", field := "spawn_target_did", source := .peerDid } ]
@@ -99,6 +103,10 @@ def subagentHostRules : List CollectionRule :=
   , { collection := "AgentResponse",     field := "requester_did", source := .peerDid }
   , { collection := "AgentMessage",      field := "requester_did", source := .peerDid }
   , { collection := "AgentToolCall",     field := "requester_did", source := .peerDid } ]
+
+def clientIndexRules : List CollectionRule :=
+  [ { collection := "AgentConversation", field := "requester_did", source := .peerDid }
+  , { collection := "AgentSession",      field := "requester_did", source := .peerDid } ]
 
 def conversationTemplate : Template :=
   { id := "conversation"
@@ -154,6 +162,12 @@ def appCollectionsTemplate : Template :=
   , scope := .unscoped
   , delivery := .replicate }
 
+def clientIndexTemplate : Template :=
+  { id := "client-index"
+  , collections := clientIndexCollections.toFinset
+  , scope := .perCollection clientIndexRules
+  , delivery := .push }
+
 def builtinCatalog : Catalog :=
   [ conversationTemplate
   , machineTemplate
@@ -163,6 +177,7 @@ def builtinCatalog : Catalog :=
   , networkControlTemplate
   , subagentCoordinatorTemplate
   , subagentHostTemplate
-  , appCollectionsTemplate ]
+  , appCollectionsTemplate
+  , clientIndexTemplate ]
 
 end ScopeTemplates

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -191,6 +191,23 @@ const CONVERSATION_RULES: &[CollectionRule] = &[
     },
 ];
 
+/// Requester-scoped session-index grant. Complete historical index hydration
+/// is handled separately by the desktop's node-global branchable pull.
+const CLIENT_INDEX_COLLECTIONS: &[&str] = &["AgentConversation", "AgentSession"];
+
+const CLIENT_INDEX_RULES: &[CollectionRule] = &[
+    CollectionRule {
+        collection: "AgentConversation",
+        field: "requester_did",
+        source: DidSource::PeerDid,
+    },
+    CollectionRule {
+        collection: "AgentSession",
+        field: "requester_did",
+        source: DidSource::PeerDid,
+    },
+];
+
 /// The fleet-discovery directory collection replicated by the `machine`
 /// template (issue #714). Registered in `gents-schemas`; named here as a
 /// literal because the catalog is deliberately dependency-free strings.
@@ -367,6 +384,7 @@ pub const SUBAGENT_COORDINATOR_TEMPLATE: &str = "subagent-coordinator";
 pub const SUBAGENT_HOST_TEMPLATE: &str = "subagent-host";
 pub const APP_COLLECTIONS_TEMPLATE: &str = "app-collections";
 pub const MACHINE_TEMPLATE: &str = "machine";
+pub const CLIENT_INDEX_TEMPLATE: &str = "client-index";
 
 static BUILTIN_TEMPLATES: &[ScopeTemplate] = &[
     ScopeTemplate {
@@ -423,6 +441,12 @@ static BUILTIN_TEMPLATES: &[ScopeTemplate] = &[
         collections: &[],
         scope: Scope::Unscoped,
         delivery: Delivery::Replicate,
+    },
+    ScopeTemplate {
+        id: CLIENT_INDEX_TEMPLATE,
+        collections: CLIENT_INDEX_COLLECTIONS,
+        scope: Scope::PerCollection(CLIENT_INDEX_RULES),
+        delivery: Delivery::Push,
     },
 ];
 
@@ -580,8 +604,26 @@ mod tests {
     }
 
     #[test]
-    fn builtin_template_count_is_nine() {
-        assert_eq!(builtin_templates().len(), 9);
+    fn builtin_template_count_is_ten() {
+        assert_eq!(builtin_templates().len(), 10);
+    }
+
+    #[test]
+    fn client_index_is_requester_scoped_push_of_the_session_index() {
+        let t = resolve_template(CLIENT_INDEX_TEMPLATE).unwrap();
+        assert_eq!(t.delivery, Delivery::Push);
+        assert!(matches!(t.scope, Scope::PerCollection(_)));
+        assert_eq!(t.collections, &["AgentConversation", "AgentSession"]);
+
+        let filter = scope_filter(&t.scope, t.collections, "did:key:phone", "did:key:home");
+        assert_eq!(filter.len(), 2);
+        for collection in CLIENT_INDEX_COLLECTIONS {
+            let predicate = filter
+                .get(*collection)
+                .expect("indexed collection is filtered");
+            assert_eq!(predicate.field, "requester_did");
+            assert_eq!(predicate.value, "did:key:phone");
+        }
     }
 
     #[test]

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -193,7 +193,7 @@ const CONVERSATION_RULES: &[CollectionRule] = &[
 
 /// Requester-scoped session-index grant. Complete historical index hydration
 /// is handled separately by the desktop's node-global branchable pull.
-const CLIENT_INDEX_COLLECTIONS: &[&str] = &["AgentConversation", "AgentSession"];
+pub const CLIENT_INDEX_COLLECTIONS: [&str; 2] = ["AgentConversation", "AgentSession"];
 
 const CLIENT_INDEX_RULES: &[CollectionRule] = &[
     CollectionRule {
@@ -444,7 +444,7 @@ static BUILTIN_TEMPLATES: &[ScopeTemplate] = &[
     },
     ScopeTemplate {
         id: CLIENT_INDEX_TEMPLATE,
-        collections: CLIENT_INDEX_COLLECTIONS,
+        collections: &CLIENT_INDEX_COLLECTIONS,
         scope: Scope::PerCollection(CLIENT_INDEX_RULES),
         delivery: Delivery::Push,
     },
@@ -617,7 +617,7 @@ mod tests {
 
         let filter = scope_filter(&t.scope, t.collections, "did:key:phone", "did:key:home");
         assert_eq!(filter.len(), 2);
-        for collection in CLIENT_INDEX_COLLECTIONS {
+        for collection in &CLIENT_INDEX_COLLECTIONS {
             let predicate = filter
                 .get(*collection)
                 .expect("indexed collection is filtered");

--- a/crates/gents/tests/conformance/scope_templates.rs
+++ b/crates/gents/tests/conformance/scope_templates.rs
@@ -83,6 +83,39 @@ fn conversation_scope_excludes_another_requester_on_the_same_agent() {
     assert_ne!(classifier_request.1, Some(predicate.value.as_str()));
 }
 
+/// Mirrors Lean `clientIndex_filter_eq` and
+/// `clientIndex_filters_requester_lineage`.
+#[test]
+fn client_index_scope_is_exactly_the_requester_scoped_session_index() {
+    let template = resolve_template("client-index").expect("client-index in catalog");
+    assert_eq!(template.delivery, Delivery::Push);
+    assert_eq!(template.collections, &["AgentConversation", "AgentSession"]);
+
+    let phone = scope_filter(
+        &template.scope,
+        template.collections,
+        "did:key:phone",
+        "did:key:home",
+    );
+    assert_eq!(phone.len(), 2);
+    for collection in template.collections {
+        let predicate = phone.get(*collection).expect("collection filtered");
+        assert_eq!(predicate.field, "requester_did");
+        assert_eq!(predicate.value, "did:key:phone");
+    }
+
+    let laptop = scope_filter(
+        &template.scope,
+        template.collections,
+        "did:key:laptop",
+        "did:key:home",
+    );
+    assert_ne!(
+        phone.get("AgentSession").unwrap().value,
+        laptop.get("AgentSession").unwrap().value
+    );
+}
+
 #[test]
 fn machine_scope_covers_conversation_and_home_owned_directory() {
     let template = resolve_template("machine").expect("machine in catalog");

--- a/docs/superpowers/plans/2026-08-17-eager-session-index-sync.md
+++ b/docs/superpowers/plans/2026-08-17-eager-session-index-sync.md
@@ -1,0 +1,509 @@
+# Eager Session-Index Sync (#1141) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A freshly paired client renders the full session list (AgentConversation + AgentSession) with no transcript-plane replication and no env gate.
+
+**Architecture:** Follow the foundation flow: extend the Lean scope-template catalog first, then the Rust catalog it mirrors, then conformance; finally rewire client bootstrap to sync exactly the two index collections once per bootstrap (branchable-collection DAG pull — node-global, unfiltered, so the client sees *all* sessions, not just its own slice) and make the pairing row request the `machine` template explicitly.
+
+**Tech Stack:** Rust (gents workspace), Lean 4 (crates/gents/proofs), DefraDB embedded node (defradb.rs pinned rev).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md`
+
+## Global Constraints
+
+- Zero `sorry`s in Lean; catalog counts are exact on both sides (Rust test asserts the count; Lean `builtinCatalog` is a literal list).
+- Always `graphql::escape_graphql_string()` for anything interpolated into GraphQL.
+- Never emit `[]` in a DefraDB mutation — emit `null` for empty lists.
+- Gate with `cargo test -p gents` (never `--lib`), and `cargo check --workspace --all-targets` before push.
+- `tracing`, never `println`.
+- Branch: `agent/ui-mobile-debug`. Reference issue #1141 in commits.
+
+---
+
+### Task 1: Lean — add the `client-index` template to the model
+
+**Files:**
+- Modify: `crates/gents/proofs/Proofs/ScopeTemplates/State.lean`
+- Modify: `crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean`
+
+**Interfaces:**
+- Produces: `clientIndexCollections : List String`, `clientIndexRules : List CollectionRule`, `clientIndexTemplate : Template`, and `builtinCatalog` now ending `…, appCollectionsTemplate, clientIndexTemplate]`. Task 2's Rust catalog must match this order and content exactly.
+
+- [ ] **Step 1: Add collections, rules, and template to `State.lean`**
+
+In `crates/gents/proofs/Proofs/ScopeTemplates/State.lean`, directly after the `subagentHostCollections` definition, add:
+
+```lean
+def clientIndexCollections : List String :=
+  ["AgentConversation", "AgentSession"]
+```
+
+Directly after the `subagentHostRules` definition, add:
+
+```lean
+def clientIndexRules : List CollectionRule :=
+  [ { collection := "AgentConversation", field := "requester_did", source := .peerDid }
+  , { collection := "AgentSession",      field := "requester_did", source := .peerDid } ]
+```
+
+Directly after the `appCollectionsTemplate` definition, add:
+
+```lean
+def clientIndexTemplate : Template :=
+  { id := "client-index"
+  , collections := clientIndexCollections.toFinset
+  , scope := .perCollection clientIndexRules
+  , delivery := .push }
+```
+
+Then change `builtinCatalog` from:
+
+```lean
+def builtinCatalog : Catalog :=
+  [ conversationTemplate
+  , machineTemplate
+  , agentConfigTemplate
+  , backupTemplate
+  , discoveryTemplate
+  , networkControlTemplate
+  , subagentCoordinatorTemplate
+  , subagentHostTemplate
+  , appCollectionsTemplate ]
+```
+
+to:
+
+```lean
+def builtinCatalog : Catalog :=
+  [ conversationTemplate
+  , machineTemplate
+  , agentConfigTemplate
+  , backupTemplate
+  , discoveryTemplate
+  , networkControlTemplate
+  , subagentCoordinatorTemplate
+  , subagentHostTemplate
+  , appCollectionsTemplate
+  , clientIndexTemplate ]
+```
+
+- [ ] **Step 2: Add theorems to `Derivation.lean`**
+
+Directly after the `appCollections_unscoped_no_filter` theorem at the end of the catalog-membership block, add:
+
+```lean
+theorem clientIndex_in_catalog :
+    resolveTemplate builtinCatalog "client-index" = some clientIndexTemplate := by
+  decide
+
+theorem clientIndex_filter_eq (peerDid localDid : Did) :
+    scopeFilter (.perCollection clientIndexRules) [] peerDid localDid
+      = [ { collection := "AgentConversation", field := "requester_did", value := peerDid }
+        , { collection := "AgentSession",      field := "requester_did", value := peerDid } ] := by
+  simp [scopeFilter, clientIndexRules]
+
+theorem clientIndex_filters_requester_lineage (peerDid localDid : Did) :
+    (scopeFilter clientIndexTemplate.scope [] peerDid localDid).all
+      (fun k => k.value = peerDid ∧ k.field = "requester_did") = true := by
+  simp [scopeFilter, clientIndexTemplate, clientIndexRules]
+
+theorem clientIndex_covers_exactly_index_collections :
+    clientIndexTemplate.collections = clientIndexCollections.toFinset := rfl
+```
+
+If any existing theorem in `Derivation.lean` enumerates the whole catalog (e.g. a totality or count theorem proved by `decide`), re-run it unchanged — `decide` re-evaluates against the new 10-entry list; fix only if the statement hard-codes `9`.
+
+- [ ] **Step 3: Build the proofs**
+
+Run from `crates/gents/proofs/`:
+```bash
+lake build
+```
+Expected: success, zero `sorry`s. If `decide` times out on `clientIndex_in_catalog`, mirror whichever proof tactic `machine_in_catalog` uses (it is `decide` today).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gents/proofs/Proofs/ScopeTemplates/State.lean crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
+git commit -m "proofs: add client-index scope template to the catalog model (#1141)"
+```
+
+---
+
+### Task 2: Rust — mirror the template in the catalog
+
+**Files:**
+- Modify: `crates/gents/src/agent/p2p_reconcile/templates.rs`
+
+**Interfaces:**
+- Consumes: the Lean catalog from Task 1 (order and content must match).
+- Produces: `pub const CLIENT_INDEX_TEMPLATE: &str = "client-index"` and a `BUILTIN_TEMPLATES` entry; `resolve_template("client-index")` returns it. Task 3 and Task 4 rely on the id string `"client-index"`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+In the `#[cfg(test)] mod tests` at the bottom of `templates.rs`, next to `builtin_template_count_is_nine`, replace that test and add one:
+
+```rust
+    #[test]
+    fn builtin_template_count_is_ten() {
+        assert_eq!(builtin_templates().len(), 10);
+    }
+
+    #[test]
+    fn client_index_is_requester_scoped_push_of_the_session_index() {
+        let t = resolve_template(CLIENT_INDEX_TEMPLATE).unwrap();
+        assert_eq!(t.delivery, Delivery::Push);
+        assert!(matches!(t.scope, Scope::PerCollection(_)));
+        assert_eq!(t.collections, &["AgentConversation", "AgentSession"]);
+        let filter = scope_filter(&t.scope, t.collections, "did:key:phone", "did:key:home");
+        assert_eq!(filter.len(), 2);
+        for col in ["AgentConversation", "AgentSession"] {
+            let pred = filter.get(col).expect("indexed collection is filtered");
+            assert_eq!(pred.field, "requester_did");
+            assert_eq!(pred.value, "did:key:phone");
+        }
+    }
+```
+
+Delete the old `builtin_template_count_is_nine` test.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p gents --lib agent::p2p_reconcile::templates
+```
+Expected: FAIL — `CLIENT_INDEX_TEMPLATE` not found (compile error). (`--lib` is acceptable for the inner red/green loop only; the task gate in Step 5 uses the full suite.)
+
+- [ ] **Step 3: Add the template**
+
+In `templates.rs`, next to the other template-id constants (`APP_COLLECTIONS_TEMPLATE`, `MACHINE_TEMPLATE`):
+
+```rust
+pub const CLIENT_INDEX_TEMPLATE: &str = "client-index";
+```
+
+After `CONVERSATION_RULES` (or adjacent rule constants), add:
+
+```rust
+/// Session-index slice for lightweight clients: conversation cards and
+/// session lifecycle rows only, scoped to the requesting peer's lineage.
+/// The full-index view a paired app renders comes from an unfiltered
+/// branchable pull of the same two collections at bootstrap; this template
+/// is the standing, filtered push for peers that should only see their own.
+const CLIENT_INDEX_COLLECTIONS: &[&str] = &["AgentConversation", "AgentSession"];
+
+const CLIENT_INDEX_RULES: &[CollectionRule] = &[
+    CollectionRule {
+        collection: "AgentConversation",
+        field: "requester_did",
+        source: DidSource::PeerDid,
+    },
+    CollectionRule {
+        collection: "AgentSession",
+        field: "requester_did",
+        source: DidSource::PeerDid,
+    },
+];
+```
+
+Append to `BUILTIN_TEMPLATES` (after the `app-collections` entry, matching the Lean order):
+
+```rust
+    ScopeTemplate {
+        id: CLIENT_INDEX_TEMPLATE,
+        collections: CLIENT_INDEX_COLLECTIONS,
+        scope: Scope::PerCollection(CLIENT_INDEX_RULES),
+        delivery: Delivery::Push,
+    },
+```
+
+- [ ] **Step 4: Run the unit tests**
+
+```bash
+cargo test -p gents --lib agent::p2p_reconcile::templates
+```
+Expected: PASS, including the two new tests.
+
+- [ ] **Step 5: Run the conformance + fence gate**
+
+```bash
+cargo test -p gents scope_templates
+cargo test -p gents embedded_all_builtin_template_filters_pass_replicator_validation
+```
+Expected: PASS. The second test runs every catalog template's filter through real `add_replicator` validation — `requester_did` is `@immutable` on both index collections, so `client-index` must pass. If it fails on immutability, STOP: the schema premise is wrong and the spec needs revisiting.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/gents/src/agent/p2p_reconcile/templates.rs
+git commit -m "feat(p2p): client-index scope template — requester-scoped session index (#1141)"
+```
+
+---
+
+### Task 3: Conformance — pin the template's contract
+
+**Files:**
+- Modify: `crates/gents/tests/conformance/scope_templates.rs`
+
+**Interfaces:**
+- Consumes: `resolve_template("client-index")`, `scope_filter` from Task 2.
+
+- [ ] **Step 1: Write the conformance test**
+
+Add to `crates/gents/tests/conformance/scope_templates.rs`, following the style of `conversation_scope_excludes_another_requester_on_the_same_agent`:
+
+```rust
+/// Mirrors Lean `clientIndex_filter_eq` / `clientIndex_filters_requester_lineage`:
+/// the index slice is exactly the two session-index collections, both scoped
+/// to the peer's requester lineage, and nothing else rides along.
+#[test]
+fn client_index_scope_is_exactly_the_requester_scoped_session_index() {
+    let t = resolve_template("client-index").expect("client-index in catalog");
+    assert_eq!(t.delivery, Delivery::Push);
+    assert_eq!(t.collections, &["AgentConversation", "AgentSession"]);
+
+    let filter = scope_filter(&t.scope, t.collections, "did:key:phone", "did:key:home");
+    assert_eq!(filter.len(), 2);
+    for col in ["AgentConversation", "AgentSession"] {
+        let pred = filter.get(col).expect("collection filtered");
+        assert_eq!(pred.field, "requester_did");
+        assert_eq!(pred.value, "did:key:phone");
+    }
+
+    // Another requester's rows do not match this peer's slice.
+    let other = scope_filter(&t.scope, t.collections, "did:key:laptop", "did:key:home");
+    assert_ne!(
+        filter.get("AgentSession").unwrap().value,
+        other.get("AgentSession").unwrap().value
+    );
+}
+```
+
+Match the existing imports at the top of the file (`resolve_template`, `scope_filter`, `Delivery`, `Scope` are already imported for the sibling tests; extend the `use` list only if the compiler asks).
+
+- [ ] **Step 2: Run it**
+
+```bash
+cargo test -p gents client_index_scope_is_exactly_the_requester_scoped_session_index
+```
+Expected: PASS.
+
+- [ ] **Step 3: Check the coverage ledger**
+
+```bash
+grep -rn "scope_templates" crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean | head
+```
+If the ledger enumerates per-template conformance cases, add a `client-index` entry mirroring the `machine` entry's shape and re-run `lake build` in `crates/gents/proofs/`. If it only tracks areas (not per-template), no change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/gents/tests/conformance/scope_templates.rs crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+git commit -m "test(conformance): pin client-index template contract (#1141)"
+```
+
+---
+
+### Task 4: Bootstrap — ungated index sync, once per bootstrap
+
+**Files:**
+- Modify: `crates/gents-desktop-core/src/client/schema.rs`
+- Modify: `crates/gents-desktop-core/src/client/core/bootstrap.rs`
+
+**Interfaces:**
+- Produces: `pub fn index_collection_names() -> [&'static str; 2]` in `schema.rs`; `sync_index_collections_with_retry(node, p2p, timeout) -> Result<Vec<String>>` in `bootstrap.rs` (label parameter dropped — the operation is node-global, not per-peer).
+- Consumes: `p2p_sync_branchable_collection(p2p, &collection_id)` (existing, `core/p2p_ops.rs`).
+
+- [ ] **Step 1: Write the failing test for the index list**
+
+In `crates/gents-desktop-core/src/client/schema.rs`'s existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn index_collections_are_the_session_index_and_are_branchable() {
+        let index = super::index_collection_names();
+        assert_eq!(index, ["AgentConversation", "AgentSession"]);
+        for name in index {
+            assert!(
+                super::branchable_collection_names().contains(&name),
+                "{name} must be branchable for DAG sync"
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cargo test -p gents-desktop-core index_collections_are
+```
+Expected: FAIL — `index_collection_names` not found.
+
+- [ ] **Step 3: Implement `index_collection_names`**
+
+In `schema.rs`, after `branchable_collection_names`:
+
+```rust
+/// The eager session index: conversation cards (title, preview, lineage)
+/// and session lifecycle rows. Synced unfiltered at bootstrap so a paired
+/// client renders the complete session list; everything transcript-shaped
+/// stays lazy (#1142).
+pub fn index_collection_names() -> [&'static str; 2] {
+    ["AgentConversation", "AgentSession"]
+}
+```
+
+- [ ] **Step 4: Rewire bootstrap**
+
+In `bootstrap.rs`:
+
+a. Rename `sync_branchable_collections_with_retry` to `sync_index_collections_with_retry`, drop the `label: &str` parameter, and iterate `crate::client::schema::index_collection_names()` instead of `branchable_collection_names()`. The body is otherwise unchanged (per-collection id resolution + retry loop against the shared deadline). Update the error message to `"timed out syncing index collection {collection_name}: {error}"`.
+
+b. Delete `branchable_pair_sync_enabled()` and the `BRANCHABLE_PAIR_SYNC_ENV` constant. Keep `env_flag_enabled`/`env_flag_value` only if `grep -rn "env_flag_enabled\|env_flag_value" crates/gents-desktop-core/src/` shows other callers; otherwise delete them too.
+
+c. In the peer loop, delete the entire `if branchable_pair_sync_enabled() { … } else { tracing::debug!(… "skipping opt-in branchable collection sync after pairing") }` block (the `configure_local_runtime_pairing` match keeps its `Ok(()) => {}` arm trivial and its `Err` arm unchanged).
+
+d. After the peer loop completes (immediately after the `statuses.push(status);` loop ends), add a single node-global index sync, gated only on at least one successful dial:
+
+```rust
+    if options.install_replicators_on_bootstrap
+        && statuses.iter().any(|s| s.dial_succeeded)
+    {
+        match sync_index_collections_with_retry(node, p2p, BOOTSTRAP_OPERATION_TIMEOUT).await {
+            Ok(synced) => {
+                tracing::info!(
+                    target: "gents_desktop_core::peer",
+                    synced_collections = ?synced,
+                    "session index sync complete"
+                );
+            }
+            Err(error) => {
+                let message = format!("session index sync failed: {error}");
+                tracing::warn!(target: "gents_desktop_core::peer", %message);
+                errors.push(message);
+            }
+        }
+    }
+```
+
+Remove the now-unused `branchable_collection_names` import from `bootstrap.rs` if nothing else in the file uses it.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cargo test -p gents-desktop-core
+```
+Expected: PASS (existing bootstrap tests compile against the new signature; fix call sites the compiler flags — `core/supervisor.rs` may reference the old fn name in its repair path; apply the same rename there).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/gents-desktop-core/src/client/schema.rs crates/gents-desktop-core/src/client/core/bootstrap.rs crates/gents-desktop-core/src/client/core/supervisor.rs
+git commit -m "feat(desktop-core): ungated eager session-index sync at bootstrap, replacing the env-gated 16-collection pull (#1141)"
+```
+
+---
+
+### Task 5: Pairing row — explicit template, no dead collections list
+
+**Files:**
+- Modify: `crates/gents-desktop-core/src/client/core/bootstrap.rs` (`write_peer_pairing_desired`)
+
+**Interfaces:**
+- Consumes: existing `machine` template id (`MACHINE_TEMPLATE` in gents; here as the literal `"machine"` — the client crates reference templates by string).
+- Produces: `PeerPairingDesired` rows carrying `template: "machine"`; the server's `desired_from_pairing_row` stops falling back to `DEFAULT_PAIRING_TEMPLATE = "conversation"`.
+
+- [ ] **Step 1: Modify the mutations**
+
+In `write_peer_pairing_desired`, delete the `collections` local (the `subscribed_collection_names()` join) — the server never reads `row.collections` for non-`app-collections` templates; it derives from `template.collections`.
+
+Replace the update mutation body:
+
+```rust
+        format!(
+            r#"mutation {{ update_PeerPairingDesired(
+                filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
+                input: {{
+                    collections: null,
+                    template: "machine",
+                    replicator_addresses: ["{replicator_addr}"],
+                    agent_did: "{agent_did}",
+                    created_at: "{created_at}",
+                    profiles: null,
+                    updated_at: "{now}"
+                }}
+            ) {{ _docID }} }}"#
+        )
+```
+
+and the create mutation body:
+
+```rust
+        format!(
+            r#"mutation {{ create_PeerPairingDesired(input: {{
+                peer_id: "{peer_id}",
+                agent_did: "{agent_did}",
+                collections: null,
+                template: "machine",
+                replicator_addresses: ["{replicator_addr}"],
+                profiles: null,
+                created_at: "{now}",
+                updated_at: "{now}"
+            }}) {{ _docID }} }}"#
+        )
+```
+
+(`collections: null`, never `[]` — the empty list literal corrupts nillable array columns. `machine` rather than `client-index`: the paired app is a full client that later rides `PersonaConfigRequest`/`SessionHydrationRequest` over this same pairing; `client-index` exists for peers that should see only the index.)
+
+- [ ] **Step 2: Compile and test**
+
+```bash
+cargo test -p gents-desktop-core
+```
+Expected: PASS. If a fixture asserts the row's `collections` contents, update it to expect null/absent and `template == "machine"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/gents-desktop-core/src/client/core/bootstrap.rs
+git commit -m "fix(desktop-core): pairing row requests the machine template explicitly, drops dead collections list (#1141)"
+```
+
+---
+
+### Task 6: Full gates + live verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Package suite**
+
+```bash
+cargo test -p gents
+```
+Expected: PASS (integration tests are separate compile units — never trust `--lib`).
+
+- [ ] **Step 2: Workspace check**
+
+```bash
+cargo check --workspace --all-targets
+```
+Expected: clean. This catches desktop/bridge construction sites the package suite skips.
+
+- [ ] **Step 3: Proofs**
+
+```bash
+cd crates/gents/proofs && lake build && cd -
+```
+Expected: clean, zero `sorry`s.
+
+- [ ] **Step 4: Live two-node smoke (manual, environment-dependent)**
+
+With the amy runtime on studio-1 reachable (see memory note / spec): build the desktop app, wipe its local store, `/status`-pair against `http://100.69.4.79:9191/status`, and verify the session list shows amy's full conversation set (titles + previews; 129 conversations at time of writing) with no transcript docs in the local store beyond the index. This mirrors the phone repro that motivated #1141.
+
+- [ ] **Step 5: Commit any straggler fixes and push**
+
+```bash
+git push origin agent/ui-mobile-debug
+```

--- a/docs/superpowers/plans/2026-08-17-eager-session-index-sync.md
+++ b/docs/superpowers/plans/2026-08-17-eager-session-index-sync.md
@@ -4,7 +4,7 @@
 
 **Goal:** A freshly paired client renders the full session list (AgentConversation + AgentSession) with no transcript-plane replication and no env gate.
 
-**Architecture:** Follow the foundation flow: first repair the small pre-existing Lean/Rust catalog drift and extend the Lean scope-template catalog, then mirror the new template in Rust and pin conformance. Finally, replace the env-gated bulk pull with a concurrent sync of exactly the two index collections: once after the saved-peer bootstrap loop, plus once after a successful interactive peer add (branchable-collection DAG pull is node-global and unfiltered, so the client sees *all* sessions, not just its requester slice). Make the pairing row request the `machine` template explicitly.
+**Architecture:** Follow the foundation flow: first repair the small pre-existing Lean/Rust catalog drift and extend the Lean scope-template catalog, then mirror the new template in Rust and pin conformance. Finally, replace the env-gated bulk pull with a supervisor-owned concurrent request for exactly the two index collections. The supervisor dispatches after startup, for a new peer, and after reconnect/repair without blocking launch or add-peer. BranchableSync is node-global and unfiltered, so the trusted full client sees all sessions rather than only its requester slice. Make the pairing row request the `machine` template explicitly.
 
 **Tech Stack:** Rust (gents workspace), Lean 4 (crates/gents/proofs), DefraDB embedded node (defradb.rs pinned rev).
 
@@ -15,8 +15,12 @@
 - The Lean catalog currently predates `DatastoreToolSurface` in the shared config plane and `PersonaConfigRequest` in `machine`. Task 1 repairs that drift before adding `client-index`; otherwise the claim that Lean and Rust mirror one another would remain false.
 - #1141 registers `client-index`, but does not select it for the desktop pairing row. The eager unfiltered DAG pull is what supplies the complete historical index in this issue; the pairing row remains `machine` so the existing requester-authored control plane keeps working. Wiring a pairing to `client-index` is outside this issue.
 - In this plan, “no transcript-plane replication” means the eager historical catch-up requests only the two index collections. The existing `machine` grant still has requester-scoped transcript routes, and the desktop still subscribes to new collection heads. If the acceptance criterion instead means *zero transcript transport of any kind*, the approved design and Task 5 conflict and must be redesigned before implementation.
-- The old env-gated bulk sync is called both during saved-peer bootstrap (`bootstrap.rs`) and interactive peer add (`writes.rs`). Both paths must be rewired. `supervisor.rs` does not call the helper and is not part of this change.
-- “Concurrent” is an acceptance detail, not just a comment: the fixed two collection sync/retry futures run together with `tokio::try_join!` under one shared deadline.
+- The pinned IROH adapter returns when it dispatches per-peer sends; it does not expose merge completion. Logs and return values therefore say “requested,” never “complete.” Supervisor lifecycle events provide re-request opportunities, while exact progress remains #1144/upstream work.
+- BranchableSync checks collection-level access but does not apply the `client-index` requester predicate. Cross-requester session-card visibility is an explicit trust decision for the current full-client product, not a tenant-safe property proved by the template.
+- Existing template-absent pairings previously resolved to `conversation`. Writing `machine` changes their effective filter and causes one teardown/reinstall/full replay on upgrade; this migration cost is explicitly accepted.
+- `GENTS_DESKTOP_SYNC_BRANCHABLE_ON_PAIR` is removed with no 16-collection replacement. Transcript history remains lazy until #1142.
+- “Concurrent” is an acceptance detail: the fixed two collection request futures run together with `tokio::try_join!`.
+- The preferred follow-up is a paginated, cursor-based index protocol with bounded document-ID pages, explicit lineage policy, observable progress, and resumability.
 
 ## Global Constraints
 
@@ -147,8 +151,10 @@ theorem clientIndex_filters_requester_lineage (peerDid localDid : Did) :
       (fun k => k.value = peerDid ∧ k.field = "requester_did") = true := by
   simp [scopeFilter, clientIndexTemplate, clientIndexRules]
 
-theorem clientIndex_covers_exactly_index_collections :
-    clientIndexTemplate.collections = clientIndexCollections.toFinset := rfl
+theorem clientIndex_covers_exactly_literal_index_collections :
+    clientIndexTemplate.collections =
+      ["AgentConversation", "AgentSession"].toFinset := by
+  decide
 ```
 
 If any existing theorem in `Derivation.lean` enumerates the whole catalog (e.g. a totality or count theorem proved by `decide`), re-run it unchanged — `decide` re-evaluates against the new 10-entry list; fix only if the statement hard-codes `9`.
@@ -344,117 +350,60 @@ git commit -m "test(conformance): pin client-index template contract (#1141)"
 
 ---
 
-### Task 4: Bootstrap — ungated index sync, once per bootstrap
+### Task 4: Supervisor — resilient, non-blocking index requests
 
 **Files:**
 - Modify: `crates/gents-desktop-core/src/client/schema.rs`
 - Modify: `crates/gents-desktop-core/src/client/core/bootstrap.rs`
+- Modify: `crates/gents-desktop-core/src/client/core/supervisor.rs`
 - Modify: `crates/gents-desktop-core/src/client/core/writes.rs`
 - Modify: `crates/gents-desktop-core/src/client/core/tests.rs`
 
 **Interfaces:**
-- Produces: `pub fn index_collection_names() -> [&'static str; 2]` in `schema.rs`; `sync_index_collections_with_retry(node, p2p, timeout) -> Result<Vec<String>>` in `bootstrap.rs` (label parameter dropped — the operation is node-global, not per-peer). The two per-collection retry futures run concurrently and return names in stable index-list order.
+- Produces: public Rust `CLIENT_INDEX_COLLECTIONS`; `index_collection_names()` reuses it; `request_index_sync(node, p2p) -> Result<Vec<String>>` validates that a peer is connected and concurrently dispatches exactly two collection requests; the supervisor tracks which saved-peer connection epochs have received a request.
 - Consumes: `p2p_sync_branchable_collection(p2p, &collection_id)` (existing, `core/p2p_ops.rs`).
 
-- [ ] **Step 1: Write the failing test for the index list**
+- [ ] **Step 1: Keep one Rust source of truth for the index list**
 
-In `crates/gents-desktop-core/src/client/schema.rs`'s existing `#[cfg(test)] mod tests`:
+Export `CLIENT_INDEX_COLLECTIONS` from the Rust template catalog and return it from `schema::index_collection_names()`. Keep the existing test that pins the literal names and verifies both are branchable. Lean remains the formal mirror, with a theorem against the literal collection names rather than against the definition used to construct the template.
 
-```rust
-    #[test]
-    fn index_collections_are_the_session_index_and_are_branchable() {
-        let index = super::index_collection_names();
-        assert_eq!(index, ["AgentConversation", "AgentSession"]);
-        for name in index {
-            assert!(
-                gents_protocol::schemas::BRANCHABLE_COLLECTION_NAMES.contains(&name),
-                "{name} must be branchable for DAG sync"
-            );
-        }
-    }
-```
-
-- [ ] **Step 2: Run to verify failure**
-
-```bash
-cargo test -p gents-desktop-core index_collections_are
-```
-Expected: FAIL — `index_collection_names` not found.
-
-- [ ] **Step 3: Implement `index_collection_names`**
-
-In `schema.rs`, after `branchable_collection_names`:
-
-```rust
-/// The eager session index: conversation cards (title, preview, lineage)
-/// and session lifecycle rows. Synced unfiltered at bootstrap so a paired
-/// client renders the complete session list; everything transcript-shaped
-/// stays lazy (#1142).
-pub fn index_collection_names() -> [&'static str; 2] {
-    ["AgentConversation", "AgentSession"]
-}
-```
-
-- [ ] **Step 4: Rewire bootstrap**
+- [ ] **Step 2: Remove the old inline paths and ineffective retry ladder**
 
 In `bootstrap.rs`:
 
-a. Rename `sync_branchable_collections_with_retry` to `sync_index_collections_with_retry` and drop the `label: &str` parameter. Resolve the two collection IDs up front, then run one retry future per collection with `tokio::try_join!` under the same deadline. Preserve deterministic output order (`AgentConversation`, then `AgentSession`) and use the error message `"timed out syncing index collection {collection_name}: {error}"`.
+- remove the old env gate and 16-collection helper;
+- remove index requests from `bootstrap_saved_peers` and `ClientCore::add_peer` so neither critical path waits on them;
+- replace the retrying helper with `request_index_sync`, which refuses zero connected peers, resolves the two collection IDs once, and dispatches the two requests with `tokio::try_join!` once; and
+- preserve `bootstrap_saved_peers` errors in `ClientCore::bootstrap_errors` rather than discarding them.
 
-b. Delete `branchable_pair_sync_enabled()` and the `BRANCHABLE_PAIR_SYNC_ENV` constant. Confirm with `rg -n "env_flag_enabled|env_flag_value" crates/gents-desktop-core/src` that the private parsing helpers have no other callers, then delete them too.
+- [ ] **Step 3: Let the supervisor own request opportunities**
 
-c. In the peer loop, delete the entire `if branchable_pair_sync_enabled() { … } else { tracing::debug!(… "skipping opt-in branchable collection sync after pairing") }` block (the `configure_local_runtime_pairing` match keeps its `Ok(()) => {}` arm trivial and its `Err` arm unchanged).
+Maintain a small in-memory set of saved peer IDs whose current healthy connection epoch has received an index request. The supervisor:
 
-d. After the peer loop completes (immediately after the `statuses.push(status);` loop ends), add a single node-global index sync, gated only on at least one successful dial. Because this call is outside the loop, multiple saved peers still trigger only one pair of collection requests:
+1. begins with the set empty, causing one request after startup for healthy saved peers;
+2. requests again when a newly saved healthy peer is absent from the set;
+3. removes a peer from the set whenever that peer enters repair, causing a fresh request after successful reconnect; and
+4. records request failures in `ClientPeerStatus.last_error`, where the UI and `saved_peer_needs_repair` already look. A successful dispatch logs that merges continue asynchronously; it never claims completion.
 
-```rust
-    if options.install_replicators_on_bootstrap
-        && statuses.iter().any(|s| s.dial_succeeded)
-    {
-        match sync_index_collections_with_retry(node, p2p, BOOTSTRAP_OPERATION_TIMEOUT).await {
-            Ok(synced) => {
-                tracing::info!(
-                    target: "gents_desktop_core::peer",
-                    synced_collections = ?synced,
-                    "session index sync complete"
-                );
-            }
-            Err(error) => {
-                let message = format!("session index sync failed: {error}");
-                tracing::warn!(target: "gents_desktop_core::peer", %message);
-                errors.push(message);
-            }
-        }
-    }
-```
+- [ ] **Step 4: Add focused regression coverage**
 
-Remove the now-unused `branchable_collection_names` import from `bootstrap.rs` and delete the helper itself now that it has no production callers; the schema test can check `BRANCHABLE_COLLECTION_NAMES` directly.
+Extend `RecordingP2P` to record collection IDs. Pin that the direct request targets exactly the two real index collection IDs. Add a supervisor-state regression covering initial request, steady-state dedupe, newly saved peer, reconnect re-arm, and visible failure when transport state reports no connected peers. Avoid timing assertions.
 
-e. In `writes.rs`, replace the second env-gated call site in `ClientCore::add_peer`. After reverse pairing succeeds, call `sync_index_collections_with_retry` ungated when `connected` is true, using `PEER_ADD_OPERATION_TIMEOUT`. If the peer was saved but did not connect, skip the immediate pull; the next successful bootstrap performs it. Update the log/warning text from “branchable” to “session index”, and remove the deleted env-helper imports.
-
-- [ ] **Step 5: Add focused sync regression coverage**
-
-Extend `RecordingP2P` in `core/tests.rs` (or add a narrow test double) to record `sync_branchable_collection` IDs. Add a test that:
-
-1. starts a local test node so the real collection-name → collection-ID lookup is exercised;
-2. calls `sync_index_collections_with_retry`;
-3. asserts exactly the `AgentConversation` and `AgentSession` collection IDs were requested, with no transcript collection, and the returned names retain stable index-list order; and
-4. keeps the concurrency implementation explicit with `tokio::try_join!`, without adding timing-sensitive test scaffolding.
-
-- [ ] **Step 6: Run the tests**
+- [ ] **Step 5: Run the tests**
 
 ```bash
 cargo test -p gents-desktop-core index_collections_are
-cargo test -p gents-desktop-core index_sync_requests_exactly
+cargo test -p gents-desktop-core index_sync_request_targets_exactly
+cargo test -p gents-desktop-core supervisor_requests_index
 cargo test -p gents-desktop-core
 ```
-Expected: PASS. `core/supervisor.rs` has no old-helper call site and should remain unchanged.
+Expected: PASS.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add crates/gents-desktop-core/src/client/schema.rs crates/gents-desktop-core/src/client/core/bootstrap.rs crates/gents-desktop-core/src/client/core/writes.rs crates/gents-desktop-core/src/client/core/tests.rs
-git commit -m "feat(desktop-core): ungated eager session-index sync at bootstrap, replacing the env-gated 16-collection pull (#1141)"
+git add crates/gents-desktop-core/src/client/schema.rs crates/gents-desktop-core/src/client/core/bootstrap.rs crates/gents-desktop-core/src/client/core/supervisor.rs crates/gents-desktop-core/src/client/core/writes.rs crates/gents-desktop-core/src/client/core/tests.rs
+git commit -m "fix(desktop-core): retry session-index requests from the P2P supervisor (#1141)"
 ```
 
 ---
@@ -576,7 +525,7 @@ With the amy runtime on studio-1 reachable (see memory note / spec):
 2. Build the desktop app, wipe only its local application store, and `/status`-pair against `http://100.69.4.79:9191/status`.
 3. Verify the local index docIDs/counts match the contemporaneous remote baseline for amy and that titles/previews render. Do not use the stale “129 conversations” observation as an assertion.
 4. Before creating any new activity, verify historical `AgentRequest`, `AgentResponse`, `AgentMessage`, `AgentToolCall`, `AgentToolResult`, `AgentToolApproval`, and `CompactionEntry` rows were not bulk-pulled.
-5. Verify logs show one two-collection index sync, not the old 16-collection pass, and inspect the resulting `PeerPairingDesired` row (`template: "machine"`, `collections: null`).
+5. Verify logs show a two-collection index request (without claiming merge completion), not the old 16-collection pass, and inspect the resulting `PeerPairingDesired` row (`template: "machine"`, `collections: null`).
 
 - [ ] **Step 6: Review the final diff and commits**
 

--- a/docs/superpowers/plans/2026-08-17-eager-session-index-sync.md
+++ b/docs/superpowers/plans/2026-08-17-eager-session-index-sync.md
@@ -4,11 +4,19 @@
 
 **Goal:** A freshly paired client renders the full session list (AgentConversation + AgentSession) with no transcript-plane replication and no env gate.
 
-**Architecture:** Follow the foundation flow: extend the Lean scope-template catalog first, then the Rust catalog it mirrors, then conformance; finally rewire client bootstrap to sync exactly the two index collections once per bootstrap (branchable-collection DAG pull — node-global, unfiltered, so the client sees *all* sessions, not just its own slice) and make the pairing row request the `machine` template explicitly.
+**Architecture:** Follow the foundation flow: first repair the small pre-existing Lean/Rust catalog drift and extend the Lean scope-template catalog, then mirror the new template in Rust and pin conformance. Finally, replace the env-gated bulk pull with a concurrent sync of exactly the two index collections: once after the saved-peer bootstrap loop, plus once after a successful interactive peer add (branchable-collection DAG pull is node-global and unfiltered, so the client sees *all* sessions, not just its requester slice). Make the pairing row request the `machine` template explicitly.
 
 **Tech Stack:** Rust (gents workspace), Lean 4 (crates/gents/proofs), DefraDB embedded node (defradb.rs pinned rev).
 
 **Spec:** `docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md`
+
+## Review Clarifications
+
+- The Lean catalog currently predates `DatastoreToolSurface` in the shared config plane and `PersonaConfigRequest` in `machine`. Task 1 repairs that drift before adding `client-index`; otherwise the claim that Lean and Rust mirror one another would remain false.
+- #1141 registers `client-index`, but does not select it for the desktop pairing row. The eager unfiltered DAG pull is what supplies the complete historical index in this issue; the pairing row remains `machine` so the existing requester-authored control plane keeps working. Wiring a pairing to `client-index` is outside this issue.
+- In this plan, “no transcript-plane replication” means the eager historical catch-up requests only the two index collections. The existing `machine` grant still has requester-scoped transcript routes, and the desktop still subscribes to new collection heads. If the acceptance criterion instead means *zero transcript transport of any kind*, the approved design and Task 5 conflict and must be redesigned before implementation.
+- The old env-gated bulk sync is called both during saved-peer bootstrap (`bootstrap.rs`) and interactive peer add (`writes.rs`). Both paths must be rewired. `supervisor.rs` does not call the helper and is not part of this change.
+- “Concurrent” is an acceptance detail, not just a comment: the fixed two collection sync/retry futures run together with `tokio::try_join!` under one shared deadline.
 
 ## Global Constraints
 
@@ -18,6 +26,7 @@
 - Gate with `cargo test -p gents` (never `--lib`), and `cargo check --workspace --all-targets` before push.
 - `tracing`, never `println`.
 - Branch: `agent/ui-mobile-debug`. Reference issue #1141 in commits.
+- Preserve unrelated worktree changes, including the existing generated iOS `Info.plist` modification.
 
 ---
 
@@ -28,9 +37,39 @@
 - Modify: `crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean`
 
 **Interfaces:**
+- Repairs: the Lean catalog includes the already-shipped Rust entries `DatastoreToolSurface` (config/conversation/machine/discovery) and `PersonaConfigRequest` (machine, requester-scoped).
 - Produces: `clientIndexCollections : List String`, `clientIndexRules : List CollectionRule`, `clientIndexTemplate : Template`, and `builtinCatalog` now ending `…, appCollectionsTemplate, clientIndexTemplate]`. Task 2's Rust catalog must match this order and content exactly.
 
-- [ ] **Step 1: Add collections, rules, and template to `State.lean`**
+- [ ] **Step 1: Repair the existing catalog mirror in `State.lean`**
+
+Before adding the new template, bring the Lean collection literals up to the current Rust catalog:
+
+```lean
+def agentConfigCollections : List String :=
+  ["AgentBehavior", "ToolSelection", "InferenceBackend", "InferenceProfile",
+   "ToolServiceRegistry", "Skill", "DatastoreToolSurface"]
+
+def machineCollections : List String :=
+  conversationCollections ++ ["PersonaConfigRequest", "AgentDirectoryEntry"]
+
+def discoveryCollections : List String :=
+  ["AgentNetwork", "NetworkMembership", "PeerEndpoint", "NetworkJoinRequest",
+   "AgentBehavior", "ToolSelection", "InferenceBackend", "InferenceProfile",
+   "ToolServiceRegistry", "Skill", "DatastoreToolSurface"]
+```
+
+Add the missing machine rule between `conversationRules` and the directory rule:
+
+```lean
+def machineRules : List CollectionRule :=
+  conversationRules ++
+    [ { collection := "PersonaConfigRequest", field := "requester_did", source := .peerDid }
+    , { collection := "AgentDirectoryEntry", field := "source_did", source := .homeDid } ]
+```
+
+Update the existing `machine_filter_eq` theorem in `Derivation.lean` to expect the requester-scoped `PersonaConfigRequest` predicate before the home-scoped directory predicate. Update the collection-set theorem/name so its statement includes all three filtered parts (conversation transcript, persona request, directory), rather than silently omitting the already-shipped persona rule.
+
+- [ ] **Step 2: Add collections, rules, and template to `State.lean`**
 
 In `crates/gents/proofs/Proofs/ScopeTemplates/State.lean`, directly after the `subagentHostCollections` definition, add:
 
@@ -88,7 +127,7 @@ def builtinCatalog : Catalog :=
   , clientIndexTemplate ]
 ```
 
-- [ ] **Step 2: Add theorems to `Derivation.lean`**
+- [ ] **Step 3: Add theorems to `Derivation.lean`**
 
 Directly after the `appCollections_unscoped_no_filter` theorem at the end of the catalog-membership block, add:
 
@@ -114,7 +153,7 @@ theorem clientIndex_covers_exactly_index_collections :
 
 If any existing theorem in `Derivation.lean` enumerates the whole catalog (e.g. a totality or count theorem proved by `decide`), re-run it unchanged — `decide` re-evaluates against the new 10-entry list; fix only if the statement hard-codes `9`.
 
-- [ ] **Step 3: Build the proofs**
+- [ ] **Step 4: Build the proofs**
 
 Run from `crates/gents/proofs/`:
 ```bash
@@ -122,11 +161,11 @@ lake build
 ```
 Expected: success, zero `sorry`s. If `decide` times out on `clientIndex_in_catalog`, mirror whichever proof tactic `machine_in_catalog` uses (it is `decide` today).
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add crates/gents/proofs/Proofs/ScopeTemplates/State.lean crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
-git commit -m "proofs: add client-index scope template to the catalog model (#1141)"
+git commit -m "proofs: align and extend the scope-template catalog (#1141)"
 ```
 
 ---
@@ -138,7 +177,7 @@ git commit -m "proofs: add client-index scope template to the catalog model (#11
 
 **Interfaces:**
 - Consumes: the Lean catalog from Task 1 (order and content must match).
-- Produces: `pub const CLIENT_INDEX_TEMPLATE: &str = "client-index"` and a `BUILTIN_TEMPLATES` entry; `resolve_template("client-index")` returns it. Task 3 and Task 4 rely on the id string `"client-index"`.
+- Produces: `pub const CLIENT_INDEX_TEMPLATE: &str = "client-index"` and a `BUILTIN_TEMPLATES` entry; `resolve_template("client-index")` returns it. Task 3 pins that catalog contract; Task 4's node-global bootstrap pull is deliberately independent of template selection.
 
 - [ ] **Step 1: Write the failing unit test**
 
@@ -186,11 +225,10 @@ pub const CLIENT_INDEX_TEMPLATE: &str = "client-index";
 After `CONVERSATION_RULES` (or adjacent rule constants), add:
 
 ```rust
-/// Session-index slice for lightweight clients: conversation cards and
-/// session lifecycle rows only, scoped to the requesting peer's lineage.
-/// The full-index view a paired app renders comes from an unfiltered
-/// branchable pull of the same two collections at bootstrap; this template
-/// is the standing, filtered push for peers that should only see their own.
+/// Requester-scoped session-index grant: conversation cards and session
+/// lifecycle rows only. #1141 registers this catalog contract; the desktop's
+/// complete historical index comes from an unfiltered branchable pull, and
+/// selecting this template for a pairing remains a separate policy decision.
 const CLIENT_INDEX_COLLECTIONS: &[&str] = &["AgentConversation", "AgentSession"];
 
 const CLIENT_INDEX_RULES: &[CollectionRule] = &[
@@ -290,17 +328,17 @@ cargo test -p gents client_index_scope_is_exactly_the_requester_scoped_session_i
 ```
 Expected: PASS.
 
-- [ ] **Step 3: Check the coverage ledger**
+- [ ] **Step 3: Confirm the coverage ledger remains area-level**
 
 ```bash
-grep -rn "scope_templates" crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean | head
+rg -n "scope.?templates|ScopeTemplates" crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
 ```
-If the ledger enumerates per-template conformance cases, add a `client-index` entry mirroring the `machine` entry's shape and re-run `lake build` in `crates/gents/proofs/`. If it only tracks areas (not per-template), no change.
+Expected: no per-template entries. The ledger tracks lifecycle/consumer surfaces, not individual static catalog members, so no ledger edit is required.
 
 - [ ] **Step 4: Commit**
 
 ```bash
-git add crates/gents/tests/conformance/scope_templates.rs crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+git add crates/gents/tests/conformance/scope_templates.rs
 git commit -m "test(conformance): pin client-index template contract (#1141)"
 ```
 
@@ -311,9 +349,11 @@ git commit -m "test(conformance): pin client-index template contract (#1141)"
 **Files:**
 - Modify: `crates/gents-desktop-core/src/client/schema.rs`
 - Modify: `crates/gents-desktop-core/src/client/core/bootstrap.rs`
+- Modify: `crates/gents-desktop-core/src/client/core/writes.rs`
+- Modify: `crates/gents-desktop-core/src/client/core/tests.rs`
 
 **Interfaces:**
-- Produces: `pub fn index_collection_names() -> [&'static str; 2]` in `schema.rs`; `sync_index_collections_with_retry(node, p2p, timeout) -> Result<Vec<String>>` in `bootstrap.rs` (label parameter dropped — the operation is node-global, not per-peer).
+- Produces: `pub fn index_collection_names() -> [&'static str; 2]` in `schema.rs`; `sync_index_collections_with_retry(node, p2p, timeout) -> Result<Vec<String>>` in `bootstrap.rs` (label parameter dropped — the operation is node-global, not per-peer). The two per-collection retry futures run concurrently and return names in stable index-list order.
 - Consumes: `p2p_sync_branchable_collection(p2p, &collection_id)` (existing, `core/p2p_ops.rs`).
 
 - [ ] **Step 1: Write the failing test for the index list**
@@ -327,7 +367,7 @@ In `crates/gents-desktop-core/src/client/schema.rs`'s existing `#[cfg(test)] mod
         assert_eq!(index, ["AgentConversation", "AgentSession"]);
         for name in index {
             assert!(
-                super::branchable_collection_names().contains(&name),
+                gents_protocol::schemas::BRANCHABLE_COLLECTION_NAMES.contains(&name),
                 "{name} must be branchable for DAG sync"
             );
         }
@@ -359,13 +399,13 @@ pub fn index_collection_names() -> [&'static str; 2] {
 
 In `bootstrap.rs`:
 
-a. Rename `sync_branchable_collections_with_retry` to `sync_index_collections_with_retry`, drop the `label: &str` parameter, and iterate `crate::client::schema::index_collection_names()` instead of `branchable_collection_names()`. The body is otherwise unchanged (per-collection id resolution + retry loop against the shared deadline). Update the error message to `"timed out syncing index collection {collection_name}: {error}"`.
+a. Rename `sync_branchable_collections_with_retry` to `sync_index_collections_with_retry` and drop the `label: &str` parameter. Resolve the two collection IDs up front, then run one retry future per collection with `tokio::try_join!` under the same deadline. Preserve deterministic output order (`AgentConversation`, then `AgentSession`) and use the error message `"timed out syncing index collection {collection_name}: {error}"`.
 
-b. Delete `branchable_pair_sync_enabled()` and the `BRANCHABLE_PAIR_SYNC_ENV` constant. Keep `env_flag_enabled`/`env_flag_value` only if `grep -rn "env_flag_enabled\|env_flag_value" crates/gents-desktop-core/src/` shows other callers; otherwise delete them too.
+b. Delete `branchable_pair_sync_enabled()` and the `BRANCHABLE_PAIR_SYNC_ENV` constant. Confirm with `rg -n "env_flag_enabled|env_flag_value" crates/gents-desktop-core/src` that the private parsing helpers have no other callers, then delete them too.
 
 c. In the peer loop, delete the entire `if branchable_pair_sync_enabled() { … } else { tracing::debug!(… "skipping opt-in branchable collection sync after pairing") }` block (the `configure_local_runtime_pairing` match keeps its `Ok(()) => {}` arm trivial and its `Err` arm unchanged).
 
-d. After the peer loop completes (immediately after the `statuses.push(status);` loop ends), add a single node-global index sync, gated only on at least one successful dial:
+d. After the peer loop completes (immediately after the `statuses.push(status);` loop ends), add a single node-global index sync, gated only on at least one successful dial. Because this call is outside the loop, multiple saved peers still trigger only one pair of collection requests:
 
 ```rust
     if options.install_replicators_on_bootstrap
@@ -388,19 +428,32 @@ d. After the peer loop completes (immediately after the `statuses.push(status);`
     }
 ```
 
-Remove the now-unused `branchable_collection_names` import from `bootstrap.rs` if nothing else in the file uses it.
+Remove the now-unused `branchable_collection_names` import from `bootstrap.rs` and delete the helper itself now that it has no production callers; the schema test can check `BRANCHABLE_COLLECTION_NAMES` directly.
 
-- [ ] **Step 5: Run the tests**
+e. In `writes.rs`, replace the second env-gated call site in `ClientCore::add_peer`. After reverse pairing succeeds, call `sync_index_collections_with_retry` ungated when `connected` is true, using `PEER_ADD_OPERATION_TIMEOUT`. If the peer was saved but did not connect, skip the immediate pull; the next successful bootstrap performs it. Update the log/warning text from “branchable” to “session index”, and remove the deleted env-helper imports.
+
+- [ ] **Step 5: Add focused sync regression coverage**
+
+Extend `RecordingP2P` in `core/tests.rs` (or add a narrow test double) to record `sync_branchable_collection` IDs. Add a test that:
+
+1. starts a local test node so the real collection-name → collection-ID lookup is exercised;
+2. calls `sync_index_collections_with_retry`;
+3. asserts exactly the `AgentConversation` and `AgentSession` collection IDs were requested, with no transcript collection, and the returned names retain stable index-list order; and
+4. keeps the concurrency implementation explicit with `tokio::try_join!`, without adding timing-sensitive test scaffolding.
+
+- [ ] **Step 6: Run the tests**
 
 ```bash
+cargo test -p gents-desktop-core index_collections_are
+cargo test -p gents-desktop-core index_sync_requests_exactly
 cargo test -p gents-desktop-core
 ```
-Expected: PASS (existing bootstrap tests compile against the new signature; fix call sites the compiler flags — `core/supervisor.rs` may reference the old fn name in its repair path; apply the same rename there).
+Expected: PASS. `core/supervisor.rs` has no old-helper call site and should remain unchanged.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add crates/gents-desktop-core/src/client/schema.rs crates/gents-desktop-core/src/client/core/bootstrap.rs crates/gents-desktop-core/src/client/core/supervisor.rs
+git add crates/gents-desktop-core/src/client/schema.rs crates/gents-desktop-core/src/client/core/bootstrap.rs crates/gents-desktop-core/src/client/core/writes.rs crates/gents-desktop-core/src/client/core/tests.rs
 git commit -m "feat(desktop-core): ungated eager session-index sync at bootstrap, replacing the env-gated 16-collection pull (#1141)"
 ```
 
@@ -410,14 +463,17 @@ git commit -m "feat(desktop-core): ungated eager session-index sync at bootstrap
 
 **Files:**
 - Modify: `crates/gents-desktop-core/src/client/core/bootstrap.rs` (`write_peer_pairing_desired`)
+- Modify: `crates/gents-desktop-core/src/client/core/tests.rs`
 
 **Interfaces:**
-- Consumes: existing `machine` template id (`MACHINE_TEMPLATE` in gents; here as the literal `"machine"` — the client crates reference templates by string).
+- Consumes: existing `gents::agent::p2p_reconcile::templates::MACHINE_TEMPLATE` constant, avoiding another copy of the catalog id string.
 - Produces: `PeerPairingDesired` rows carrying `template: "machine"`; the server's `desired_from_pairing_row` stops falling back to `DEFAULT_PAIRING_TEMPLATE = "conversation"`.
 
 - [ ] **Step 1: Modify the mutations**
 
 In `write_peer_pairing_desired`, delete the `collections` local (the `subscribed_collection_names()` join) — the server never reads `row.collections` for non-`app-collections` templates; it derives from `template.collections`.
+
+Import `gents::agent::p2p_reconcile::templates::MACHINE_TEMPLATE`, escape it with the other interpolated values, and bind it as `template` before building either mutation.
 
 Replace the update mutation body:
 
@@ -427,7 +483,7 @@ Replace the update mutation body:
                 filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
                 input: {{
                     collections: null,
-                    template: "machine",
+                    template: "{template}",
                     replicator_addresses: ["{replicator_addr}"],
                     agent_did: "{agent_did}",
                     created_at: "{created_at}",
@@ -446,7 +502,7 @@ and the create mutation body:
                 peer_id: "{peer_id}",
                 agent_did: "{agent_did}",
                 collections: null,
-                template: "machine",
+                template: "{template}",
                 replicator_addresses: ["{replicator_addr}"],
                 profiles: null,
                 created_at: "{now}",
@@ -457,17 +513,22 @@ and the create mutation body:
 
 (`collections: null`, never `[]` — the empty list literal corrupts nillable array columns. `machine` rather than `client-index`: the paired app is a full client that later rides `PersonaConfigRequest`/`SessionHydrationRequest` over this same pairing; `client-index` exists for peers that should see only the index.)
 
-- [ ] **Step 2: Compile and test**
+- [ ] **Step 2: Pin both create and update behavior**
+
+Reuse the existing `core/tests.rs` fixture that calls `write_peer_pairing_desired`: query `collections` and `template`, then assert `collections` is null and `template == "machine"`. Call the writer a second time with a changed requester address and assert there is still one row with the updated address, `collections: null`, and `template: "machine"`. This exercises both mutation branches without adding another embedded-node fixture.
+
+- [ ] **Step 3: Compile and test**
 
 ```bash
+cargo test -p gents-desktop-core remove_peer_retains_saved_deployment_when_p2p_cleanup_fails
 cargo test -p gents-desktop-core
 ```
 Expected: PASS. If a fixture asserts the row's `collections` contents, update it to expect null/absent and `template == "machine"`.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add crates/gents-desktop-core/src/client/core/bootstrap.rs
+git add crates/gents-desktop-core/src/client/core/bootstrap.rs crates/gents-desktop-core/src/client/core/tests.rs
 git commit -m "fix(desktop-core): pairing row requests the machine template explicitly, drops dead collections list (#1141)"
 ```
 
@@ -477,33 +538,52 @@ git commit -m "fix(desktop-core): pairing row requests the machine template expl
 
 **Files:** none new.
 
-- [ ] **Step 1: Package suite**
+- [ ] **Step 1: Format and desktop package suite**
+
+```bash
+cargo fmt --all -- --check
+cargo test -p gents-desktop-core
+```
+Expected: clean.
+
+- [ ] **Step 2: Runtime package suite**
 
 ```bash
 cargo test -p gents
 ```
 Expected: PASS (integration tests are separate compile units — never trust `--lib`).
 
-- [ ] **Step 2: Workspace check**
+- [ ] **Step 3: Workspace check**
 
 ```bash
 cargo check --workspace --all-targets
 ```
 Expected: clean. This catches desktop/bridge construction sites the package suite skips.
 
-- [ ] **Step 3: Proofs**
+- [ ] **Step 4: Proofs**
 
 ```bash
 cd crates/gents/proofs && lake build && cd -
+rg -n '\bsorry\b' crates/gents/proofs/Proofs --glob '*.lean'
 ```
-Expected: clean, zero `sorry`s.
+Expected: build clean; the `rg` command returns no matches.
 
-- [ ] **Step 4: Live two-node smoke (manual, environment-dependent)**
+- [ ] **Step 5: Live two-node smoke (manual, environment-dependent)**
 
-With the amy runtime on studio-1 reachable (see memory note / spec): build the desktop app, wipe its local store, `/status`-pair against `http://100.69.4.79:9191/status`, and verify the session list shows amy's full conversation set (titles + previews; 129 conversations at time of writing) with no transcript docs in the local store beyond the index. This mirrors the phone repro that motivated #1141.
+With the amy runtime on studio-1 reachable (see memory note / spec):
 
-- [ ] **Step 5: Commit any straggler fixes and push**
+1. Record a fresh remote baseline of `_docID`s/counts for `AgentConversation` and `AgentSession`, plus the transcript collection counts.
+2. Build the desktop app, wipe only its local application store, and `/status`-pair against `http://100.69.4.79:9191/status`.
+3. Verify the local index docIDs/counts match the contemporaneous remote baseline for amy and that titles/previews render. Do not use the stale “129 conversations” observation as an assertion.
+4. Before creating any new activity, verify historical `AgentRequest`, `AgentResponse`, `AgentMessage`, `AgentToolCall`, `AgentToolResult`, `AgentToolApproval`, and `CompactionEntry` rows were not bulk-pulled.
+5. Verify logs show one two-collection index sync, not the old 16-collection pass, and inspect the resulting `PeerPairingDesired` row (`template: "machine"`, `collections: null`).
+
+- [ ] **Step 6: Review the final diff and commits**
 
 ```bash
-git push origin agent/ui-mobile-debug
+git status --short
+git diff origin/main...HEAD --stat
+git log --oneline origin/main..HEAD
 ```
+
+Expected: only scoped implementation/docs changes plus the pre-existing unrelated `Info.plist` modification in the worktree. Stop ready-to-push; do not push unless explicitly requested.

--- a/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
+++ b/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
@@ -1,0 +1,172 @@
+# Mobile session sync — design
+
+**Milestone:** [Mobile session sync](https://github.com/source-inc/gents/milestones/9) — #1141 → #1142 → #1143 → #1144, with #1145/#1146 independent.
+**Status:** approved in session 2026-08-17; this document is the durable record.
+
+## Problem
+
+A freshly paired client (iOS or desktop) renders behaviors but no conversation
+history, and sync activity is invisible. Root causes, established empirically
+against a live pairing (amy on studio-1 ↔ iPhone):
+
+1. The only history path, `sync_branchable_collections_with_retry`
+   (`crates/gents-desktop-core/src/client/core/bootstrap.rs`), is gated behind
+   `GENTS_DESKTOP_SYNC_BRANCHABLE_ON_PAIR`, default off and unsettable on iOS.
+   Gossip subscriptions deliver new heads only, so collections that churn
+   (behaviors, touched every reconcile) arrive while static history never does.
+   A wiped phone held 37 documents against the server's 500+.
+2. No sync state reaches the UI. The signals exist (`P2PHealth`,
+   `PairingCollectionStatus`, observe-loop metrics, DefraDB `SyncStatus`) but
+   are unexposed or FFI-unreachable.
+
+## Constraints established by research
+
+Four survey passes (Go DefraDB, defradb.rs at the pinned rev, the wider
+sourcenetwork org, and a gents abstraction audit) fixed these load-bearing
+facts:
+
+- **Replication filter fields must be `@immutable` scalar LWW.** `session_id`
+  is not `@immutable` on any transcript collection, so per-session replicator
+  filters are rejected at install. `requester_did`/`agent_did` are `@immutable`
+  — which is why the existing templates filter on them.
+- **Any replicator filter change forces a full replay of every collection in
+  the install** (defradb.rs `iroh.rs`), and the gents reconcile diff answers a
+  filter change with teardown + reinstall. Filter churn is therefore not a
+  hydration mechanism (filed upstream as defradb.rs#1506).
+- **The ecosystem contract for query-shaped partial sync is app-side docID
+  resolution + pull.** Go DefraDB punts predicate sync to the application
+  (`SyncDocuments(col, docIDs)`); its only remote query primitive returns
+  docIDs only. defradb.rs `sync_documents` fetches never-seen docs by ID
+  (≤1000/request, no retry ladder, completion observed via `MergeComplete`).
+- **gents already has the correct lifecycle shape to copy**: the
+  `PersonaConfigRequest` pattern — a client-authored control document riding
+  the `machine` template, admitted and served by a reconcile sweep
+  (`p2p_reconcile/persona_requests.rs`), fenced by a Lean lifecycle model
+  (`PersonaRequest.lean`: `admits`/`applyStep`, grants-nothing, idempotence,
+  ownership safety).
+- **In-flight upstream work to anticipate** (`fix/1116-sync-ownership-stage3`):
+  selective-CAR frontier fetch, CAR served/filtered counters,
+  reconnect-as-enabling-event. Do not build CID-level fetch or an app-side
+  reconnect kick; read `SyncStatus` fields defensively.
+
+## Design
+
+Three mechanisms, split by job:
+
+### 1. Standing scope — filtered replicators (#1141)
+
+A new `client-index` scope template: `AgentConversation` + `AgentSession`,
+`PerCollection` rules on `@immutable` identity fields, `delivery = Push`.
+Bootstrap replaces the env-gated 16-collection bulk sync with an ungated,
+once-per-bootstrap, concurrent branchable sync of exactly those two
+collections. `write_peer_pairing_desired` gains an explicit `template` field
+(today the server silently falls back to `conversation`) and drops the dead
+`collections` list. The session list (`AgentConversation` carries title,
+preview_text, updated_at, fork lineage; `AgentSession` carries live status)
+renders fully with no transcript-plane replication. ~2 small docs per session,
+one row each per new session.
+
+### 2. Per-session hydration — `SessionHydrationRequest` (#1142, #1143)
+
+A branchable control collection, mirroring `PersonaConfigRequest`:
+
+```
+SessionHydrationRequest {
+  request_key   String @index(unique) @immutable   # "{peer_id}:{session_id}"
+  requester_did String @index @immutable
+  agent_did     String @immutable
+  session_id    String @immutable
+  created_at    DateTime
+  status        String @index    # pending | served | rejected (server-written)
+  status_detail String
+  served_doc_count Int           # the client's progress denominator
+  processed_at  DateTime
+}
+```
+
+Client writes it on session open (upsert by `request_key`); it rides the
+`machine` template to the server. A server sweep
+(`p2p_reconcile/session_hydration.rs`, sibling of `persona_requests.rs`)
+admits rows from paired, membership-valid peers whose session ownership checks
+out, enumerates the session's docs across the transcript collections
+(AgentRequest, AgentResponse, AgentMessage, AgentToolCall, AgentToolResult,
+AgentToolApproval, CompactionEntry), pushes them through the **existing
+doc-pusher under the existing admission bounds and persisted retry ladder** —
+no new delivery machinery — then writes `served` + `served_doc_count`.
+Failures write `rejected` + detail; retry is the client's decision.
+
+**Lean first** (`proofs/Proofs/SessionHydration/`), mirroring
+`PersonaRequest.lean`, with obligations:
+
+1. `hydration_request_grants_nothing` — unadmitted rows cause no push.
+2. **Tenancy soundness** — every served doc satisfies
+   `requester_did = request.requester_did`. The replicator filter enforced
+   this for standing scopes; a doc-set push must re-prove it at the admission
+   gate. This is the load-bearing new obligation.
+3. Session ownership — `session_id` resolves to a session owned by the
+   requester (mirrors `unknown_agent_changes_nothing`).
+4. Idempotent re-serve; crash repair.
+5. Non-interference — `PairingReconcile.no_flap_on_converged` holds while
+   hydration runs (formally justifies "separate lifecycle, not a scope layer").
+6. Terminality — every pending row reaches served/rejected.
+
+Plus CoverageLedger entry, `Executable.lean` contract, Rust conformance file,
+proofs README update. Zero `sorry`s.
+
+Client half (#1143): `ClientCore::request_session_hydration` (the first
+client-authored control-request write path — establishes the pattern),
+`focused_session_id` on `ObservedStore`, a hydration/progress `watch` channel
+beside `p2p_health`, and `P2PSupervisorCommand::{Foregrounded,
+NetworkChanged}` reusing the existing repair cycle. Progress is
+receiver-side: `served_doc_count` is the denominator, locally merged docIDs
+the numerator. Hydrated sessions persist on-device; no eviction in v1.
+
+### 3. Indicators — surface what exists (#1144)
+
+- `PairingCollectionStatus` (retry counts, error class, `stuck_since`) is
+  computed every tick and never exposed — the cheapest win.
+- Bridge: `desktop_session_hydrate`, `desktop_sync_status`,
+  `SessionHydrationView`, `PairingCollectionStatusView`,
+  `ClientUpdateEvent.reason += "hydration"`.
+- UI: global sync pill (healthy / syncing / stalled / offline-since),
+  per-session hydration progress, settings debug panel with raw counters.
+  Stalled (retry class + stuck_since) renders distinctly from syncing;
+  quarantined DAGs are terminal errors, not spinners.
+
+### Independent
+
+- **#1145** — widen `PairingFilters` to the transport's predicate model;
+  `merge_layered_desired` currently last-writer-wins overlapping collection
+  filters silently (the #687 leak class).
+- **#1146** — mobile Behaviors page has no back navigation.
+
+## Rejected alternatives
+
+- **Per-session filtered replicators** — `session_id` not `@immutable`;
+  filter churn forces full replay + reinstall on links that idle-close.
+- **Scope-template parameterization** — `&'static` catalog, DID-only value
+  space, one predicate per collection; a session layer would silently
+  overwrite the tenancy fence in `merge_layered_desired`.
+- **Full branchable bulk sync** (flip the env gate) — pulls every transcript
+  ever to every device; the mobile storage/bandwidth profile is wrong.
+- **Server answers with docID list, client pulls `sync_documents`** — viable
+  (the Go-blessed shape) but the server push path reuses the persisted retry
+  ladder for free, keeps a single delivery mechanism, and `sync_documents`
+  broadcasts to all connected peers rather than targeting the server.
+
+## Upstream issues filed
+
+- defradb.rs#1504 — `SyncStatus` unreachable from FFI/embedded clients.
+- defradb.rs#1505 — `ReplicatorCompleted` has no payload.
+- defradb.rs#1506 — iroh/libp2p replay-trigger asymmetry; filter change
+  replays all collections.
+
+None block the critical path.
+
+## Testing
+
+Lean models + conformance per the foundation flow; Rust unit tests for
+enumeration/tenancy filtering; a two-node e2e (server-authored session,
+client pairs, index syncs, hydration round-trips, progress observed) in the
+existing e2e harness. Gates: `cargo test -p gents`,
+`cargo check --workspace --all-targets`.

--- a/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
+++ b/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
@@ -53,18 +53,47 @@ facts:
 
 Three mechanisms, split by job:
 
-### 1. Standing scope — filtered replicators (#1141)
+### 1. Standing scope and eager index request (#1141)
 
-A new `client-index` scope template: `AgentConversation` + `AgentSession`,
-`PerCollection` rules on `@immutable` identity fields, `delivery = Push`.
-Bootstrap replaces the env-gated 16-collection bulk sync with an ungated,
-once-per-bootstrap, concurrent branchable sync of exactly those two
-collections. `write_peer_pairing_desired` gains an explicit `template` field
-(today the server silently falls back to `conversation`) and drops the dead
-`collections` list. The session list (`AgentConversation` carries title,
-preview_text, updated_at, fork lineage; `AgentSession` carries live status)
-renders fully with no transcript-plane replication. ~2 small docs per session,
-one row each per new session.
+A new `client-index` scope template formalizes the requester-scoped index
+contract: `AgentConversation` + `AgentSession`, `PerCollection` rules on
+`@immutable` identity fields, `delivery = Push`. Full desktop pairings continue
+to select `machine`; #1141 registers `client-index` for narrower consumers but
+does not select it for the desktop pairing row.
+
+The desktop P2P supervisor replaces the env-gated 16-collection bulk pull with
+an ungated, concurrent BranchableSync request for exactly those two index
+collections. It requests once after startup, for newly added peers, and again
+after reconnect/repair, off the launch and add-peer critical paths. The pinned
+IROH adapter acknowledges dispatch, not merge completion, so logs say
+"requested" and the supervisor supplies new request opportunities at the
+events it can observe. Exact progress/completion remains #1144/upstream work.
+
+**Trust boundary:** BranchableSync authorizes at collection granularity and
+returns every head in the collection; it does not apply the template's
+document predicate. A paired full client therefore receives session cards for
+all requester lineages on that agent. This is intentional for the current
+single-user/full-client product, but it is not a tenant-safe use of the
+`client-index` predicate and must not be reused for an untrusted peer class.
+
+`write_peer_pairing_desired` explicitly selects `machine` instead of the old
+implicit `conversation` fallback and drops the dead `collections` list. On the
+first upgrade reconcile, existing template-absent pairings incur one teardown,
+reinstall, and replay because their effective filter changes. This is an
+accepted migration cost, not an index-hydration mechanism. The removed
+`GENTS_DESKTOP_SYNC_BRANCHABLE_ON_PAIR` escape hatch has no 16-collection
+replacement; transcript history remains lazy until #1142.
+
+The session list (`AgentConversation` carries title, preview_text, updated_at,
+fork lineage; `AgentSession` carries live status) renders with no eager
+transcript-plane pull: about two small documents per session.
+
+**Preferred end state:** replace the collection-wide index pull with a
+paginated, cursor-based index protocol. The server should apply the explicitly
+chosen lineage policy, return bounded pages of index document IDs, and let the
+client fetch those pages with observable progress and resumable cursors. That
+removes the current collection-level trust exception and scales without a
+single all-head response; it is deliberately outside #1141.
 
 ### 2. Per-session hydration — `SessionHydrationRequest` (#1142, #1143)
 


### PR DESCRIPTION
## Summary

- add the formally modeled requester-scoped `client-index` template and align the Lean catalog with the existing Rust catalog
- replace the opt-in serial 16-collection pull with a supervisor-owned concurrent request for only `AgentConversation` and `AgentSession`
- dispatch off the bootstrap/add-peer critical paths, re-arm after reconnect or repair, deduplicate healthy ticks, and surface request failures in peer status
- make `PeerPairingDesired` explicitly request the existing `machine` template and emit `collections: null`

## Why

Freshly paired mobile clients can receive new gossip heads but miss the historical session index. This eagerly hydrates only the lightweight index while leaving transcript collections lazy.

## Review decisions and limits

- the pinned IROH adapter acknowledges per-peer send dispatch, not merge completion; logs say `request dispatched`, and the supervisor supplies new opportunities after connection repair
- BranchableSync is collection-global and does not apply the requester predicate; cross-requester session cards are intentionally accepted for the current trusted full-client/single-user deployment, not as a tenant-safe boundary
- migrating existing template-absent pairing rows to explicit `machine` changes their filter and causes a one-time teardown, reinstall, and replay
- `GENTS_DESKTOP_SYNC_BRANCHABLE_ON_PAIR` is removed without a 16-collection replacement; transcript history remains lazy until #1142
- the preferred follow-up is a paginated, cursor-based index protocol with explicit lineage policy, bounded document-ID pages, observable progress, and resumability

## Validation

- `lake build` (zero `sorry`s)
- `cargo fmt --all -- --check`
- `cargo test -p gents-desktop-core`
- `RUST_MIN_STACK=8388608 cargo test -p gents`
- `cargo check --workspace --all-targets`
- targeted index-request/supervisor regressions, scope-template conformance, and embedded replicator-filter validation
- disposable-client Amy smoke attempted against both advertised endpoint and direct P2P addresses; HTTP discovery succeeded, but both P2P dials timed out before sync could begin

On macOS, the default-stack `cargo test -p gents` reproducibly overflows in the pre-existing `startup_recovery::run_agent_shutdown_is_prompt_while_request_waits_for_backend_capacity` test. The complete suite passes with `RUST_MIN_STACK=8388608`; this is related to the historical startup-recovery stack issue tracked in #1060, not this patch.

Closes #1141
