### PR TITLE
Add global navigation to the desktop app

### DIFF
--- a/apps/gents-desktop/src/App.css
+++ b/apps/gents-desktop/src/App.css
@@ -10,6 +10,7 @@
 @import "./styles/primitives/forms.css";
 @import "./styles/primitives/data.css";
 @import "./styles/shell.css";
+@import "./styles/navigation.css";
 @import "./styles/sidebar/base.css";
 @import "./styles/sidebar/connected-peer.css";
 @import "./styles/sidebar/lists.css";

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { createDesktopClient } from "@source-inc/gents-desktop-client";
 import { listen } from "@tauri-apps/api/event";
 import { ChatWorkspace } from "./components/ChatWorkspace";
+import { AppNavigation } from "./components/AppNavigation";
 import { CodeContextHeader } from "./components/code/CodeContextHeader";
 import { ConfigWorkspace } from "./components/ConfigWorkspace";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -15,15 +16,30 @@ import { useAppShortcuts } from "./hooks/useAppShortcuts";
 import { useMobileBackSwipe } from "./hooks/useMobileBackSwipe";
 import { Sidebar } from "./components/Sidebar";
 import { StartupScreen } from "./components/StartupScreen";
+import {
+  ConfigNavigationGuardBoundary,
+  useConfigNavigationGuard,
+} from "./components/config/ConfigNavigationGuard";
 import { useDesktopShell, type DesktopShellBridge } from "./hooks/useDesktopShell";
+import {
+  useAppNavigation,
+  type MobileChatPane,
+  type WorkspaceView,
+} from "./hooks/useAppNavigation";
 import { installExternalLinkGuard } from "./lib/externalLinks";
+import {
+  loadNavigationExpanded,
+  saveNavigationExpanded,
+} from "./lib/navigationPreference";
 import { startNativeSimulatorE2e } from "./lib/nativeSimulatorE2e";
 import "./App.css";
 
 function App({ bridge }: { bridge?: DesktopShellBridge } = {}) {
   return (
     <ErrorBoundary>
-      <AppShell bridge={bridge} />
+      <ConfigNavigationGuardBoundary>
+        <AppShell bridge={bridge} />
+      </ConfigNavigationGuardBoundary>
     </ErrorBoundary>
   );
 }
@@ -38,6 +54,8 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
   }, []);
   const bridge = explicitBridge ?? defaultBridge;
   const shell = useDesktopShell(bridge);
+  const navigation = useAppNavigation();
+  const { requestNavigation } = useConfigNavigationGuard();
 
   useEffect(() => {
     applyTheme(loadTheme());
@@ -60,62 +78,62 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
     });
     return () => unlisten?.();
   }, [bridge.api]);
-  const [workspaceView, setWorkspaceView] = useState<
-    "fleet" | "chat" | "config" | "code"
-  >("fleet");
-  const [mobileChatPane, setMobileChatPane] = useState<"navigation" | "conversation">(
-    "navigation",
-  );
-  const [configReturnView, setConfigReturnView] = useState<"fleet" | "chat">("fleet");
+  const [navigationExpanded, setNavigationExpanded] = useState(loadNavigationExpanded);
+  const [navigationDrawerOpen, setNavigationDrawerOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const closeNavigationDrawer = useCallback(() => setNavigationDrawerOpen(false), []);
+  const openNavigationDrawer = useCallback(() => setNavigationDrawerOpen(true), []);
+  const showShortcuts = useCallback(() => setShortcutsOpen(true), []);
+  const toggleNavigationExpanded = useCallback(() => {
+    setNavigationExpanded((expanded) => {
+      saveNavigationExpanded(!expanded);
+      return !expanded;
+    });
+  }, []);
+
+  const navigateTo = useCallback(
+    (view: WorkspaceView, mobileChatPane?: MobileChatPane) => {
+      if (view !== "fleet" && !shell.selectedDeployment) return;
+      requestNavigation(() => {
+        navigation.navigate(view, { mobileChatPane });
+        setNavigationDrawerOpen(false);
+      });
+    },
+    [navigation.navigate, requestNavigation, shell.selectedDeployment],
+  );
 
   const navigateBack = useCallback(() => {
-    if (workspaceView === "config") {
-      setWorkspaceView(configReturnView);
-      if (configReturnView === "chat") {
-        setMobileChatPane("navigation");
-      }
-      return;
-    }
-    if (workspaceView === "code") {
-      setWorkspaceView("chat");
-      setMobileChatPane("navigation");
-      return;
-    }
-    if (workspaceView === "chat" && mobileChatPane === "conversation") {
-      setMobileChatPane("navigation");
-      return;
-    }
-    if (workspaceView === "chat") {
-      setWorkspaceView("fleet");
-    }
-  }, [configReturnView, mobileChatPane, workspaceView]);
+    requestNavigation(navigation.back);
+  }, [navigation.back, requestNavigation]);
 
-  useMobileBackSwipe(workspaceView !== "fleet", navigateBack);
+  useMobileBackSwipe(navigation.view !== "fleet", navigateBack);
 
   useAppShortcuts({
     setView: (view) => {
-      if (view === "chat" || view === "code") {
-        setMobileChatPane("conversation");
-      }
-      setWorkspaceView(view);
+      navigateTo(
+        view,
+        view === "chat" || view === "code" ? "conversation" : "navigation",
+      );
     },
     newConversation: () => {
       const behaviorId =
         shell.selectedBehaviorId ?? shell.behaviorOptions[0]?.behaviorId ?? null;
       if (behaviorId) {
-        setWorkspaceView("chat");
-        setMobileChatPane("conversation");
-        shell.onStartNewConversation(behaviorId);
+        requestNavigation(() => {
+          navigation.navigate("chat", { mobileChatPane: "conversation" });
+          shell.onStartNewConversation(behaviorId);
+        });
       }
     },
     focusComposer: () => {
-      setWorkspaceView("chat");
-      setMobileChatPane("conversation");
-      requestAnimationFrame(() => {
-        document
-          .querySelector<HTMLTextAreaElement>('[data-testid="composer-input"]')
-          ?.focus();
+      if (!shell.selectedDeployment) return;
+      requestNavigation(() => {
+        navigation.navigate("chat", { mobileChatPane: "conversation" });
+        requestAnimationFrame(() => {
+          document
+            .querySelector<HTMLTextAreaElement>('[data-testid="composer-input"]')
+            ?.focus();
+        });
       });
     },
     toggleHelp: () => setShortcutsOpen((open) => !open),
@@ -128,28 +146,29 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
     // Fleet selects an agent instance first. On narrow screens the sidebar is
     // that instance view (behaviors + conversations); opening the conversation
     // pane here made it impossible to reach that navigation from Fleet.
-    setMobileChatPane("navigation");
-    setWorkspaceView("chat");
+    requestNavigation(() =>
+      navigation.navigate("chat", { mobileChatPane: "navigation" }),
+    );
   }
 
   function openCode(agentDid?: string) {
     if (agentDid) {
       shell.setSelectedAgentDid(agentDid);
     }
-    setMobileChatPane("conversation");
-    setWorkspaceView("code");
+    requestNavigation(() =>
+      navigation.navigate("code", { mobileChatPane: "conversation" }),
+    );
   }
 
   function openConfig(agentDid?: string) {
     if (agentDid) {
       shell.setSelectedAgentDid(agentDid);
     }
-    setConfigReturnView(workspaceView === "fleet" ? "fleet" : "chat");
-    setWorkspaceView("config");
+    requestNavigation(() => navigation.navigate("config"));
   }
 
   return (
-    <main className={`app-shell app-view-${workspaceView}`}>
+    <main className={`app-shell app-view-${navigation.view}`}>
       <div aria-hidden="true" className="titlebar-drag-region" data-tauri-drag-region />
       {shell.error && shell.startupPhase === "ready" ? (
         <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
@@ -162,158 +181,185 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
           onRetry={shell.onRetryStartup}
           phase={shell.startupPhase}
         />
-      ) : workspaceView === "fleet" ? (
-        <FleetHostDashboard
-          api={bridge.api}
-          addingPeer={shell.addingPeer}
-          bootstrap={shell.snapshot?.bootstrap ?? null}
-          deployments={shell.deployments}
-          loading={shell.loading}
-          p2pHealth={shell.runtimeHealth}
-          repairingP2P={shell.repairingP2P}
-          starting={shell.starting}
-          onAddPeer={shell.onAddPeer}
-          onPairBearer={shell.onPairBearer}
-          onProbePeerAddress={shell.onProbePeerAddress}
-          onInitLocalRuntime={shell.onInitLocalRuntime}
-          onStartManagedServer={
-            bridge.api.startManagedServer
-              ? (agentName) => bridge.api.startManagedServer!(agentName)
-              : undefined
-          }
-          onCommitManagedServerAutoStart={
-            bridge.api.commitManagedServerAutoStart
-              ? (agentName) => bridge.api.commitManagedServerAutoStart!(agentName)
-              : undefined
-          }
-          onOpenChat={openChat}
-          onOpenCode={openCode}
-          onOpenConfig={openConfig}
-          onRemovePeer={shell.onRemovePeer}
-          onRenamePeer={shell.onRenamePeer}
-          onRepairP2P={shell.onRepairP2P}
-          onSaveBackendConfig={shell.onSaveBackendConfig}
-          onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
-          onProbeInferenceEndpoint={shell.onProbeInferenceEndpoint}
-          onCodexLogin={shell.onCodexLogin}
-          onCancelCodexLogin={shell.onCancelCodexLogin}
-          onGrokLogin={shell.onGrokLogin}
-          onCancelGrokLogin={shell.onCancelGrokLogin}
-        />
-      ) : workspaceView === "chat" || workspaceView === "code" ? (
-        <section
-          className={`workspace mobile-chat-pane-${mobileChatPane}`}
-          data-mobile-chat-pane={mobileChatPane}
-        >
-          <Sidebar
-            behaviorOptions={shell.behaviorOptions}
-            conversations={shell.selectedDeployment?.conversations ?? []}
-            deployments={shell.deployments}
-            onConfigureDeployment={(agentDid) => openConfig(agentDid)}
-            onOpenCode={(agentDid) => openCode(agentDid)}
-            onOpenFleet={() => setWorkspaceView("fleet")}
-            onSelectBehavior={shell.setSelectedBehaviorId}
-            onSelectAgent={(agentDid) => {
-              shell.setSelectedAgentDid(agentDid);
-              shell.setSelectedSessionId(null);
-            }}
-            onSelectSession={shell.onSelectSession}
-            onOpenSession={(sessionId) => {
-              shell.onSelectSession(sessionId);
-              setMobileChatPane("conversation");
-            }}
-            onRenameConversationTitle={shell.onRenameConversationTitle}
-            onSyncConversations={shell.onRepairP2P}
-            syncingConversations={shell.repairingP2P}
-            onStartNewConversation={(behaviorId) => {
-              shell.onStartNewConversation(behaviorId);
-              setMobileChatPane("conversation");
-            }}
-            selectedAgentDid={shell.selectedAgentDid}
-            selectedBehaviorId={shell.selectedBehaviorId}
-            selectedSessionId={shell.selectedSessionId}
-          />
-
-          <section className="chat-column">
-            {workspaceView === "code" ? (
-              <CodeContextHeader
-                deployment={shell.selectedDeployment ?? null}
-                selectedBehaviorId={shell.selectedBehaviorId}
-                onBackToChat={() => setWorkspaceView("chat")}
-              />
-            ) : null}
-            <ChatWorkspace
-              api={bridge.api}
-              activeRequestId={
-                shell.activeRequestId ?? shell.session?.latestRequestId ?? null
-              }
-              approxSerializedBytes={shell.snapshot?.client?.approxSerializedBytes ?? 0}
-              canSend={shell.canSendMessage}
-              configuredPeerCount={shell.snapshot?.client?.configuredPeerCount ?? 0}
-              dialedPeerCount={shell.snapshot?.client?.dialedPeerCount ?? 0}
-              draft={shell.draft}
-              interruptVisible={shell.interruptVisible}
-              onDraftChange={shell.setDraft}
-              onRenameConversationTitle={shell.onRenameConversationTitle}
-              onSend={shell.onSendMessage}
-              onRetryMessage={shell.onRetryMessage}
-              rowCount={shell.snapshot?.client?.rowCount ?? 0}
-              runtimeHealth={shell.runtimeHealth}
-              sendHint={
-                shell.sendStatus.kind === "disabled" ? shell.sendStatus.hint : null
-              }
-              selectedBehaviorId={shell.selectedBehaviorId}
-              selectedConversationTitle={
-                shell.session
-                  ? (shell.session.title ?? null)
-                  : (shell.selectedConversation?.title ?? null)
-              }
-              selectedDeployment={shell.selectedDeployment}
-              selectedSessionId={shell.selectedSessionId}
-              sending={shell.sending}
-              session={shell.session}
-              turnState={shell.turnState ?? shell.session?.turnState ?? null}
-              onOpenMobileNavigation={() => setMobileChatPane("navigation")}
-              onForkedConversation={shell.onSelectSession}
-              onInterruptAccepted={async () => {
-                await shell.refreshSession(shell.selectedSessionId);
-              }}
-            />
-          </section>
-        </section>
       ) : (
-        <section className="config-page">
-          <ConfigWorkspace
-            api={bridge.api}
-            bootstrap={shell.snapshot?.bootstrap ?? null}
-            onBack={navigateBack}
-            onDeleteSkillConfig={shell.onDeleteSkillConfig}
-            onDeleteTaskConfig={shell.onDeleteTaskConfig}
-            onDeleteScheduleConfig={shell.onDeleteScheduleConfig}
-            onDeleteEventTriggerConfig={shell.onDeleteEventTriggerConfig}
-            onDeleteBackendConfig={shell.onDeleteBackendConfig}
-            onDeleteInferenceProfileConfig={shell.onDeleteInferenceProfileConfig}
-            onDeleteToolSelectionConfig={shell.onDeleteToolSelectionConfig}
-            onDeleteToolServiceConfig={shell.onDeleteToolServiceConfig}
-            onDeleteBehaviorConfig={shell.onDeleteBehaviorConfig}
-            onSaveAgentConfig={shell.onSaveAgentConfig}
-            onRunTask={shell.onRunTask}
-            onSaveBackendConfig={shell.onSaveBackendConfig}
-            onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
-            onSaveEventTriggerConfig={shell.onSaveEventTriggerConfig}
-            onSaveInferenceProfileConfig={shell.onSaveInferenceProfileConfig}
-            onSaveScheduleConfig={shell.onSaveScheduleConfig}
-            onSaveSkillConfig={shell.onSaveSkillConfig}
-            onSaveTaskConfig={shell.onSaveTaskConfig}
-            onSaveToolSelectionConfig={shell.onSaveToolSelectionConfig}
-            onSaveToolServiceConfig={shell.onSaveToolServiceConfig}
-            onTestToolService={shell.onTestToolService}
-            onRunSchedule={shell.onRunSchedule}
-            runningTask={shell.runningTask}
-            saving={shell.savingConfig}
-            selectedBehaviorId={shell.selectedBehaviorId}
-            selectedDeployment={shell.selectedDeployment}
+        <section className="app-ready-shell">
+          <AppNavigation
+            currentView={navigation.view}
+            deploymentAvailable={Boolean(shell.selectedDeployment)}
+            drawerOpen={navigationDrawerOpen}
+            expanded={navigationExpanded}
+            onCloseDrawer={closeNavigationDrawer}
+            onNavigate={(view) =>
+              navigateTo(view, view === "code" ? "conversation" : "navigation")
+            }
+            onOpenDrawer={openNavigationDrawer}
+            onShowShortcuts={showShortcuts}
+            onToggleExpanded={toggleNavigationExpanded}
           />
+          <div className="app-ready-content">
+            {navigation.view === "fleet" ? (
+              <FleetHostDashboard
+                api={bridge.api}
+                addingPeer={shell.addingPeer}
+                bootstrap={shell.snapshot?.bootstrap ?? null}
+                deployments={shell.deployments}
+                loading={shell.loading}
+                p2pHealth={shell.runtimeHealth}
+                repairingP2P={shell.repairingP2P}
+                starting={shell.starting}
+                onAddPeer={shell.onAddPeer}
+                onPairBearer={shell.onPairBearer}
+                onProbePeerAddress={shell.onProbePeerAddress}
+                onInitLocalRuntime={shell.onInitLocalRuntime}
+                onStartManagedServer={
+                  bridge.api.startManagedServer
+                    ? (agentName) => bridge.api.startManagedServer!(agentName)
+                    : undefined
+                }
+                onCommitManagedServerAutoStart={
+                  bridge.api.commitManagedServerAutoStart
+                    ? (agentName) => bridge.api.commitManagedServerAutoStart!(agentName)
+                    : undefined
+                }
+                onOpenChat={openChat}
+                onOpenCode={openCode}
+                onOpenConfig={openConfig}
+                onRemovePeer={shell.onRemovePeer}
+                onRenamePeer={shell.onRenamePeer}
+                onRepairP2P={shell.onRepairP2P}
+                onSaveBackendConfig={shell.onSaveBackendConfig}
+                onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
+                onProbeInferenceEndpoint={shell.onProbeInferenceEndpoint}
+                onCodexLogin={shell.onCodexLogin}
+                onCancelCodexLogin={shell.onCancelCodexLogin}
+                onGrokLogin={shell.onGrokLogin}
+                onCancelGrokLogin={shell.onCancelGrokLogin}
+              />
+            ) : navigation.view === "chat" || navigation.view === "code" ? (
+              <section
+                className={`workspace mobile-chat-pane-${navigation.mobileChatPane}`}
+                data-mobile-chat-pane={navigation.mobileChatPane}
+              >
+                <Sidebar
+                  behaviorOptions={shell.behaviorOptions}
+                  conversations={shell.selectedDeployment?.conversations ?? []}
+                  deployments={shell.deployments}
+                  onSelectBehavior={shell.setSelectedBehaviorId}
+                  onSelectAgent={(agentDid) => {
+                    shell.setSelectedAgentDid(agentDid);
+                    shell.setSelectedSessionId(null);
+                  }}
+                  onSelectSession={shell.onSelectSession}
+                  onOpenSession={(sessionId) => {
+                    shell.onSelectSession(sessionId);
+                    navigation.showConversation();
+                  }}
+                  onRenameConversationTitle={shell.onRenameConversationTitle}
+                  onSyncConversations={shell.onRepairP2P}
+                  syncingConversations={shell.repairingP2P}
+                  onStartNewConversation={(behaviorId) => {
+                    shell.onStartNewConversation(behaviorId);
+                    navigation.showConversation();
+                  }}
+                  selectedAgentDid={shell.selectedAgentDid}
+                  selectedBehaviorId={shell.selectedBehaviorId}
+                  selectedSessionId={shell.selectedSessionId}
+                />
+
+                <section className="chat-column">
+                  {navigation.view === "code" ? (
+                    <CodeContextHeader
+                      deployment={shell.selectedDeployment ?? null}
+                      selectedBehaviorId={shell.selectedBehaviorId}
+                      onBackToChat={() =>
+                        navigation.navigate("chat", {
+                          mobileChatPane: "conversation",
+                          replace: true,
+                        })
+                      }
+                    />
+                  ) : null}
+                  <ChatWorkspace
+                    api={bridge.api}
+                    activeRequestId={
+                      shell.activeRequestId ?? shell.session?.latestRequestId ?? null
+                    }
+                    approxSerializedBytes={
+                      shell.snapshot?.client?.approxSerializedBytes ?? 0
+                    }
+                    canSend={shell.canSendMessage}
+                    configuredPeerCount={
+                      shell.snapshot?.client?.configuredPeerCount ?? 0
+                    }
+                    dialedPeerCount={shell.snapshot?.client?.dialedPeerCount ?? 0}
+                    draft={shell.draft}
+                    interruptVisible={shell.interruptVisible}
+                    onDraftChange={shell.setDraft}
+                    onRenameConversationTitle={shell.onRenameConversationTitle}
+                    onSend={shell.onSendMessage}
+                    onRetryMessage={shell.onRetryMessage}
+                    rowCount={shell.snapshot?.client?.rowCount ?? 0}
+                    runtimeHealth={shell.runtimeHealth}
+                    sendHint={
+                      shell.sendStatus.kind === "disabled"
+                        ? shell.sendStatus.hint
+                        : null
+                    }
+                    selectedBehaviorId={shell.selectedBehaviorId}
+                    selectedConversationTitle={
+                      shell.session
+                        ? (shell.session.title ?? null)
+                        : (shell.selectedConversation?.title ?? null)
+                    }
+                    selectedDeployment={shell.selectedDeployment}
+                    selectedSessionId={shell.selectedSessionId}
+                    sending={shell.sending}
+                    session={shell.session}
+                    turnState={shell.turnState ?? shell.session?.turnState ?? null}
+                    onOpenMobileNavigation={navigation.showChatNavigation}
+                    onForkedConversation={shell.onSelectSession}
+                    onInterruptAccepted={async () => {
+                      await shell.refreshSession(shell.selectedSessionId);
+                    }}
+                  />
+                </section>
+              </section>
+            ) : (
+              <section className="config-page">
+                <ConfigWorkspace
+                  api={bridge.api}
+                  bootstrap={shell.snapshot?.bootstrap ?? null}
+                  onBack={navigation.back}
+                  onDeleteSkillConfig={shell.onDeleteSkillConfig}
+                  onDeleteTaskConfig={shell.onDeleteTaskConfig}
+                  onDeleteScheduleConfig={shell.onDeleteScheduleConfig}
+                  onDeleteEventTriggerConfig={shell.onDeleteEventTriggerConfig}
+                  onDeleteBackendConfig={shell.onDeleteBackendConfig}
+                  onDeleteInferenceProfileConfig={shell.onDeleteInferenceProfileConfig}
+                  onDeleteToolSelectionConfig={shell.onDeleteToolSelectionConfig}
+                  onDeleteToolServiceConfig={shell.onDeleteToolServiceConfig}
+                  onDeleteBehaviorConfig={shell.onDeleteBehaviorConfig}
+                  onSaveAgentConfig={shell.onSaveAgentConfig}
+                  onRunTask={shell.onRunTask}
+                  onSaveBackendConfig={shell.onSaveBackendConfig}
+                  onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
+                  onSaveEventTriggerConfig={shell.onSaveEventTriggerConfig}
+                  onSaveInferenceProfileConfig={shell.onSaveInferenceProfileConfig}
+                  onSaveScheduleConfig={shell.onSaveScheduleConfig}
+                  onSaveSkillConfig={shell.onSaveSkillConfig}
+                  onSaveTaskConfig={shell.onSaveTaskConfig}
+                  onSaveToolSelectionConfig={shell.onSaveToolSelectionConfig}
+                  onSaveToolServiceConfig={shell.onSaveToolServiceConfig}
+                  onTestToolService={shell.onTestToolService}
+                  onRunSchedule={shell.onRunSchedule}
+                  runningTask={shell.runningTask}
+                  saving={shell.savingConfig}
+                  selectedBehaviorId={shell.selectedBehaviorId}
+                  selectedDeployment={shell.selectedDeployment}
+                />
+              </section>
+            )}
+          </div>
         </section>
       )}
     </main>

--- a/apps/gents-desktop/src/components/AppNavigation.tsx
+++ b/apps/gents-desktop/src/components/AppNavigation.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import sourceMarkUrl from "../assets/source-mark-light.png";
+import type { WorkspaceView } from "../hooks/useAppNavigation";
+import { ThemeToggle } from "./ThemeToggle";
+
+const SHORTCUT_MODIFIER = navigator.platform.toUpperCase().includes("MAC")
+  ? "⌘"
+  : "Ctrl+";
+
+type NavigationItem = {
+  view: WorkspaceView;
+  label: string;
+  shortcut: string;
+  requiresDeployment: boolean;
+  icon: ReactNode;
+};
+
+const NAVIGATION_ITEMS: NavigationItem[] = [
+  {
+    view: "fleet",
+    label: "Fleet",
+    shortcut: "1",
+    requiresDeployment: false,
+    icon: <FleetIcon />,
+  },
+  {
+    view: "chat",
+    label: "Chat",
+    shortcut: "2",
+    requiresDeployment: true,
+    icon: <ChatIcon />,
+  },
+  {
+    view: "code",
+    label: "Code",
+    shortcut: "3",
+    requiresDeployment: true,
+    icon: <CodeIcon />,
+  },
+  {
+    view: "config",
+    label: "Configure",
+    shortcut: "4",
+    requiresDeployment: true,
+    icon: <SettingsIcon />,
+  },
+];
+
+export type AppNavigationProps = {
+  currentView: WorkspaceView;
+  deploymentAvailable: boolean;
+  drawerOpen: boolean;
+  expanded: boolean;
+  onCloseDrawer: () => void;
+  onNavigate: (view: WorkspaceView) => void;
+  onOpenDrawer: () => void;
+  onShowShortcuts: () => void;
+  onToggleExpanded: () => void;
+};
+
+export function AppNavigation({
+  currentView,
+  deploymentAvailable,
+  drawerOpen,
+  expanded,
+  onCloseDrawer,
+  onNavigate,
+  onOpenDrawer,
+  onShowShortcuts,
+  onToggleExpanded,
+}: AppNavigationProps) {
+  const drawer = useRef<HTMLElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const navigation = drawer.current;
+    const focusable = navigation?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable?.[0];
+    const last = focusable?.[focusable.length - 1];
+    const frame = requestAnimationFrame(() => {
+      navigation?.querySelector<HTMLElement>('[aria-current="page"]')?.focus();
+    });
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseDrawer();
+        return;
+      }
+      if (event.key !== "Tab" || !first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("keydown", onKeyDown);
+      trigger.current?.focus();
+    };
+  }, [drawerOpen, onCloseDrawer]);
+
+  return (
+    <>
+      <button
+        aria-controls="app-navigation"
+        aria-expanded={drawerOpen}
+        aria-label="Open navigation"
+        className="ghost-button app-menu-trigger"
+        data-testid="app-menu-trigger"
+        onClick={onOpenDrawer}
+        ref={trigger}
+        type="button"
+      >
+        <MenuIcon />
+      </button>
+      <button
+        aria-label="Close navigation"
+        className={`app-navigation-backdrop${drawerOpen ? " open" : ""}`}
+        onClick={onCloseDrawer}
+        tabIndex={drawerOpen ? 0 : -1}
+        type="button"
+      />
+      <aside
+        aria-label="Application"
+        className={`app-navigation${expanded ? " expanded" : " collapsed"}${
+          drawerOpen ? " drawer-open" : ""
+        }`}
+        data-testid="app-navigation"
+        id="app-navigation"
+        ref={drawer}
+      >
+        <div className="app-navigation-brand">
+          <img alt="" src={sourceMarkUrl} />
+          <div className="app-navigation-label app-navigation-brand-copy">
+            <span>Source Network</span>
+            <strong>Gents</strong>
+          </div>
+        </div>
+
+        <nav aria-label="Workspace" className="app-navigation-items">
+          {NAVIGATION_ITEMS.map((item) => {
+            const disabled = item.requiresDeployment && !deploymentAvailable;
+            const title = disabled
+              ? `${item.label} — select an agent first`
+              : `${item.label} (⌘/Ctrl+${item.shortcut})`;
+            return (
+              <button
+                aria-current={currentView === item.view ? "page" : undefined}
+                aria-label={
+                  disabled ? `${item.label} — select an agent first` : item.label
+                }
+                className="app-navigation-item"
+                data-testid={`app-nav-${item.view}`}
+                disabled={disabled}
+                key={item.view}
+                onClick={() => onNavigate(item.view)}
+                title={title}
+                type="button"
+              >
+                <span className="app-navigation-icon">{item.icon}</span>
+                <span className="app-navigation-label">{item.label}</span>
+                <kbd className="app-navigation-label">
+                  {SHORTCUT_MODIFIER}
+                  {item.shortcut}
+                </kbd>
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="app-navigation-utilities">
+          <ThemeToggle showLabel />
+          <button
+            className="ghost-button app-navigation-utility"
+            onClick={onShowShortcuts}
+            title="Keyboard shortcuts (⌘/Ctrl+/)"
+            type="button"
+          >
+            <HelpIcon />
+            <span className="app-navigation-label">Shortcuts</span>
+          </button>
+          <button
+            aria-expanded={expanded}
+            className="ghost-button app-navigation-utility app-navigation-collapse"
+            data-testid="app-navigation-collapse"
+            onClick={onToggleExpanded}
+            title={expanded ? "Collapse navigation" : "Expand navigation"}
+            type="button"
+          >
+            <CollapseIcon />
+            <span className="app-navigation-label">
+              {expanded ? "Collapse" : "Expand"}
+            </span>
+          </button>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function SvgIcon({ children }: { children: ReactNode }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      {children}
+    </svg>
+  );
+}
+
+function FleetIcon() {
+  return (
+    <SvgIcon>
+      <rect height="7" rx="1" width="7" x="3" y="3" />
+      <rect height="7" rx="1" width="7" x="14" y="3" />
+      <rect height="7" rx="1" width="7" x="3" y="14" />
+      <rect height="7" rx="1" width="7" x="14" y="14" />
+    </SvgIcon>
+  );
+}
+
+function ChatIcon() {
+  return (
+    <SvgIcon>
+      <path d="M20 15a3 3 0 0 1-3 3H8l-5 3V7a3 3 0 0 1 3-3h11a3 3 0 0 1 3 3Z" />
+    </SvgIcon>
+  );
+}
+
+function CodeIcon() {
+  return (
+    <SvgIcon>
+      <path d="m8 9-4 3 4 3" />
+      <path d="m16 9 4 3-4 3" />
+      <path d="m14 5-4 14" />
+    </SvgIcon>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <SvgIcon>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6v.2h-4V21a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 0 0 .3-1.9A1.7 1.7 0 0 0 3 14H2.8v-4H3a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.2 7 7 4.2l.1.1A1.7 1.7 0 0 0 9 4.6a1.7 1.7 0 0 0 1-1.6v-.2h4V3a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.2v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+    </SvgIcon>
+  );
+}
+
+function HelpIcon() {
+  return (
+    <SvgIcon>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9.8 9a2.3 2.3 0 1 1 3.4 2c-.8.5-1.2 1-1.2 2" />
+      <path d="M12 17h.01" />
+    </SvgIcon>
+  );
+}
+
+function CollapseIcon() {
+  return (
+    <SvgIcon>
+      <path d="m14 6-6 6 6 6" />
+      <path d="M20 4v16" />
+    </SvgIcon>
+  );
+}
+
+function MenuIcon() {
+  return (
+    <SvgIcon>
+      <path d="M4 7h16M4 12h16M4 17h16" />
+    </SvgIcon>
+  );
+}

--- a/apps/gents-desktop/src/components/ConfigWorkspace.tsx
+++ b/apps/gents-desktop/src/components/ConfigWorkspace.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AgentConfigSaveRequest,
   BackendSaveRequest,
@@ -41,9 +40,7 @@ import {
   ToolSelectionConfigPanel,
   ToolServiceConfigPanel,
 } from "./config";
-import { ConfirmDialog } from "@source-inc/gents-desktop-ui";
-import { ConfigNavigationGuardProvider } from "./config/ConfigNavigationGuard";
-import sourceMarkUrl from "../assets/source-mark-light.png";
+import { useConfigNavigationGuard } from "./config/ConfigNavigationGuard";
 
 type ConfigWorkspaceProps = {
   api?: DesktopApiAdapter;
@@ -116,9 +113,7 @@ export function ConfigWorkspace({
   onSaveEventTriggerConfig,
   onRunTask,
 }: ConfigWorkspaceProps) {
-  const [configDirty, setConfigDirty] = useState(false);
-  const [confirmingDiscard, setConfirmingDiscard] = useState(false);
-  const pendingNavigation = useRef<(() => void) | null>(null);
+  const { requestNavigation } = useConfigNavigationGuard();
   const {
     activeTab,
     savedStatus,
@@ -146,55 +141,13 @@ export function ConfigWorkspace({
     setSelectedToolServiceId,
   } = useConfigWorkspaceSelection(selectedDeployment, selectedBehaviorId);
 
-  const requestNavigation = useCallback(
-    (navigate: () => void) => {
-      if (!configDirty) {
-        navigate();
-        return;
-      }
-      pendingNavigation.current = navigate;
-      setConfirmingDiscard(true);
-    },
-    [configDirty],
-  );
-
-  const navigationGuard = useMemo(
-    () => ({ reportDirty: setConfigDirty, requestNavigation }),
-    [requestNavigation],
-  );
-
-  useEffect(() => {
-    if (!configDirty) {
-      return;
-    }
-    const preventAccidentalClose = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      event.returnValue = "";
-    };
-    window.addEventListener("beforeunload", preventAccidentalClose);
-    return () => window.removeEventListener("beforeunload", preventAccidentalClose);
-  }, [configDirty]);
-
-  const cancelDiscard = useCallback(() => {
-    pendingNavigation.current = null;
-    setConfirmingDiscard(false);
-  }, []);
-
-  const confirmDiscard = useCallback(() => {
-    const navigate = pendingNavigation.current;
-    pendingNavigation.current = null;
-    setConfirmingDiscard(false);
-    setConfigDirty(false);
-    navigate?.();
-  }, []);
-
   if (!selectedDeployment) {
     return (
       <article className="panel centered-panel">
         <p className="eyebrow">Config</p>
         <h2>Select a deployment</h2>
         <button className="ghost-button" onClick={onBack} type="button">
-          Back to Chat
+          Back
         </button>
       </article>
     );
@@ -205,13 +158,12 @@ export function ConfigWorkspace({
   const activeTabControlId = `config-tab-control-${activeTabConfig.id}`;
 
   return (
-    <ConfigNavigationGuardProvider value={navigationGuard}>
+    <>
       <section className="config-workspace config-workspace-full">
         <header className="config-header">
           <div className="config-brand">
-            <img alt="Source" className="config-brand-logo" src={sourceMarkUrl} />
             <div className="config-title-block">
-              <p className="eyebrow">Source Network Config</p>
+              <p className="eyebrow">Configuration</p>
               <h1>{selectedDeployment.label}</h1>
               <p className="muted mono" title={selectedDeployment.agentDid}>
                 {selectedDeployment.agentDid}
@@ -241,7 +193,7 @@ export function ConfigWorkspace({
               onClick={() => requestNavigation(onBack)}
               type="button"
             >
-              Back to Chat
+              Back
             </button>
           </div>
         </header>
@@ -496,16 +448,6 @@ export function ConfigWorkspace({
           ) : null}
         </section>
       </section>
-      <ConfirmDialog
-        cancelLabel="Keep editing"
-        confirmLabel="Discard changes"
-        danger
-        message="This configuration has unsaved changes. Discard them and continue?"
-        onCancel={cancelDiscard}
-        onConfirm={confirmDiscard}
-        open={confirmingDiscard}
-        title="Discard unsaved changes?"
-      />
-    </ConfigNavigationGuardProvider>
+    </>
   );
 }

--- a/apps/gents-desktop/src/components/ShortcutsHelp.tsx
+++ b/apps/gents-desktop/src/components/ShortcutsHelp.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from "react";
 
 const IS_MAC = navigator.platform.toUpperCase().includes("MAC");
 const MOD = IS_MAC ? "⌘" : "Ctrl+";
@@ -20,6 +20,17 @@ export function ShortcutsHelp({
   open: boolean;
   onClose: () => void;
 }) {
+  const closeButton = useRef<HTMLButtonElement>(null);
+  const dialog = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const previousFocus =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    closeButton.current?.focus();
+    return () => previousFocus?.focus();
+  }, [open]);
+
   useEffect(() => {
     if (!open) {
       return;
@@ -36,16 +47,55 @@ export function ShortcutsHelp({
   if (!open) {
     return null;
   }
+
+  function onDialogKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Tab" || !dialog.current) return;
+    const focusable = Array.from(
+      dialog.current.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) {
+      event.preventDefault();
+      dialog.current.focus();
+    } else if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   return (
     <div className="dialog-backdrop open" role="presentation" onClick={onClose}>
       <div
-        aria-label="Keyboard shortcuts"
+        aria-labelledby="shortcuts-help-title"
+        aria-modal="true"
         className="dialog shortcuts-help"
         data-testid="shortcuts-help"
+        onKeyDown={onDialogKeyDown}
+        ref={dialog}
         role="dialog"
+        tabIndex={-1}
         onClick={(event) => event.stopPropagation()}
       >
-        <p className="eyebrow">Keyboard shortcuts</p>
+        <header className="shortcuts-help-header">
+          <p className="eyebrow" id="shortcuts-help-title">
+            Keyboard shortcuts
+          </p>
+          <button
+            aria-label="Close keyboard shortcuts"
+            className="ghost-button shortcuts-help-close"
+            onClick={onClose}
+            ref={closeButton}
+            type="button"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
         <dl className="shortcuts-list">
           {SHORTCUTS.map(([keys, action]) => (
             <div className="shortcuts-row" key={keys}>

--- a/apps/gents-desktop/src/components/Sidebar.tsx
+++ b/apps/gents-desktop/src/components/Sidebar.tsx
@@ -16,9 +16,6 @@ export type SidebarProps = {
   selectedAgentDid: string | null;
   selectedBehaviorId: string | null;
   selectedSessionId: string | null;
-  onOpenFleet: () => void;
-  onConfigureDeployment: (agentDid: string) => void;
-  onOpenCode?: (agentDid: string) => void;
   onSelectBehavior: (behaviorId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onOpenSession?: (sessionId: string) => void;
@@ -39,9 +36,6 @@ export function Sidebar({
   selectedAgentDid,
   selectedBehaviorId,
   selectedSessionId,
-  onOpenFleet,
-  onConfigureDeployment,
-  onOpenCode,
   onSelectBehavior,
   onSelectSession,
   onOpenSession,
@@ -57,9 +51,6 @@ export function Sidebar({
         deployments={deployments}
         onSelectAgent={onSelectAgent}
         selectedAgentDid={selectedAgentDid}
-        onConfigureDeployment={onConfigureDeployment}
-        onOpenCode={onOpenCode}
-        onOpenFleet={onOpenFleet}
       />
 
       <BehaviorSelectorSection

--- a/apps/gents-desktop/src/components/ThemeToggle.tsx
+++ b/apps/gents-desktop/src/components/ThemeToggle.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { applyTheme, loadTheme } from "../lib/theme";
 
-export function ThemeToggle() {
+export function ThemeToggle({ showLabel = false }: { showLabel?: boolean } = {}) {
   const [theme, setTheme] = useState(loadTheme);
   const next = theme === "dark" ? "light" : "dark";
 
@@ -35,6 +35,7 @@ export function ThemeToggle() {
           <path d="M20 13.2A7.8 7.8 0 1 1 10.8 4 6.2 6.2 0 0 0 20 13.2Z" />
         </svg>
       )}
+      {showLabel ? <span className="app-navigation-label">Theme</span> : null}
     </button>
   );
 }

--- a/apps/gents-desktop/src/components/config/ConfigNavigationGuard.tsx
+++ b/apps/gents-desktop/src/components/config/ConfigNavigationGuard.tsx
@@ -1,4 +1,15 @@
-import { createContext, useContext, useLayoutEffect, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { ConfirmDialog } from "@source-inc/gents-desktop-ui";
 
 type ConfigNavigationGuardValue = {
   reportDirty: (dirty: boolean) => void;
@@ -24,6 +35,68 @@ export function ConfigNavigationGuardProvider({
     <ConfigNavigationGuardContext.Provider value={value}>
       {children}
     </ConfigNavigationGuardContext.Provider>
+  );
+}
+
+export function ConfigNavigationGuardBoundary({ children }: { children: ReactNode }) {
+  const [dirty, setDirty] = useState(false);
+  const [confirmingDiscard, setConfirmingDiscard] = useState(false);
+  const pendingNavigation = useRef<(() => void) | null>(null);
+
+  const requestNavigation = useCallback(
+    (navigate: () => void) => {
+      if (!dirty) {
+        navigate();
+        return;
+      }
+      pendingNavigation.current = navigate;
+      setConfirmingDiscard(true);
+    },
+    [dirty],
+  );
+
+  const value = useMemo(
+    () => ({ reportDirty: setDirty, requestNavigation }),
+    [requestNavigation],
+  );
+
+  useEffect(() => {
+    if (!dirty) return;
+    const preventAccidentalClose = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", preventAccidentalClose);
+    return () => window.removeEventListener("beforeunload", preventAccidentalClose);
+  }, [dirty]);
+
+  const cancelDiscard = useCallback(() => {
+    pendingNavigation.current = null;
+    setConfirmingDiscard(false);
+  }, []);
+
+  const confirmDiscard = useCallback(() => {
+    const navigate = pendingNavigation.current;
+    pendingNavigation.current = null;
+    setConfirmingDiscard(false);
+    setDirty(false);
+    navigate?.();
+  }, []);
+
+  return (
+    <ConfigNavigationGuardProvider value={value}>
+      {children}
+      <ConfirmDialog
+        cancelLabel="Keep editing"
+        confirmLabel="Discard changes"
+        danger
+        message="This configuration has unsaved changes. Discard them and continue?"
+        onCancel={cancelDiscard}
+        onConfirm={confirmDiscard}
+        open={confirmingDiscard}
+        title="Discard unsaved changes?"
+      />
+    </ConfigNavigationGuardProvider>
   );
 }
 

--- a/apps/gents-desktop/src/components/fleet/FleetHostDashboard.tsx
+++ b/apps/gents-desktop/src/components/fleet/FleetHostDashboard.tsx
@@ -17,9 +17,6 @@ import type {
   InferenceProbeResult,
 } from "@source-inc/gents-desktop-client";
 
-import { ThemeToggle } from "../ThemeToggle";
-import { BrandLockup } from "./BrandLockup";
-
 export type FleetHostDashboardProps = Omit<
   FleetDashboardProps,
   "brand" | "headerLeadingActions" | "localRuntimeSetup" | "renderInferenceSetup"
@@ -52,7 +49,7 @@ export function FleetHostDashboard({
   return (
     <FleetDashboard
       {...fleetProps}
-      brand={<BrandLockup />}
+      brand={null}
       copy={{
         ...fleetProps.copy,
         pairingQrHint: fleetProps.copy?.pairingQrHint ?? (
@@ -62,7 +59,7 @@ export function FleetHostDashboard({
           </>
         ),
       }}
-      headerLeadingActions={<ThemeToggle />}
+      headerLeadingActions={null}
       localRuntimeSetup={
         <LocalRuntimeConnect
           bootstrap={fleetProps.bootstrap}

--- a/apps/gents-desktop/src/components/sidebar-widgets/ConnectedPeerSection.tsx
+++ b/apps/gents-desktop/src/components/sidebar-widgets/ConnectedPeerSection.tsx
@@ -3,18 +3,12 @@ import type { DeploymentView } from "@source-inc/gents-desktop-client";
 export type ConnectedPeerSectionProps = {
   deployments: DeploymentView[];
   selectedAgentDid: string | null;
-  onOpenFleet: () => void;
-  onConfigureDeployment: (agentDid: string) => void;
-  onOpenCode?: (agentDid: string) => void;
   onSelectAgent?: (agentDid: string) => void;
 };
 
 export function ConnectedPeerSection({
   deployments,
   selectedAgentDid,
-  onOpenFleet,
-  onConfigureDeployment,
-  onOpenCode,
   onSelectAgent,
 }: ConnectedPeerSectionProps) {
   const selectedDeployment =
@@ -23,47 +17,6 @@ export function ConnectedPeerSection({
   return (
     <section className="sidebar-section connected-peer-section">
       <div className="connected-peer-card">
-        <div className="connected-peer-toolbar">
-          <button
-            aria-label="Back to Fleet"
-            className="ghost-button connected-peer-back"
-            data-testid="sidebar-back-to-fleet"
-            onClick={onOpenFleet}
-            type="button"
-          >
-            <span aria-hidden="true">←</span>
-            Fleet
-          </button>
-          <div className="connected-peer-actions">
-            {onOpenCode ? (
-              <button
-                className="ghost-button connected-peer-action"
-                data-testid="sidebar-open-code"
-                disabled={!selectedDeployment}
-                onClick={() => {
-                  if (selectedDeployment) {
-                    onOpenCode(selectedDeployment.agentDid);
-                  }
-                }}
-                type="button"
-              >
-                Code
-              </button>
-            ) : null}
-            <button
-              className="ghost-button connected-peer-action"
-              disabled={!selectedDeployment}
-              onClick={() => {
-                if (selectedDeployment) {
-                  onConfigureDeployment(selectedDeployment.agentDid);
-                }
-              }}
-              type="button"
-            >
-              Configure
-            </button>
-          </div>
-        </div>
         <div className="connected-peer-header">
           <div>
             <p className="eyebrow">Connected Peer</p>

--- a/apps/gents-desktop/src/hooks/useAppNavigation.ts
+++ b/apps/gents-desktop/src/hooks/useAppNavigation.ts
@@ -1,0 +1,89 @@
+import { useCallback, useRef, useState } from "react";
+
+export type WorkspaceView = "fleet" | "chat" | "code" | "config";
+export type MobileChatPane = "navigation" | "conversation";
+
+export type AppLocation = {
+  view: WorkspaceView;
+  mobileChatPane: MobileChatPane;
+};
+
+type NavigateOptions = {
+  mobileChatPane?: MobileChatPane;
+  replace?: boolean;
+};
+
+const INITIAL_LOCATION: AppLocation = {
+  view: "fleet",
+  mobileChatPane: "navigation",
+};
+
+export function useAppNavigation() {
+  const [location, setLocation] = useState<AppLocation>(INITIAL_LOCATION);
+  const history = useRef<AppLocation[]>([]);
+
+  const navigate = useCallback((view: WorkspaceView, options: NavigateOptions = {}) => {
+    setLocation((current) => {
+      const next: AppLocation = {
+        view,
+        mobileChatPane:
+          options.mobileChatPane ??
+          (view === "code"
+            ? "conversation"
+            : view === "chat" && current.view === "chat"
+              ? current.mobileChatPane
+              : "navigation"),
+      };
+
+      if (
+        current.view === next.view &&
+        current.mobileChatPane === next.mobileChatPane
+      ) {
+        return current;
+      }
+      if (
+        options.replace &&
+        history.current[history.current.length - 1]?.view === next.view
+      ) {
+        history.current.pop();
+      }
+      if (current.view !== next.view && !options.replace) {
+        history.current.push(current);
+      }
+      return next;
+    });
+  }, []);
+
+  const showChatNavigation = useCallback(() => {
+    setLocation(() => ({
+      view: "chat",
+      mobileChatPane: "navigation",
+    }));
+  }, []);
+
+  const showConversation = useCallback(() => {
+    setLocation((current) => ({
+      view: current.view === "code" ? "code" : "chat",
+      mobileChatPane: "conversation",
+    }));
+  }, []);
+
+  const back = useCallback(() => {
+    setLocation((current) => {
+      if (current.view === "chat" && current.mobileChatPane === "conversation") {
+        return { ...current, mobileChatPane: "navigation" };
+      }
+      const previous = history.current.pop();
+      if (previous) return previous;
+      return INITIAL_LOCATION;
+    });
+  }, []);
+
+  return {
+    ...location,
+    back,
+    navigate,
+    showChatNavigation,
+    showConversation,
+  };
+}

--- a/apps/gents-desktop/src/lib/navigationPreference.ts
+++ b/apps/gents-desktop/src/lib/navigationPreference.ts
@@ -1,0 +1,15 @@
+const NAVIGATION_EXPANDED_KEY = "gents-desktop-navigation-expanded";
+
+export function loadNavigationExpanded(): boolean {
+  try {
+    return window.localStorage.getItem(NAVIGATION_EXPANDED_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function saveNavigationExpanded(expanded: boolean) {
+  try {
+    window.localStorage.setItem(NAVIGATION_EXPANDED_KEY, String(expanded));
+  } catch {}
+}

--- a/apps/gents-desktop/src/styles/navigation.css
+++ b/apps/gents-desktop/src/styles/navigation.css
@@ -1,0 +1,309 @@
+@layer components {
+  .app-ready-shell {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--space-6);
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .app-ready-content {
+    min-width: 0;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .app-navigation {
+    width: 68px;
+    min-height: 0;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    gap: var(--space-7);
+    padding: var(--space-5) var(--space-3);
+    border: 1px solid rgb(var(--source-green-rgb) / 0.16);
+    border-radius: var(--radius-sm);
+    background: rgb(var(--scrim-rgb) / 0.76);
+    overflow: hidden;
+    transition: width var(--motion-fast) ease;
+  }
+
+  .app-navigation.expanded {
+    width: 224px;
+  }
+
+  .app-navigation-brand {
+    min-width: 0;
+    min-height: 42px;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 0 var(--space-2);
+  }
+
+  .app-navigation-brand img {
+    width: 30px;
+    height: 36px;
+    flex: none;
+    object-fit: contain;
+  }
+
+  .app-navigation-brand-copy {
+    min-width: 0;
+    display: grid;
+    line-height: 1.1;
+    white-space: nowrap;
+  }
+
+  .app-navigation-brand-copy span {
+    color: var(--color-text-muted);
+    font-size: var(--text-2xs);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .app-navigation-brand-copy strong {
+    margin-top: var(--space-1);
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+  }
+
+  .app-navigation-items,
+  .app-navigation-utilities {
+    display: grid;
+    align-content: start;
+    gap: var(--space-2);
+  }
+
+  .app-navigation-utilities {
+    align-content: end;
+    padding-top: var(--space-4);
+    border-top: 1px solid rgb(var(--source-green-rgb) / 0.12);
+  }
+
+  .app-navigation-item,
+  .app-navigation-utility,
+  .app-navigation .theme-toggle {
+    width: 100%;
+    height: 42px;
+    min-height: 42px;
+    display: grid;
+    grid-template-columns: 32px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 0 var(--space-2);
+    border: 1px solid transparent;
+    border-radius: 0;
+    background: transparent;
+    color: var(--color-text-soft);
+    text-align: left;
+  }
+
+  .app-navigation .theme-toggle {
+    justify-items: stretch;
+  }
+
+  .app-navigation .theme-toggle .app-navigation-label {
+    justify-self: start;
+  }
+
+  .app-navigation-item:hover:not(:disabled),
+  .app-navigation-utility:hover,
+  .app-navigation .theme-toggle:hover {
+    border-color: rgb(var(--source-green-rgb) / 0.16);
+    background: rgb(var(--source-green-rgb) / 0.08);
+    color: var(--color-text);
+  }
+
+  .app-navigation-item[aria-current="page"] {
+    position: relative;
+    border-color: var(--border-selected);
+    background: rgb(var(--source-green-rgb) / 0.13);
+    color: var(--color-accent);
+  }
+
+  .app-navigation-item[aria-current="page"]::before {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    width: 3px;
+    background: var(--color-accent);
+  }
+
+  .app-navigation-item:disabled {
+    cursor: not-allowed;
+    opacity: 0.42;
+  }
+
+  .app-navigation-icon,
+  .app-navigation-item > svg,
+  .app-navigation-utility > svg,
+  .app-navigation .theme-toggle > svg {
+    width: 18px;
+    height: 18px;
+    justify-self: center;
+  }
+
+  .app-navigation svg {
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.8;
+  }
+
+  .app-navigation-icon {
+    display: grid;
+    place-items: center;
+  }
+
+  .app-navigation-icon svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .app-navigation-item kbd {
+    border: 0;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+  }
+
+  .app-navigation.collapsed .app-navigation-label {
+    display: none;
+  }
+
+  .app-navigation.collapsed .app-navigation-item,
+  .app-navigation.collapsed .app-navigation-utility,
+  .app-navigation.collapsed .theme-toggle {
+    grid-template-columns: 1fr;
+  }
+
+  .app-navigation.collapsed .app-navigation-collapse svg {
+    transform: rotate(180deg);
+  }
+
+  .app-menu-trigger,
+  .app-navigation-backdrop {
+    display: none;
+  }
+
+  @media (max-width: 760px) {
+    .app-shell,
+    .app-shell.app-view-chat,
+    .app-shell.app-view-code {
+      padding-top: calc(var(--space-10) + var(--space-9) + env(safe-area-inset-top));
+    }
+
+    .app-ready-shell {
+      display: contents;
+    }
+
+    .app-ready-content {
+      display: contents;
+    }
+
+    .app-menu-trigger {
+      position: fixed;
+      top: calc(var(--space-3) + env(safe-area-inset-top));
+      left: calc(var(--space-3) + env(safe-area-inset-left));
+      z-index: 62;
+      width: 38px;
+      height: 38px;
+      min-height: 38px;
+      display: grid;
+      place-items: center;
+      padding: 0;
+      border-color: var(--border-default);
+      border-radius: 0;
+      background: var(--color-surface-strong);
+      box-shadow: var(--shadow-icon-button);
+    }
+
+    .app-menu-trigger svg {
+      width: 18px;
+      height: 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-linecap: round;
+      stroke-width: 1.8;
+    }
+
+    .app-navigation {
+      position: fixed;
+      inset: 0 auto 0 0;
+      z-index: 64;
+      width: min(304px, calc(100vw - 44px));
+      padding: calc(var(--space-6) + env(safe-area-inset-top)) var(--space-5)
+        calc(var(--space-6) + env(safe-area-inset-bottom))
+        calc(var(--space-5) + env(safe-area-inset-left));
+      border: 0;
+      border-right: 1px solid var(--border-default);
+      border-radius: 0;
+      visibility: hidden;
+      transform: translateX(-102%);
+      transition:
+        transform var(--motion-medium) ease,
+        visibility var(--motion-medium) step-end;
+    }
+
+    .app-navigation.expanded,
+    .app-navigation.collapsed {
+      width: min(304px, calc(100vw - 44px));
+    }
+
+    .app-navigation.drawer-open {
+      visibility: visible;
+      transform: translateX(0);
+      transition:
+        transform var(--motion-medium) ease,
+        visibility var(--motion-fast) step-start;
+    }
+
+    .app-navigation.collapsed .app-navigation-label {
+      display: initial;
+    }
+
+    .app-navigation.collapsed .app-navigation-brand-copy {
+      display: grid;
+    }
+
+    .app-navigation.collapsed .app-navigation-item,
+    .app-navigation.collapsed .app-navigation-utility,
+    .app-navigation.collapsed .theme-toggle {
+      grid-template-columns: 32px minmax(0, 1fr) auto;
+    }
+
+    .app-navigation-collapse {
+      display: none;
+    }
+
+    .app-navigation-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 63;
+      width: 100%;
+      height: 100%;
+      display: block;
+      padding: 0;
+      border: 0;
+      visibility: hidden;
+      opacity: 0;
+      background: rgb(var(--scrim-rgb) / 0.62);
+      transition:
+        opacity var(--motion-fast) ease,
+        visibility var(--motion-fast) step-end;
+    }
+
+    .app-navigation-backdrop.open {
+      visibility: visible;
+      opacity: 1;
+      transition:
+        opacity var(--motion-fast) ease,
+        visibility var(--motion-fast) step-start;
+    }
+  }
+}

--- a/apps/gents-desktop/src/styles/shell.css
+++ b/apps/gents-desktop/src/styles/shell.css
@@ -19,6 +19,7 @@
 
   .shortcuts-help {
     min-width: 320px;
+    padding: var(--space-7) var(--space-9);
   }
 
   .shortcuts-list {

--- a/apps/gents-desktop/src/styles/shell.css
+++ b/apps/gents-desktop/src/styles/shell.css
@@ -22,6 +22,25 @@
     padding: var(--space-7) var(--space-9);
   }
 
+  .shortcuts-help-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+  }
+
+  .shortcuts-help-close {
+    width: 32px;
+    height: 32px;
+    min-height: 32px;
+    display: grid;
+    place-items: center;
+    flex: none;
+    padding: 0;
+    font-size: var(--text-xl);
+    line-height: 1;
+  }
+
   .shortcuts-list {
     margin: var(--space-5) 0 0;
     display: grid;

--- a/apps/gents-desktop/src/styles/sidebar/connected-peer.css
+++ b/apps/gents-desktop/src/styles/sidebar/connected-peer.css
@@ -15,23 +15,6 @@
     padding: var(--space-5);
   }
 
-  .connected-peer-toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-3);
-    min-width: 0;
-  }
-
-  .connected-peer-back {
-    min-height: 34px;
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: 0 var(--space-3);
-    color: var(--color-accent);
-  }
-
   .connected-peer-header {
     display: flex;
     align-items: flex-start;
@@ -60,20 +43,6 @@
     line-height: 1.2;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-  }
-
-  .connected-peer-actions {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: var(--space-2);
-  }
-
-  .connected-peer-action {
-    min-height: 34px;
-    justify-content: center;
-    padding: 0 var(--space-3);
-    font-size: var(--text-sm);
   }
 
   .connected-peer-stats {
@@ -121,12 +90,6 @@
 
     .connected-peer-header h2 {
       font-size: var(--text-lg);
-    }
-
-    .connected-peer-action {
-      min-height: 40px;
-      padding: 0 var(--space-2);
-      font-size: var(--text-xs);
     }
 
     .connected-peer-back {

--- a/apps/gents-desktop/tests/app-navigation-state.test.tsx
+++ b/apps/gents-desktop/tests/app-navigation-state.test.tsx
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useAppNavigation } from "../src/hooks/useAppNavigation";
+
+describe("app navigation state", () => {
+  it("starts on Fleet and returns through top-level history", () => {
+    const { result } = renderHook(() => useAppNavigation());
+
+    expect(result.current.view).toBe("fleet");
+    act(() => result.current.navigate("chat"));
+    act(() => result.current.navigate("config"));
+    expect(result.current.view).toBe("config");
+
+    act(() => result.current.back());
+    expect(result.current.view).toBe("chat");
+    act(() => result.current.back());
+    expect(result.current.view).toBe("fleet");
+  });
+
+  it("backs out of a mobile conversation before leaving Chat", () => {
+    const { result } = renderHook(() => useAppNavigation());
+
+    act(() => result.current.navigate("chat", { mobileChatPane: "conversation" }));
+    expect(result.current.mobileChatPane).toBe("conversation");
+
+    act(() => result.current.back());
+    expect(result.current.view).toBe("chat");
+    expect(result.current.mobileChatPane).toBe("navigation");
+
+    act(() => result.current.back());
+    expect(result.current.view).toBe("fleet");
+  });
+
+  it("does not add history when only the Chat pane changes", () => {
+    const { result } = renderHook(() => useAppNavigation());
+
+    act(() => result.current.navigate("chat"));
+    act(() => result.current.showConversation());
+    act(() => result.current.back());
+    act(() => result.current.back());
+    act(() => result.current.back());
+
+    expect(result.current.view).toBe("fleet");
+  });
+
+  it("replaces Code with Chat without creating a back-navigation loop", () => {
+    const { result } = renderHook(() => useAppNavigation());
+
+    act(() => result.current.navigate("chat"));
+    act(() => result.current.navigate("code"));
+    act(() =>
+      result.current.navigate("chat", {
+        mobileChatPane: "conversation",
+        replace: true,
+      }),
+    );
+    act(() => result.current.back());
+    act(() => result.current.back());
+
+    expect(result.current.view).toBe("fleet");
+  });
+});

--- a/apps/gents-desktop/tests/app-navigation.test.tsx
+++ b/apps/gents-desktop/tests/app-navigation.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppNavigation } from "../src/components/AppNavigation";
+import {
+  loadNavigationExpanded,
+  saveNavigationExpanded,
+} from "../src/lib/navigationPreference";
+
+const handlers = () => ({
+  onCloseDrawer: vi.fn(),
+  onNavigate: vi.fn(),
+  onOpenDrawer: vi.fn(),
+  onShowShortcuts: vi.fn(),
+  onToggleExpanded: vi.fn(),
+});
+
+describe("app navigation", () => {
+  it("marks the current destination and disables agent views without a deployment", () => {
+    const props = handlers();
+    render(
+      <AppNavigation
+        {...props}
+        currentView="fleet"
+        deploymentAvailable={false}
+        drawerOpen={false}
+        expanded
+      />,
+    );
+
+    expect(screen.getByTestId("app-nav-fleet")).toHaveAttribute("aria-current", "page");
+    expect(screen.getByTestId("app-nav-chat")).toBeDisabled();
+    expect(screen.getByTestId("app-nav-code")).toHaveAccessibleName(
+      "Code — select an agent first",
+    );
+    expect(screen.getByTestId("app-nav-config")).toBeDisabled();
+  });
+
+  it("wires destinations, utilities, and the expansion control", () => {
+    const props = handlers();
+    render(
+      <AppNavigation
+        {...props}
+        currentView="chat"
+        deploymentAvailable
+        drawerOpen={false}
+        expanded
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("app-nav-code"));
+    expect(props.onNavigate).toHaveBeenCalledWith("code");
+    fireEvent.click(screen.getByRole("button", { name: "Shortcuts" }));
+    expect(props.onShowShortcuts).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByTestId("app-navigation-collapse"));
+    expect(props.onToggleExpanded).toHaveBeenCalledOnce();
+  });
+
+  it("closes the mobile drawer with Escape and restores trigger focus", () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <AppNavigation
+          currentView="fleet"
+          deploymentAvailable
+          drawerOpen={open}
+          expanded
+          onCloseDrawer={() => setOpen(false)}
+          onNavigate={vi.fn()}
+          onOpenDrawer={() => setOpen(true)}
+          onShowShortcuts={vi.fn()}
+          onToggleExpanded={vi.fn()}
+        />
+      );
+    }
+
+    render(<Harness />);
+    const trigger = screen.getByTestId("app-menu-trigger");
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveFocus();
+  });
+});
+
+describe("navigation expansion preference", () => {
+  it("defaults to expanded and remembers an explicit collapse", () => {
+    window.localStorage.removeItem("gents-desktop-navigation-expanded");
+    expect(loadNavigationExpanded()).toBe(true);
+    saveNavigationExpanded(false);
+    expect(loadNavigationExpanded()).toBe(false);
+  });
+});

--- a/apps/gents-desktop/tests/app-shortcuts.test.tsx
+++ b/apps/gents-desktop/tests/app-shortcuts.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ShortcutsHelp } from "../src/components/ShortcutsHelp";
@@ -17,6 +18,18 @@ function makeHandlers(): AppShortcutHandlers {
     focusComposer: vi.fn(),
     toggleHelp: vi.fn(),
   };
+}
+
+function ShortcutsHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen(true)} type="button">
+        Open shortcuts
+      </button>
+      <ShortcutsHelp open={open} onClose={() => setOpen(false)} />
+    </>
+  );
 }
 
 describe("app shortcuts", () => {
@@ -45,12 +58,33 @@ describe("app shortcuts", () => {
     const onClose = vi.fn();
     render(<ShortcutsHelp open onClose={onClose} />);
 
-    expect(screen.getByTestId("shortcuts-help")).toBeInTheDocument();
+    expect(screen.getByTestId("shortcuts-help")).toHaveAttribute("aria-modal", "true");
     expect(screen.getByText("New conversation")).toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onClose).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("presentation"));
     expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("contains focus and restores it to the opener when closed", () => {
+    render(<ShortcutsHarness />);
+    const opener = screen.getByRole("button", { name: "Open shortcuts" });
+    opener.focus();
+    fireEvent.click(opener);
+
+    const close = screen.getByRole("button", {
+      name: "Close keyboard shortcuts",
+    });
+    expect(close).toHaveFocus();
+
+    fireEvent.keyDown(close, { key: "Tab" });
+    expect(close).toHaveFocus();
+    fireEvent.keyDown(close, { key: "Tab", shiftKey: true });
+    expect(close).toHaveFocus();
+
+    fireEvent.click(close);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
   });
 });

--- a/apps/gents-desktop/tests/config-navigation-guard.test.tsx
+++ b/apps/gents-desktop/tests/config-navigation-guard.test.tsx
@@ -2,13 +2,24 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ConfigWorkspace } from "../src/components/ConfigWorkspace";
+import { ConfigNavigationGuardBoundary } from "../src/components/config/ConfigNavigationGuard";
+import { useConfigNavigationGuard } from "../src/components/config/ConfigNavigationGuard";
 import {
   bootstrap,
   deployment,
   workspaceHandlers,
 } from "./config-panel-wiring/fixtures";
 
-function renderWorkspace() {
+function ExternalNavigationProbe({ onNavigate }: { onNavigate: () => void }) {
+  const { requestNavigation } = useConfigNavigationGuard();
+  return (
+    <button onClick={() => requestNavigation(onNavigate)} type="button">
+      Fleet destination
+    </button>
+  );
+}
+
+function renderWorkspace(onExternalNavigate?: () => void) {
   const handlers = {
     ...workspaceHandlers(),
     onDeleteSkillConfig: vi.fn(),
@@ -23,14 +34,19 @@ function renderWorkspace() {
   };
 
   render(
-    <ConfigWorkspace
-      bootstrap={bootstrap}
-      selectedBehaviorId="default"
-      selectedDeployment={deployment}
-      saving={false}
-      runningTask={false}
-      {...handlers}
-    />,
+    <ConfigNavigationGuardBoundary>
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        saving={false}
+        runningTask={false}
+        {...handlers}
+      />
+      {onExternalNavigate ? (
+        <ExternalNavigationProbe onNavigate={onExternalNavigate} />
+      ) : null}
+    </ConfigNavigationGuardBoundary>,
   );
   return handlers;
 }
@@ -109,5 +125,21 @@ describe("config navigation guard", () => {
 
     fireEvent.click(screen.getByTestId("confirm-dialog-confirm"));
     expect(handlers.onBack).toHaveBeenCalledOnce();
+  });
+
+  it("guards destinations outside the configuration workspace", () => {
+    const onNavigate = vi.fn();
+    renderWorkspace(onNavigate);
+    editBehaviorPrompt("keep this edit during global navigation");
+
+    fireEvent.click(screen.getByRole("button", { name: "Fleet destination" }));
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("confirm-dialog-cancel"));
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fleet destination" }));
+    fireEvent.click(screen.getByTestId("confirm-dialog-confirm"));
+    expect(onNavigate).toHaveBeenCalledOnce();
   });
 });

--- a/apps/gents-desktop/tests/playwright/desktop-code.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-code.spec.ts
@@ -1,4 +1,4 @@
-import { expect, gotoHarness, openChat, openChatNavigation, test } from "./desktopTest";
+import { expect, gotoHarness, openAppNavigation, openChat, test } from "./desktopTest";
 
 test.describe("desktop code experience", () => {
   test("renders file edits as diffs and commands as terminal output", async ({
@@ -26,8 +26,8 @@ test.describe("desktop code experience", () => {
   }) => {
     await gotoHarness(page, "coding");
     await openChat(page);
-    await openChatNavigation(page);
-    await page.getByTestId("sidebar-open-code").click();
+    await openAppNavigation(page);
+    await page.getByTestId("app-nav-code").click();
 
     const header = page.getByTestId("code-context-header");
     await expect(header).toBeVisible();

--- a/apps/gents-desktop/tests/playwright/desktop-fleet-actions.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-fleet-actions.spec.ts
@@ -1,4 +1,4 @@
-import { expect, gotoHarness, PEER_ID, test } from "./desktopTest";
+import { expect, gotoHarness, openAppNavigation, PEER_ID, test } from "./desktopTest";
 
 test.describe("fleet deployment navigation", () => {
   test("signed bearer invite is the primary remote pairing flow", async ({ page }) => {
@@ -30,7 +30,8 @@ test.describe("fleet deployment navigation", () => {
     await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
 
     await page.getByTestId(`fleet-row-${PEER_ID}`).click();
-    await page.getByRole("button", { name: "Configure" }).click();
+    await openAppNavigation(page);
+    await page.getByTestId("app-nav-config").click();
 
     await expect(page.locator(".config-workspace")).toBeVisible();
   });

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -2,6 +2,7 @@ import {
   expect,
   expectNoPageHorizontalOverflow,
   gotoHarness,
+  openAppNavigation,
   openChat,
   openChatNavigation,
   openConfig,
@@ -19,6 +20,39 @@ const scenarios = [
 ] as const;
 
 test.describe("desktop responsive layout guardrails", () => {
+  test("global navigation adapts between a collapsible rail and mobile drawer", async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+    const navigation = page.getByTestId("app-navigation");
+    const narrow = (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) <= 760;
+
+    if (narrow) {
+      await expect(navigation).toBeHidden();
+      await openAppNavigation(page);
+      await expect(navigation).toBeVisible();
+      await expect(navigation.getByText("Chat", { exact: true })).toBeVisible();
+      await page
+        .getByRole("button", { name: "Close navigation" })
+        .click({ position: { x: 380, y: 400 } });
+      await expect(navigation).toBeHidden();
+      return;
+    }
+
+    await expect(navigation).toBeVisible();
+    await expect(navigation.getByText("Chat", { exact: true })).toBeVisible();
+    await expect(page.getByTestId("theme-toggle")).toBeVisible();
+    const expandedWidth = (await navigation.boundingBox())?.width ?? 0;
+
+    await page.getByTestId("app-navigation-collapse").click();
+    await expect(navigation).toHaveClass(/collapsed/);
+    const collapsedWidth = (await navigation.boundingBox())?.width ?? expandedWidth;
+    expect(collapsedWidth).toBeLessThan(expandedWidth);
+
+    await page.getByTestId("app-navigation-collapse").click();
+    await expect(navigation).toHaveClass(/expanded/);
+  });
+
   for (const scenario of scenarios) {
     test(`${scenario} has no page-level horizontal overflow`, async ({ page }) => {
       await gotoHarness(page, scenario);
@@ -90,7 +124,8 @@ test.describe("desktop responsive layout guardrails", () => {
     const deploymentRow = page.getByTestId(`fleet-row-${PEER_ID}`);
     await expect(deploymentRow).toBeVisible();
     await deploymentRow.click();
-    const configureButton = page.getByRole("button", { name: "Configure" });
+    await openAppNavigation(page);
+    const configureButton = page.getByTestId("app-nav-config");
     await expect(configureButton).toBeVisible();
 
     await expectNoPageHorizontalOverflow(page);

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -46,8 +46,9 @@ test.describe("desktop responsive layout guardrails", () => {
 
     await page.getByTestId("app-navigation-collapse").click();
     await expect(navigation).toHaveClass(/collapsed/);
-    const collapsedWidth = (await navigation.boundingBox())?.width ?? expandedWidth;
-    expect(collapsedWidth).toBeLessThan(expandedWidth);
+    await expect
+      .poll(async () => (await navigation.boundingBox())?.width ?? expandedWidth)
+      .toBeLessThan(expandedWidth);
 
     await page.getByTestId("app-navigation-collapse").click();
     await expect(navigation).toHaveClass(/expanded/);

--- a/apps/gents-desktop/tests/playwright/desktop-sidebar.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-sidebar.spec.ts
@@ -4,12 +4,13 @@ import {
   gotoHarness,
   openChat,
   openChatNavigation,
+  openAppNavigation,
   openConfigTab,
   test,
 } from "./desktopTest";
 
 test.describe("desktop sidebar workflows", () => {
-  test("connected peer actions, behavior switching, and new chats stay wired", async ({
+  test("connected peer context, behavior switching, and new chats stay wired", async ({
     page,
   }) => {
     await gotoHarness(page);
@@ -20,12 +21,14 @@ test.describe("desktop sidebar workflows", () => {
     await expect(connectedPeer).toContainText("Bombadil UI Agent");
     await expect(connectedPeer).toContainText("connected");
 
-    await connectedPeer.getByRole("button", { name: "Back to Fleet" }).click();
+    await openAppNavigation(page);
+    await page.getByTestId("app-nav-fleet").click();
     await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
 
     await openChat(page);
     await openChatNavigation(page);
-    await connectedPeer.getByRole("button", { name: "Configure" }).click();
+    await openAppNavigation(page);
+    await page.getByTestId("app-nav-config").click();
     await expect(page.locator(".config-workspace")).toBeVisible();
     await page.getByTestId("config-back-tab").click();
     await openChatNavigation(page);
@@ -58,12 +61,8 @@ test.describe("desktop sidebar workflows", () => {
     await expect(taskFilter).toHaveCount(0);
     await expect(page.getByTestId("conversation-session-intro")).toBeVisible();
 
-    await page
-      .locator(".connected-peer-card")
-      .getByRole("button", {
-        name: "Configure",
-      })
-      .click();
+    await openAppNavigation(page);
+    await page.getByTestId("app-nav-config").click();
     await openConfigTab(page, "tasks");
     await page.getByTestId("task-run").click();
     await expect(page.getByTestId("task-run-status")).toContainText("request-");

--- a/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
@@ -3,6 +3,7 @@ import {
   captureStableScreenshot,
   expect,
   gotoHarness,
+  openAppNavigation,
   openChat,
   openChatNavigation,
   openConfig,
@@ -33,7 +34,8 @@ test.describe("desktop UI harness", () => {
     await captureStableScreenshot(page, testInfo, "chat-with-transcript");
 
     await openChatNavigation(page);
-    await page.getByRole("button", { name: "Configure" }).click();
+    await openAppNavigation(page);
+    await page.getByTestId("app-nav-config").click();
     await expect(page.locator(".config-workspace")).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Bombadil UI Agent" }),

--- a/apps/gents-desktop/tests/playwright/desktopTest.ts
+++ b/apps/gents-desktop/tests/playwright/desktopTest.ts
@@ -102,11 +102,18 @@ export async function openChatNavigation(page: Page) {
   await expect(sidebar).toBeVisible();
 }
 
+export async function openAppNavigation(page: Page) {
+  if ((page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) <= 760) {
+    await page.getByTestId("app-menu-trigger").click();
+    await expect(page.getByTestId("app-navigation")).toHaveClass(/drawer-open/);
+  }
+}
+
 export async function openConfig(page: Page) {
   await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
   await page.getByTestId(`fleet-row-${PEER_ID}`).click();
-  await openChatNavigation(page);
-  await page.getByRole("button", { name: "Configure" }).click();
+  await openAppNavigation(page);
+  await page.getByTestId("app-nav-config").click();
   await expect(page.locator(".config-workspace")).toBeVisible();
 }
 

--- a/apps/gents-desktop/tests/sidebar-agent-switcher.test.tsx
+++ b/apps/gents-desktop/tests/sidebar-agent-switcher.test.tsx
@@ -23,8 +23,6 @@ describe("sidebar agent switcher", () => {
       <ConnectedPeerSection
         deployments={[dep("did:a", "Alpha"), dep("did:b", "Beta")]}
         selectedAgentDid="did:a"
-        onOpenFleet={vi.fn()}
-        onConfigureDeployment={vi.fn()}
         onSelectAgent={onSelectAgent}
       />,
     );
@@ -40,8 +38,6 @@ describe("sidebar agent switcher", () => {
       <ConnectedPeerSection
         deployments={[dep("did:a", "Alpha")]}
         selectedAgentDid="did:a"
-        onOpenFleet={vi.fn()}
-        onConfigureDeployment={vi.fn()}
         onSelectAgent={vi.fn()}
       />,
     );
@@ -49,8 +45,7 @@ describe("sidebar agent switcher", () => {
     expect(screen.getByRole("heading", { name: "Alpha" })).toBeInTheDocument();
   });
 
-  it("keeps back navigation and document counts at the top of agent details", () => {
-    const onOpenFleet = vi.fn();
+  it("keeps document counts at the top of agent details", () => {
     const deployment = {
       ...dep("did:a", "Alpha"),
       behaviors: [{ behaviorId: "default" }, { behaviorId: "review" }],
@@ -59,18 +54,11 @@ describe("sidebar agent switcher", () => {
     } as unknown as DeploymentView;
 
     render(
-      <ConnectedPeerSection
-        deployments={[deployment]}
-        selectedAgentDid="did:a"
-        onOpenFleet={onOpenFleet}
-        onConfigureDeployment={vi.fn()}
-      />,
+      <ConnectedPeerSection deployments={[deployment]} selectedAgentDid="did:a" />,
     );
 
     expect(
       screen.getByLabelText("2 behaviors, 1 conversations, 1 tasks"),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("sidebar-back-to-fleet"));
-    expect(onOpenFleet).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- add a persistent collapsible navigation rail and responsive mobile drawer for Fleet, Chat, Code, and Configure
- centralize navigation history and preserve unsaved-config safeguards across links, shortcuts, and back gestures
- integrate left-aligned theme and shortcuts controls, refine navigation borders and spacing, and simplify duplicated workspace navigation
- add unit and Playwright coverage for navigation state, accessibility, responsive behavior, and existing workflows

<img width="1642" height="1152" alt="Screenshot_2026-08-18_09-34-47" src="https://github.com/user-attachments/assets/027f151b-978a-4e5d-afee-9ed79c639c3b" />
<img width="1642" height="1152" alt="Screenshot_2026-08-18_09-34-53" src="https://github.com/user-attachments/assets/1c3f8349-eda7-44d1-b34a-ee7c6dc69b1b" />

## Testing
- `npm run build:packages`
- `npm run format:check`
- `npm run build`
- `npm run test:ui:unit` (361 passed, 15 skipped)
- `npx playwright test tests/playwright/desktop-sidebar.spec.ts tests/playwright/desktop-layout.spec.ts tests/playwright/desktop-ui.spec.ts tests/playwright/desktop-fleet-actions.spec.ts` (72 passed, 6 skipped)