### PR TITLE
test(hygiene): unmask CI signal, honest live gates, env-overridable D4F

### DIFF
--- a/.github/scripts/compile-rust-ci-suite.sh
+++ b/.github/scripts/compile-rust-ci-suite.sh
@@ -18,8 +18,6 @@ case "${suite}" in
   cli)
     packages=(
       gents-cli
-      gents-chatgpt-login
-      gents-codex-protocol
     )
     ;;
   desktop)
@@ -35,6 +33,10 @@ case "${suite}" in
     separate_package="gents-desktop-tauri"
     ;;
   support)
+    # gents-chatgpt-login and gents-codex-protocol live here (not in `cli`)
+    # because the support shard is where their tests RUN on every event; the
+    # compile fence must cover what the test step executes. They are still
+    # built on the cli shard as ordinary gents-cli dependencies.
     packages=(
       gents-lean-contract
       gents-migration
@@ -42,6 +44,8 @@ case "${suite}" in
       gents-fs-runner
       gents-protocol
       gents-schemas
+      gents-chatgpt-login
+      gents-codex-protocol
     )
     ;;
   *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,10 @@ jobs:
       # so a broken assertion in them can survive indefinitely.
       - name: Run support package tests
         if: matrix.suite == 'support'
+        # --no-fail-fast: a node flake in gents-migration must not mask the
+        # 140 pure gents-protocol/gents-schemas assertions that run after it.
         run: |
-          cargo test \
+          cargo test --no-fail-fast \
             -p gents-migration \
             -p gents-lens-fixture-add-label \
             -p gents-protocol \
@@ -295,22 +297,27 @@ jobs:
         if: matrix.suite == 'runtime' && github.event_name != 'pull_request'
         env:
           RUST_MIN_STACK: 16777216
-        run: cargo test -p gents --lib --tests
+        run: cargo test --no-fail-fast -p gents --lib --tests
 
       - name: Run desktop Rust package tests
         if: matrix.suite == 'desktop'
+        # --no-fail-fast: the client_core iroh dial must not mask the 15
+        # binaries and the tauri lib tests that run after it.
         run: |
-          cargo test \
+          cargo test --no-fail-fast \
             -p gents-desktop-core \
             -p gents-desktop \
             -p gents-desktop-bridge \
             -p fixture-domain-plugin \
             -p gents-fixture-host
-          cargo test -p gents-desktop-tauri --lib
+          cargo test --no-fail-fast -p gents-desktop-tauri --lib
 
       - name: Run full CLI test suite
         if: matrix.suite == 'cli' && github.event_name != 'pull_request'
-        run: cargo test -p gents-cli -- --nocapture --test-threads=1
+        # --no-fail-fast: cli binaries run alphabetically; without this the
+        # first red binary hides every later one (how a broken cli_subagent
+        # masked cli_trace_export for days — see #1139).
+        run: cargo test --no-fail-fast -p gents-cli -- --nocapture --test-threads=1
 
       - name: Show Rust build cache stats
         # The three heavy suites use runner-local incremental state. Keep one

--- a/crates/gents-cli/tests/cli_fleet_delegation_live.rs
+++ b/crates/gents-cli/tests/cli_fleet_delegation_live.rs
@@ -210,7 +210,7 @@ struct TranscriptToolExchange {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored"]
+#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored; currently blocked on defra.rs #1033 filtered replication (replicator_filter installs null) — see #1147"]
 async fn five_process_filtered_conversation_delegation_live() -> Result<()> {
     require_live_gate("GENTS_LIVE_OPENAI")?;
 
@@ -1878,7 +1878,7 @@ fn is_workflow_terminal(state: Option<&str>) -> bool {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored"]
+#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored; currently blocked on defra.rs #1033 filtered replication (replicator_filter installs null) — see #1147"]
 async fn five_process_workflow_orchestration_live() -> Result<()> {
     require_live_gate("GENTS_LIVE_OPENAI")?;
     let endpoint = std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")
@@ -2518,7 +2518,7 @@ async fn assert_child_materialized_nowhere(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored"]
+#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored; currently blocked on defra.rs #1033 filtered replication (replicator_filter installs null) — see #1147"]
 async fn five_process_workflow_d10_partial_failure_live() -> Result<()> {
     require_live_gate("GENTS_LIVE_OPENAI")?;
     let endpoint = std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")
@@ -2708,7 +2708,7 @@ async fn five_process_workflow_d10_partial_failure_live() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored"]
+#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored; currently blocked on defra.rs #1033 filtered replication (replicator_filter installs null) — see #1147"]
 async fn five_process_workflow_d10_materialized_failure_live() -> Result<()> {
     require_live_gate("GENTS_LIVE_OPENAI")?;
     let endpoint = std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")
@@ -2916,7 +2916,7 @@ async fn five_process_workflow_d10_materialized_failure_live() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored"]
+#[ignore = "live: set GENTS_LIVE_OPENAI=1 and pass --ignored; currently blocked on defra.rs #1033 filtered replication (replicator_filter installs null) — see #1147"]
 async fn five_process_workflow_synthesizer_deleted_midrun_live() -> Result<()> {
     require_live_gate("GENTS_LIVE_OPENAI")?;
     let endpoint = std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")

--- a/crates/gents-cli/tests/cli_p2p_templates.rs
+++ b/crates/gents-cli/tests/cli_p2p_templates.rs
@@ -521,6 +521,9 @@ async fn filter_change_reinstalls_replicator_under_new_scope() -> Result<()> {
 /// bump: enable it (remove `#[ignore]`) as the closeout of the #1033 pin bump.
 /// Do NOT delete it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "acceptance test for the defra.rs #1033 pin bump: filtered replication is stubbed \
+            (non-empty filter falls back to an unfiltered install), so a pass today is a \
+            false pass — enable as the closeout of the pin bump"]
 async fn end_to_end_scoped_filtering_only_replicates_scoped_did() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_src = tempdir.path().join("e2e-src");

--- a/crates/gents-cli/tests/support/mod.rs
+++ b/crates/gents-cli/tests/support/mod.rs
@@ -35,8 +35,12 @@ pub use waits::{
     wait_for_tool_call,
 };
 
-pub const DEFAULT_MODEL_ENDPOINT: &str = "http://192.168.1.78:8000/v1";
-pub const DEFAULT_MODEL_NAME: &str = "MiniMax-M2.7-NVFP4";
+// Matches the DEFAULT_LIVE_ENDPOINT the gents e2e_live suite uses
+// (workstation-1 over Tailscale). The previous default was a LAN address
+// unroutable from anywhere else, so tests falling through the
+// GENTS_CLI_E2E_MODEL_* overrides hung until their deadlines.
+pub const DEFAULT_MODEL_ENDPOINT: &str = "http://100.73.235.38:8000/v1";
+pub const DEFAULT_MODEL_NAME: &str = "GLM-5.2";
 
 /// Initialize an agent home through `gents init --identity-only` and open its
 /// embedded node with the registered signing identity. Homes assembled without

--- a/crates/gents/src/llm/mod.rs
+++ b/crates/gents/src/llm/mod.rs
@@ -18,6 +18,12 @@ pub(crate) mod responses_normalize;
 pub mod rig_compat;
 pub mod tool;
 
+// Deterministic client-side JSON arg-repair pins for the post_status tool
+// shape; moved out of tests/e2e_live so that binary holds only live-gated
+// tests (the file needs no backend and exercises the public ToolDyn seam).
+#[cfg(test)]
+mod post_status_json_repair_tests;
+
 /// Whether/how the model must call a tool before answering. Mirrors rig's
 /// `ToolChoice`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/gents/src/llm/post_status_json_repair_tests.rs
+++ b/crates/gents/src/llm/post_status_json_repair_tests.rs
@@ -49,7 +49,7 @@
 //! These tests are deterministic and need no live backend; they exercise the
 //! real `ToolDyn::call` seam directly.
 
-use gents::llm::tool::{Tool, ToolDefinition, ToolDyn, ToolError, UnparseableArgsKind};
+use crate::llm::tool::{Tool, ToolDefinition, ToolDyn, ToolError, UnparseableArgsKind};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]

--- a/crates/gents/tests/e2e_live.rs
+++ b/crates/gents/tests/e2e_live.rs
@@ -12,8 +12,6 @@ mod interrupt_live;
 mod lsp_live;
 #[path = "e2e_live/p2p_admission_concurrent_live.rs"]
 mod p2p_admission_concurrent_live;
-#[path = "e2e_live/post_status_json_live.rs"]
-mod post_status_json_live;
 #[path = "e2e_live/seed_live.rs"]
 mod seed_live;
 #[path = "e2e_live/steward_loop_live.rs"]

--- a/crates/gents/tests/e2e_live/steward_loop_live.rs
+++ b/crates/gents/tests/e2e_live/steward_loop_live.rs
@@ -62,9 +62,19 @@ fn d4f_enabled() -> bool {
     std::env::var("GENTS_D4F_LIVE").as_deref() == Ok("1")
 }
 
-const D4F_ENDPOINT: &str = "http://100.73.235.38:8000/v1";
-const D4F_MODEL: &str = "d4f";
 const D4F_BACKEND_ID: &str = "backend-d4f-live";
+
+/// Live backend endpoint/model for the D4F suite, overridable so it can run
+/// against whatever the workstation currently serves — the `d4f` vLLM alias
+/// comes and goes with server restarts (#1147).
+fn d4f_endpoint() -> String {
+    std::env::var("GENTS_D4F_ENDPOINT")
+        .unwrap_or_else(|_| "http://100.73.235.38:8000/v1".to_string())
+}
+
+fn d4f_model() -> String {
+    std::env::var("GENTS_D4F_MODEL").unwrap_or_else(|_| "d4f".to_string())
+}
 
 pub async fn bind_d4f_backend(
     node: &EmbeddedNode,
@@ -83,7 +93,7 @@ pub async fn bind_d4f_backend(
         .expect("load default behavior")
         .expect("default behavior document exists after bootstrap");
     behavior.backend_id = Some(D4F_BACKEND_ID.to_string());
-    behavior.model_name = Some(D4F_MODEL.to_string());
+    behavior.model_name = Some(d4f_model());
     behavior.inference_profile_id = Some(default_inference_profile_id_for_behavior(&behavior_id));
     behavior.enabled = true;
     upsert_agent_behavior(node, &behavior)
@@ -96,8 +106,8 @@ pub async fn bind_d4f_backend(
 
 async fn upsert_d4f_backend(node: &EmbeddedNode) {
     let escaped_backend_id = escape_graphql_string(D4F_BACKEND_ID);
-    let escaped_endpoint = escape_graphql_string(D4F_ENDPOINT);
-    let escaped_model = escape_graphql_string(D4F_MODEL);
+    let escaped_endpoint = escape_graphql_string(&d4f_endpoint());
+    let escaped_model = escape_graphql_string(&d4f_model());
     let mutation = format!(
         r#"mutation {{
             upsert_InferenceBackend(
@@ -156,7 +166,7 @@ pub async fn boot_d4f_agent(db: &TestDb, identity: Arc<dyn AgentIdentity>) -> Re
 }
 
 async fn assert_d4f_reachable() {
-    let url = format!("{}/models", D4F_ENDPOINT.trim_end_matches('/'));
+    let url = format!("{}/models", d4f_endpoint().trim_end_matches('/'));
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()


### PR DESCRIPTION
First of two PRs from the test-estate audit (see the Test Estate report and #1147). This one is the surgical set; the compile-count restructure follows separately.

## Signal (no coverage change)
- **`--no-fail-fast` on all four multi-binary CI test steps.** Cargo stops at the first failing test binary, so one flake was hiding entire suites: a gents-migration node flake masks all 140 gents-protocol assertions (they run dead last), one iroh dial masks 15 desktop binaries, and a broken `cli_subagent` hid `cli_trace_export` for days (#1139). Each step carries a comment naming its masking incident.
- **Support-shard compile fence now covers what the shard tests.** `gents-codex-protocol` and `gents-chatgpt-login` tests have always run on the support shard, but the packages were listed under the *cli* compile suite on a different runner. Moved; coverage-guard union unchanged (16/16 packages).

## Honest gates
- **Restored the missing `#[ignore]`** on `end_to_end_scoped_filtering_only_replicates_scoped_did` — its own doc says it cannot legitimately pass until the defra.rs #1033 pin bump (non-empty filters fall back to an unfiltered install), so its current green is a false pass. It remains the acceptance test for the pin bump.
- **Annotated the five fleet live ignore reasons** with the same #1033 blockage (`replicator_filter` installs `null` — full forensics in #1147) so the next live run doesn't rediscover it.

## Live means live
- The three deterministic post_status JSON arg-repair tests moved from `tests/e2e_live/` into `src/llm/` as a lib test module — they exercise the public `ToolDyn` seam and need no backend. `e2e_live`'s default run is now 3 harness-judgment guards + 12 ignored live tests (the follow-up PR feature-gates the whole binary).
- **D4F endpoint/model are env-overridable** (`GENTS_D4F_ENDPOINT` / `GENTS_D4F_MODEL`) — the `d4f` vLLM alias comes and goes with workstation restarts.
- **Replaced the unroutable LAN default** (`192.168.1.78`) in the CLI test support with the same Tailscale endpoint the e2e_live defaults use; fallthrough tests used to hang against it until their deadlines.

## Verification
Coverage guard 16/16; moved module 3/3 in the lib suite; `e2e_live` default 3 passed / 12 ignored; `cli_p2p_templates` 3 passed / 1 ignored; `cargo check --workspace --all-targets` clean; rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)