### PR TITLE
Make mobile pairing state converge reliably

### DIFF
--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -285,6 +285,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
         <section className="config-page">
           <ConfigWorkspace
             api={bridge.api}
+            backLabel={configReturnView === "fleet" ? "Back to Fleet" : "Back to Chat"}
             bootstrap={shell.snapshot?.bootstrap ?? null}
             onBack={navigateBack}
             onDeleteSkillConfig={shell.onDeleteSkillConfig}

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -95,6 +95,12 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
 
   useAppShortcuts({
     setView: (view) => {
+      if (view === "config") {
+        if (workspaceView !== "config") {
+          openConfig();
+        }
+        return;
+      }
       if (view === "chat" || view === "code") {
         setMobileChatPane("conversation");
       }

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { createDesktopClient } from "@source-inc/gents-desktop-client";
+import { ConfirmDialog } from "@source-inc/gents-desktop-ui";
 import { listen } from "@tauri-apps/api/event";
 import { ChatWorkspace } from "./components/ChatWorkspace";
 import { CodeContextHeader } from "./components/code/CodeContextHeader";
 import { ConfigWorkspace } from "./components/ConfigWorkspace";
+import { useConfigNavigationController } from "./components/config/ConfigNavigationGuard";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FleetHostDashboard } from "./components/fleet/FleetHostDashboard";
 import { ErrorBanner } from "./components/ErrorBanner";
@@ -68,13 +70,28 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
   );
   const [configReturnView, setConfigReturnView] = useState<"fleet" | "chat">("fleet");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const configNavigation = useConfigNavigationController();
+  const requestConfigNavigation = configNavigation.requestNavigation;
+
+  const requestWorkspaceNavigation = useCallback(
+    (navigate: () => void) => {
+      if (workspaceView === "config") {
+        requestConfigNavigation(navigate);
+      } else {
+        navigate();
+      }
+    },
+    [requestConfigNavigation, workspaceView],
+  );
 
   const navigateBack = useCallback(() => {
     if (workspaceView === "config") {
-      setWorkspaceView(configReturnView);
-      if (configReturnView === "chat") {
-        setMobileChatPane("navigation");
-      }
+      requestConfigNavigation(() => {
+        setWorkspaceView(configReturnView);
+        if (configReturnView === "chat") {
+          setMobileChatPane("navigation");
+        }
+      });
       return;
     }
     if (workspaceView === "code") {
@@ -89,7 +106,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
     if (workspaceView === "chat") {
       setWorkspaceView("fleet");
     }
-  }, [configReturnView, mobileChatPane, workspaceView]);
+  }, [configReturnView, mobileChatPane, requestConfigNavigation, workspaceView]);
 
   useMobileBackSwipe(workspaceView !== "fleet", navigateBack);
 
@@ -101,49 +118,59 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
         }
         return;
       }
-      if (view === "chat" || view === "code") {
-        setMobileChatPane("conversation");
-      }
-      setWorkspaceView(view);
+      requestWorkspaceNavigation(() => {
+        if (view === "chat" || view === "code") {
+          setMobileChatPane("conversation");
+        }
+        setWorkspaceView(view);
+      });
     },
     newConversation: () => {
       const behaviorId =
         shell.selectedBehaviorId ?? shell.behaviorOptions[0]?.behaviorId ?? null;
       if (behaviorId) {
-        setWorkspaceView("chat");
-        setMobileChatPane("conversation");
-        shell.onStartNewConversation(behaviorId);
+        requestWorkspaceNavigation(() => {
+          setWorkspaceView("chat");
+          setMobileChatPane("conversation");
+          shell.onStartNewConversation(behaviorId);
+        });
       }
     },
     focusComposer: () => {
-      setWorkspaceView("chat");
-      setMobileChatPane("conversation");
-      requestAnimationFrame(() => {
-        document
-          .querySelector<HTMLTextAreaElement>('[data-testid="composer-input"]')
-          ?.focus();
+      requestWorkspaceNavigation(() => {
+        setWorkspaceView("chat");
+        setMobileChatPane("conversation");
+        requestAnimationFrame(() => {
+          document
+            .querySelector<HTMLTextAreaElement>('[data-testid="composer-input"]')
+            ?.focus();
+        });
       });
     },
     toggleHelp: () => setShortcutsOpen((open) => !open),
   });
 
   function openChat(agentDid?: string) {
-    if (agentDid) {
-      shell.setSelectedAgentDid(agentDid);
-    }
-    // Fleet selects an agent instance first. On narrow screens the sidebar is
-    // that instance view (behaviors + conversations); opening the conversation
-    // pane here made it impossible to reach that navigation from Fleet.
-    setMobileChatPane("navigation");
-    setWorkspaceView("chat");
+    requestWorkspaceNavigation(() => {
+      if (agentDid) {
+        shell.setSelectedAgentDid(agentDid);
+      }
+      // Fleet selects an agent instance first. On narrow screens the sidebar is
+      // that instance view (behaviors + conversations); opening the conversation
+      // pane here made it impossible to reach that navigation from Fleet.
+      setMobileChatPane("navigation");
+      setWorkspaceView("chat");
+    });
   }
 
   function openCode(agentDid?: string) {
-    if (agentDid) {
-      shell.setSelectedAgentDid(agentDid);
-    }
-    setMobileChatPane("conversation");
-    setWorkspaceView("code");
+    requestWorkspaceNavigation(() => {
+      if (agentDid) {
+        shell.setSelectedAgentDid(agentDid);
+      }
+      setMobileChatPane("conversation");
+      setWorkspaceView("code");
+    });
   }
 
   function openConfig(agentDid?: string) {
@@ -161,6 +188,16 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
         <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
       ) : null}
       <ShortcutsHelp open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
+      <ConfirmDialog
+        cancelLabel="Keep editing"
+        confirmLabel="Discard changes"
+        danger
+        message="This configuration has unsaved changes. Discard them and continue?"
+        onCancel={configNavigation.cancelDiscard}
+        onConfirm={configNavigation.confirmDiscard}
+        open={configNavigation.confirmingDiscard}
+        title="Discard unsaved changes?"
+      />
 
       {shell.startupPhase !== "ready" ? (
         <StartupScreen
@@ -294,6 +331,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
             backLabel={configReturnView === "fleet" ? "Back to Fleet" : "Back to Chat"}
             bootstrap={shell.snapshot?.bootstrap ?? null}
             onBack={navigateBack}
+            onDirtyChange={configNavigation.reportDirty}
             onDeleteSkillConfig={shell.onDeleteSkillConfig}
             onDeleteTaskConfig={shell.onDeleteTaskConfig}
             onDeleteScheduleConfig={shell.onDeleteScheduleConfig}
@@ -315,6 +353,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
             onSaveToolSelectionConfig={shell.onSaveToolSelectionConfig}
             onSaveToolServiceConfig={shell.onSaveToolServiceConfig}
             onTestToolService={shell.onTestToolService}
+            requestNavigation={requestConfigNavigation}
             onRunSchedule={shell.onRunSchedule}
             runningTask={shell.runningTask}
             saving={shell.savingConfig}

--- a/apps/gents-desktop/src/components/ConfigWorkspace.tsx
+++ b/apps/gents-desktop/src/components/ConfigWorkspace.tsx
@@ -191,7 +191,7 @@ export function ConfigWorkspace({
             <button
               className="ghost-button config-back-button"
               data-testid="config-back-tab"
-              onClick={() => requestNavigation(onBack)}
+              onClick={onBack}
               type="button"
             >
               ← {backLabel}

--- a/apps/gents-desktop/src/components/ConfigWorkspace.tsx
+++ b/apps/gents-desktop/src/components/ConfigWorkspace.tsx
@@ -53,6 +53,7 @@ type ConfigWorkspaceProps = {
   saving: boolean;
   runningTask: boolean;
   onBack: () => void;
+  backLabel?: string;
   onSaveAgentConfig: (request: AgentConfigSaveRequest) => Promise<unknown>;
   onSaveBackendConfig: (request: BackendSaveRequest) => Promise<unknown>;
   onSaveInferenceProfileConfig: (
@@ -93,6 +94,7 @@ export function ConfigWorkspace({
   saving,
   runningTask,
   onBack,
+  backLabel = "Back to Chat",
   onSaveAgentConfig,
   onSaveBackendConfig,
   onSaveInferenceProfileConfig,
@@ -193,8 +195,12 @@ export function ConfigWorkspace({
       <article className="panel centered-panel">
         <p className="eyebrow">Config</p>
         <h2>Select a deployment</h2>
-        <button className="ghost-button" onClick={onBack} type="button">
-          Back to Chat
+        <button
+          className="ghost-button config-back-button"
+          onClick={onBack}
+          type="button"
+        >
+          ← {backLabel}
         </button>
       </article>
     );
@@ -219,6 +225,14 @@ export function ConfigWorkspace({
             </div>
           </div>
           <div className="config-header-actions">
+            <button
+              className="ghost-button config-back-button"
+              data-testid="config-back-tab"
+              onClick={() => requestNavigation(onBack)}
+              type="button"
+            >
+              ← {backLabel}
+            </button>
             <span
               aria-hidden="true"
               className={
@@ -235,14 +249,6 @@ export function ConfigWorkspace({
             <span className="chip">
               {selectedDeployment.dialSucceeded ? "connected" : "saved"}
             </span>
-            <button
-              className="ghost-button"
-              data-testid="config-back-tab"
-              onClick={() => requestNavigation(onBack)}
-              type="button"
-            >
-              Back to Chat
-            </button>
           </div>
         </header>
 

--- a/apps/gents-desktop/src/components/ConfigWorkspace.tsx
+++ b/apps/gents-desktop/src/components/ConfigWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import type {
   AgentConfigSaveRequest,
   BackendSaveRequest,
@@ -41,7 +41,6 @@ import {
   ToolSelectionConfigPanel,
   ToolServiceConfigPanel,
 } from "./config";
-import { ConfirmDialog } from "@source-inc/gents-desktop-ui";
 import { ConfigNavigationGuardProvider } from "./config/ConfigNavigationGuard";
 import sourceMarkUrl from "../assets/source-mark-light.png";
 
@@ -54,6 +53,8 @@ type ConfigWorkspaceProps = {
   runningTask: boolean;
   onBack: () => void;
   backLabel?: string;
+  onDirtyChange: (dirty: boolean) => void;
+  requestNavigation: (navigate: () => void) => void;
   onSaveAgentConfig: (request: AgentConfigSaveRequest) => Promise<unknown>;
   onSaveBackendConfig: (request: BackendSaveRequest) => Promise<unknown>;
   onSaveInferenceProfileConfig: (
@@ -95,6 +96,8 @@ export function ConfigWorkspace({
   runningTask,
   onBack,
   backLabel = "Back to Chat",
+  onDirtyChange,
+  requestNavigation,
   onSaveAgentConfig,
   onSaveBackendConfig,
   onSaveInferenceProfileConfig,
@@ -118,9 +121,6 @@ export function ConfigWorkspace({
   onSaveEventTriggerConfig,
   onRunTask,
 }: ConfigWorkspaceProps) {
-  const [configDirty, setConfigDirty] = useState(false);
-  const [confirmingDiscard, setConfirmingDiscard] = useState(false);
-  const pendingNavigation = useRef<(() => void) | null>(null);
   const {
     activeTab,
     savedStatus,
@@ -148,47 +148,10 @@ export function ConfigWorkspace({
     setSelectedToolServiceId,
   } = useConfigWorkspaceSelection(selectedDeployment, selectedBehaviorId);
 
-  const requestNavigation = useCallback(
-    (navigate: () => void) => {
-      if (!configDirty) {
-        navigate();
-        return;
-      }
-      pendingNavigation.current = navigate;
-      setConfirmingDiscard(true);
-    },
-    [configDirty],
-  );
-
   const navigationGuard = useMemo(
-    () => ({ reportDirty: setConfigDirty, requestNavigation }),
-    [requestNavigation],
+    () => ({ reportDirty: onDirtyChange, requestNavigation }),
+    [onDirtyChange, requestNavigation],
   );
-
-  useEffect(() => {
-    if (!configDirty) {
-      return;
-    }
-    const preventAccidentalClose = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      event.returnValue = "";
-    };
-    window.addEventListener("beforeunload", preventAccidentalClose);
-    return () => window.removeEventListener("beforeunload", preventAccidentalClose);
-  }, [configDirty]);
-
-  const cancelDiscard = useCallback(() => {
-    pendingNavigation.current = null;
-    setConfirmingDiscard(false);
-  }, []);
-
-  const confirmDiscard = useCallback(() => {
-    const navigate = pendingNavigation.current;
-    pendingNavigation.current = null;
-    setConfirmingDiscard(false);
-    setConfigDirty(false);
-    navigate?.();
-  }, []);
 
   if (!selectedDeployment) {
     return (
@@ -502,16 +465,6 @@ export function ConfigWorkspace({
           ) : null}
         </section>
       </section>
-      <ConfirmDialog
-        cancelLabel="Keep editing"
-        confirmLabel="Discard changes"
-        danger
-        message="This configuration has unsaved changes. Discard them and continue?"
-        onCancel={cancelDiscard}
-        onConfirm={confirmDiscard}
-        open={confirmingDiscard}
-        title="Discard unsaved changes?"
-      />
     </ConfigNavigationGuardProvider>
   );
 }

--- a/apps/gents-desktop/src/components/config/ConfigNavigationGuard.tsx
+++ b/apps/gents-desktop/src/components/config/ConfigNavigationGuard.tsx
@@ -1,4 +1,13 @@
-import { createContext, useContext, useLayoutEffect, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 type ConfigNavigationGuardValue = {
   reportDirty: (dirty: boolean) => void;
@@ -29,6 +38,55 @@ export function ConfigNavigationGuardProvider({
 
 export function useConfigNavigationGuard() {
   return useContext(ConfigNavigationGuardContext);
+}
+
+export function useConfigNavigationController() {
+  const [dirty, reportDirty] = useState(false);
+  const [confirmingDiscard, setConfirmingDiscard] = useState(false);
+  const pendingNavigation = useRef<(() => void) | null>(null);
+
+  const requestNavigation = useCallback(
+    (navigate: () => void) => {
+      if (!dirty) {
+        navigate();
+        return;
+      }
+      pendingNavigation.current = navigate;
+      setConfirmingDiscard(true);
+    },
+    [dirty],
+  );
+
+  const cancelDiscard = useCallback(() => {
+    pendingNavigation.current = null;
+    setConfirmingDiscard(false);
+  }, []);
+
+  const confirmDiscard = useCallback(() => {
+    const navigate = pendingNavigation.current;
+    pendingNavigation.current = null;
+    setConfirmingDiscard(false);
+    reportDirty(false);
+    navigate?.();
+  }, []);
+
+  useEffect(() => {
+    if (!dirty) return;
+    const preventAccidentalClose = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", preventAccidentalClose);
+    return () => window.removeEventListener("beforeunload", preventAccidentalClose);
+  }, [dirty]);
+
+  return {
+    cancelDiscard,
+    confirmDiscard,
+    confirmingDiscard,
+    reportDirty,
+    requestNavigation,
+  };
 }
 
 export function useReportConfigDirty(dirty: boolean) {

--- a/apps/gents-desktop/src/styles/config/workspace.css
+++ b/apps/gents-desktop/src/styles/config/workspace.css
@@ -181,6 +181,10 @@
     flex: 0 0 auto;
   }
 
+  .config-back-button {
+    white-space: nowrap;
+  }
+
   .config-status-dot {
     width: 10px;
     height: 10px;

--- a/apps/gents-desktop/tests/config-navigation-guard.test.tsx
+++ b/apps/gents-desktop/tests/config-navigation-guard.test.tsx
@@ -38,6 +38,7 @@ function GuardedWorkspace({ handlers }: { handlers: ReturnType<typeof makeHandle
         onDirtyChange={navigation.reportDirty}
         requestNavigation={navigation.requestNavigation}
         {...handlers}
+        onBack={() => navigation.requestNavigation(handlers.onBack)}
       />
       <ConfirmDialog
         cancelLabel="Keep editing"

--- a/apps/gents-desktop/tests/config-navigation-guard.test.tsx
+++ b/apps/gents-desktop/tests/config-navigation-guard.test.tsx
@@ -1,15 +1,17 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ConfirmDialog } from "@source-inc/gents-desktop-ui";
 import { describe, expect, it, vi } from "vitest";
 
 import { ConfigWorkspace } from "../src/components/ConfigWorkspace";
+import { useConfigNavigationController } from "../src/components/config/ConfigNavigationGuard";
 import {
   bootstrap,
   deployment,
   workspaceHandlers,
 } from "./config-panel-wiring/fixtures";
 
-function renderWorkspace() {
-  const handlers = {
+function makeHandlers() {
+  return {
     ...workspaceHandlers(),
     onDeleteSkillConfig: vi.fn(),
     onDeleteTaskConfig: vi.fn(),
@@ -21,17 +23,40 @@ function renderWorkspace() {
     onDeleteToolServiceConfig: vi.fn(),
     onDeleteBehaviorConfig: vi.fn(),
   };
+}
 
-  render(
-    <ConfigWorkspace
-      bootstrap={bootstrap}
-      selectedBehaviorId="default"
-      selectedDeployment={deployment}
-      saving={false}
-      runningTask={false}
-      {...handlers}
-    />,
+function GuardedWorkspace({ handlers }: { handlers: ReturnType<typeof makeHandlers> }) {
+  const navigation = useConfigNavigationController();
+  return (
+    <>
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        saving={false}
+        runningTask={false}
+        onDirtyChange={navigation.reportDirty}
+        requestNavigation={navigation.requestNavigation}
+        {...handlers}
+      />
+      <ConfirmDialog
+        cancelLabel="Keep editing"
+        confirmLabel="Discard changes"
+        danger
+        message="This configuration has unsaved changes. Discard them and continue?"
+        onCancel={navigation.cancelDiscard}
+        onConfirm={navigation.confirmDiscard}
+        open={navigation.confirmingDiscard}
+        title="Discard unsaved changes?"
+      />
+    </>
   );
+}
+
+function renderWorkspace() {
+  const handlers = makeHandlers();
+
+  render(<GuardedWorkspace handlers={handlers} />);
   return handlers;
 }
 

--- a/apps/gents-desktop/tests/config-tabs-a11y.test.tsx
+++ b/apps/gents-desktop/tests/config-tabs-a11y.test.tsx
@@ -14,6 +14,7 @@ function renderWorkspace(backLabel?: string, onBack = vi.fn()) {
       saving={false}
       runningTask={false}
       onBack={onBack}
+      onDirtyChange={() => undefined}
       onDeleteSkillConfig={vi.fn()}
       onSaveAgentConfig={vi.fn()}
       onRunTask={vi.fn()}
@@ -28,6 +29,7 @@ function renderWorkspace(backLabel?: string, onBack = vi.fn()) {
       onSaveToolServiceConfig={vi.fn()}
       onTestToolService={vi.fn()}
       onRunSchedule={vi.fn()}
+      requestNavigation={(navigate) => navigate()}
     />,
   );
 }

--- a/apps/gents-desktop/tests/config-tabs-a11y.test.tsx
+++ b/apps/gents-desktop/tests/config-tabs-a11y.test.tsx
@@ -4,15 +4,16 @@ import { describe, expect, it, vi } from "vitest";
 import { ConfigWorkspace } from "../src/components/ConfigWorkspace";
 import { deployment } from "./config-panel-wiring/fixtures";
 
-function renderWorkspace() {
+function renderWorkspace(backLabel?: string, onBack = vi.fn()) {
   render(
     <ConfigWorkspace
+      backLabel={backLabel}
       bootstrap={null}
       selectedDeployment={deployment}
       selectedBehaviorId={null}
       saving={false}
       runningTask={false}
-      onBack={vi.fn()}
+      onBack={onBack}
       onDeleteSkillConfig={vi.fn()}
       onSaveAgentConfig={vi.fn()}
       onRunTask={vi.fn()}
@@ -32,6 +33,17 @@ function renderWorkspace() {
 }
 
 describe("config tabs keyboard navigation", () => {
+  it("keeps the Fleet return path visible across config tabs", () => {
+    const onBack = vi.fn();
+    renderWorkspace("Back to Fleet", onBack);
+
+    const back = screen.getByRole("button", { name: "← Back to Fleet" });
+    fireEvent.click(screen.getByTestId("config-tab-backends"));
+    expect(back).toBeVisible();
+    fireEvent.click(back);
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
   it("ArrowRight moves selection and focus; Home/End jump; wraps around", () => {
     renderWorkspace();
     const tablist = screen.getByRole("tablist", { name: "Configuration" });

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -441,10 +441,12 @@ fn filter_mentions_agent_request(filter: &str, peer_agent_did: &str) -> bool {
     let Ok(filters) = gents::agent::p2p_reconcile::templates::decode_pairing_filters(filter) else {
         return false;
     };
-    filters.get("AgentRequest").is_some_and(|filter| {
-        let conditions = gents::agent::p2p_reconcile::templates::filter_conditions(filter);
-        condition_mentions_value(&Value::Object(conditions), peer_agent_did)
-    })
+    filters
+        .get("AgentRequest")
+        .and_then(gents::agent::p2p_reconcile::templates::filter_conditions)
+        .is_some_and(|conditions| {
+            condition_mentions_value(&Value::Object(conditions), peer_agent_did)
+        })
 }
 
 fn condition_mentions_value(value: &Value, expected: &str) -> bool {

--- a/crates/gents-cli/src/commands/demo/fleet.rs
+++ b/crates/gents-cli/src/commands/demo/fleet.rs
@@ -438,14 +438,26 @@ async fn wait_conversation_replicator(
 }
 
 fn filter_mentions_agent_request(filter: &str, peer_agent_did: &str) -> bool {
-    let Ok(value) = serde_json::from_str::<Value>(filter) else {
+    let Ok(filters) = gents::agent::p2p_reconcile::templates::decode_pairing_filters(filter) else {
         return false;
     };
-    value
-        .get("AgentRequest")
-        .and_then(|entry| entry.get("value"))
-        .and_then(Value::as_str)
-        == Some(peer_agent_did)
+    filters.get("AgentRequest").is_some_and(|filter| {
+        let conditions = gents::agent::p2p_reconcile::templates::filter_conditions(filter);
+        condition_mentions_value(&Value::Object(conditions), peer_agent_did)
+    })
+}
+
+fn condition_mentions_value(value: &Value, expected: &str) -> bool {
+    match value {
+        Value::Object(object) => object.iter().any(|(key, value)| {
+            (key == "_eq" && value.as_str() == Some(expected))
+                || condition_mentions_value(value, expected)
+        }),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| condition_mentions_value(value, expected)),
+        _ => false,
+    }
 }
 
 async fn wait_replicator_filter(graphql: &str, peer_id: &str, needles: &[String]) -> Result<()> {
@@ -720,4 +732,22 @@ fn resolve_desktop_bin() -> Option<PathBuf> {
             .map(|dir| dir.join(name))
             .find(|candidate| candidate.is_file())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fleet_wait_recognizes_tagged_agent_request_filter() {
+        let filters = [(
+            "AgentRequest".to_string(),
+            gents::agent::p2p_reconcile::equality_filter("requester_did", "did:key:phone"),
+        )]
+        .into_iter()
+        .collect::<gents::agent::p2p_reconcile::PairingFilters>();
+        let encoded = serde_json::to_string(&filters).expect("filter json");
+
+        assert!(filter_mentions_agent_request(&encoded, "did:key:phone"));
+    }
 }

--- a/crates/gents-cli/src/commands/p2p/pairings.rs
+++ b/crates/gents-cli/src/commands/p2p/pairings.rs
@@ -219,6 +219,7 @@ fn pairings_list_query() -> &'static str {
 fn applied_list_query() -> &'static str {
     r#"query {
         PeerPairingApplied {
+            _docID
             peer_id
             collections
             replicator_addresses
@@ -362,21 +363,32 @@ fn parse_pairing_rows(rows: Vec<Value>) -> Vec<PeerPairingDesiredRow> {
 }
 
 fn parse_applied_rows(rows: Vec<Value>) -> Vec<PeerPairingAppliedRow> {
-    rows.into_iter()
+    let mut rows = rows
+        .into_iter()
         .filter_map(|row| {
+            let doc_id = row.get("_docID")?.as_str()?.to_string();
             let peer_id = row
                 .get("peer_id")
                 .and_then(Value::as_str)
                 .map(str::trim)
                 .filter(|value| !value.is_empty())?
                 .to_string();
-            Some(PeerPairingAppliedRow {
-                peer_id,
-                collections: string_list(&row, "collections"),
-                replicator_addresses: string_list(&row, "replicator_addresses"),
-            })
+            Some((
+                doc_id,
+                PeerPairingAppliedRow {
+                    peer_id,
+                    collections: string_list(&row, "collections"),
+                    replicator_addresses: string_list(&row, "replicator_addresses"),
+                },
+            ))
         })
-        .collect()
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut canonical = BTreeMap::new();
+    for (_, row) in rows {
+        canonical.entry(row.peer_id.clone()).or_insert(row);
+    }
+    canonical.into_values().collect()
 }
 
 fn annotate_pairing_health(
@@ -697,6 +709,17 @@ mod tests {
         assert!(mutation.contains("collections: null"));
         assert!(!mutation.contains("collections: ["));
         assert!(!mutation.contains("[]"));
+    }
+
+    #[test]
+    fn applied_rows_use_the_canonical_document() {
+        let rows = parse_applied_rows(vec![
+            json!({"_docID": "b", "peer_id": "peer-a", "replicator_addresses": ["stale"]}),
+            json!({"_docID": "a", "peer_id": "peer-a", "replicator_addresses": ["fresh"]}),
+        ]);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].replicator_addresses, ["fresh"]);
     }
 
     fn applied(peer_id: &str, collections: &[&str], addresses: &[&str]) -> PeerPairingAppliedRow {

--- a/crates/gents-cli/src/commands/p2p/replicators.rs
+++ b/crates/gents-cli/src/commands/p2p/replicators.rs
@@ -1,5 +1,7 @@
 use anyhow::{Context, Result};
-use gents::agent::p2p_reconcile::templates::{FilterPredicate, PairingFilters};
+use gents::agent::p2p_reconcile::templates::{
+    combine_filters, equality_filter, filter_conditions, PairingFilters,
+};
 use serde_json::{json, Value};
 
 use crate::cli::args::{P2pAccessArgs, P2pReplicatorAddArgs, P2pReplicatorRemoveArgs};
@@ -45,15 +47,13 @@ pub(super) async fn p2p_replicators_add(args: P2pReplicatorAddArgs) -> Result<()
     // them in the request body. The node installs a filtered replicator (#1033)
     // that pushes only matching documents; an empty map requests an unfiltered
     // replicator (the field is omitted on the wire).
-    let wire_filters: std::collections::BTreeMap<String, crate::shared::P2pReplicatorFilter> =
+    let wire_filters: std::collections::BTreeMap<String, defra_p2p_adapter::ReplicationFilter> =
         filters
             .iter()
             .map(|(col, pred)| {
                 (
                     col.clone(),
-                    crate::shared::P2pReplicatorFilter {
-                        conditions: pred.conditions(),
-                    },
+                    defra_p2p_adapter::ReplicationFilter::predicate(filter_conditions(pred)),
                 )
             })
             .collect();
@@ -65,12 +65,13 @@ pub(super) async fn p2p_replicators_add(args: P2pReplicatorAddArgs) -> Result<()
     http_post_json(&client, &format!("{api_base}/p2p/replicators"), &request).await?;
     let p2p = fetch_live_http_p2p_status(args.home.as_deref(), &graphql).await?;
     let home_dir = resolve_home_dir(args.home.as_deref());
-    let filters_json: serde_json::Map<String, Value> = filters
+    let filters_json: serde_json::Map<String, Value> = request
+        .filters
         .iter()
-        .map(|(col, pred)| {
+        .map(|(col, filter)| {
             (
                 col.clone(),
-                serde_json::to_value(pred).unwrap_or(Value::Null),
+                serde_json::to_value(filter).unwrap_or(Value::Null),
             )
         })
         .collect();
@@ -118,10 +119,10 @@ pub(super) fn parse_replicator_filters(filters: &[String]) -> Result<PairingFilt
         if value.is_empty() {
             anyhow::bail!("invalid --filter {raw:?}: filter value must not be empty");
         }
-        let predicate = FilterPredicate::eq(field, value);
+        let predicate = equality_filter(field, value);
         match map.remove(collection) {
             Some(existing) => {
-                map.insert(collection.to_string(), existing.and(predicate));
+                map.insert(collection.to_string(), combine_filters(existing, predicate));
             }
             None => {
                 map.insert(collection.to_string(), predicate);
@@ -155,6 +156,7 @@ pub(super) async fn p2p_replicators_remove(args: P2pReplicatorRemoveArgs) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gents::agent::p2p_reconcile::single_string_eq;
     use std::collections::BTreeMap;
 
     #[test]
@@ -185,9 +187,9 @@ mod tests {
 
         assert_eq!(filters.len(), 2);
         let req = filters.get("AgentRequest").unwrap();
-        assert_eq!(req.single_string_eq(), Some(("agent_did", "did:key:alice")));
+        assert_eq!(single_string_eq(req), Some(("agent_did", "did:key:alice")));
         let resp = filters.get("AgentResponse").unwrap();
-        assert_eq!(resp.single_string_eq(), Some(("agent_did", "did:key:bob")));
+        assert_eq!(single_string_eq(resp), Some(("agent_did", "did:key:bob")));
     }
 
     #[test]
@@ -205,7 +207,7 @@ mod tests {
         .expect("valid filters");
 
         assert_eq!(
-            Value::Object(filters["AgentRequest"].conditions()),
+            Value::Object(filter_conditions(&filters["AgentRequest"])),
             serde_json::json!({
                 "_and": [
                     { "requester_did": { "_eq": "did:key:alice" } },
@@ -276,9 +278,6 @@ mod tests {
             parse_replicator_filters(&["AgentRequest:agent_did=did:key:z=abc".to_string()])
                 .expect("filter value with = should parse");
         let pred = filters.get("AgentRequest").unwrap();
-        assert_eq!(
-            pred.single_string_eq(),
-            Some(("agent_did", "did:key:z=abc"))
-        );
+        assert_eq!(single_string_eq(pred), Some(("agent_did", "did:key:z=abc")));
     }
 }

--- a/crates/gents-cli/src/commands/p2p/replicators.rs
+++ b/crates/gents-cli/src/commands/p2p/replicators.rs
@@ -52,8 +52,7 @@ pub(super) async fn p2p_replicators_add(args: P2pReplicatorAddArgs) -> Result<()
                 (
                     col.clone(),
                     crate::shared::P2pReplicatorFilter {
-                        field: pred.field.clone(),
-                        value: Value::String(pred.value.clone()),
+                        conditions: pred.conditions(),
                     },
                 )
             })
@@ -71,7 +70,7 @@ pub(super) async fn p2p_replicators_add(args: P2pReplicatorAddArgs) -> Result<()
         .map(|(col, pred)| {
             (
                 col.clone(),
-                json!({ "field": pred.field, "value": pred.value }),
+                serde_json::to_value(pred).unwrap_or(Value::Null),
             )
         })
         .collect();
@@ -119,13 +118,15 @@ pub(super) fn parse_replicator_filters(filters: &[String]) -> Result<PairingFilt
         if value.is_empty() {
             anyhow::bail!("invalid --filter {raw:?}: filter value must not be empty");
         }
-        map.insert(
-            collection.to_string(),
-            FilterPredicate {
-                field: field.to_string(),
-                value: value.to_string(),
-            },
-        );
+        let predicate = FilterPredicate::eq(field, value);
+        match map.remove(collection) {
+            Some(existing) => {
+                map.insert(collection.to_string(), existing.and(predicate));
+            }
+            None => {
+                map.insert(collection.to_string(), predicate);
+            }
+        }
     }
     Ok(map)
 }
@@ -184,17 +185,34 @@ mod tests {
 
         assert_eq!(filters.len(), 2);
         let req = filters.get("AgentRequest").unwrap();
-        assert_eq!(req.field, "agent_did");
-        assert_eq!(req.value, "did:key:alice");
+        assert_eq!(req.single_string_eq(), Some(("agent_did", "did:key:alice")));
         let resp = filters.get("AgentResponse").unwrap();
-        assert_eq!(resp.field, "agent_did");
-        assert_eq!(resp.value, "did:key:bob");
+        assert_eq!(resp.single_string_eq(), Some(("agent_did", "did:key:bob")));
     }
 
     #[test]
     fn parse_replicator_filters_empty_is_ok() {
         let filters = parse_replicator_filters(&[]).expect("empty filters should parse");
         assert!(filters.is_empty());
+    }
+
+    #[test]
+    fn repeated_collection_filters_are_conjunctive() {
+        let filters = parse_replicator_filters(&[
+            "AgentRequest:requester_did=did:key:alice".to_string(),
+            "AgentRequest:status=pending".to_string(),
+        ])
+        .expect("valid filters");
+
+        assert_eq!(
+            Value::Object(filters["AgentRequest"].conditions()),
+            serde_json::json!({
+                "_and": [
+                    { "requester_did": { "_eq": "did:key:alice" } },
+                    { "status": { "_eq": "pending" } }
+                ]
+            })
+        );
     }
 
     #[test]
@@ -258,7 +276,9 @@ mod tests {
             parse_replicator_filters(&["AgentRequest:agent_did=did:key:z=abc".to_string()])
                 .expect("filter value with = should parse");
         let pred = filters.get("AgentRequest").unwrap();
-        assert_eq!(pred.field, "agent_did");
-        assert_eq!(pred.value, "did:key:z=abc");
+        assert_eq!(
+            pred.single_string_eq(),
+            Some(("agent_did", "did:key:z=abc"))
+        );
     }
 }

--- a/crates/gents-cli/src/commands/p2p/replicators.rs
+++ b/crates/gents-cli/src/commands/p2p/replicators.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use gents::agent::p2p_reconcile::templates::{
-    combine_filters, equality_filter, filter_conditions, PairingFilters,
+    combine_filters, equality_filter, to_replication_filters, PairingFilters,
 };
 use serde_json::{json, Value};
 
@@ -47,16 +47,7 @@ pub(super) async fn p2p_replicators_add(args: P2pReplicatorAddArgs) -> Result<()
     // them in the request body. The node installs a filtered replicator (#1033)
     // that pushes only matching documents; an empty map requests an unfiltered
     // replicator (the field is omitted on the wire).
-    let wire_filters: std::collections::BTreeMap<String, defra_p2p_adapter::ReplicationFilter> =
-        filters
-            .iter()
-            .map(|(col, pred)| {
-                (
-                    col.clone(),
-                    defra_p2p_adapter::ReplicationFilter::predicate(filter_conditions(pred)),
-                )
-            })
-            .collect();
+    let wire_filters = to_replication_filters(&filters).map_err(anyhow::Error::msg)?;
     let request = P2pReplicatorRequest {
         collections: collections.clone(),
         addresses: vec![args.peer.clone()],
@@ -207,7 +198,12 @@ mod tests {
         .expect("valid filters");
 
         assert_eq!(
-            Value::Object(filter_conditions(&filters["AgentRequest"])),
+            Value::Object(
+                gents::agent::p2p_reconcile::templates::filter_conditions(
+                    &filters["AgentRequest"],
+                )
+                .expect("predicate conditions"),
+            ),
             serde_json::json!({
                 "_and": [
                     { "requester_did": { "_eq": "did:key:alice" } },

--- a/crates/gents-cli/src/shared.rs
+++ b/crates/gents-cli/src/shared.rs
@@ -224,13 +224,7 @@ pub(crate) struct P2pReplicatorRequest {
         rename = "Filters",
         skip_serializing_if = "std::collections::BTreeMap::is_empty"
     )]
-    pub(crate) filters: std::collections::BTreeMap<String, P2pReplicatorFilter>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct P2pReplicatorFilter {
-    #[serde(rename = "Conditions")]
-    pub(crate) conditions: serde_json::Map<String, Value>,
+    pub(crate) filters: std::collections::BTreeMap<String, defra_p2p_adapter::ReplicationFilter>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/gents-cli/src/shared.rs
+++ b/crates/gents-cli/src/shared.rs
@@ -217,7 +217,7 @@ pub(crate) struct P2pReplicatorRequest {
     #[serde(rename = "Addresses")]
     pub(crate) addresses: Vec<String>,
     /// Per-collection replication filters. Serialized to defradb's
-    /// `ReplicatorRequest.Filters` shape (`{Collection: {Field, Value}}`); the
+    /// `ReplicatorRequest.Filters` shape (`{Collection: {Conditions}}`); the
     /// node installs a filtered replicator that pushes only matching documents.
     /// Omitted entirely when empty so an unfiltered replicator is requested.
     #[serde(
@@ -229,10 +229,8 @@ pub(crate) struct P2pReplicatorRequest {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct P2pReplicatorFilter {
-    #[serde(rename = "Field")]
-    pub(crate) field: String,
-    #[serde(rename = "Value")]
-    pub(crate) value: Value,
+    #[serde(rename = "Conditions")]
+    pub(crate) conditions: serde_json::Map<String, Value>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -278,8 +278,7 @@ pub(super) async fn observe_bearer_pairing_readiness(
                 admin_sig
             }}
             BearerPairingReady(
-                filter: {{ readiness_key: {{ _eq: "{readiness_key}" }} }},
-                limit: 1
+                filter: {{ readiness_key: {{ _eq: "{readiness_key}" }} }}
             ) {{
                 issuer_did
                 claimant_did
@@ -319,19 +318,26 @@ pub(super) async fn observe_bearer_pairing_readiness(
     let readiness_rows =
         serde_json::from_value::<Vec<BearerPairingReadyObservationRow>>(readiness_rows)
             .context("decoding the replicated bearer readiness acknowledgement")?;
-    let Some(readiness) = readiness_rows.first() else {
+    if readiness_rows.is_empty() {
         return Ok(false);
-    };
-    verify_bearer_pairing_ready_row(
-        identity,
-        issuer_did,
-        identity.did(),
-        template,
-        local_endpoint,
-        readiness,
-    )
-    .await?;
-    Ok(true)
+    }
+    let mut readiness_error = None;
+    for readiness in &readiness_rows {
+        match verify_bearer_pairing_ready_row(
+            identity,
+            issuer_did,
+            identity.did(),
+            template,
+            local_endpoint,
+            readiness,
+        )
+        .await
+        {
+            Ok(()) => return Ok(true),
+            Err(error) => readiness_error = Some(error),
+        }
+    }
+    Err(readiness_error.expect("non-empty readiness rows produced an error"))
 }
 
 async fn verify_bearer_pairing_ready_row(

--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -321,9 +321,8 @@ pub(super) async fn observe_bearer_pairing_readiness(
     if readiness_rows.is_empty() {
         return Ok(false);
     }
-    let mut readiness_error = None;
     for readiness in &readiness_rows {
-        match verify_bearer_pairing_ready_row(
+        if verify_bearer_pairing_ready_row(
             identity,
             issuer_did,
             identity.did(),
@@ -332,12 +331,12 @@ pub(super) async fn observe_bearer_pairing_readiness(
             readiness,
         )
         .await
+        .is_ok()
         {
-            Ok(()) => return Ok(true),
-            Err(error) => readiness_error = Some(error),
+            return Ok(true);
         }
     }
-    Err(readiness_error.expect("non-empty readiness rows produced an error"))
+    Ok(false)
 }
 
 async fn verify_bearer_pairing_ready_row(
@@ -691,7 +690,7 @@ async fn install_bearer_replicator(
     issuer_did: &str,
     template_id: &str,
 ) -> Result<()> {
-    let filters = bearer_replicator_filters(template_id, requester_did, issuer_did);
+    let filters = bearer_replicator_filters(template_id, requester_did, issuer_did)?;
     let collections = bearer_replicator_collections(template_id);
 
     match timeout(
@@ -711,26 +710,18 @@ fn bearer_replicator_filters(
     template_id: &str,
     requester_did: &str,
     issuer_did: &str,
-) -> ReplicationFilters {
+) -> Result<ReplicationFilters> {
     let template = resolve_template(template_id)
         .filter(|template| conversation_like(template.id))
         .unwrap_or_else(|| resolve_template("conversation").expect("conversation template"));
-    let mut filters = scope_filter(
+    let pairing_filters = scope_filter(
         &template.scope,
         template.collections,
         requester_did,
         issuer_did,
-    )
-    .into_iter()
-    .map(|(collection, predicate)| {
-        (
-            collection,
-            ReplicationFilter::predicate(
-                gents::agent::p2p_reconcile::templates::filter_conditions(&predicate),
-            ),
-        )
-    })
-    .collect::<ReplicationFilters>();
+    );
+    let mut filters = gents::agent::p2p_reconcile::to_replication_filters(&pairing_filters)
+        .map_err(anyhow::Error::msg)?;
     filters.insert(
         "PairingBearerClaim".to_string(),
         ReplicationFilter::eq(
@@ -742,7 +733,7 @@ fn bearer_replicator_filters(
         "PeerEndpoint".to_string(),
         ReplicationFilter::eq("did", serde_json::Value::String(requester_did.to_string())),
     );
-    filters
+    Ok(filters)
 }
 
 pub(super) async fn publish_local_endpoint(
@@ -1227,7 +1218,8 @@ mod tests {
             )
         };
         let collections = bearer_replicator_collections("conversation");
-        let filters = bearer_replicator_filters("conversation", "did:key:phone", "did:key:issuer");
+        let filters = bearer_replicator_filters("conversation", "did:key:phone", "did:key:issuer")
+            .expect("conversation filters");
         assert!(collections.contains(&"AgentRequest".to_string()));
         assert!(collections.contains(&"AgentResponse".to_string()));
         assert!(collections.contains(&"AgentBehavior".to_string()));
@@ -1298,7 +1290,8 @@ mod tests {
             )
         };
         let collections = bearer_replicator_collections("machine");
-        let filters = bearer_replicator_filters("machine", "did:key:phone", "did:key:issuer");
+        let filters = bearer_replicator_filters("machine", "did:key:phone", "did:key:issuer")
+            .expect("machine filters");
 
         assert!(collections.contains(&AGENT_DIRECTORY_COLLECTION.to_string()));
         assert_eq!(

--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -719,7 +719,7 @@ fn bearer_replicator_filters(
     .map(|(collection, predicate)| {
         (
             collection,
-            ReplicationFilter::eq(&predicate.field, serde_json::Value::String(predicate.value)),
+            ReplicationFilter::predicate(predicate.conditions()),
         )
     })
     .collect::<ReplicationFilters>();

--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -322,7 +322,7 @@ pub(super) async fn observe_bearer_pairing_readiness(
         return Ok(false);
     }
     for readiness in &readiness_rows {
-        if verify_bearer_pairing_ready_row(
+        match verify_bearer_pairing_ready_row(
             identity,
             issuer_did,
             identity.did(),
@@ -331,9 +331,13 @@ pub(super) async fn observe_bearer_pairing_readiness(
             readiness,
         )
         .await
-        .is_ok()
         {
-            return Ok(true);
+            Ok(()) => return Ok(true),
+            Err(error) => tracing::warn!(
+                error = %error,
+                issuer_did,
+                "ignoring invalid bearer pairing readiness acknowledgement"
+            ),
         }
     }
     Ok(false)

--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -719,7 +719,9 @@ fn bearer_replicator_filters(
     .map(|(collection, predicate)| {
         (
             collection,
-            ReplicationFilter::predicate(predicate.conditions()),
+            ReplicationFilter::predicate(
+                gents::agent::p2p_reconcile::templates::filter_conditions(&predicate),
+            ),
         )
     })
     .collect::<ReplicationFilters>();
@@ -1210,6 +1212,14 @@ mod tests {
 
     #[test]
     fn combined_replicator_contains_scoped_conversation_and_claim_control_plane() {
+        let predicate = |field: &str, value: &str| {
+            ReplicationFilter::predicate(
+                serde_json::json!({ (field): { "_eq": value } })
+                    .as_object()
+                    .expect("predicate")
+                    .clone(),
+            )
+        };
         let collections = bearer_replicator_collections("conversation");
         let filters = bearer_replicator_filters("conversation", "did:key:phone", "did:key:issuer");
         assert!(collections.contains(&"AgentRequest".to_string()));
@@ -1238,10 +1248,7 @@ mod tests {
             };
             assert_eq!(
                 filters.get(collection),
-                Some(&ReplicationFilter::eq(
-                    field,
-                    serde_json::json!("did:key:phone")
-                ))
+                Some(&predicate(field, "did:key:phone"))
             );
         }
         for collection in [
@@ -1270,39 +1277,35 @@ mod tests {
         );
         assert_eq!(
             filters.get("AgentRequest"),
-            Some(&ReplicationFilter::eq(
-                "requester_did",
-                serde_json::json!("did:key:phone")
-            ))
+            Some(&predicate("requester_did", "did:key:phone"))
         );
     }
 
     #[test]
     fn machine_replicator_adds_only_issuer_owned_directory_rows() {
+        let predicate = |field: &str, value: &str| {
+            ReplicationFilter::predicate(
+                serde_json::json!({ (field): { "_eq": value } })
+                    .as_object()
+                    .expect("predicate")
+                    .clone(),
+            )
+        };
         let collections = bearer_replicator_collections("machine");
         let filters = bearer_replicator_filters("machine", "did:key:phone", "did:key:issuer");
 
         assert!(collections.contains(&AGENT_DIRECTORY_COLLECTION.to_string()));
         assert_eq!(
             filters.get(AGENT_DIRECTORY_COLLECTION),
-            Some(&ReplicationFilter::eq(
-                "source_did",
-                serde_json::json!("did:key:issuer")
-            ))
+            Some(&predicate("source_did", "did:key:issuer"))
         );
         assert_eq!(
             filters.get("AgentRequest"),
-            Some(&ReplicationFilter::eq(
-                "requester_did",
-                serde_json::json!("did:key:phone")
-            ))
+            Some(&predicate("requester_did", "did:key:phone"))
         );
         assert_eq!(
             filters.get("BearerPairingReady"),
-            Some(&ReplicationFilter::eq(
-                "claimant_did",
-                serde_json::json!("did:key:phone")
-            ))
+            Some(&predicate("claimant_did", "did:key:phone"))
         );
     }
 

--- a/crates/gents-desktop-core/src/remote_admin/http_impl.rs
+++ b/crates/gents-desktop-core/src/remote_admin/http_impl.rs
@@ -132,10 +132,8 @@ struct AddReplicatorBody<'a> {
 
 #[derive(Debug, Serialize)]
 struct HttpReplicationFilter {
-    #[serde(rename = "Field")]
-    field: String,
-    #[serde(rename = "Value")]
-    value: serde_json::Value,
+    #[serde(rename = "Conditions")]
+    conditions: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -250,8 +248,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
                     (
                         collection.clone(),
                         HttpReplicationFilter {
-                            field: predicate.field.clone(),
-                            value: serde_json::Value::String(predicate.value.clone()),
+                            conditions: predicate.conditions(),
                         },
                     )
                 })
@@ -896,6 +893,44 @@ mod tests {
             )
             .await
             .expect("add_replicator");
+    }
+
+    #[tokio::test]
+    async fn add_replicator_posts_composed_conditions() {
+        let server = MockServer::start().await;
+        let expected = serde_json::json!({
+            "Collections": ["AgentRequest"],
+            "Addresses": ["peer1"],
+            "Filters": {
+                "AgentRequest": {
+                    "Conditions": {
+                        "_and": [
+                            { "requester_did": { "_eq": "did:key:phone" } },
+                            { "status": { "_eq": "pending" } }
+                        ]
+                    }
+                }
+            }
+        });
+        Mock::given(method("POST"))
+            .and(path("/api/v0/p2p/replicators"))
+            .and(body_json(expected))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let filters = [(
+            "AgentRequest".to_string(),
+            gents::agent::p2p_reconcile::FilterPredicate::eq("requester_did", "did:key:phone").and(
+                gents::agent::p2p_reconcile::FilterPredicate::eq("status", "pending"),
+            ),
+        )]
+        .into_iter()
+        .collect();
+
+        admin_for(&server)
+            .add_replicator(&["peer1".into()], &["AgentRequest".into()], &filters)
+            .await
+            .expect("add composed replicator");
     }
 
     #[tokio::test]

--- a/crates/gents-desktop-core/src/remote_admin/http_impl.rs
+++ b/crates/gents-desktop-core/src/remote_admin/http_impl.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use defra_p2p_adapter::ReplicationFilter;
 use reqwest::{header::CONTENT_TYPE, Client, Method, RequestBuilder};
 use serde::{Deserialize, Serialize};
 
@@ -127,13 +128,7 @@ struct AddReplicatorBody<'a> {
     #[serde(rename = "Addresses")]
     addresses: &'a [String],
     #[serde(rename = "Filters", skip_serializing_if = "BTreeMap::is_empty")]
-    filters: BTreeMap<String, HttpReplicationFilter>,
-}
-
-#[derive(Debug, Serialize)]
-struct HttpReplicationFilter {
-    #[serde(rename = "Conditions")]
-    conditions: serde_json::Map<String, serde_json::Value>,
+    filters: BTreeMap<String, ReplicationFilter>,
 }
 
 #[derive(Debug, Serialize)]
@@ -247,9 +242,9 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
                 .map(|(collection, predicate)| {
                     (
                         collection.clone(),
-                        HttpReplicationFilter {
-                            conditions: predicate.conditions(),
-                        },
+                        ReplicationFilter::predicate(
+                            gents::agent::p2p_reconcile::templates::filter_conditions(predicate),
+                        ),
                     )
                 })
                 .collect(),
@@ -506,6 +501,7 @@ async fn check_status(resp: reqwest::Response) -> RemoteP2pAdminResult<reqwest::
 mod tests {
     use super::*;
     use crate::client::{DesktopPaths, PrincipalIdentity};
+    use gents::agent::p2p_reconcile::combine_filters;
     use wiremock::matchers::{body_bytes, body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -920,8 +916,9 @@ mod tests {
             .await;
         let filters = [(
             "AgentRequest".to_string(),
-            gents::agent::p2p_reconcile::FilterPredicate::eq("requester_did", "did:key:phone").and(
-                gents::agent::p2p_reconcile::FilterPredicate::eq("status", "pending"),
+            combine_filters(
+                gents::agent::p2p_reconcile::equality_filter("requester_did", "did:key:phone"),
+                gents::agent::p2p_reconcile::equality_filter("status", "pending"),
             ),
         )]
         .into_iter()

--- a/crates/gents-desktop-core/src/remote_admin/http_impl.rs
+++ b/crates/gents-desktop-core/src/remote_admin/http_impl.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use defra_node::EmbeddedNode;
 use gents::agent::p2p_reconcile::{
-    PairingFilters, RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
+    to_replication_filters, PairingFilters, RemoteP2pAdmin, RemoteP2pAdminError,
+    RemoteP2pAdminResult, RemoteReplicator,
 };
 
 use crate::client::PrincipalIdentity;
@@ -237,17 +238,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
         let body = AddReplicatorBody {
             collections,
             addresses,
-            filters: filters
-                .iter()
-                .map(|(collection, predicate)| {
-                    (
-                        collection.clone(),
-                        ReplicationFilter::predicate(
-                            gents::agent::p2p_reconcile::templates::filter_conditions(predicate),
-                        ),
-                    )
-                })
-                .collect(),
+            filters: to_replication_filters(filters).map_err(RemoteP2pAdminError::LocalError)?,
         };
         let resp = self
             .json_request(Method::POST, "/p2p/replicators", &body)?

--- a/crates/gents/proofs/Proofs/PairingReconcile/Convergence.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Convergence.lean
@@ -136,6 +136,11 @@ theorem no_flap_on_converged_step
       unfold ReconcileState.converged at h
       simp [h_desired] at h
       exact h_not_desired (h.2.2.2.1 h_applied)
+  | pruneMissingAppliedReplicator desired target h_desired h_applied h_not_desired h_missing h_post =>
+      exfalso
+      unfold ReconcileState.converged at h
+      simp [h_desired] at h
+      exact h_missing (h.2.1 (h.2.2.2.1 h_applied))
   | crash h_post =>
       subst h_post
       simp [managedWiringUnchanged]
@@ -296,6 +301,19 @@ theorem partial_applied_replicator_stuck
       Finset.card_pos.mpr ⟨_, h_mem⟩
     simp only [disagreementCount, h_desired]
     omega
+
+theorem stale_applied_replicator_can_be_pruned
+    {s : ReconcileState} {desired : PairingDesired} {r : ReplicatorId}
+    (h_desired : s.desired = some desired)
+    (h_applied : r ∈ s.applied.replicators)
+    (h_not_desired : r ∉ desired.replicators)
+    (h_missing : r ∉ s.actual.replicators) :
+    Transition s (pruneMissingAppliedReplicatorState s r) ∧
+      (pruneMissingAppliedReplicatorState s r).actual = s.actual ∧
+      r ∉ (pruneMissingAppliedReplicatorState s r).applied.replicators := by
+  refine ⟨Transition.pruneMissingAppliedReplicator desired r h_desired h_applied h_not_desired h_missing rfl,
+    rfl, ?_⟩
+  exact Finset.not_mem_erase r s.applied.replicators
 
 theorem convergence_requires_successful_install
     {s post : ReconcileState} {desired : PairingDesired} {r : ReplicatorId}

--- a/crates/gents/proofs/Proofs/PairingReconcile/Convergence.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Convergence.lean
@@ -131,16 +131,11 @@ theorem no_flap_on_converged_step
   | reconcileInstallReplicatorFailed desired target h_desired h_target h_missing h_connected h_post =>
       subst h_post
       simp [managedWiringUnchanged]
-  | reconcileTeardownReplicator desired target h_desired h_actual h_not_desired h_applied h_post =>
+  | reconcileTeardownReplicator desired target h_desired h_not_desired h_applied h_post =>
       exfalso
       unfold ReconcileState.converged at h
       simp [h_desired] at h
       exact h_not_desired (h.2.2.2.1 h_applied)
-  | pruneMissingAppliedReplicator desired target h_desired h_applied h_not_desired h_missing h_post =>
-      exfalso
-      unfold ReconcileState.converged at h
-      simp [h_desired] at h
-      exact h_missing (h.2.1 (h.2.2.2.1 h_applied))
   | crash h_post =>
       subst h_post
       simp [managedWiringUnchanged]
@@ -186,7 +181,6 @@ theorem filter_change_forces_reinstall
     (hf : f1 ≠ f2)
     (h_new_desired : ((a, f2, cs) : ReplicatorId) ∈ desired.replicators)
     (h_old_not_desired : ((a, f1, cs) : ReplicatorId) ∉ desired.replicators)
-    (h_old_actual : ((a, f1, cs) : ReplicatorId) ∈ s.actual.replicators)
     (h_old_applied : ((a, f1, cs) : ReplicatorId) ∈ s.applied.replicators)
     (h_new_not_actual : ((a, f2, cs) : ReplicatorId) ∉ s.actual.replicators)
     (h_connected : s.actual.connected = true) :
@@ -206,7 +200,7 @@ theorem filter_change_forces_reinstall
     simp only [disagreementCount, h_desired]
     omega
   · exact Transition.reconcileTeardownReplicator desired (a, f1, cs)
-      h_desired h_old_actual h_old_not_desired h_old_applied rfl
+      h_desired h_old_not_desired h_old_applied rfl
   · exact Transition.reconcileInstallReplicator desired (a, f2, cs)
       h_desired h_new_desired h_new_not_actual h_connected rfl
   ·
@@ -224,7 +218,6 @@ theorem collections_change_forces_reinstall
     (hcs : cs1 ≠ cs2)
     (h_new_desired : ((a, f, cs2) : ReplicatorId) ∈ desired.replicators)
     (h_old_not_desired : ((a, f, cs1) : ReplicatorId) ∉ desired.replicators)
-    (h_old_actual : ((a, f, cs1) : ReplicatorId) ∈ s.actual.replicators)
     (h_old_applied : ((a, f, cs1) : ReplicatorId) ∈ s.applied.replicators)
     (h_new_not_actual : ((a, f, cs2) : ReplicatorId) ∉ s.actual.replicators)
     (h_connected : s.actual.connected = true) :
@@ -243,7 +236,7 @@ theorem collections_change_forces_reinstall
     simp only [disagreementCount, h_desired]
     omega
   · exact Transition.reconcileTeardownReplicator desired (a, f, cs1)
-      h_desired h_old_actual h_old_not_desired h_old_applied rfl
+      h_desired h_old_not_desired h_old_applied rfl
   · exact Transition.reconcileInstallReplicator desired (a, f, cs2)
       h_desired h_new_desired h_new_not_actual h_connected rfl
   · exact Finset.mem_insert_self _ _
@@ -302,18 +295,18 @@ theorem partial_applied_replicator_stuck
     simp only [disagreementCount, h_desired]
     omega
 
-theorem stale_applied_replicator_can_be_pruned
+theorem stale_applied_replicator_can_be_torn_down
     {s : ReconcileState} {desired : PairingDesired} {r : ReplicatorId}
     (h_desired : s.desired = some desired)
     (h_applied : r ∈ s.applied.replicators)
-    (h_not_desired : r ∉ desired.replicators)
-    (h_missing : r ∉ s.actual.replicators) :
-    Transition s (pruneMissingAppliedReplicatorState s r) ∧
-      (pruneMissingAppliedReplicatorState s r).actual = s.actual ∧
-      r ∉ (pruneMissingAppliedReplicatorState s r).applied.replicators := by
-  refine ⟨Transition.pruneMissingAppliedReplicator desired r h_desired h_applied h_not_desired h_missing rfl,
-    rfl, ?_⟩
-  exact Finset.not_mem_erase r s.applied.replicators
+    (h_not_desired : r ∉ desired.replicators) :
+    Transition s (teardownReplicatorState s r) ∧
+      r ∉ (teardownReplicatorState s r).actual.replicators ∧
+      r ∉ (teardownReplicatorState s r).applied.replicators := by
+  refine ⟨Transition.reconcileTeardownReplicator desired r h_desired h_not_desired h_applied rfl,
+    ?_, ?_⟩
+  · exact Finset.not_mem_erase r s.actual.replicators
+  · exact Finset.not_mem_erase r s.applied.replicators
 
 theorem convergence_requires_successful_install
     {s post : ReconcileState} {desired : PairingDesired} {r : ReplicatorId}

--- a/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
@@ -1,11 +1,11 @@
-import Proofs.Basic
-import Mathlib.Data.Finset.Basic
+import Proofs.PairingReconcile.State
 
 namespace PairingReconcile.Layering
 
 structure Layer where
   subscriptions : Finset String
   replicatorCollections : Finset String
+  filters : ReplicatorFilter := ∅
   isAppCollections : Bool
   deriving DecidableEq
 
@@ -20,6 +20,7 @@ def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer
   | some b, some d =>
       some { subscriptions := b.subscriptions ∪ d.subscriptions
            , replicatorCollections := b.replicatorCollections ∪ d.replicatorCollections
+           , filters := b.filters ∪ d.filters
            , isAppCollections := b.isAppCollections || d.isAppCollections }
 
 theorem appCollections_subscription_survives
@@ -68,5 +69,39 @@ theorem base_preserved
           simp [mergeLayered, clampDataPlane, h] at hm
           subst hm
           exact ⟨Finset.subset_union_left, Finset.subset_union_left⟩
+
+/-- Layering is conjunctive: no base predicate can be overwritten by a
+    data-plane predicate on the same collection. -/
+theorem base_filters_preserved
+    (b : Layer) (dp : Option Layer) (m : Layer)
+    (hm : mergeLayered (some b) dp = some m) :
+    b.filters ⊆ m.filters := by
+  cases dp with
+  | none =>
+      simp [mergeLayered] at hm
+      subst hm
+      exact Finset.Subset.refl _
+  | some d =>
+      cases h : d.isAppCollections <;>
+        simp [mergeLayered, clampDataPlane, h] at hm <;>
+        subst hm <;> exact Finset.subset_union_left
+
+/-- Every data-plane predicate also survives a two-layer merge. Together with
+    `base_filters_preserved`, overlapping collection predicates are ANDed. -/
+theorem data_plane_filters_preserved
+    (b d m : Layer) (hm : mergeLayered (some b) (some d) = some m) :
+    d.filters ⊆ m.filters := by
+  cases h : d.isAppCollections <;>
+    simp [mergeLayered, clampDataPlane, h] at hm <;>
+    subst hm <;> exact Finset.subset_union_right
+
+theorem overlapping_collection_filters_compose
+    (b d m : Layer) (baseFilter dataFilter : CollectionFilterKey)
+    (hm : mergeLayered (some b) (some d) = some m)
+    (hbase : baseFilter ∈ b.filters) (hdata : dataFilter ∈ d.filters)
+    (_hoverlap : baseFilter.collection = dataFilter.collection) :
+    baseFilter ∈ m.filters ∧ dataFilter ∈ m.filters := by
+  exact ⟨base_filters_preserved b (some d) m hm hbase,
+    data_plane_filters_preserved b d m hm hdata⟩
 
 end PairingReconcile.Layering

--- a/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
@@ -9,6 +9,13 @@ structure Layer where
   isAppCollections : Bool
   deriving DecidableEq
 
+def materializeBase (localDid peerDid : String) (layer : Layer) : Option Layer :=
+  if peerDid = localDid then none else some layer
+
+theorem self_pairing_is_not_materialized (localDid : String) (layer : Layer) :
+    materializeBase localDid localDid layer = none := by
+  simp [materializeBase]
+
 def clampDataPlane (l : Layer) : Layer :=
   if l.isAppCollections then l else { l with subscriptions := (∅ : Finset String) }
 

--- a/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
@@ -12,6 +12,11 @@ structure Layer where
 def clampDataPlane (l : Layer) : Layer :=
   if l.isAppCollections then l else { l with subscriptions := (∅ : Finset String) }
 
+def mergeFilters (base dataPlane : Layer) : ReplicatorFilter :=
+  base.filters ∪ dataPlane.filters.filter (fun f =>
+    f.collection ≠ "BearerPairingReady" ∨
+      ∀ baseFilter ∈ base.filters, baseFilter.collection ≠ "BearerPairingReady")
+
 def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer :=
   match base, dataPlane.map clampDataPlane with
   | none, none => none
@@ -20,7 +25,7 @@ def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer
   | some b, some d =>
       some { subscriptions := b.subscriptions ∪ d.subscriptions
            , replicatorCollections := b.replicatorCollections ∪ d.replicatorCollections
-           , filters := b.filters ∪ d.filters
+           , filters := mergeFilters b d
            , isAppCollections := b.isAppCollections || d.isAppCollections }
 
 theorem appCollections_subscription_survives
@@ -86,22 +91,59 @@ theorem base_filters_preserved
         simp [mergeLayered, clampDataPlane, h] at hm <;>
         subst hm <;> exact Finset.subset_union_left
 
-/-- Every data-plane predicate also survives a two-layer merge. Together with
-    `base_filters_preserved`, overlapping collection predicates are ANDed. -/
+/-- Data-plane predicates survive unless a control-plane readiness predicate
+    already names the claimant. Other overlaps remain conjunctive. -/
 theorem data_plane_filters_preserved
-    (b d m : Layer) (hm : mergeLayered (some b) (some d) = some m) :
+    (b d m : Layer) (hm : mergeLayered (some b) (some d) = some m)
+    (hready : ∀ f ∈ d.filters, f.collection = "BearerPairingReady" →
+      ∀ baseFilter ∈ b.filters, baseFilter.collection ≠ "BearerPairingReady") :
     d.filters ⊆ m.filters := by
   cases h : d.isAppCollections <;>
     simp [mergeLayered, clampDataPlane, h] at hm <;>
-    subst hm <;> exact Finset.subset_union_right
+    subst hm <;>
+    intro f hf <;>
+    simp only [mergeFilters, Finset.mem_union, Finset.mem_filter] <;>
+    exact Or.inr ⟨hf, by
+      by_cases hc : f.collection = "BearerPairingReady"
+      · exact Or.inr (hready f hf hc)
+      · exact Or.inl hc⟩
 
 theorem overlapping_collection_filters_compose
     (b d m : Layer) (baseFilter dataFilter : CollectionFilterKey)
     (hm : mergeLayered (some b) (some d) = some m)
     (hbase : baseFilter ∈ b.filters) (hdata : dataFilter ∈ d.filters)
+    (hnotReady : dataFilter.collection ≠ "BearerPairingReady")
     (_hoverlap : baseFilter.collection = dataFilter.collection) :
     baseFilter ∈ m.filters ∧ dataFilter ∈ m.filters := by
-  exact ⟨base_filters_preserved b (some d) m hm hbase,
-    data_plane_filters_preserved b d m hm hdata⟩
+  refine ⟨base_filters_preserved b (some d) m hm hbase, ?_⟩
+  cases h : d.isAppCollections <;>
+    simp [mergeLayered, clampDataPlane, h] at hm <;>
+    subst hm <;>
+    exact Finset.mem_union_right _ (Finset.mem_filter.mpr ⟨hdata, Or.inl hnotReady⟩)
+
+theorem base_readiness_filter_is_authoritative
+    (b d m : Layer) (baseFilter : CollectionFilterKey)
+    (hm : mergeLayered (some b) (some d) = some m)
+    (hbase : baseFilter ∈ b.filters)
+    (hready : baseFilter.collection = "BearerPairingReady") :
+    m.filters.filter (fun f => f.collection = "BearerPairingReady") =
+      b.filters.filter (fun f => f.collection = "BearerPairingReady") := by
+  have hmerge :
+      (mergeFilters b d).filter (fun f => f.collection = "BearerPairingReady") =
+        b.filters.filter (fun f => f.collection = "BearerPairingReady") := by
+    ext f
+    simp only [mergeFilters, Finset.mem_filter, Finset.mem_union]
+    constructor
+    · rintro ⟨hf | ⟨_hdata, hallowed⟩, hcollection⟩
+      · exact ⟨hf, hcollection⟩
+      · rcases hallowed with hnot | hall
+        · exact False.elim (hnot hcollection)
+        · exact False.elim (hall baseFilter hbase hready)
+    · rintro ⟨hf, hcollection⟩
+      exact ⟨Or.inl hf, hcollection⟩
+  cases h : d.isAppCollections <;>
+    simp [mergeLayered, clampDataPlane, h] at hm <;>
+    subst hm <;>
+    exact hmerge
 
 end PairingReconcile.Layering

--- a/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Layering.lean
@@ -12,19 +12,15 @@ structure Layer where
 def materializeBase (localDid peerDid : String) (layer : Layer) : Option Layer :=
   if peerDid = localDid then none else some layer
 
-theorem self_pairing_is_not_materialized (localDid : String) (layer : Layer) :
-    materializeBase localDid localDid layer = none := by
-  simp [materializeBase]
-
 def clampDataPlane (l : Layer) : Layer :=
   if l.isAppCollections then l else { l with subscriptions := (∅ : Finset String) }
 
 def mergeFilters (base dataPlane : Layer) : ReplicatorFilter :=
-  base.filters ∪ dataPlane.filters.filter (fun f =>
-    f.collection ≠ "BearerPairingReady" ∨
-      ∀ baseFilter ∈ base.filters, baseFilter.collection ≠ "BearerPairingReady")
+  base.filters.filter (fun baseFilter =>
+    ∀ dataFilter ∈ dataPlane.filters, dataFilter.collection ≠ baseFilter.collection) ∪
+    dataPlane.filters
 
-def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer :=
+def mergeMaterialized (base : Option Layer) (dataPlane : Option Layer) : Option Layer :=
   match base, dataPlane.map clampDataPlane with
   | none, none => none
   | some b, none => some b
@@ -35,122 +31,83 @@ def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer
            , filters := mergeFilters b d
            , isAppCollections := b.isAppCollections || d.isAppCollections }
 
+def mergeLayered (localDid peerDid : String) (base : Option Layer)
+    (dataPlane : Option Layer) : Option Layer :=
+  mergeMaterialized (base.bind (materializeBase localDid peerDid)) dataPlane
+
+theorem self_pairing_is_not_materialized (localDid : String) (layer : Layer) :
+    mergeLayered localDid localDid (some layer) none = none := by
+  simp [mergeLayered, mergeMaterialized, materializeBase]
+
 theorem appCollections_subscription_survives
     (base : Option Layer) (d : Layer) (h : d.isAppCollections = true)
-    (m : Layer) (hm : mergeLayered base (some d) = some m) :
+    (m : Layer) (hm : mergeMaterialized base (some d) = some m) :
     d.subscriptions ⊆ m.subscriptions := by
   cases base with
   | none =>
-      simp [mergeLayered, clampDataPlane, h] at hm
+      simp [mergeMaterialized, clampDataPlane, h] at hm
       subst hm
       exact Finset.Subset.refl _
   | some b =>
-      simp [mergeLayered, clampDataPlane, h] at hm
+      simp [mergeMaterialized, clampDataPlane, h] at hm
       subst hm
       exact Finset.subset_union_right
 
 theorem nonApp_none_base_no_subscription
     (d : Layer) (h : d.isAppCollections = false) :
-    mergeLayered none (some d) = some { d with subscriptions := (∅ : Finset String) } := by
-  simp [mergeLayered, clampDataPlane, h]
+    mergeMaterialized none (some d) = some { d with subscriptions := (∅ : Finset String) } := by
+  simp [mergeMaterialized, clampDataPlane, h]
 
 theorem nonApp_subscription_eq_base
     (b d : Layer) (h : d.isAppCollections = false)
-    (m : Layer) (hm : mergeLayered (some b) (some d) = some m) :
+    (m : Layer) (hm : mergeMaterialized (some b) (some d) = some m) :
     m.subscriptions = b.subscriptions := by
-  simp [mergeLayered, clampDataPlane, h] at hm
+  simp [mergeMaterialized, clampDataPlane, h] at hm
   subst hm
   simp
 
 theorem base_preserved
     (b : Layer) (dp : Option Layer) (m : Layer)
-    (hm : mergeLayered (some b) dp = some m) :
+    (hm : mergeMaterialized (some b) dp = some m) :
     b.subscriptions ⊆ m.subscriptions ∧ b.replicatorCollections ⊆ m.replicatorCollections := by
   cases dp with
   | none =>
-      simp [mergeLayered] at hm
+      simp [mergeMaterialized] at hm
       subst hm
       exact ⟨Finset.Subset.refl _, Finset.Subset.refl _⟩
   | some d =>
       cases h : d.isAppCollections with
       | false =>
-          simp [mergeLayered, clampDataPlane, h] at hm
+          simp [mergeMaterialized, clampDataPlane, h] at hm
           subst hm
           exact ⟨by simp, by simp [Finset.subset_union_left]⟩
       | true =>
-          simp [mergeLayered, clampDataPlane, h] at hm
+          simp [mergeMaterialized, clampDataPlane, h] at hm
           subst hm
           exact ⟨Finset.subset_union_left, Finset.subset_union_left⟩
 
-/-- Layering is conjunctive: no base predicate can be overwritten by a
-    data-plane predicate on the same collection. -/
-theorem base_filters_preserved
-    (b : Layer) (dp : Option Layer) (m : Layer)
-    (hm : mergeLayered (some b) dp = some m) :
-    b.filters ⊆ m.filters := by
-  cases dp with
-  | none =>
-      simp [mergeLayered] at hm
-      subst hm
-      exact Finset.Subset.refl _
-  | some d =>
-      cases h : d.isAppCollections <;>
-        simp [mergeLayered, clampDataPlane, h] at hm <;>
-        subst hm <;> exact Finset.subset_union_left
-
-/-- Data-plane predicates survive unless a control-plane readiness predicate
-    already names the claimant. Other overlaps remain conjunctive. -/
 theorem data_plane_filters_preserved
-    (b d m : Layer) (hm : mergeLayered (some b) (some d) = some m)
-    (hready : ∀ f ∈ d.filters, f.collection = "BearerPairingReady" →
-      ∀ baseFilter ∈ b.filters, baseFilter.collection ≠ "BearerPairingReady") :
+    (b d m : Layer) (hm : mergeMaterialized (some b) (some d) = some m) :
     d.filters ⊆ m.filters := by
   cases h : d.isAppCollections <;>
-    simp [mergeLayered, clampDataPlane, h] at hm <;>
-    subst hm <;>
-    intro f hf <;>
-    simp only [mergeFilters, Finset.mem_union, Finset.mem_filter] <;>
-    exact Or.inr ⟨hf, by
-      by_cases hc : f.collection = "BearerPairingReady"
-      · exact Or.inr (hready f hf hc)
-      · exact Or.inl hc⟩
+    simp [mergeMaterialized, clampDataPlane, h] at hm <;>
+    subst hm <;> exact Finset.subset_union_right
 
-theorem overlapping_collection_filters_compose
+theorem overridden_base_filter_is_removed
     (b d m : Layer) (baseFilter dataFilter : CollectionFilterKey)
-    (hm : mergeLayered (some b) (some d) = some m)
-    (hbase : baseFilter ∈ b.filters) (hdata : dataFilter ∈ d.filters)
-    (hnotReady : dataFilter.collection ≠ "BearerPairingReady")
-    (_hoverlap : baseFilter.collection = dataFilter.collection) :
-    baseFilter ∈ m.filters ∧ dataFilter ∈ m.filters := by
-  refine ⟨base_filters_preserved b (some d) m hm hbase, ?_⟩
+    (hm : mergeMaterialized (some b) (some d) = some m)
+    (hdata : dataFilter ∈ d.filters) (hnotData : baseFilter ∉ d.filters)
+    (hoverlap : baseFilter.collection = dataFilter.collection) :
+    baseFilter ∉ m.filters ∧ dataFilter ∈ m.filters := by
+  have hremoved : baseFilter ∉ mergeFilters b d := by
+    simp only [mergeFilters, Finset.mem_union, Finset.mem_filter]
+    rintro (⟨_, hall⟩ | hmember)
+    · exact (hall dataFilter hdata) hoverlap.symm
+    · exact hnotData hmember
+  have hpreserved : dataFilter ∈ mergeFilters b d :=
+    Finset.mem_union_right _ hdata
   cases h : d.isAppCollections <;>
-    simp [mergeLayered, clampDataPlane, h] at hm <;>
-    subst hm <;>
-    exact Finset.mem_union_right _ (Finset.mem_filter.mpr ⟨hdata, Or.inl hnotReady⟩)
-
-theorem base_readiness_filter_is_authoritative
-    (b d m : Layer) (baseFilter : CollectionFilterKey)
-    (hm : mergeLayered (some b) (some d) = some m)
-    (hbase : baseFilter ∈ b.filters)
-    (hready : baseFilter.collection = "BearerPairingReady") :
-    m.filters.filter (fun f => f.collection = "BearerPairingReady") =
-      b.filters.filter (fun f => f.collection = "BearerPairingReady") := by
-  have hmerge :
-      (mergeFilters b d).filter (fun f => f.collection = "BearerPairingReady") =
-        b.filters.filter (fun f => f.collection = "BearerPairingReady") := by
-    ext f
-    simp only [mergeFilters, Finset.mem_filter, Finset.mem_union]
-    constructor
-    · rintro ⟨hf | ⟨_hdata, hallowed⟩, hcollection⟩
-      · exact ⟨hf, hcollection⟩
-      · rcases hallowed with hnot | hall
-        · exact False.elim (hnot hcollection)
-        · exact False.elim (hall baseFilter hbase hready)
-    · rintro ⟨hf, hcollection⟩
-      exact ⟨Or.inl hf, hcollection⟩
-  cases h : d.isAppCollections <;>
-    simp [mergeLayered, clampDataPlane, h] at hm <;>
-    subst hm <;>
-    exact hmerge
+    simp [mergeMaterialized, clampDataPlane, h] at hm <;>
+    subst hm <;> exact ⟨hremoved, hpreserved⟩
 
 end PairingReconcile.Layering

--- a/crates/gents/proofs/Proofs/PairingReconcile/State.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/State.lean
@@ -9,9 +9,11 @@ abbrev PeerId := String
 structure CollectionFilterKey where
   collection : String
   field : String
+  operator : String := "_eq"
   value : String
   deriving DecidableEq, Repr
 
+/-- Filter atoms are interpreted conjunctively for each collection. -/
 abbrev ReplicatorFilter := Finset CollectionFilterKey
 
 abbrev ReplicatorCollections := Finset String

--- a/crates/gents/proofs/Proofs/PairingReconcile/Transition.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Transition.lean
@@ -38,13 +38,6 @@ def teardownReplicatorState (pre : ReconcileState) (r : ReplicatorId) : Reconcil
     } : PairingActual),
     applied := ({ collections := pre.applied.collections, replicators := pre.applied.replicators.erase r } : PairingApplied) }
 
-def pruneMissingAppliedReplicatorState (pre : ReconcileState) (r : ReplicatorId) : ReconcileState :=
-  { pre with
-    applied := ({
-      collections := pre.applied.collections,
-      replicators := pre.applied.replicators.erase r
-    } : PairingApplied) }
-
 def dialState (pre : ReconcileState) : ReconcileState :=
   { pre with
     actual := ({
@@ -121,18 +114,9 @@ inductive Transition : ReconcileState → ReconcileState → Prop where
       Transition pre post
   | reconcileTeardownReplicator {pre post : ReconcileState} (desired : PairingDesired) (r : ReplicatorId) :
       pre.desired = some desired →
-      r ∈ pre.actual.replicators →
       r ∉ desired.replicators →
       r ∈ pre.applied.replicators →
       post = teardownReplicatorState pre r →
-      Transition pre post
-  | pruneMissingAppliedReplicator {pre post : ReconcileState}
-      (desired : PairingDesired) (r : ReplicatorId) :
-      pre.desired = some desired →
-      r ∈ pre.applied.replicators →
-      r ∉ desired.replicators →
-      r ∉ pre.actual.replicators →
-      post = pruneMissingAppliedReplicatorState pre r →
       Transition pre post
   | crash {pre post : ReconcileState} :
       post = { pre with pairing := [] } →
@@ -175,13 +159,6 @@ theorem reconcileTeardownReplicator_removes_target
     r ∉ post.actual.replicators := by
   cases h_post
   exact Finset.not_mem_erase r pre.actual.replicators
-
-theorem pruneMissingAppliedReplicator_preserves_actual_and_removes_target
-    {pre post : ReconcileState} {r : ReplicatorId}
-    (h_post : post = pruneMissingAppliedReplicatorState pre r) :
-    post.actual = pre.actual ∧ r ∉ post.applied.replicators := by
-  cases h_post
-  exact ⟨rfl, Finset.not_mem_erase r pre.applied.replicators⟩
 
 theorem readFailure_preserves_actual_applied
     {pre post : ReconcileState}
@@ -232,10 +209,7 @@ theorem unmanaged_collection_survives
   | reconcileInstallReplicatorFailed desired target h_desired h_target h_missing h_connected h_post =>
       cases h_post
       exact hc
-  | reconcileTeardownReplicator desired target h_desired h_actual h_not_desired h_applied h_post =>
-      cases h_post
-      exact hc
-  | pruneMissingAppliedReplicator desired target h_desired h_applied h_not_desired h_missing h_post =>
+  | reconcileTeardownReplicator desired target h_desired h_not_desired h_applied h_post =>
       cases h_post
       exact hc
   | crash h_post =>
@@ -278,15 +252,12 @@ theorem unmanaged_replicator_survives
   | reconcileInstallReplicatorFailed desired target h_desired h_target h_missing h_connected h_post =>
       cases h_post
       exact hr
-  | reconcileTeardownReplicator desired target h_desired h_actual h_not_desired h_applied h_post =>
+  | reconcileTeardownReplicator desired target h_desired h_not_desired h_applied h_post =>
       cases h_post
       by_cases h_eq : r = target
       · subst h_eq
         exact False.elim (hunmanaged h_applied)
       · exact Finset.mem_erase.mpr ⟨h_eq, hr⟩
-  | pruneMissingAppliedReplicator desired target h_desired h_applied h_not_desired h_missing h_post =>
-      cases h_post
-      exact hr
   | crash h_post =>
       cases h_post
       exact hr

--- a/crates/gents/proofs/Proofs/PairingReconcile/Transition.lean
+++ b/crates/gents/proofs/Proofs/PairingReconcile/Transition.lean
@@ -38,6 +38,13 @@ def teardownReplicatorState (pre : ReconcileState) (r : ReplicatorId) : Reconcil
     } : PairingActual),
     applied := ({ collections := pre.applied.collections, replicators := pre.applied.replicators.erase r } : PairingApplied) }
 
+def pruneMissingAppliedReplicatorState (pre : ReconcileState) (r : ReplicatorId) : ReconcileState :=
+  { pre with
+    applied := ({
+      collections := pre.applied.collections,
+      replicators := pre.applied.replicators.erase r
+    } : PairingApplied) }
+
 def dialState (pre : ReconcileState) : ReconcileState :=
   { pre with
     actual := ({
@@ -119,6 +126,14 @@ inductive Transition : ReconcileState → ReconcileState → Prop where
       r ∈ pre.applied.replicators →
       post = teardownReplicatorState pre r →
       Transition pre post
+  | pruneMissingAppliedReplicator {pre post : ReconcileState}
+      (desired : PairingDesired) (r : ReplicatorId) :
+      pre.desired = some desired →
+      r ∈ pre.applied.replicators →
+      r ∉ desired.replicators →
+      r ∉ pre.actual.replicators →
+      post = pruneMissingAppliedReplicatorState pre r →
+      Transition pre post
   | crash {pre post : ReconcileState} :
       post = { pre with pairing := [] } →
       Transition pre post
@@ -160,6 +175,13 @@ theorem reconcileTeardownReplicator_removes_target
     r ∉ post.actual.replicators := by
   cases h_post
   exact Finset.not_mem_erase r pre.actual.replicators
+
+theorem pruneMissingAppliedReplicator_preserves_actual_and_removes_target
+    {pre post : ReconcileState} {r : ReplicatorId}
+    (h_post : post = pruneMissingAppliedReplicatorState pre r) :
+    post.actual = pre.actual ∧ r ∉ post.applied.replicators := by
+  cases h_post
+  exact ⟨rfl, Finset.not_mem_erase r pre.applied.replicators⟩
 
 theorem readFailure_preserves_actual_applied
     {pre post : ReconcileState}
@@ -213,6 +235,9 @@ theorem unmanaged_collection_survives
   | reconcileTeardownReplicator desired target h_desired h_actual h_not_desired h_applied h_post =>
       cases h_post
       exact hc
+  | pruneMissingAppliedReplicator desired target h_desired h_applied h_not_desired h_missing h_post =>
+      cases h_post
+      exact hc
   | crash h_post =>
       cases h_post
       exact hc
@@ -259,6 +284,9 @@ theorem unmanaged_replicator_survives
       · subst h_eq
         exact False.elim (hunmanaged h_applied)
       · exact Finset.mem_erase.mpr ⟨h_eq, hr⟩
+  | pruneMissingAppliedReplicator desired target h_desired h_applied h_not_desired h_missing h_post =>
+      cases h_post
+      exact hr
   | crash h_post =>
       cases h_post
       exact hr

--- a/crates/gents/proofs/Proofs/ScopeTemplates/State.lean
+++ b/crates/gents/proofs/Proofs/ScopeTemplates/State.lean
@@ -32,12 +32,14 @@ inductive Scope where
 
 structure ScopeFilterKey where
   field : String
+  operator : String := "_eq"
   value : Did
   deriving DecidableEq, Repr
 
 structure CollectionScopeFilter where
   collection : String
   field : String
+  operator : String := "_eq"
   value : Did
   deriving DecidableEq, Repr
 

--- a/crates/gents/src/agent/p2p_reconcile/diff.rs
+++ b/crates/gents/src/agent/p2p_reconcile/diff.rs
@@ -127,11 +127,11 @@ pub fn compute_owned_pairing_diff(
     // collection set after the control-plane layer merged in.
     let filter_changed = desired.replicator_filter != applied.replicator_filter;
     let desired_replicator_collections = desired.effective_replicator_collections();
-    for r in desired
+    for r in applied
         .replicator_addresses
-        .difference(&actual.replicator_addresses)
+        .difference(&desired.replicator_addresses)
     {
-        ops.push(DiffOp::InstallReplicator(r.clone()));
+        ops.push(DiffOp::TeardownReplicator(r.clone()));
     }
     for r in actual
         .replicator_addresses
@@ -147,12 +147,11 @@ pub fn compute_owned_pairing_diff(
             ops.push(DiffOp::InstallReplicator(r.clone()));
         }
     }
-    for r in actual
+    for r in desired
         .replicator_addresses
-        .intersection(&applied.replicator_addresses)
-        .filter(|r| !desired.replicator_addresses.contains(*r))
+        .difference(&actual.replicator_addresses)
     {
-        ops.push(DiffOp::TeardownReplicator(r.clone()));
+        ops.push(DiffOp::InstallReplicator(r.clone()));
     }
     ops
 }

--- a/crates/gents/src/agent/p2p_reconcile/diff.rs
+++ b/crates/gents/src/agent/p2p_reconcile/diff.rs
@@ -242,7 +242,7 @@ mod tests {
         let mut f = PairingFilters::new();
         f.insert(
             "AgentRequest".to_string(),
-            super::super::templates::FilterPredicate::eq(field, value),
+            super::super::templates::equality_filter(field, value),
         );
         f
     }

--- a/crates/gents/src/agent/p2p_reconcile/diff.rs
+++ b/crates/gents/src/agent/p2p_reconcile/diff.rs
@@ -242,10 +242,7 @@ mod tests {
         let mut f = PairingFilters::new();
         f.insert(
             "AgentRequest".to_string(),
-            super::super::templates::FilterPredicate {
-                field: field.to_string(),
-                value: value.to_string(),
-            },
+            super::super::templates::FilterPredicate::eq(field, value),
         );
         f
     }

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -5,14 +5,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use defra_p2p_adapter::{
-    P2PError, P2PResult, P2pDocumentRequest, ReplicationFilter, ReplicationFilters,
-};
+use defra_p2p_adapter::{P2PError, P2PResult, P2pDocumentRequest};
 use tokio::time::timeout;
 
 use crate::defra_node::EmbeddedNode;
 
-use super::templates::{filter_conditions, PairingFilters};
+use super::templates::{to_replication_filters, PairingFilters};
 use super::{RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator};
 
 const DEFAULT_EMBEDDED_ADMIN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -105,7 +103,8 @@ impl RemoteP2pAdmin for EmbeddedRemoteP2pAdmin {
     ) -> RemoteP2pAdminResult<()> {
         let p2p = self.p2p()?;
         let addr = addresses.first().map(String::as_str);
-        let defra_filters = to_defra_filters(filters);
+        let defra_filters =
+            to_replication_filters(filters).map_err(RemoteP2pAdminError::LocalError)?;
         self.run(
             "add_replicator",
             p2p.add_replicator(collections.to_vec(), addr, defra_filters, Vec::new(), None),
@@ -241,18 +240,6 @@ impl RemoteP2pAdmin for EmbeddedRemoteP2pAdmin {
     }
 }
 
-fn to_defra_filters(filters: &PairingFilters) -> ReplicationFilters {
-    filters
-        .iter()
-        .map(|(collection, predicate)| {
-            (
-                collection.clone(),
-                ReplicationFilter::predicate(filter_conditions(predicate)),
-            )
-        })
-        .collect()
-}
-
 fn document_requests(doc_ids: &[String]) -> Vec<P2pDocumentRequest> {
     doc_ids
         .iter()
@@ -315,7 +302,7 @@ mod tests {
         .into_iter()
         .collect();
 
-        let converted = to_defra_filters(&filters);
+        let converted = to_replication_filters(&filters).expect("supported filters");
         assert_eq!(
             converted["AgentRequest"].conditions.as_ref(),
             serde_json::json!({

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -12,7 +12,7 @@ use tokio::time::timeout;
 
 use crate::defra_node::EmbeddedNode;
 
-use super::templates::PairingFilters;
+use super::templates::{filter_conditions, PairingFilters};
 use super::{RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator};
 
 const DEFAULT_EMBEDDED_ADMIN_TIMEOUT: Duration = Duration::from_secs(10);
@@ -247,7 +247,7 @@ fn to_defra_filters(filters: &PairingFilters) -> ReplicationFilters {
         .map(|(collection, predicate)| {
             (
                 collection.clone(),
-                ReplicationFilter::predicate(predicate.conditions()),
+                ReplicationFilter::predicate(filter_conditions(predicate)),
             )
         })
         .collect()
@@ -286,7 +286,8 @@ mod tests {
 
     use super::*;
     use crate::agent::p2p_reconcile::templates::{Scope, SUBAGENT_HOST_TEMPLATE};
-    use crate::agent::p2p_reconcile::{resolve_template, scope_filter, FilterPredicate};
+    use crate::agent::p2p_reconcile::{combine_filters, equality_filter};
+    use crate::agent::p2p_reconcile::{resolve_template, scope_filter};
     use crate::defra_node::P2PConfig;
     use crate::ensure_runtime_schemas;
     use crate::graphql::escape_graphql_string;
@@ -306,8 +307,10 @@ mod tests {
     fn adapter_preserves_conjunctive_filters_as_conditions() {
         let filters = [(
             "AgentRequest".to_string(),
-            FilterPredicate::eq("requester_did", "did:key:phone")
-                .and(FilterPredicate::eq("status", "pending")),
+            combine_filters(
+                equality_filter("requester_did", "did:key:phone"),
+                equality_filter("status", "pending"),
+            ),
         )]
         .into_iter()
         .collect();
@@ -769,11 +772,11 @@ mod tests {
         let mut filters = PairingFilters::new();
         filters.insert(
             "AgentRequest".to_string(),
-            FilterPredicate::eq("requester_did", "did:key:coord"),
+            equality_filter("requester_did", "did:key:coord"),
         );
         filters.insert(
             "AgentToolCall".to_string(),
-            FilterPredicate::eq("spawn_target_did", "did:key:host"),
+            equality_filter("spawn_target_did", "did:key:host"),
         );
         sender_admin
             .add_replicator(&receiver_addresses, &collections, &filters)

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -247,11 +247,7 @@ fn to_defra_filters(filters: &PairingFilters) -> ReplicationFilters {
         .map(|(collection, predicate)| {
             (
                 collection.clone(),
-                ReplicationFilter {
-                    field: predicate.field.clone(),
-                    value: serde_json::Value::String(predicate.value.clone()),
-                    conditions: None,
-                },
+                ReplicationFilter::predicate(predicate.conditions()),
             )
         })
         .collect()
@@ -304,6 +300,29 @@ mod tests {
     struct TestNode {
         node: Arc<EmbeddedNode>,
         _tempdir: tempfile::TempDir,
+    }
+
+    #[test]
+    fn adapter_preserves_conjunctive_filters_as_conditions() {
+        let filters = [(
+            "AgentRequest".to_string(),
+            FilterPredicate::eq("requester_did", "did:key:phone")
+                .and(FilterPredicate::eq("status", "pending")),
+        )]
+        .into_iter()
+        .collect();
+
+        let converted = to_defra_filters(&filters);
+        assert_eq!(
+            converted["AgentRequest"].conditions.as_ref(),
+            serde_json::json!({
+                "_and": [
+                    { "requester_did": { "_eq": "did:key:phone" } },
+                    { "status": { "_eq": "pending" } }
+                ]
+            })
+            .as_object()
+        );
     }
 
     async fn p2p_node() -> TestNode {
@@ -750,17 +769,11 @@ mod tests {
         let mut filters = PairingFilters::new();
         filters.insert(
             "AgentRequest".to_string(),
-            FilterPredicate {
-                field: "requester_did".to_string(),
-                value: "did:key:coord".to_string(),
-            },
+            FilterPredicate::eq("requester_did", "did:key:coord"),
         );
         filters.insert(
             "AgentToolCall".to_string(),
-            FilterPredicate {
-                field: "spawn_target_did".to_string(),
-                value: "did:key:host".to_string(),
-            },
+            FilterPredicate::eq("spawn_target_did", "did:key:host"),
         );
         sender_admin
             .add_replicator(&receiver_addresses, &collections, &filters)

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -21,12 +21,12 @@ use super::graphql_helpers::{ensure_no_errors, first_row, graphql_string_list_li
 use super::network::{GraphqlNetworkStore, NetworkEndpointEntry, NetworkStore};
 use super::reciprocal::GraphqlReciprocalStore;
 use super::templates::{
-    decode_pairing_filters, equality_filter, merge_pairing_filters, resolve_template, scope_filter,
-    single_string_eq, Delivery, DidSource, PairingFilters, Scope, APP_COLLECTIONS_TEMPLATE,
+    decode_pairing_filters, equality_filter, resolve_template, scope_filter, single_string_eq,
+    Delivery, DidSource, PairingFilters, Scope, APP_COLLECTIONS_TEMPLATE,
 };
 use super::{
     compute_owned_pairing_diff, DiffOp, EmbeddedRemoteP2pAdmin, PairingActual, PairingApplied,
-    PairingDesired, RemoteP2pAdmin,
+    PairingDesired, RemoteP2pAdmin, RemoteP2pAdminError,
 };
 
 pub const PAIRING_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
@@ -215,54 +215,10 @@ async fn reconcile_prepared_peer(
         });
     };
     let desired_state = desired.clone().unwrap_or_default();
-    let actual = read_actual(
-        admin,
-        &desired_state.replicator_addresses,
-        &applied_record.state.replicator_addresses,
-    )
-    .await?;
+    let actual = read_actual(admin, &applied_record.state.replicator_addresses).await?;
 
-    let mut applied_changed = !applied_record.duplicate_doc_ids.is_empty();
-
-    if applied_record.state.replicator_addresses != desired_state.replicator_addresses
-        && same_replicator_peers(
-            &applied_record.state.replicator_addresses,
-            &desired_state.replicator_addresses,
-        )
-        && desired_state
-            .replicator_addresses
-            .is_subset(&actual.state.replicator_addresses)
-    {
-        applied_record.state.replicator_addresses = desired_state.replicator_addresses.clone();
-        applied_changed = true;
-        tracing::info!(
-            peer_id = %peer_id,
-            "refreshed route for existing replicator peer"
-        );
-    }
-
-    if desired.is_some() {
-        let previous_count = applied_record.state.replicator_addresses.len();
-        applied_record.state.replicator_addresses.retain(|address| {
-            desired_state.replicator_addresses.contains(address)
-                || actual.state.replicator_addresses.contains(address)
-        });
-        if applied_record.state.replicator_addresses.len() != previous_count {
-            if applied_record.state.replicator_addresses.is_empty() {
-                applied_record.state.replicator_filter.clear();
-            }
-            applied_changed = true;
-            tracing::info!(
-                peer_id = %peer_id,
-                pruned = previous_count - applied_record.state.replicator_addresses.len(),
-                "pruned stale applied replicator endpoints"
-            );
-        }
-    }
-
-    if applied_changed {
-        store.persist_applied(&peer_id, &applied_record).await?;
-        applied_record.duplicate_doc_ids.clear();
+    if !applied_record.duplicate_doc_ids.is_empty() {
+        persist_applied_record(store, &peer_id, &mut applied_record).await?;
     }
 
     let ops = compute_owned_pairing_diff(&desired_state, &actual.state, &applied_record.state);
@@ -302,13 +258,13 @@ async fn reconcile_prepared_peer(
     for op in ops {
         apply_op(admin, &op, &desired_state, &actual).await?;
         update_applied_after_success(&mut applied_record.state, &op, &desired_state);
-        store.persist_applied(&peer_id, &applied_record).await?;
+        persist_applied_record(store, &peer_id, &mut applied_record).await?;
         ops_applied.push(op);
     }
 
     if desired.is_none() && !applied_record.state.is_empty() {
         applied_record.state = PairingApplied::default();
-        store.persist_applied(&peer_id, &applied_record).await?;
+        persist_applied_record(store, &peer_id, &mut applied_record).await?;
     }
     store
         .reconcile_bearer_readiness(&peer_id, desired.as_ref(), &applied_record.state)
@@ -320,6 +276,19 @@ async fn reconcile_prepared_peer(
         replayed_replicators,
         desired_read_failed: false,
     })
+}
+
+async fn persist_applied_record(
+    store: &dyn PairingStateStore,
+    peer_id: &str,
+    applied: &mut LoadedPairingApplied,
+) -> Result<()> {
+    store.persist_applied(peer_id, applied).await?;
+    if applied.state.is_empty() {
+        applied.canonical_doc_id = None;
+    }
+    applied.duplicate_doc_ids.clear();
+    Ok(())
 }
 
 async fn peer_already_active(admin: &dyn RemoteP2pAdmin, peer_id: &str) -> bool {
@@ -339,24 +308,6 @@ async fn peer_already_active(admin: &dyn RemoteP2pAdmin, peer_id: &str) -> bool 
             .map(|(parsed, _)| parsed.as_str() == peer_id)
             .unwrap_or_else(|_| entry.contains(peer_id))
     })
-}
-
-fn replicator_peers(addresses: &BTreeSet<String>) -> Option<BTreeSet<String>> {
-    addresses
-        .iter()
-        .map(|address| {
-            parse_public_peer_addr(address)
-                .ok()
-                .map(|(peer_id, _)| peer_id.to_string())
-        })
-        .collect()
-}
-
-fn same_replicator_peers(left: &BTreeSet<String>, right: &BTreeSet<String>) -> bool {
-    !left.is_empty()
-        && replicator_peers(left)
-            .zip(replicator_peers(right))
-            .is_some_and(|(left, right)| left == right)
 }
 
 pub async fn run_pairing_reconciler(
@@ -562,7 +513,6 @@ struct ActualSnapshot {
 
 async fn read_actual(
     admin: &dyn RemoteP2pAdmin,
-    desired_addresses: &BTreeSet<String>,
     applied_addresses: &BTreeSet<String>,
 ) -> Result<ActualSnapshot> {
     let mut collections = BTreeSet::new();
@@ -597,8 +547,7 @@ async fn read_actual(
     let mut replicator_ids_by_addr = BTreeMap::new();
     let mut replicator_collections_by_addr = BTreeMap::new();
     for replicator in remote_replicators {
-        let address =
-            canonical_replicator_address(&replicator, desired_addresses, applied_addresses);
+        let address = canonical_replicator_address(&replicator, applied_addresses);
         let Some(address) = address else {
             tracing::warn!("remote replicator has neither a peer id nor an address; ignoring it");
             continue;
@@ -648,22 +597,22 @@ async fn read_actual(
 
 fn canonical_replicator_address(
     replicator: &super::RemoteReplicator,
-    desired_addresses: &BTreeSet<String>,
     applied_addresses: &BTreeSet<String>,
 ) -> Option<String> {
-    let Some(id) = replicator.id.as_deref() else {
+    if replicator.address.is_some() {
         return replicator.address.clone();
+    }
+    let Some(id) = replicator.id.as_deref() else {
+        return None;
     };
-    desired_addresses
+    applied_addresses
         .iter()
-        .chain(applied_addresses)
         .find(|address| {
             parse_public_peer_addr(address)
                 .map(|(peer_id, _)| peer_id.as_str() == id)
                 .unwrap_or(false)
         })
         .cloned()
-        .or_else(|| replicator.address.clone())
         .or_else(|| Some(id.to_string()))
 }
 
@@ -703,9 +652,13 @@ async fn apply_op(
             Ok(())
         }
         DiffOp::TeardownReplicator(address) => {
+            let parsed_peer_id = parse_public_peer_addr(address)
+                .ok()
+                .map(|(peer_id, _)| peer_id.to_string());
             let id = actual
                 .replicator_ids_by_addr
                 .get(address)
+                .or(parsed_peer_id.as_ref())
                 .map(String::as_str)
                 .unwrap_or(address.as_str());
             let collections = actual
@@ -714,10 +667,12 @@ async fn apply_op(
                 .cloned()
                 .filter(|collections| !collections.is_empty())
                 .unwrap_or_else(|| desired.collections.iter().cloned().collect());
-            admin
-                .delete_replicator(id, &collections)
-                .await
-                .with_context(|| format!("teardown P2P replicator {address}"))
+            match admin.delete_replicator(id, &collections).await {
+                Ok(()) | Err(RemoteP2pAdminError::RemoteNotFound(_)) => Ok(()),
+                Err(error) => {
+                    Err(error).with_context(|| format!("teardown P2P replicator {address}"))
+                }
+            }
         }
     }
 }
@@ -1301,9 +1256,6 @@ fn desired_from_pairing_row(
     }
 
     let peer_did = row.agent_did.as_deref().map(str::trim).unwrap_or_default();
-    if peer_did == local_did {
-        return Ok(None);
-    }
     if peer_did.is_empty() && scope_requires_peer_did(&template.scope) {
         anyhow::bail!(
             "pairing row for peer-DID-dependent template {template_id:?} has a blank \
@@ -1323,13 +1275,25 @@ fn desired_from_pairing_row(
         Delivery::Replicate => replicator_collections.clone(),
     };
 
-    Ok(Some(PairingDesired {
-        collections: subscription_collections,
-        replicator_addresses,
-        replicator_collections,
-        replicator_filter,
-        template_ids: BTreeSet::from([template.id.to_string()]),
-    }))
+    Ok(materialize_base_desired(
+        local_did,
+        peer_did,
+        PairingDesired {
+            collections: subscription_collections,
+            replicator_addresses,
+            replicator_collections,
+            replicator_filter,
+            template_ids: BTreeSet::from([template.id.to_string()]),
+        },
+    ))
+}
+
+pub fn materialize_base_desired(
+    local_did: &str,
+    peer_did: &str,
+    desired: PairingDesired,
+) -> Option<PairingDesired> {
+    (peer_did != local_did).then_some(desired)
 }
 
 fn data_plane_desired_from_pairing_row(
@@ -1517,11 +1481,7 @@ pub fn merge_layered_desired(
             left.replicator_addresses.extend(right.replicator_addresses);
             left.replicator_collections
                 .extend(right.replicator_collections);
-            let mut data_plane_filters = right.replicator_filter;
-            if left.replicator_filter.contains_key("BearerPairingReady") {
-                data_plane_filters.remove("BearerPairingReady");
-            }
-            merge_pairing_filters(&mut left.replicator_filter, data_plane_filters);
+            left.replicator_filter.extend(right.replicator_filter);
             left.template_ids.extend(right.template_ids);
             Some(left)
         }

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -21,8 +21,8 @@ use super::graphql_helpers::{ensure_no_errors, first_row, graphql_string_list_li
 use super::network::{GraphqlNetworkStore, NetworkEndpointEntry, NetworkStore};
 use super::reciprocal::GraphqlReciprocalStore;
 use super::templates::{
-    merge_pairing_filters, resolve_template, scope_filter, Delivery, DidSource, PairingFilters,
-    Scope, APP_COLLECTIONS_TEMPLATE,
+    decode_pairing_filters, equality_filter, merge_pairing_filters, resolve_template, scope_filter,
+    single_string_eq, Delivery, DidSource, PairingFilters, Scope, APP_COLLECTIONS_TEMPLATE,
 };
 use super::{
     compute_owned_pairing_diff, DiffOp, EmbeddedRemoteP2pAdmin, PairingActual, PairingApplied,
@@ -40,13 +40,20 @@ pub struct PairingTickOutcome {
     pub desired_read_failed: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LoadedPairingApplied {
+    pub state: PairingApplied,
+    pub canonical_doc_id: Option<String>,
+    pub duplicate_doc_ids: Vec<String>,
+}
+
 #[async_trait]
 pub trait PairingStateStore: Send + Sync {
     async fn load_desired(&self, peer_id: &str) -> Result<Option<PairingDesired>>;
 
-    async fn load_applied(&self, peer_id: &str) -> Result<PairingApplied>;
+    async fn load_applied(&self, peer_id: &str) -> Result<LoadedPairingApplied>;
 
-    async fn persist_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()>;
+    async fn persist_applied(&self, peer_id: &str, applied: &LoadedPairingApplied) -> Result<()>;
 
     async fn list_peer_ids(&self) -> Result<BTreeSet<String>>;
 
@@ -91,7 +98,7 @@ enum PreparedPairingState {
     DesiredReadFailed,
     Ready {
         desired: Option<PairingDesired>,
-        applied: PairingApplied,
+        applied: LoadedPairingApplied,
         reconnected: bool,
         force_replay: bool,
     },
@@ -139,8 +146,8 @@ async fn prepare_pairing_peer(
     let mut active_before = observed_active_before.unwrap_or(false);
     let mut reconnected = false;
     if desired_state.has_wiring() && !desired_state.replicator_addresses.is_empty() {
-        let endpoint_changed = !applied.replicator_addresses.is_empty()
-            && applied.replicator_addresses != desired_state.replicator_addresses;
+        let endpoint_changed = !applied.state.replicator_addresses.is_empty()
+            && applied.state.replicator_addresses != desired_state.replicator_addresses;
         if observed_active_before.is_none() {
             active_before = peer_already_active(admin, &peer_id).await;
         }
@@ -167,7 +174,7 @@ async fn prepare_pairing_peer(
             if endpoint_changed {
                 tracing::info!(
                     peer_id = %peer_id,
-                    previous_addresses = ?applied.replicator_addresses,
+                    previous_addresses = ?applied.state.replicator_addresses,
                     desired_addresses = ?desired_state.replicator_addresses,
                     "pairing endpoint changed; refreshed peer connection before reconcile"
                 );
@@ -195,7 +202,7 @@ async fn reconcile_prepared_peer(
     let peer_id = prepared.peer_id;
     let PreparedPairingState::Ready {
         desired,
-        mut applied,
+        applied: mut applied_record,
         reconnected,
         force_replay,
     } = prepared.state?
@@ -208,17 +215,26 @@ async fn reconcile_prepared_peer(
         });
     };
     let desired_state = desired.clone().unwrap_or_default();
-    let mut actual = read_actual(admin).await?;
+    let actual = read_actual(
+        admin,
+        &desired_state.replicator_addresses,
+        &applied_record.state.replicator_addresses,
+    )
+    .await?;
 
-    if applied.replicator_addresses != desired_state.replicator_addresses
+    let mut applied_changed = !applied_record.duplicate_doc_ids.is_empty();
+
+    if applied_record.state.replicator_addresses != desired_state.replicator_addresses
         && same_replicator_peers(
-            &applied.replicator_addresses,
+            &applied_record.state.replicator_addresses,
             &desired_state.replicator_addresses,
         )
-        && normalize_replicator_routes(&mut actual, &desired_state.replicator_addresses)
+        && desired_state
+            .replicator_addresses
+            .is_subset(&actual.state.replicator_addresses)
     {
-        applied.replicator_addresses = desired_state.replicator_addresses.clone();
-        store.persist_applied(&peer_id, &applied).await?;
+        applied_record.state.replicator_addresses = desired_state.replicator_addresses.clone();
+        applied_changed = true;
         tracing::info!(
             peer_id = %peer_id,
             "refreshed route for existing replicator peer"
@@ -226,25 +242,30 @@ async fn reconcile_prepared_peer(
     }
 
     if desired.is_some() {
-        let previous_count = applied.replicator_addresses.len();
-        applied.replicator_addresses.retain(|address| {
+        let previous_count = applied_record.state.replicator_addresses.len();
+        applied_record.state.replicator_addresses.retain(|address| {
             desired_state.replicator_addresses.contains(address)
                 || actual.state.replicator_addresses.contains(address)
         });
-        if applied.replicator_addresses.len() != previous_count {
-            if applied.replicator_addresses.is_empty() {
-                applied.replicator_filter.clear();
+        if applied_record.state.replicator_addresses.len() != previous_count {
+            if applied_record.state.replicator_addresses.is_empty() {
+                applied_record.state.replicator_filter.clear();
             }
-            store.persist_applied(&peer_id, &applied).await?;
+            applied_changed = true;
             tracing::info!(
                 peer_id = %peer_id,
-                pruned = previous_count - applied.replicator_addresses.len(),
+                pruned = previous_count - applied_record.state.replicator_addresses.len(),
                 "pruned stale applied replicator endpoints"
             );
         }
     }
 
-    let ops = compute_owned_pairing_diff(&desired_state, &actual.state, &applied);
+    if applied_changed {
+        store.persist_applied(&peer_id, &applied_record).await?;
+        applied_record.duplicate_doc_ids.clear();
+    }
+
+    let ops = compute_owned_pairing_diff(&desired_state, &actual.state, &applied_record.state);
     let mut ops_applied = Vec::new();
     let mut replayed_replicators = Vec::new();
 
@@ -280,18 +301,17 @@ async fn reconcile_prepared_peer(
 
     for op in ops {
         apply_op(admin, &op, &desired_state, &actual).await?;
-        update_applied_after_success(&mut applied, &op, &desired_state);
-        store.persist_applied(&peer_id, &applied).await?;
+        update_applied_after_success(&mut applied_record.state, &op, &desired_state);
+        store.persist_applied(&peer_id, &applied_record).await?;
         ops_applied.push(op);
     }
 
-    if desired.is_none() && !applied.is_empty() {
-        store
-            .persist_applied(&peer_id, &PairingApplied::default())
-            .await?;
+    if desired.is_none() && !applied_record.state.is_empty() {
+        applied_record.state = PairingApplied::default();
+        store.persist_applied(&peer_id, &applied_record).await?;
     }
     store
-        .reconcile_bearer_readiness(&peer_id, desired.as_ref(), &applied)
+        .reconcile_bearer_readiness(&peer_id, desired.as_ref(), &applied_record.state)
         .await?;
 
     Ok(PairingTickOutcome {
@@ -337,45 +357,6 @@ fn same_replicator_peers(left: &BTreeSet<String>, right: &BTreeSet<String>) -> b
         && replicator_peers(left)
             .zip(replicator_peers(right))
             .is_some_and(|(left, right)| left == right)
-}
-
-fn normalize_replicator_routes(
-    actual: &mut ActualSnapshot,
-    desired_addresses: &BTreeSet<String>,
-) -> bool {
-    if !same_replicator_peers(&actual.state.replicator_addresses, desired_addresses) {
-        return false;
-    }
-
-    let desired_by_peer = desired_addresses
-        .iter()
-        .filter_map(|address| {
-            parse_public_peer_addr(address)
-                .ok()
-                .map(|(peer_id, _)| (peer_id.to_string(), address.clone()))
-        })
-        .collect::<BTreeMap<_, _>>();
-    let normalize_key = |address: &str| {
-        parse_public_peer_addr(address)
-            .ok()
-            .and_then(|(peer_id, _)| desired_by_peer.get(&peer_id.to_string()).cloned())
-            .unwrap_or_else(|| address.to_string())
-    };
-    actual.state.replicator_addresses = desired_addresses.clone();
-    actual.state.replicator_collections = std::mem::take(&mut actual.state.replicator_collections)
-        .into_iter()
-        .map(|(address, collections)| (normalize_key(&address), collections))
-        .collect();
-    actual.replicator_ids_by_addr = std::mem::take(&mut actual.replicator_ids_by_addr)
-        .into_iter()
-        .map(|(address, id)| (normalize_key(&address), id))
-        .collect();
-    actual.replicator_collections_by_addr =
-        std::mem::take(&mut actual.replicator_collections_by_addr)
-            .into_iter()
-            .map(|(address, collections)| (normalize_key(&address), collections))
-            .collect();
-    true
 }
 
 pub async fn run_pairing_reconciler(
@@ -579,7 +560,11 @@ struct ActualSnapshot {
     replicator_collections_by_addr: BTreeMap<String, Vec<String>>,
 }
 
-async fn read_actual(admin: &dyn RemoteP2pAdmin) -> Result<ActualSnapshot> {
+async fn read_actual(
+    admin: &dyn RemoteP2pAdmin,
+    desired_addresses: &BTreeSet<String>,
+    applied_addresses: &BTreeSet<String>,
+) -> Result<ActualSnapshot> {
     let mut collections = BTreeSet::new();
     for id in admin
         .list_p2p_collections()
@@ -608,18 +593,22 @@ async fn read_actual(admin: &dyn RemoteP2pAdmin) -> Result<ActualSnapshot> {
         .list_replicators()
         .await
         .context("list remote P2P replicators")?;
-    let replicator_addresses = remote_replicators
-        .iter()
-        .filter_map(|replicator| replicator.address.clone())
-        .collect::<BTreeSet<_>>();
-    let replicator_ids_by_addr = remote_replicators
-        .iter()
-        .filter_map(|replicator| Some((replicator.address.clone()?, replicator.id.clone()?)))
-        .collect::<BTreeMap<_, _>>();
-    let replicator_collections_by_addr = remote_replicators
-        .into_iter()
-        .filter_map(|replicator| Some((replicator.address?, replicator.collections)))
-        .collect::<BTreeMap<_, _>>();
+    let mut replicator_addresses = BTreeSet::new();
+    let mut replicator_ids_by_addr = BTreeMap::new();
+    let mut replicator_collections_by_addr = BTreeMap::new();
+    for replicator in remote_replicators {
+        let address =
+            canonical_replicator_address(&replicator, desired_addresses, applied_addresses);
+        let Some(address) = address else {
+            tracing::warn!("remote replicator has neither a peer id nor an address; ignoring it");
+            continue;
+        };
+        replicator_addresses.insert(address.clone());
+        if let Some(id) = replicator.id {
+            replicator_ids_by_addr.insert(address.clone(), id);
+        }
+        replicator_collections_by_addr.insert(address, replicator.collections);
+    }
 
     let mut replicator_collections = BTreeMap::new();
     for (address, ids) in &replicator_collections_by_addr {
@@ -655,6 +644,27 @@ async fn read_actual(admin: &dyn RemoteP2pAdmin) -> Result<ActualSnapshot> {
         replicator_ids_by_addr,
         replicator_collections_by_addr,
     })
+}
+
+fn canonical_replicator_address(
+    replicator: &super::RemoteReplicator,
+    desired_addresses: &BTreeSet<String>,
+    applied_addresses: &BTreeSet<String>,
+) -> Option<String> {
+    let Some(id) = replicator.id.as_deref() else {
+        return replicator.address.clone();
+    };
+    desired_addresses
+        .iter()
+        .chain(applied_addresses)
+        .find(|address| {
+            parse_public_peer_addr(address)
+                .map(|(peer_id, _)| peer_id.as_str() == id)
+                .unwrap_or(false)
+        })
+        .cloned()
+        .or_else(|| replicator.address.clone())
+        .or_else(|| Some(id.to_string()))
 }
 
 async fn apply_op(
@@ -836,7 +846,7 @@ impl GraphqlPairingStateStore {
         ))
     }
 
-    async fn load_canonical_applied(&self, peer_id: &str) -> Result<Option<AppliedStateRow>> {
+    async fn load_applied_rows(&self, peer_id: &str) -> Result<Vec<AppliedStateRow>> {
         let peer_id = escape_graphql_string(peer_id);
         let query = format!(
             r#"{{
@@ -850,9 +860,9 @@ impl GraphqlPairingStateStore {
         );
         let response = self.node.execute(&query).await;
         ensure_no_errors(&response, "query PeerPairingApplied")?;
-        Ok(rows::<AppliedStateRow>(&response, "PeerPairingApplied")?
-            .into_iter()
-            .min_by(|left, right| left.doc_id.cmp(&right.doc_id)))
+        let mut rows = rows::<AppliedStateRow>(&response, "PeerPairingApplied")?;
+        rows.sort_by(|left, right| left.doc_id.cmp(&right.doc_id));
+        Ok(rows)
     }
 
     async fn bearer_readiness_is_current(
@@ -1026,16 +1036,20 @@ impl PairingStateStore for GraphqlPairingStateStore {
         Ok(merge_layered_desired(base, data_plane))
     }
 
-    async fn load_applied(&self, peer_id: &str) -> Result<PairingApplied> {
-        Ok(self
-            .load_canonical_applied(peer_id)
-            .await?
-            .map(AppliedStateRow::into_applied)
-            .unwrap_or_default())
+    async fn load_applied(&self, peer_id: &str) -> Result<LoadedPairingApplied> {
+        let mut rows = self.load_applied_rows(peer_id).await?.into_iter();
+        let Some(canonical) = rows.next() else {
+            return Ok(LoadedPairingApplied::default());
+        };
+        Ok(LoadedPairingApplied {
+            canonical_doc_id: Some(canonical.doc_id.clone()),
+            state: canonical.into_applied(),
+            duplicate_doc_ids: rows.map(|row| row.doc_id).collect(),
+        })
     }
 
-    async fn persist_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()> {
-        if applied.is_empty() {
+    async fn persist_applied(&self, peer_id: &str, applied: &LoadedPairingApplied) -> Result<()> {
+        if applied.state.is_empty() {
             let peer_id = escape_graphql_string(peer_id);
             let mutation = format!(
                 r#"mutation {{
@@ -1053,19 +1067,15 @@ impl PairingStateStore for GraphqlPairingStateStore {
             .map(|_| ());
         }
 
-        let existing_doc_id = self
-            .load_canonical_applied(peer_id)
-            .await?
-            .map(|row| row.doc_id);
         let peer_id = escape_graphql_string(peer_id);
-        let collections = graphql_nullable_string_array(&applied.collections);
-        let replicator_addresses = graphql_nullable_string_array(&applied.replicator_addresses);
-        let replicator_filter = graphql_nullable_filter_literal(&applied.replicator_filter);
+        let collections = graphql_nullable_string_array(&applied.state.collections);
+        let replicator_addresses =
+            graphql_nullable_string_array(&applied.state.replicator_addresses);
+        let replicator_filter = graphql_nullable_filter_literal(&applied.state.replicator_filter);
         let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
-        let mutation = match existing_doc_id {
+        let save = match &applied.canonical_doc_id {
             Some(doc_id) => format!(
-                r#"mutation {{
-                    update_PeerPairingApplied(
+                r#"update_PeerPairingApplied(
                         filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
                         input: {{
                             collections: {collections},
@@ -1073,23 +1083,41 @@ impl PairingStateStore for GraphqlPairingStateStore {
                             replicator_filter: {replicator_filter},
                             updated_at: "{now}"
                         }}
-                    ) {{ _docID }}
-                }}"#,
+                    ) {{ _docID }}"#,
                 doc_id = escape_graphql_string(&doc_id),
             ),
             None => format!(
-                r#"mutation {{
-                    create_PeerPairingApplied(input: {{
+                r#"upsert_PeerPairingApplied(
+                    filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
+                    add: {{
                         peer_id: "{peer_id}",
                         collections: {collections},
                         replicator_addresses: {replicator_addresses},
                         replicator_filter: {replicator_filter},
                         created_at: "{now}",
                         updated_at: "{now}"
-                    }}) {{ _docID }}
-                }}"#,
+                    }},
+                    update: {{
+                        collections: {collections},
+                        replicator_addresses: {replicator_addresses},
+                        replicator_filter: {replicator_filter},
+                        updated_at: "{now}"
+                    }}
+                ) {{ _docID }}"#,
             ),
         };
+        let delete_duplicates = if applied.duplicate_doc_ids.is_empty() {
+            String::new()
+        } else {
+            let ids =
+                graphql_string_list_literal(applied.duplicate_doc_ids.iter().map(String::as_str));
+            format!(
+                r#"delete_PeerPairingApplied(
+                    filter: {{ _docID: {{ _in: {ids} }} }}
+                ) {{ _docID }}"#
+            )
+        };
+        let mutation = format!("mutation {{ {save} {delete_duplicates} }}");
         crate::graphql::graphql_mutation_with_transaction_retry(
             &self.node,
             &mutation,
@@ -1439,12 +1467,7 @@ fn data_plane_scope_filter(
     match scope {
         Scope::PeerDid { field } => collections
             .iter()
-            .map(|&col| {
-                (
-                    col.to_string(),
-                    super::templates::FilterPredicate::eq(*field, local_did),
-                )
-            })
+            .map(|&col| (col.to_string(), equality_filter(*field, local_did)))
             .collect(),
         Scope::Unscoped => BTreeMap::new(),
         Scope::PerCollection(rules) => rules
@@ -1457,7 +1480,7 @@ fn data_plane_scope_filter(
                 };
                 (
                     rule.collection.to_string(),
-                    super::templates::FilterPredicate::eq(rule.field, value),
+                    equality_filter(rule.field, value),
                 )
             })
             .collect(),
@@ -1482,7 +1505,11 @@ pub fn merge_layered_desired(
             left.replicator_addresses.extend(right.replicator_addresses);
             left.replicator_collections
                 .extend(right.replicator_collections);
-            merge_pairing_filters(&mut left.replicator_filter, right.replicator_filter);
+            let mut data_plane_filters = right.replicator_filter;
+            if left.replicator_filter.contains_key("BearerPairingReady") {
+                data_plane_filters.remove("BearerPairingReady");
+            }
+            merge_pairing_filters(&mut left.replicator_filter, data_plane_filters);
             left.template_ids.extend(right.template_ids);
             Some(left)
         }
@@ -1515,7 +1542,7 @@ fn earned_bearer_readiness(
         return None;
     }
     let readiness_filter = desired.replicator_filter.get("BearerPairingReady")?;
-    let Some((field, claimant_did)) = readiness_filter.single_string_eq() else {
+    let Some((field, claimant_did)) = single_string_eq(readiness_filter) else {
         return None;
     };
     if field != "claimant_did" {
@@ -1640,7 +1667,7 @@ fn decode_replicator_filter(value: Option<&str>) -> PairingFilters {
     let Some(raw) = value.map(str::trim).filter(|v| !v.is_empty()) else {
         return PairingFilters::default();
     };
-    serde_json::from_str(raw).unwrap_or_else(|error| {
+    decode_pairing_filters(raw).unwrap_or_else(|error| {
         tracing::warn!(
             error = %error,
             "PeerPairingApplied.replicator_filter failed to decode; treating as unfiltered"

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -21,8 +21,8 @@ use super::graphql_helpers::{ensure_no_errors, first_row, graphql_string_list_li
 use super::network::{GraphqlNetworkStore, NetworkEndpointEntry, NetworkStore};
 use super::reciprocal::GraphqlReciprocalStore;
 use super::templates::{
-    decode_pairing_filters, equality_filter, resolve_template, scope_filter, single_string_eq,
-    Delivery, DidSource, PairingFilters, Scope, APP_COLLECTIONS_TEMPLATE,
+    decode_pairing_filters, equality_filter, resolve_template, scope_filter, Delivery, DidSource,
+    FilterPredicate, PairingFilters, Scope, APP_COLLECTIONS_TEMPLATE,
 };
 use super::{
     compute_owned_pairing_diff, DiffOp, EmbeddedRemoteP2pAdmin, PairingActual, PairingApplied,
@@ -43,7 +43,6 @@ pub struct PairingTickOutcome {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LoadedPairingApplied {
     pub state: PairingApplied,
-    pub canonical_doc_id: Option<String>,
     pub duplicate_doc_ids: Vec<String>,
 }
 
@@ -284,9 +283,6 @@ async fn persist_applied_record(
     applied: &mut LoadedPairingApplied,
 ) -> Result<()> {
     store.persist_applied(peer_id, applied).await?;
-    if applied.state.is_empty() {
-        applied.canonical_doc_id = None;
-    }
     applied.duplicate_doc_ids.clear();
     Ok(())
 }
@@ -544,8 +540,8 @@ async fn read_actual(
         .await
         .context("list remote P2P replicators")?;
     let mut replicator_addresses = BTreeSet::new();
-    let mut replicator_ids_by_addr = BTreeMap::new();
-    let mut replicator_collections_by_addr = BTreeMap::new();
+    let mut replicator_ids_by_addr: BTreeMap<String, String> = BTreeMap::new();
+    let mut replicator_collections_by_addr: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for replicator in remote_replicators {
         let address = canonical_replicator_address(&replicator, applied_addresses);
         let Some(address) = address else {
@@ -554,9 +550,19 @@ async fn read_actual(
         };
         replicator_addresses.insert(address.clone());
         if let Some(id) = replicator.id {
-            replicator_ids_by_addr.insert(address.clone(), id);
+            replicator_ids_by_addr
+                .entry(address.clone())
+                .and_modify(|existing| {
+                    if id.as_str() < existing.as_str() {
+                        existing.clone_from(&id);
+                    }
+                })
+                .or_insert(id);
         }
-        replicator_collections_by_addr.insert(address, replicator.collections);
+        replicator_collections_by_addr
+            .entry(address)
+            .or_insert_with(Vec::new)
+            .extend(replicator.collections);
     }
 
     let mut replicator_collections = BTreeMap::new();
@@ -605,15 +611,16 @@ fn canonical_replicator_address(
     let Some(id) = replicator.id.as_deref() else {
         return None;
     };
-    applied_addresses
-        .iter()
-        .find(|address| {
-            parse_public_peer_addr(address)
-                .map(|(peer_id, _)| peer_id.as_str() == id)
-                .unwrap_or(false)
-        })
-        .cloned()
-        .or_else(|| Some(id.to_string()))
+    let mut matches = applied_addresses.iter().filter(|address| {
+        parse_public_peer_addr(address)
+            .map(|(peer_id, _)| peer_id.as_str() == id)
+            .unwrap_or(false)
+    });
+    let only_match = matches.next();
+    if only_match.is_some() && matches.next().is_none() {
+        return only_match.cloned();
+    }
+    Some(id.to_string())
 }
 
 async fn apply_op(
@@ -666,7 +673,13 @@ async fn apply_op(
                 .get(address)
                 .cloned()
                 .filter(|collections| !collections.is_empty())
-                .unwrap_or_else(|| desired.collections.iter().cloned().collect());
+                .unwrap_or_else(|| {
+                    desired
+                        .effective_replicator_collections()
+                        .iter()
+                        .cloned()
+                        .collect()
+                });
             match admin.delete_replicator(id, &collections).await {
                 Ok(()) | Err(RemoteP2pAdminError::RemoteNotFound(_)) => Ok(()),
                 Err(error) => {
@@ -824,7 +837,7 @@ impl GraphqlPairingStateStore {
         &self,
         readiness_key: &str,
         expected: &BearerPairingReadyRecord,
-    ) -> Result<bool> {
+    ) -> Result<(bool, usize)> {
         let readiness_key = escape_graphql_string(readiness_key);
         let query = format!(
             r#"{{
@@ -843,7 +856,10 @@ impl GraphqlPairingStateStore {
         );
         let response = self.node.execute(&query).await;
         ensure_no_errors(&response, "query BearerPairingReady")?;
-        for row in rows::<BearerPairingReadyRow>(&response, "BearerPairingReady")? {
+        let rows = rows::<BearerPairingReadyRow>(&response, "BearerPairingReady")?;
+        let row_count = rows.len();
+        let mut current = false;
+        for row in &rows {
             let existing = match bearer_pairing_ready_record(&row) {
                 Ok(Some(existing)) => existing,
                 Ok(None) => continue,
@@ -872,7 +888,7 @@ impl GraphqlPairingStateStore {
                 )
                 .await
             {
-                Ok(true) => return Ok(true),
+                Ok(true) => current = true,
                 Ok(false) => {}
                 Err(error) => tracing::warn!(
                     error = %error,
@@ -881,7 +897,7 @@ impl GraphqlPairingStateStore {
                 ),
             }
         }
-        Ok(false)
+        Ok((current, row_count))
     }
 
     async fn upsert_bearer_readiness(
@@ -901,10 +917,10 @@ impl GraphqlPairingStateStore {
             acknowledged_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
             sig: Vec::new(),
         };
-        if self
+        let (current, row_count) = self
             .bearer_readiness_is_current(&readiness_key, &record)
-            .await?
-        {
+            .await?;
+        if current && row_count == 1 {
             return Ok(());
         }
         record.sig = self
@@ -980,7 +996,14 @@ impl PairingStateStore for GraphqlPairingStateStore {
         );
         let response = self.node.execute(&query).await;
         ensure_no_errors(&response, "query pairing desired state")?;
-        let base = first_row::<PairingStateRow>(&response, "PeerPairingDesired")?
+        let base_row = first_row::<PairingStateRow>(&response, "PeerPairingDesired")?;
+        let base_peer_did = base_row
+            .as_ref()
+            .and_then(|row| row.agent_did.as_deref())
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_string();
+        let base = base_row
             .map(|row| desired_from_pairing_row(row, self.identity.did()))
             .transpose()?
             .flatten();
@@ -997,7 +1020,12 @@ impl PairingStateStore for GraphqlPairingStateStore {
             }
             _ => None,
         };
-        Ok(merge_layered_desired(base, data_plane))
+        Ok(merge_layered_desired(
+            self.identity.did(),
+            &base_peer_did,
+            base,
+            data_plane,
+        ))
     }
 
     async fn load_applied(&self, peer_id: &str) -> Result<LoadedPairingApplied> {
@@ -1006,7 +1034,6 @@ impl PairingStateStore for GraphqlPairingStateStore {
             return Ok(LoadedPairingApplied::default());
         };
         Ok(LoadedPairingApplied {
-            canonical_doc_id: Some(canonical.doc_id.clone()),
             state: canonical.into_applied(),
             duplicate_doc_ids: rows.map(|row| row.doc_id).collect(),
         })
@@ -1037,21 +1064,8 @@ impl PairingStateStore for GraphqlPairingStateStore {
             graphql_nullable_string_array(&applied.state.replicator_addresses);
         let replicator_filter = graphql_nullable_filter_literal(&applied.state.replicator_filter);
         let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
-        let save = match &applied.canonical_doc_id {
-            Some(doc_id) => format!(
-                r#"update_PeerPairingApplied(
-                        filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
-                        input: {{
-                            collections: {collections},
-                            replicator_addresses: {replicator_addresses},
-                            replicator_filter: {replicator_filter},
-                            updated_at: "{now}"
-                        }}
-                    ) {{ _docID }}"#,
-                doc_id = escape_graphql_string(&doc_id),
-            ),
-            None => format!(
-                r#"upsert_PeerPairingApplied(
+        let save = format!(
+            r#"upsert_PeerPairingApplied(
                     filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
                     add: {{
                         peer_id: "{peer_id}",
@@ -1068,8 +1082,7 @@ impl PairingStateStore for GraphqlPairingStateStore {
                         updated_at: "{now}"
                     }}
                 ) {{ _docID }}"#,
-            ),
-        };
+        );
         let delete_duplicates = if applied.duplicate_doc_ids.is_empty() {
             String::new()
         } else {
@@ -1081,7 +1094,7 @@ impl PairingStateStore for GraphqlPairingStateStore {
                 ) {{ _docID }}"#
             )
         };
-        let mutation = format!("mutation {{ {save} {delete_duplicates} }}");
+        let mutation = format!("mutation {{ {delete_duplicates} {save} }}");
         crate::graphql::graphql_mutation_with_transaction_retry(
             &self.node,
             &mutation,
@@ -1275,25 +1288,13 @@ fn desired_from_pairing_row(
         Delivery::Replicate => replicator_collections.clone(),
     };
 
-    Ok(materialize_base_desired(
-        local_did,
-        peer_did,
-        PairingDesired {
-            collections: subscription_collections,
-            replicator_addresses,
-            replicator_collections,
-            replicator_filter,
-            template_ids: BTreeSet::from([template.id.to_string()]),
-        },
-    ))
-}
-
-pub fn materialize_base_desired(
-    local_did: &str,
-    peer_did: &str,
-    desired: PairingDesired,
-) -> Option<PairingDesired> {
-    (peer_did != local_did).then_some(desired)
+    Ok(Some(PairingDesired {
+        collections: subscription_collections,
+        replicator_addresses,
+        replicator_collections,
+        replicator_filter,
+        template_ids: BTreeSet::from([template.id.to_string()]),
+    }))
 }
 
 fn data_plane_desired_from_pairing_row(
@@ -1464,9 +1465,12 @@ fn data_plane_scope_filter(
 }
 
 pub fn merge_layered_desired(
+    local_did: &str,
+    peer_did: &str,
     base: Option<PairingDesired>,
     data_plane: Option<PairingDesired>,
 ) -> Option<PairingDesired> {
+    let base = if peer_did == local_did { None } else { base };
     let data_plane = data_plane.map(|mut desired| {
         if !desired.template_ids.contains(APP_COLLECTIONS_TEMPLATE) {
             desired.collections.clear();
@@ -1514,12 +1518,13 @@ fn earned_bearer_readiness(
         return None;
     }
     let readiness_filter = desired.replicator_filter.get("BearerPairingReady")?;
-    let Some((field, claimant_did)) = single_string_eq(readiness_filter) else {
+    let Some(claimant_did) = conjunctive_string_eq(readiness_filter, "claimant_did") else {
+        tracing::warn!(
+            "BearerPairingReady filter has no unambiguous claimant_did equality; \
+             withholding readiness"
+        );
         return None;
     };
-    if field != "claimant_did" {
-        return None;
-    }
     let claimant_did = claimant_did.trim();
     if claimant_did.is_empty() {
         return None;
@@ -1530,10 +1535,16 @@ fn earned_bearer_readiness(
         claimant_did,
         local_did,
     );
-    if expected
-        .iter()
-        .any(|(collection, predicate)| desired.replicator_filter.get(collection) != Some(predicate))
-    {
+    if expected.iter().any(|(collection, predicate)| {
+        let Some(actual) = desired.replicator_filter.get(collection) else {
+            return true;
+        };
+        if collection == "BearerPairingReady" {
+            conjunctive_string_eq(actual, "claimant_did") != Some(claimant_did)
+        } else {
+            actual != predicate
+        }
+    }) {
         return None;
     }
     let address = desired
@@ -1543,6 +1554,43 @@ fn earned_bearer_readiness(
         .trim()
         .to_string();
     (!address.is_empty()).then(|| (claimant_did.to_string(), address, template.id.to_string()))
+}
+
+fn conjunctive_string_eq<'a>(filter: &'a FilterPredicate, field: &str) -> Option<&'a str> {
+    fn collect<'a>(filter: &'a FilterPredicate, field: &str, found: &mut Option<&'a str>) -> bool {
+        match filter {
+            FilterPredicate::Predicate(conditions) => {
+                let Some(condition) = conditions.get(field) else {
+                    return true;
+                };
+                let Some(value) = condition
+                    .as_object()
+                    .and_then(|condition| condition.get("_eq"))
+                    .and_then(serde_json::Value::as_str)
+                else {
+                    return false;
+                };
+                match found {
+                    Some(existing) => *existing == value,
+                    None => {
+                        *found = Some(value);
+                        true
+                    }
+                }
+            }
+            FilterPredicate::All(filters) => {
+                filters.iter().all(|filter| collect(filter, field, found))
+            }
+            FilterPredicate::Acp { .. } => false,
+        }
+    }
+
+    let mut found = None;
+    if collect(filter, field, &mut found) {
+        found
+    } else {
+        None
+    }
 }
 
 fn bearer_pairing_ready_record(
@@ -1603,6 +1651,9 @@ pub fn bearer_pairing_ready_upsert_mutation(
     let issuer_sig = escape_graphql_string(&bs58::encode(&record.sig).into_string());
     format!(
         r#"mutation {{
+            delete_BearerPairingReady(
+                filter: {{ readiness_key: {{ _eq: "{readiness_key}" }} }}
+            ) {{ _docID }}
             upsert_BearerPairingReady(
                 filter: {{ readiness_key: {{ _eq: "{readiness_key}" }} }},
                 add: {{

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -21,8 +21,8 @@ use super::graphql_helpers::{ensure_no_errors, first_row, graphql_string_list_li
 use super::network::{GraphqlNetworkStore, NetworkEndpointEntry, NetworkStore};
 use super::reciprocal::GraphqlReciprocalStore;
 use super::templates::{
-    resolve_template, scope_filter, Delivery, DidSource, PairingFilters, Scope,
-    APP_COLLECTIONS_TEMPLATE,
+    merge_pairing_filters, resolve_template, scope_filter, Delivery, DidSource, PairingFilters,
+    Scope, APP_COLLECTIONS_TEMPLATE,
 };
 use super::{
     compute_owned_pairing_diff, DiffOp, EmbeddedRemoteP2pAdmin, PairingActual, PairingApplied,
@@ -1331,10 +1331,7 @@ fn data_plane_scope_filter(
             .map(|&col| {
                 (
                     col.to_string(),
-                    super::templates::FilterPredicate {
-                        field: (*field).to_string(),
-                        value: local_did.to_string(),
-                    },
+                    super::templates::FilterPredicate::eq(*field, local_did),
                 )
             })
             .collect(),
@@ -1349,10 +1346,7 @@ fn data_plane_scope_filter(
                 };
                 (
                     rule.collection.to_string(),
-                    super::templates::FilterPredicate {
-                        field: rule.field.to_string(),
-                        value: value.to_string(),
-                    },
+                    super::templates::FilterPredicate::eq(rule.field, value),
                 )
             })
             .collect(),
@@ -1377,7 +1371,7 @@ pub fn merge_layered_desired(
             left.replicator_addresses.extend(right.replicator_addresses);
             left.replicator_collections
                 .extend(right.replicator_collections);
-            left.replicator_filter.extend(right.replicator_filter);
+            merge_pairing_filters(&mut left.replicator_filter, right.replicator_filter);
             left.template_ids.extend(right.template_ids);
             Some(left)
         }
@@ -1410,10 +1404,13 @@ fn earned_bearer_readiness(
         return None;
     }
     let readiness_filter = desired.replicator_filter.get("BearerPairingReady")?;
-    if readiness_filter.field != "claimant_did" {
+    let Some((field, claimant_did)) = readiness_filter.single_string_eq() else {
+        return None;
+    };
+    if field != "claimant_did" {
         return None;
     }
-    let claimant_did = readiness_filter.value.trim();
+    let claimant_did = claimant_did.trim();
     if claimant_did.is_empty() {
         return None;
     }

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -874,8 +874,7 @@ impl GraphqlPairingStateStore {
         let query = format!(
             r#"{{
                 BearerPairingReady(
-                    filter: {{ readiness_key: {{ _eq: "{readiness_key}" }} }},
-                    limit: 1
+                    filter: {{ readiness_key: {{ _eq: "{readiness_key}" }} }}
                 ) {{
                     issuer_did
                     claimant_did
@@ -889,39 +888,45 @@ impl GraphqlPairingStateStore {
         );
         let response = self.node.execute(&query).await;
         ensure_no_errors(&response, "query BearerPairingReady")?;
-        let Some(row) = first_row::<BearerPairingReadyRow>(&response, "BearerPairingReady")? else {
-            return Ok(false);
-        };
-        let Some(existing) = bearer_pairing_ready_record(&row)? else {
-            return Ok(false);
-        };
-        if existing.issuer_did != expected.issuer_did
-            || existing.claimant_did != expected.claimant_did
-            || existing.peer_id != expected.peer_id
-            || existing.address != expected.address
-            || existing.template != expected.template
-        {
-            return Ok(false);
-        }
-        match self
-            .identity
-            .verify(
-                &existing.issuer_did,
-                &existing.signing_payload(),
-                &existing.sig,
-            )
-            .await
-        {
-            Ok(valid) => Ok(valid),
-            Err(error) => {
-                tracing::warn!(
+        for row in rows::<BearerPairingReadyRow>(&response, "BearerPairingReady")? {
+            let existing = match bearer_pairing_ready_record(&row) {
+                Ok(Some(existing)) => existing,
+                Ok(None) => continue,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "failed to decode existing bearer readiness acknowledgement"
+                    );
+                    continue;
+                }
+            };
+            if existing.issuer_did != expected.issuer_did
+                || existing.claimant_did != expected.claimant_did
+                || existing.peer_id != expected.peer_id
+                || existing.address != expected.address
+                || existing.template != expected.template
+            {
+                continue;
+            }
+            match self
+                .identity
+                .verify(
+                    &existing.issuer_did,
+                    &existing.signing_payload(),
+                    &existing.sig,
+                )
+                .await
+            {
+                Ok(true) => return Ok(true),
+                Ok(false) => {}
+                Err(error) => tracing::warn!(
                     error = %error,
                     claimant_did = %existing.claimant_did,
-                    "failed to verify existing bearer readiness acknowledgement; rewriting it"
-                );
-                Ok(false)
+                    "failed to verify existing bearer readiness acknowledgement"
+                ),
             }
         }
+        Ok(false)
     }
 
     async fn upsert_bearer_readiness(
@@ -964,10 +969,14 @@ impl GraphqlPairingStateStore {
 
     async fn delete_bearer_readiness_for_peer(&self, peer_id: &str) -> Result<()> {
         let peer_id = escape_graphql_string(peer_id);
+        let issuer_did = escape_graphql_string(self.identity.did());
         let mutation = format!(
             r#"mutation {{
                 delete_BearerPairingReady(
-                    filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}
+                    filter: {{
+                        peer_id: {{ _eq: "{peer_id}" }},
+                        issuer_did: {{ _eq: "{issuer_did}" }}
+                    }}
                 ) {{ _docID }}
             }}"#
         );
@@ -1292,6 +1301,9 @@ fn desired_from_pairing_row(
     }
 
     let peer_did = row.agent_did.as_deref().map(str::trim).unwrap_or_default();
+    if peer_did == local_did {
+        return Ok(None);
+    }
     if peer_did.is_empty() && scope_requires_peer_did(&template.scope) {
         anyhow::bail!(
             "pairing row for peer-DID-dependent template {template_id:?} has a blank \

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -46,9 +46,7 @@ pub trait PairingStateStore: Send + Sync {
 
     async fn load_applied(&self, peer_id: &str) -> Result<PairingApplied>;
 
-    async fn save_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()>;
-
-    async fn delete_applied(&self, peer_id: &str) -> Result<()>;
+    async fn persist_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()>;
 
     async fn list_peer_ids(&self) -> Result<BTreeSet<String>>;
 
@@ -210,7 +208,41 @@ async fn reconcile_prepared_peer(
         });
     };
     let desired_state = desired.clone().unwrap_or_default();
-    let actual = read_actual(admin).await?;
+    let mut actual = read_actual(admin).await?;
+
+    if applied.replicator_addresses != desired_state.replicator_addresses
+        && same_replicator_peers(
+            &applied.replicator_addresses,
+            &desired_state.replicator_addresses,
+        )
+        && normalize_replicator_routes(&mut actual, &desired_state.replicator_addresses)
+    {
+        applied.replicator_addresses = desired_state.replicator_addresses.clone();
+        store.persist_applied(&peer_id, &applied).await?;
+        tracing::info!(
+            peer_id = %peer_id,
+            "refreshed route for existing replicator peer"
+        );
+    }
+
+    if desired.is_some() {
+        let previous_count = applied.replicator_addresses.len();
+        applied.replicator_addresses.retain(|address| {
+            desired_state.replicator_addresses.contains(address)
+                || actual.state.replicator_addresses.contains(address)
+        });
+        if applied.replicator_addresses.len() != previous_count {
+            if applied.replicator_addresses.is_empty() {
+                applied.replicator_filter.clear();
+            }
+            store.persist_applied(&peer_id, &applied).await?;
+            tracing::info!(
+                peer_id = %peer_id,
+                pruned = previous_count - applied.replicator_addresses.len(),
+                "pruned stale applied replicator endpoints"
+            );
+        }
+    }
 
     let ops = compute_owned_pairing_diff(&desired_state, &actual.state, &applied);
     let mut ops_applied = Vec::new();
@@ -249,12 +281,14 @@ async fn reconcile_prepared_peer(
     for op in ops {
         apply_op(admin, &op, &desired_state, &actual).await?;
         update_applied_after_success(&mut applied, &op, &desired_state);
-        persist_applied(store, &peer_id, &applied).await?;
+        store.persist_applied(&peer_id, &applied).await?;
         ops_applied.push(op);
     }
 
     if desired.is_none() && !applied.is_empty() {
-        store.delete_applied(&peer_id).await?;
+        store
+            .persist_applied(&peer_id, &PairingApplied::default())
+            .await?;
     }
     store
         .reconcile_bearer_readiness(&peer_id, desired.as_ref(), &applied)
@@ -285,6 +319,63 @@ async fn peer_already_active(admin: &dyn RemoteP2pAdmin, peer_id: &str) -> bool 
             .map(|(parsed, _)| parsed.as_str() == peer_id)
             .unwrap_or_else(|_| entry.contains(peer_id))
     })
+}
+
+fn replicator_peers(addresses: &BTreeSet<String>) -> Option<BTreeSet<String>> {
+    addresses
+        .iter()
+        .map(|address| {
+            parse_public_peer_addr(address)
+                .ok()
+                .map(|(peer_id, _)| peer_id.to_string())
+        })
+        .collect()
+}
+
+fn same_replicator_peers(left: &BTreeSet<String>, right: &BTreeSet<String>) -> bool {
+    !left.is_empty()
+        && replicator_peers(left)
+            .zip(replicator_peers(right))
+            .is_some_and(|(left, right)| left == right)
+}
+
+fn normalize_replicator_routes(
+    actual: &mut ActualSnapshot,
+    desired_addresses: &BTreeSet<String>,
+) -> bool {
+    if !same_replicator_peers(&actual.state.replicator_addresses, desired_addresses) {
+        return false;
+    }
+
+    let desired_by_peer = desired_addresses
+        .iter()
+        .filter_map(|address| {
+            parse_public_peer_addr(address)
+                .ok()
+                .map(|(peer_id, _)| (peer_id.to_string(), address.clone()))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let normalize_key = |address: &str| {
+        parse_public_peer_addr(address)
+            .ok()
+            .and_then(|(peer_id, _)| desired_by_peer.get(&peer_id.to_string()).cloned())
+            .unwrap_or_else(|| address.to_string())
+    };
+    actual.state.replicator_addresses = desired_addresses.clone();
+    actual.state.replicator_collections = std::mem::take(&mut actual.state.replicator_collections)
+        .into_iter()
+        .map(|(address, collections)| (normalize_key(&address), collections))
+        .collect();
+    actual.replicator_ids_by_addr = std::mem::take(&mut actual.replicator_ids_by_addr)
+        .into_iter()
+        .map(|(address, id)| (normalize_key(&address), id))
+        .collect();
+    actual.replicator_collections_by_addr =
+        std::mem::take(&mut actual.replicator_collections_by_addr)
+            .into_iter()
+            .map(|(address, collections)| (normalize_key(&address), collections))
+            .collect();
+    true
 }
 
 pub async fn run_pairing_reconciler(
@@ -687,18 +778,6 @@ pub fn update_applied_after_success(
     }
 }
 
-async fn persist_applied(
-    store: &dyn PairingStateStore,
-    peer_id: &str,
-    applied: &PairingApplied,
-) -> Result<()> {
-    if applied.is_empty() {
-        store.delete_applied(peer_id).await
-    } else {
-        store.save_applied(peer_id, applied).await
-    }
-}
-
 #[derive(Clone)]
 pub struct GraphqlPairingStateStore {
     node: Arc<EmbeddedNode>,
@@ -755,6 +834,25 @@ impl GraphqlPairingStateStore {
             peer_id,
             self.identity.did(),
         ))
+    }
+
+    async fn load_canonical_applied(&self, peer_id: &str) -> Result<Option<AppliedStateRow>> {
+        let peer_id = escape_graphql_string(peer_id);
+        let query = format!(
+            r#"{{
+                PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}) {{
+                    _docID
+                    collections
+                    replicator_addresses
+                    replicator_filter
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        ensure_no_errors(&response, "query PeerPairingApplied")?;
+        Ok(rows::<AppliedStateRow>(&response, "PeerPairingApplied")?
+            .into_iter()
+            .min_by(|left, right| left.doc_id.cmp(&right.doc_id)))
     }
 
     async fn bearer_readiness_is_current(
@@ -929,82 +1027,73 @@ impl PairingStateStore for GraphqlPairingStateStore {
     }
 
     async fn load_applied(&self, peer_id: &str) -> Result<PairingApplied> {
-        let peer_id = escape_graphql_string(peer_id);
-        let query = format!(
-            r#"{{
-                PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}) {{
-                    collections
-                    replicator_addresses
-                    replicator_filter
-                }}
-            }}"#
-        );
-        let response = self.node.execute(&query).await;
-        ensure_no_errors(&response, "query PeerPairingApplied")?;
-        Ok(
-            first_row::<PairingStateRow>(&response, "PeerPairingApplied")?
-                .map(|row| PairingApplied {
-                    collections: row.collections.unwrap_or_default().into_iter().collect(),
-                    replicator_addresses: row
-                        .replicator_addresses
-                        .unwrap_or_default()
-                        .into_iter()
-                        .collect(),
-                    replicator_filter: decode_replicator_filter(row.replicator_filter.as_deref()),
-                })
-                .unwrap_or_default(),
-        )
+        Ok(self
+            .load_canonical_applied(peer_id)
+            .await?
+            .map(AppliedStateRow::into_applied)
+            .unwrap_or_default())
     }
 
-    async fn save_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()> {
+    async fn persist_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()> {
+        if applied.is_empty() {
+            let peer_id = escape_graphql_string(peer_id);
+            let mutation = format!(
+                r#"mutation {{
+                    delete_PeerPairingApplied(
+                        filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}
+                    ) {{ _docID }}
+                }}"#
+            );
+            return crate::graphql::graphql_mutation_with_transaction_retry(
+                &self.node,
+                &mutation,
+                "delete PeerPairingApplied",
+            )
+            .await
+            .map(|_| ());
+        }
+
+        let existing_doc_id = self
+            .load_canonical_applied(peer_id)
+            .await?
+            .map(|row| row.doc_id);
         let peer_id = escape_graphql_string(peer_id);
         let collections = graphql_nullable_string_array(&applied.collections);
         let replicator_addresses = graphql_nullable_string_array(&applied.replicator_addresses);
         let replicator_filter = graphql_nullable_filter_literal(&applied.replicator_filter);
         let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
-        let mutation = format!(
-            r#"mutation {{
-                upsert_PeerPairingApplied(
-                    filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
-                    add: {{
+        let mutation = match existing_doc_id {
+            Some(doc_id) => format!(
+                r#"mutation {{
+                    update_PeerPairingApplied(
+                        filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                        input: {{
+                            collections: {collections},
+                            replicator_addresses: {replicator_addresses},
+                            replicator_filter: {replicator_filter},
+                            updated_at: "{now}"
+                        }}
+                    ) {{ _docID }}
+                }}"#,
+                doc_id = escape_graphql_string(&doc_id),
+            ),
+            None => format!(
+                r#"mutation {{
+                    create_PeerPairingApplied(input: {{
                         peer_id: "{peer_id}",
                         collections: {collections},
                         replicator_addresses: {replicator_addresses},
                         replicator_filter: {replicator_filter},
                         created_at: "{now}",
                         updated_at: "{now}"
-                    }},
-                    update: {{
-                        collections: {collections},
-                        replicator_addresses: {replicator_addresses},
-                        replicator_filter: {replicator_filter},
-                        updated_at: "{now}"
-                    }}
-                ) {{ _docID }}
-            }}"#
-        );
+                    }}) {{ _docID }}
+                }}"#,
+            ),
+        };
         crate::graphql::graphql_mutation_with_transaction_retry(
             &self.node,
             &mutation,
-            "upsert PeerPairingApplied",
-        )
-        .await
-        .map(|_| ())
-    }
-
-    async fn delete_applied(&self, peer_id: &str) -> Result<()> {
-        let peer_id = escape_graphql_string(peer_id);
-        let mutation = format!(
-            r#"mutation {{
-                delete_PeerPairingApplied(
-                    filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}
-                ) {{ _docID }}
-            }}"#
-        );
-        crate::graphql::graphql_mutation_with_transaction_retry(
-            &self.node,
-            &mutation,
-            "delete PeerPairingApplied",
+            "save PeerPairingApplied",
         )
         .await
         .map(|_| ())
@@ -1095,8 +1184,30 @@ struct PairingStateRow {
     replicator_addresses: Option<Vec<String>>,
     #[serde(default)]
     template: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AppliedStateRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    collections: Option<Vec<String>>,
+    replicator_addresses: Option<Vec<String>>,
     #[serde(default)]
     replicator_filter: Option<String>,
+}
+
+impl AppliedStateRow {
+    fn into_applied(self) -> PairingApplied {
+        PairingApplied {
+            collections: self.collections.unwrap_or_default().into_iter().collect(),
+            replicator_addresses: self
+                .replicator_addresses
+                .unwrap_or_default()
+                .into_iter()
+                .collect(),
+            replicator_filter: decode_replicator_filter(self.replicator_filter.as_deref()),
+        }
+    }
 }
 
 pub const DEFAULT_PAIRING_TEMPLATE: &str = "conversation";

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -245,7 +245,6 @@ fn data_plane_desired_uses_signed_endpoint_address_and_requester_did() {
             collections: None,
             replicator_addresses: Some(vec!["/ip4/192.0.2.1/tcp/9999/p2p/forged".to_string()]),
             template: Some("conversation".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:self",
@@ -279,7 +278,6 @@ fn data_plane_subagent_coordinator_uses_signed_peer_for_targeted_bridge() {
             collections: None,
             replicator_addresses: Some(vec![signed_endpoint.address.clone()]),
             template: Some("subagent-coordinator".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:coord",
@@ -311,7 +309,6 @@ fn data_plane_subagent_host_scopes_return_projection_to_signed_requester() {
             collections: None,
             replicator_addresses: Some(vec![signed_endpoint.address.clone()]),
             template: Some("subagent-host".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:host",
@@ -350,7 +347,6 @@ fn data_plane_desired_rejects_foreign_agent_did_scope() {
             collections: None,
             replicator_addresses: Some(vec![signed_endpoint.address.clone()]),
             template: Some("conversation".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:self",
@@ -380,7 +376,7 @@ struct MockStore {
     list_peer_ids_calls: Mutex<usize>,
     list_peer_ids_retry_started: Option<Arc<tokio::sync::Notify>>,
     list_peer_ids_retry_release: Option<Arc<tokio::sync::Notify>>,
-    save_applied_completed: Option<Arc<tokio::sync::Notify>>,
+    persist_applied_completed: Option<Arc<tokio::sync::Notify>>,
 }
 
 impl Default for MockStore {
@@ -394,7 +390,7 @@ impl Default for MockStore {
             list_peer_ids_calls: Mutex::new(0),
             list_peer_ids_retry_started: None,
             list_peer_ids_retry_release: None,
-            save_applied_completed: None,
+            persist_applied_completed: None,
         }
     }
 }
@@ -422,18 +418,16 @@ impl PairingStateStore for MockStore {
         Ok(self.applied.lock().unwrap().clone())
     }
 
-    async fn save_applied(&self, _peer_id: &str, applied: &PairingApplied) -> Result<()> {
+    async fn persist_applied(&self, _peer_id: &str, applied: &PairingApplied) -> Result<()> {
         *self.applied.lock().unwrap() = applied.clone();
-        self.saved.lock().unwrap().push(applied.clone());
-        if let Some(completed) = &self.save_applied_completed {
-            completed.notify_one();
+        if applied.is_empty() {
+            *self.deleted.lock().unwrap() += 1;
+        } else {
+            self.saved.lock().unwrap().push(applied.clone());
+            if let Some(completed) = &self.persist_applied_completed {
+                completed.notify_one();
+            }
         }
-        Ok(())
-    }
-
-    async fn delete_applied(&self, _peer_id: &str) -> Result<()> {
-        *self.applied.lock().unwrap() = PairingApplied::default();
-        *self.deleted.lock().unwrap() += 1;
         Ok(())
     }
 
@@ -482,16 +476,13 @@ impl PairingStateStore for MultiPeerStore {
             .unwrap_or_default())
     }
 
-    async fn save_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()> {
-        self.applied
-            .lock()
-            .unwrap()
-            .insert(peer_id.to_string(), applied.clone());
-        Ok(())
-    }
-
-    async fn delete_applied(&self, peer_id: &str) -> Result<()> {
-        self.applied.lock().unwrap().remove(peer_id);
+    async fn persist_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()> {
+        let mut states = self.applied.lock().unwrap();
+        if applied.is_empty() {
+            states.remove(peer_id);
+        } else {
+            states.insert(peer_id.to_string(), applied.clone());
+        }
         Ok(())
     }
 
@@ -774,7 +765,7 @@ async fn pairing_reconciler_retries_initial_enumeration_failure_then_cancels_cle
         list_peer_ids_failures: Mutex::new(1),
         list_peer_ids_retry_started: Some(retry_started.clone()),
         list_peer_ids_retry_release: Some(retry_release.clone()),
-        save_applied_completed: Some(convergence_completed.clone()),
+        persist_applied_completed: Some(convergence_completed.clone()),
         ..Default::default()
     };
     let admin = MockAdmin::default();
@@ -1304,14 +1295,16 @@ async fn active_peer_skips_redial_and_upgrades_data_plane_replicator() {
 /// contains that peer. Otherwise the subsequent replicator install can
 /// reuse the stale route and the response never reaches the relaunched app.
 #[tokio::test]
-async fn changed_endpoint_redials_active_peer_before_replacing_replicator() {
+async fn changed_endpoint_redials_without_replacing_same_peer_replicator() {
+    let old_address = "stable-peer@127.0.0.1:4100";
+    let fresh_address = "stable-peer@127.0.0.1:4200";
     let store = MockStore::with_desired(Some(PairingDesired {
-        replicator_addresses: set(&["addr2"]),
+        replicator_addresses: set(&[fresh_address]),
         replicator_collections: set(&["AgentRequest"]),
         ..Default::default()
     }));
     *store.applied.lock().unwrap() = PairingApplied {
-        replicator_addresses: set(&["addr1"]),
+        replicator_addresses: set(&[old_address]),
         ..Default::default()
     };
     let admin = MockAdmin {
@@ -1319,11 +1312,11 @@ async fn changed_endpoint_redials_active_peer_before_replacing_replicator() {
         ..Default::default()
     };
     admin.replicators.lock().unwrap().insert(
-        "addr1".into(),
+        old_address.into(),
         RemoteReplicator {
             id: Some("id-addr1".into()),
             collections: vec![mock_collection_id("AgentRequest")],
-            address: Some("addr1".into()),
+            address: Some(old_address.into()),
         },
     );
 
@@ -1331,14 +1324,116 @@ async fn changed_endpoint_redials_active_peer_before_replacing_replicator() {
         .await
         .expect("changed endpoint reconcile");
 
-    assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr2"]]);
     assert_eq!(
-        outcome.ops_applied,
-        vec![
-            DiffOp::InstallReplicator("addr2".into()),
-            DiffOp::TeardownReplicator("addr1".into()),
-        ]
+        *admin.connects.lock().unwrap(),
+        vec![vec![fresh_address.to_string()]]
     );
+    assert!(outcome.ops_applied.is_empty());
+    assert_eq!(
+        store.applied.lock().unwrap().replicator_addresses,
+        set(&[fresh_address])
+    );
+}
+
+#[tokio::test]
+async fn applied_state_persist_targets_one_canonical_document_when_duplicates_exist() {
+    let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+    node.add_schema(
+        r#"
+        type PeerPairingApplied {
+            peer_id: String
+            collections: [String!]
+            replicator_addresses: [String!]
+            replicator_filter: String
+            created_at: DateTime
+            updated_at: DateTime
+        }
+        "#,
+    )
+    .await
+    .unwrap();
+    for (address, timestamp) in [
+        ("old-a", "2026-08-19T00:00:00Z"),
+        ("old-b", "2026-08-19T00:01:00Z"),
+    ] {
+        let response = node
+            .execute(&format!(
+                r#"mutation {{
+                    create_PeerPairingApplied(input: {{
+                        peer_id: "peer-a",
+                        replicator_addresses: ["{address}"],
+                        created_at: "{timestamp}",
+                        updated_at: "{timestamp}"
+                    }}) {{ _docID }}
+                }}"#
+            ))
+            .await;
+        assert!(!response.has_errors(), "seed failed: {:?}", response.errors);
+    }
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let identity = Arc::new(
+        crate::identity::KeyIdentity::load_or_create(tempdir.path().join("agent.key"), None)
+            .unwrap(),
+    );
+    let store = GraphqlPairingStateStore::new(node.clone(), identity);
+    store
+        .persist_applied(
+            "peer-a",
+            &PairingApplied {
+                replicator_addresses: set(&["fresh"]),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("duplicate-tolerant save");
+
+    let response = node
+        .execute(
+            r#"{
+                PeerPairingApplied(filter: { peer_id: { _eq: "peer-a" } }) {
+                    _docID
+                    replicator_addresses
+                }
+            }"#,
+        )
+        .await;
+    let mut rows = rows::<AppliedStateRow>(&response, "PeerPairingApplied").unwrap();
+    rows.sort_by(|left, right| left.doc_id.cmp(&right.doc_id));
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].replicator_addresses, Some(vec!["fresh".into()]));
+    assert_ne!(rows[1].replicator_addresses, Some(vec!["fresh".into()]));
+}
+
+#[tokio::test]
+async fn stale_applied_endpoint_absent_from_actual_is_pruned_once() {
+    let desired = PairingDesired {
+        replicator_addresses: set(&["addr2"]),
+        replicator_collections: set(&["AgentRequest"]),
+        ..Default::default()
+    };
+    let store = MockStore::with_desired(Some(desired));
+    *store.applied.lock().unwrap() = PairingApplied {
+        replicator_addresses: set(&["addr1", "addr2"]),
+        ..Default::default()
+    };
+    let admin = MockAdmin {
+        active: Mutex::new(vec!["peer-a".into()]),
+        ..Default::default()
+    };
+    let first = reconcile_peer_tick(&admin, &store, "peer-a")
+        .await
+        .expect("first reconcile");
+    let second = reconcile_peer_tick(&admin, &store, "peer-a")
+        .await
+        .expect("second reconcile");
+
+    assert_eq!(
+        first.ops_applied,
+        vec![DiffOp::InstallReplicator("addr2".into())]
+    );
+    assert!(second.ops_applied.is_empty());
+    assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr2"]]);
     assert_eq!(
         store.applied.lock().unwrap().replicator_addresses,
         set(&["addr2"])
@@ -1618,7 +1713,6 @@ fn desired_row(template: Option<&str>, agent_did: Option<&str>) -> PairingStateR
         collections: None,
         replicator_addresses: Some(vec!["addr1".into()]),
         template: template.map(str::to_string),
-        replicator_filter: None,
     }
 }
 
@@ -1750,7 +1844,6 @@ fn app_collections_on_control_plane_path_soft_skips() {
             collections: None,
             replicator_addresses: Some(vec!["addr-b".to_string()]),
             template: Some("app-collections".to_string()),
-            replicator_filter: None,
         },
         "did:key:self",
     )
@@ -1774,7 +1867,6 @@ fn app_collections_row_resolves_row_collections_as_subscription_and_replicator()
             collections: Some(vec!["ChangeProposed".to_string()]),
             replicator_addresses: None,
             template: Some("app-collections".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:self",
@@ -1803,7 +1895,6 @@ fn app_collections_empty_collections_soft_skips() {
             collections: Some(vec!["   ".to_string()]),
             replicator_addresses: None,
             template: Some("app-collections".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:self",
@@ -1831,7 +1922,6 @@ fn foreign_agent_did_still_hard_fails_whole_peer_load() {
             collections: Some(vec!["ChangeProposed".to_string()]),
             replicator_addresses: None,
             template: Some("app-collections".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:self",
@@ -2082,7 +2172,6 @@ fn data_plane_desired_machine_scopes_conversation_and_owned_directory() {
             collections: None,
             replicator_addresses: Some(vec![signed_endpoint.address.clone()]),
             template: Some("machine".to_string()),
-            replicator_filter: None,
         },
         &signed_endpoint,
         "did:key:self",

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -1311,7 +1311,7 @@ async fn active_peer_skips_redial_and_upgrades_data_plane_replicator() {
 /// Route rotation is peer-scoped even with other replicators present or an
 /// address-less restored record.
 #[tokio::test]
-async fn changed_endpoint_redials_without_replacing_same_peer_replicator() {
+async fn changed_endpoint_replaces_same_peer_replicator_teardown_first() {
     let old_address = "stable-peer@127.0.0.1:4100";
     let fresh_address = "stable-peer@127.0.0.1:4200";
     let store = MockStore::with_desired(Some(PairingDesired {
@@ -1352,11 +1352,32 @@ async fn changed_endpoint_redials_without_replacing_same_peer_replicator() {
         *admin.connects.lock().unwrap(),
         vec![vec![fresh_address.to_string()]]
     );
-    assert!(outcome.ops_applied.is_empty());
+    assert_eq!(
+        outcome.ops_applied,
+        vec![
+            DiffOp::TeardownReplicator(old_address.to_string()),
+            DiffOp::InstallReplicator(fresh_address.to_string()),
+        ]
+    );
     assert_eq!(
         store.applied.lock().unwrap().replicator_addresses,
         set(&[fresh_address])
     );
+}
+
+#[tokio::test]
+async fn empty_persist_forgets_deleted_canonical_document() {
+    let store = MockStore::default();
+    let mut applied = LoadedPairingApplied {
+        canonical_doc_id: Some("deleted-doc".to_string()),
+        ..Default::default()
+    };
+
+    persist_applied_record(&store, "peer-a", &mut applied)
+        .await
+        .expect("empty persist");
+
+    assert_eq!(applied.canonical_doc_id, None);
 }
 
 #[tokio::test]
@@ -1428,7 +1449,7 @@ async fn applied_state_persist_targets_one_canonical_document_when_duplicates_ex
 }
 
 #[tokio::test]
-async fn stale_applied_endpoint_absent_from_actual_is_pruned_once() {
+async fn stale_applied_endpoint_absent_from_actual_is_torn_down_once() {
     let desired = PairingDesired {
         replicator_addresses: set(&["addr2"]),
         replicator_collections: set(&["AgentRequest"]),
@@ -1452,7 +1473,10 @@ async fn stale_applied_endpoint_absent_from_actual_is_pruned_once() {
 
     assert_eq!(
         first.ops_applied,
-        vec![DiffOp::InstallReplicator("addr2".into())]
+        vec![
+            DiffOp::TeardownReplicator("addr1".into()),
+            DiffOp::InstallReplicator("addr2".into()),
+        ]
     );
     assert!(second.ops_applied.is_empty());
     assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr2"]]);
@@ -1621,7 +1645,7 @@ async fn second_tick_converges_across_name_and_id_spaces() {
 }
 
 #[tokio::test]
-async fn teardown_is_restricted_to_applied_actual_extras() {
+async fn teardown_is_restricted_to_applied_extras() {
     // Applied holds collection *names* (the observable contract). The remote
     // subscription set is tracked in id-space internally by the mock, but
     // `read_actual` reverse-resolves it to names for the diff.

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -4,7 +4,9 @@ use anyhow::anyhow;
 use events::Bus;
 
 use super::*;
-use crate::agent::p2p_reconcile::{RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator};
+use crate::agent::p2p_reconcile::{
+    FilterPredicate, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
+};
 
 fn set(values: &[&str]) -> BTreeSet<String> {
     values.iter().map(|value| value.to_string()).collect()
@@ -14,10 +16,7 @@ fn one_filter(collection: &str, field: &str, value: &str) -> PairingFilters {
     let mut filters = PairingFilters::new();
     filters.insert(
         collection.to_string(),
-        crate::agent::p2p_reconcile::FilterPredicate {
-            field: field.to_string(),
-            value: value.to_string(),
-        },
+        crate::agent::p2p_reconcile::FilterPredicate::eq(field, value),
     );
     filters
 }
@@ -66,11 +65,10 @@ fn bearer_readiness_requires_exact_applied_conversation_replicator() {
     );
 
     let mut wrong_filter = applied;
-    wrong_filter
-        .replicator_filter
-        .get_mut("AgentRequest")
-        .expect("request filter")
-        .value = "did:key:someone-else".to_string();
+    wrong_filter.replicator_filter.insert(
+        "AgentRequest".to_string(),
+        FilterPredicate::eq("requester_did", "did:key:someone-else"),
+    );
     assert_eq!(
         earned_bearer_readiness(Some(&desired), &wrong_filter, "did:key:issuer"),
         None
@@ -131,7 +129,7 @@ fn merge_desired_unions_control_and_data_plane_state() {
         merged
             .replicator_filter
             .get("AgentRequest")
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("agent_did", "did:key:a"))
     );
     assert!(!merged.replicator_filter.contains_key("AgentNetwork"));
@@ -242,7 +240,7 @@ fn data_plane_desired_uses_signed_endpoint_address_and_requester_did() {
         desired
             .replicator_filter
             .get("AgentRequest")
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("requester_did", "did:key:peer-b"))
     );
 }
@@ -274,7 +272,7 @@ fn data_plane_subagent_coordinator_uses_signed_peer_for_targeted_bridge() {
         desired
             .replicator_filter
             .get("AgentToolCall")
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("spawn_target_did", "did:key:host"))
     );
 }
@@ -311,8 +309,10 @@ fn data_plane_subagent_host_scopes_return_projection_to_signed_requester() {
     );
     assert_eq!(desired.replicator_filter.len(), 4);
     for predicate in desired.replicator_filter.values() {
-        assert_eq!(predicate.field, "requester_did");
-        assert_eq!(predicate.value, "did:key:coord");
+        assert_eq!(
+            predicate.single_string_eq(),
+            Some(("requester_did", "did:key:coord"))
+        );
     }
 }
 
@@ -1621,8 +1621,10 @@ fn push_template_resolves_to_filter_without_subscription() {
         .replicator_filter
         .get("AgentRequest")
         .expect("AgentRequest filter");
-    assert_eq!(pred.field, "requester_did");
-    assert_eq!(pred.value, "did:key:bob");
+    assert_eq!(
+        pred.single_string_eq(),
+        Some(("requester_did", "did:key:bob"))
+    );
 }
 
 /// A `Replicate` template (agent-config) subscribes to its collection set
@@ -1683,7 +1685,7 @@ fn subagent_coordinator_template_filters_only_targeted_bridge() {
         desired
             .replicator_filter
             .get("AgentToolCall")
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("spawn_target_did", "did:key:host"))
     );
 }
@@ -1709,8 +1711,10 @@ fn subagent_host_template_filters_return_projection_to_requester() {
     );
     assert_eq!(desired.replicator_filter.len(), 4);
     for predicate in desired.replicator_filter.values() {
-        assert_eq!(predicate.field, "requester_did");
-        assert_eq!(predicate.value, "did:key:coord");
+        assert_eq!(
+            predicate.single_string_eq(),
+            Some(("requester_did", "did:key:coord"))
+        );
     }
 }
 
@@ -1858,8 +1862,10 @@ async fn push_template_installs_filtered_replicator_without_subscription() {
         .1
         .get("AgentRequest")
         .expect("AgentRequest filter on installed replicator");
-    assert_eq!(pred.field, "requester_did");
-    assert_eq!(pred.value, "did:key:bob");
+    assert_eq!(
+        pred.single_string_eq(),
+        Some(("requester_did", "did:key:bob"))
+    );
 }
 
 /// End-to-end reconcile of a `Replicate` (agent-config) template: it both
@@ -1922,10 +1928,10 @@ async fn changing_scoped_did_reinstalls_replicator() {
     for col in resolve_template("conversation").unwrap().collections.iter() {
         alice_filter.insert(
             (*col).to_string(),
-            crate::agent::p2p_reconcile::templates::FilterPredicate {
-                field: "requester_did".to_string(),
-                value: "did:key:alice".to_string(),
-            },
+            crate::agent::p2p_reconcile::templates::FilterPredicate::eq(
+                "requester_did",
+                "did:key:alice",
+            ),
         );
     }
     *store.applied.lock().unwrap() = PairingApplied {
@@ -1961,9 +1967,8 @@ async fn changing_scoped_did_reinstalls_replicator() {
     assert_eq!(
         last.1
             .get("AgentRequest")
-            .expect("AgentRequest filter")
-            .value,
-        "did:key:bob"
+            .and_then(FilterPredicate::single_string_eq),
+        Some(("requester_did", "did:key:bob"))
     );
 }
 
@@ -2001,10 +2006,7 @@ async fn add_replicator_records_filters_at_seam() {
     let mut filters = PairingFilters::default();
     filters.insert(
         "AgentRequest".to_string(),
-        FilterPredicate {
-            field: "agent_did".to_string(),
-            value: "did:key:alice".to_string(),
-        },
+        FilterPredicate::eq("agent_did", "did:key:alice"),
     );
     admin
         .add_replicator(&addresses, &collections, &filters)
@@ -2016,8 +2018,10 @@ async fn add_replicator_records_filters_at_seam() {
     let recorded = &calls[1].1;
     assert_eq!(recorded.len(), 1);
     let pred = recorded.get("AgentRequest").expect("AgentRequest filter");
-    assert_eq!(pred.field, "agent_did");
-    assert_eq!(pred.value, "did:key:alice");
+    assert_eq!(
+        pred.single_string_eq(),
+        Some(("agent_did", "did:key:alice"))
+    );
 }
 
 #[test]
@@ -2082,7 +2086,7 @@ fn data_plane_desired_machine_scopes_conversation_and_owned_directory() {
             desired
                 .replicator_filter
                 .get(col)
-                .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+                .and_then(FilterPredicate::single_string_eq),
             Some(("requester_did", "did:key:peer-b")),
             "conversation collection {col} must be requester-scoped exactly like `conversation`"
         );
@@ -2091,7 +2095,7 @@ fn data_plane_desired_machine_scopes_conversation_and_owned_directory() {
         desired
             .replicator_filter
             .get(crate::agent::p2p_reconcile::templates::AGENT_DIRECTORY_COLLECTION)
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("source_did", "did:key:self"))
     );
 }
@@ -2129,14 +2133,16 @@ fn control_plane_desired_machine_scopes_conversation_and_owned_directory() {
             .replicator_filter
             .get(col)
             .unwrap_or_else(|| panic!("missing filter for conversation collection {col}"));
-        assert_eq!(pred.field, "requester_did");
-        assert_eq!(pred.value, "did:key:phone");
+        assert_eq!(
+            pred.single_string_eq(),
+            Some(("requester_did", "did:key:phone"))
+        );
     }
     assert_eq!(
         desired
             .replicator_filter
             .get(crate::agent::p2p_reconcile::templates::AGENT_DIRECTORY_COLLECTION)
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("source_did", "did:key:server"))
     );
 }

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -95,6 +95,22 @@ fn bearer_readiness_accepts_merged_conversation_layers() {
 }
 
 #[test]
+fn self_pairing_row_is_not_materialized() {
+    let desired = desired_from_pairing_row(
+        PairingStateRow {
+            agent_did: Some("did:key:self".to_string()),
+            collections: None,
+            replicator_addresses: Some(vec!["iroh-ticket".to_string()]),
+            template: Some("machine".to_string()),
+        },
+        "did:key:self",
+    )
+    .expect("pairing row parses");
+
+    assert!(desired.is_none());
+}
+
+#[test]
 fn bearer_readiness_mutation_escapes_signed_fields() {
     let record = BearerPairingReadyRecord {
         issuer_did: "did:key:issuer".to_string(),

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -76,6 +76,27 @@ fn bearer_readiness_requires_exact_applied_conversation_replicator() {
 }
 
 #[test]
+fn bearer_readiness_accepts_merged_conversation_layers() {
+    let control = bearer_desired("conversation", "did:key:claimant", "iroh-ticket");
+    let data = control.clone();
+    let desired = merge_layered_desired(Some(control), Some(data)).expect("merged desired");
+    let applied = PairingApplied {
+        replicator_addresses: desired.replicator_addresses.clone(),
+        replicator_filter: desired.replicator_filter.clone(),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        earned_bearer_readiness(Some(&desired), &applied, "did:key:issuer"),
+        Some((
+            "did:key:claimant".to_string(),
+            "iroh-ticket".to_string(),
+            "conversation".to_string()
+        ))
+    );
+}
+
+#[test]
 fn bearer_readiness_mutation_escapes_signed_fields() {
     let record = BearerPairingReadyRecord {
         issuer_did: "did:key:issuer".to_string(),

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -4,9 +4,7 @@ use anyhow::anyhow;
 use events::Bus;
 
 use super::*;
-use crate::agent::p2p_reconcile::{
-    FilterPredicate, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
-};
+use crate::agent::p2p_reconcile::{RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator};
 
 fn set(values: &[&str]) -> BTreeSet<String> {
     values.iter().map(|value| value.to_string()).collect()
@@ -16,7 +14,7 @@ fn one_filter(collection: &str, field: &str, value: &str) -> PairingFilters {
     let mut filters = PairingFilters::new();
     filters.insert(
         collection.to_string(),
-        crate::agent::p2p_reconcile::FilterPredicate::eq(field, value),
+        crate::agent::p2p_reconcile::equality_filter(field, value),
     );
     filters
 }
@@ -67,7 +65,7 @@ fn bearer_readiness_requires_exact_applied_conversation_replicator() {
     let mut wrong_filter = applied;
     wrong_filter.replicator_filter.insert(
         "AgentRequest".to_string(),
-        FilterPredicate::eq("requester_did", "did:key:someone-else"),
+        equality_filter("requester_did", "did:key:someone-else"),
     );
     assert_eq!(
         earned_bearer_readiness(Some(&desired), &wrong_filter, "did:key:issuer"),
@@ -150,7 +148,7 @@ fn merge_desired_unions_control_and_data_plane_state() {
         merged
             .replicator_filter
             .get("AgentRequest")
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("agent_did", "did:key:a"))
     );
     assert!(!merged.replicator_filter.contains_key("AgentNetwork"));
@@ -260,7 +258,7 @@ fn data_plane_desired_uses_signed_endpoint_address_and_requester_did() {
         desired
             .replicator_filter
             .get("AgentRequest")
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("requester_did", "did:key:peer-b"))
     );
 }
@@ -291,7 +289,7 @@ fn data_plane_subagent_coordinator_uses_signed_peer_for_targeted_bridge() {
         desired
             .replicator_filter
             .get("AgentToolCall")
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("spawn_target_did", "did:key:host"))
     );
 }
@@ -328,7 +326,7 @@ fn data_plane_subagent_host_scopes_return_projection_to_signed_requester() {
     assert_eq!(desired.replicator_filter.len(), 4);
     for predicate in desired.replicator_filter.values() {
         assert_eq!(
-            predicate.single_string_eq(),
+            single_string_eq(predicate),
             Some(("requester_did", "did:key:coord"))
         );
     }
@@ -414,16 +412,19 @@ impl PairingStateStore for MockStore {
             .map_err(|message| anyhow!(message))
     }
 
-    async fn load_applied(&self, _peer_id: &str) -> Result<PairingApplied> {
-        Ok(self.applied.lock().unwrap().clone())
+    async fn load_applied(&self, _peer_id: &str) -> Result<LoadedPairingApplied> {
+        Ok(LoadedPairingApplied {
+            state: self.applied.lock().unwrap().clone(),
+            ..Default::default()
+        })
     }
 
-    async fn persist_applied(&self, _peer_id: &str, applied: &PairingApplied) -> Result<()> {
-        *self.applied.lock().unwrap() = applied.clone();
-        if applied.is_empty() {
+    async fn persist_applied(&self, _peer_id: &str, applied: &LoadedPairingApplied) -> Result<()> {
+        *self.applied.lock().unwrap() = applied.state.clone();
+        if applied.state.is_empty() {
             *self.deleted.lock().unwrap() += 1;
         } else {
-            self.saved.lock().unwrap().push(applied.clone());
+            self.saved.lock().unwrap().push(applied.state.clone());
             if let Some(completed) = &self.persist_applied_completed {
                 completed.notify_one();
             }
@@ -466,22 +467,25 @@ impl PairingStateStore for MultiPeerStore {
         Ok(self.desired.get(peer_id).cloned())
     }
 
-    async fn load_applied(&self, peer_id: &str) -> Result<PairingApplied> {
-        Ok(self
-            .applied
-            .lock()
-            .unwrap()
-            .get(peer_id)
-            .cloned()
-            .unwrap_or_default())
+    async fn load_applied(&self, peer_id: &str) -> Result<LoadedPairingApplied> {
+        Ok(LoadedPairingApplied {
+            state: self
+                .applied
+                .lock()
+                .unwrap()
+                .get(peer_id)
+                .cloned()
+                .unwrap_or_default(),
+            ..Default::default()
+        })
     }
 
-    async fn persist_applied(&self, peer_id: &str, applied: &PairingApplied) -> Result<()> {
+    async fn persist_applied(&self, peer_id: &str, applied: &LoadedPairingApplied) -> Result<()> {
         let mut states = self.applied.lock().unwrap();
-        if applied.is_empty() {
+        if applied.state.is_empty() {
             states.remove(peer_id);
         } else {
-            states.insert(peer_id.to_string(), applied.clone());
+            states.insert(peer_id.to_string(), applied.state.clone());
         }
         Ok(())
     }
@@ -1288,12 +1292,8 @@ async fn active_peer_skips_redial_and_upgrades_data_plane_replicator() {
     assert_eq!(recorded[0].1, conversation_filter);
 }
 
-/// A stable peer id is not enough to prove that the live transport route
-/// survived an app relaunch. The phone republishes a signed endpoint with
-/// the same peer id and a fresh ticket; if applied still records the old
-/// ticket, the tick must dial the fresh address even when `active_peers`
-/// contains that peer. Otherwise the subsequent replicator install can
-/// reuse the stale route and the response never reaches the relaunched app.
+/// Route rotation is peer-scoped even with other replicators present or an
+/// address-less restored record.
 #[tokio::test]
 async fn changed_endpoint_redials_without_replacing_same_peer_replicator() {
     let old_address = "stable-peer@127.0.0.1:4100";
@@ -1314,9 +1314,17 @@ async fn changed_endpoint_redials_without_replacing_same_peer_replicator() {
     admin.replicators.lock().unwrap().insert(
         old_address.into(),
         RemoteReplicator {
-            id: Some("id-addr1".into()),
+            id: Some("stable-peer".into()),
             collections: vec![mock_collection_id("AgentRequest")],
-            address: Some(old_address.into()),
+            address: None,
+        },
+    );
+    admin.replicators.lock().unwrap().insert(
+        "other-peer@127.0.0.1:4300".into(),
+        RemoteReplicator {
+            id: Some("other-peer".into()),
+            collections: vec![mock_collection_id("AgentRequest")],
+            address: Some("other-peer@127.0.0.1:4300".into()),
         },
     );
 
@@ -1377,14 +1385,13 @@ async fn applied_state_persist_targets_one_canonical_document_when_duplicates_ex
             .unwrap(),
     );
     let store = GraphqlPairingStateStore::new(node.clone(), identity);
+    let mut applied = store.load_applied("peer-a").await.expect("load duplicates");
+    applied.state = PairingApplied {
+        replicator_addresses: set(&["fresh"]),
+        ..Default::default()
+    };
     store
-        .persist_applied(
-            "peer-a",
-            &PairingApplied {
-                replicator_addresses: set(&["fresh"]),
-                ..Default::default()
-            },
-        )
+        .persist_applied("peer-a", &applied)
         .await
         .expect("duplicate-tolerant save");
 
@@ -1400,9 +1407,8 @@ async fn applied_state_persist_targets_one_canonical_document_when_duplicates_ex
         .await;
     let mut rows = rows::<AppliedStateRow>(&response, "PeerPairingApplied").unwrap();
     rows.sort_by(|left, right| left.doc_id.cmp(&right.doc_id));
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].replicator_addresses, Some(vec!["fresh".into()]));
-    assert_ne!(rows[1].replicator_addresses, Some(vec!["fresh".into()]));
 }
 
 #[tokio::test]
@@ -1558,18 +1564,7 @@ async fn other_active_peer_does_not_suppress_dial() {
     assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr1"]]);
 }
 
-/// Review Finding #1: the remote subscription set is tracked in *id*-space by
-/// the adapter (`list_p2p_collections` returns ids), while desired state and
-/// the persisted `PeerPairingApplied` row are in *name*-space. `read_actual`
-/// reverse-resolves the ids to names so the diff compares like with like. A
-/// first tick installs the collection; a SECOND tick must observe convergence
-/// (zero ops). With the pre-fix code the desired name never matched the actual
-/// id, so every sweep re-emitted `InstallCollection` forever.
-///
-/// The teeth: the mock's `list_p2p_collections` returns a distinct id
-/// (`col_<name>_id`), so convergence only holds because reverse-resolution
-/// maps that id back to the name. If `resolve_collection_name` echoed the id,
-/// actual(id) would never equal desired(name) and this test would fail.
+/// Collection IDs are reverse-resolved before diffing against desired names.
 #[tokio::test]
 async fn second_tick_converges_across_name_and_id_spaces() {
     let store = MockStore::with_desired(Some(PairingDesired {
@@ -1737,7 +1732,7 @@ fn push_template_resolves_to_filter_without_subscription() {
         .get("AgentRequest")
         .expect("AgentRequest filter");
     assert_eq!(
-        pred.single_string_eq(),
+        single_string_eq(pred),
         Some(("requester_did", "did:key:bob"))
     );
 }
@@ -1800,7 +1795,7 @@ fn subagent_coordinator_template_filters_only_targeted_bridge() {
         desired
             .replicator_filter
             .get("AgentToolCall")
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("spawn_target_did", "did:key:host"))
     );
 }
@@ -1827,7 +1822,7 @@ fn subagent_host_template_filters_return_projection_to_requester() {
     assert_eq!(desired.replicator_filter.len(), 4);
     for predicate in desired.replicator_filter.values() {
         assert_eq!(
-            predicate.single_string_eq(),
+            single_string_eq(predicate),
             Some(("requester_did", "did:key:coord"))
         );
     }
@@ -1974,7 +1969,7 @@ async fn push_template_installs_filtered_replicator_without_subscription() {
         .get("AgentRequest")
         .expect("AgentRequest filter on installed replicator");
     assert_eq!(
-        pred.single_string_eq(),
+        single_string_eq(pred),
         Some(("requester_did", "did:key:bob"))
     );
 }
@@ -2039,7 +2034,7 @@ async fn changing_scoped_did_reinstalls_replicator() {
     for col in resolve_template("conversation").unwrap().collections.iter() {
         alice_filter.insert(
             (*col).to_string(),
-            crate::agent::p2p_reconcile::templates::FilterPredicate::eq(
+            crate::agent::p2p_reconcile::templates::equality_filter(
                 "requester_did",
                 "did:key:alice",
             ),
@@ -2076,9 +2071,7 @@ async fn changing_scoped_did_reinstalls_replicator() {
     let calls = admin.recorded_filters.lock().unwrap();
     let last = calls.last().expect("an install happened");
     assert_eq!(
-        last.1
-            .get("AgentRequest")
-            .and_then(FilterPredicate::single_string_eq),
+        last.1.get("AgentRequest").and_then(single_string_eq),
         Some(("requester_did", "did:key:bob"))
     );
 }
@@ -2092,8 +2085,6 @@ async fn changing_scoped_did_reinstalls_replicator() {
 /// (back-compat) while a non-empty one is faithfully recorded.
 #[tokio::test]
 async fn add_replicator_records_filters_at_seam() {
-    use crate::agent::p2p_reconcile::templates::FilterPredicate;
-
     let admin = MockAdmin::default();
     let addresses = vec!["addr-a".to_string()];
     let collections: Vec<String> = vec![];
@@ -2117,7 +2108,7 @@ async fn add_replicator_records_filters_at_seam() {
     let mut filters = PairingFilters::default();
     filters.insert(
         "AgentRequest".to_string(),
-        FilterPredicate::eq("agent_did", "did:key:alice"),
+        equality_filter("agent_did", "did:key:alice"),
     );
     admin
         .add_replicator(&addresses, &collections, &filters)
@@ -2129,10 +2120,7 @@ async fn add_replicator_records_filters_at_seam() {
     let recorded = &calls[1].1;
     assert_eq!(recorded.len(), 1);
     let pred = recorded.get("AgentRequest").expect("AgentRequest filter");
-    assert_eq!(
-        pred.single_string_eq(),
-        Some(("agent_did", "did:key:alice"))
-    );
+    assert_eq!(single_string_eq(pred), Some(("agent_did", "did:key:alice")));
 }
 
 #[test]
@@ -2196,7 +2184,7 @@ fn data_plane_desired_machine_scopes_conversation_and_owned_directory() {
             desired
                 .replicator_filter
                 .get(col)
-                .and_then(FilterPredicate::single_string_eq),
+                .and_then(single_string_eq),
             Some(("requester_did", "did:key:peer-b")),
             "conversation collection {col} must be requester-scoped exactly like `conversation`"
         );
@@ -2205,7 +2193,7 @@ fn data_plane_desired_machine_scopes_conversation_and_owned_directory() {
         desired
             .replicator_filter
             .get(crate::agent::p2p_reconcile::templates::AGENT_DIRECTORY_COLLECTION)
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("source_did", "did:key:self"))
     );
 }
@@ -2244,7 +2232,7 @@ fn control_plane_desired_machine_scopes_conversation_and_owned_directory() {
             .get(col)
             .unwrap_or_else(|| panic!("missing filter for conversation collection {col}"));
         assert_eq!(
-            pred.single_string_eq(),
+            single_string_eq(pred),
             Some(("requester_did", "did:key:phone"))
         );
     }
@@ -2252,7 +2240,7 @@ fn control_plane_desired_machine_scopes_conversation_and_owned_directory() {
         desired
             .replicator_filter
             .get(crate::agent::p2p_reconcile::templates::AGENT_DIRECTORY_COLLECTION)
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("source_did", "did:key:server"))
     );
 }

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -4,7 +4,9 @@ use anyhow::anyhow;
 use events::Bus;
 
 use super::*;
-use crate::agent::p2p_reconcile::{RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator};
+use crate::agent::p2p_reconcile::{
+    single_string_eq, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
+};
 
 fn set(values: &[&str]) -> BTreeSet<String> {
     values.iter().map(|value| value.to_string()).collect()
@@ -17,6 +19,13 @@ fn one_filter(collection: &str, field: &str, value: &str) -> PairingFilters {
         crate::agent::p2p_reconcile::equality_filter(field, value),
     );
     filters
+}
+
+fn merge_desired(
+    base: Option<PairingDesired>,
+    data_plane: Option<PairingDesired>,
+) -> Option<PairingDesired> {
+    merge_layered_desired("did:key:local", "did:key:peer", base, data_plane)
 }
 
 fn bearer_desired(template_id: &str, claimant_did: &str, address: &str) -> PairingDesired {
@@ -77,7 +86,15 @@ fn bearer_readiness_requires_exact_applied_conversation_replicator() {
 fn bearer_readiness_accepts_merged_conversation_layers() {
     let control = bearer_desired("conversation", "did:key:claimant", "iroh-ticket");
     let data = control.clone();
-    let desired = merge_layered_desired(Some(control), Some(data)).expect("merged desired");
+    let mut desired = merge_desired(Some(control), Some(data)).expect("merged desired");
+    let claimant = desired
+        .replicator_filter
+        .remove("BearerPairingReady")
+        .expect("readiness filter");
+    desired.replicator_filter.insert(
+        "BearerPairingReady".to_string(),
+        FilterPredicate::All(vec![claimant, equality_filter("template", "conversation")]),
+    );
     let applied = PairingApplied {
         replicator_addresses: desired.replicator_addresses.clone(),
         replicator_filter: desired.replicator_filter.clone(),
@@ -96,7 +113,7 @@ fn bearer_readiness_accepts_merged_conversation_layers() {
 
 #[test]
 fn self_pairing_row_is_not_materialized() {
-    let desired = desired_from_pairing_row(
+    let base = desired_from_pairing_row(
         PairingStateRow {
             agent_did: Some("did:key:self".to_string()),
             collections: None,
@@ -107,7 +124,7 @@ fn self_pairing_row_is_not_materialized() {
     )
     .expect("pairing row parses");
 
-    assert!(desired.is_none());
+    assert!(merge_layered_desired("did:key:self", "did:key:self", base, None).is_none());
 }
 
 #[test]
@@ -123,6 +140,10 @@ fn bearer_readiness_mutation_escapes_signed_fields() {
     };
 
     let mutation = bearer_pairing_ready_upsert_mutation("ready\"key", &record);
+    assert!(
+        mutation.find("delete_BearerPairingReady").unwrap()
+            < mutation.find("upsert_BearerPairingReady").unwrap()
+    );
     assert!(mutation.contains(r#"readiness_key: "ready\"key""#));
     assert!(mutation.contains(r#"claimant_did: "did:key:claimant\"quoted""#));
     assert!(mutation.contains(r#"address: "ticket\\route""#));
@@ -146,7 +167,7 @@ fn merge_desired_unions_control_and_data_plane_state() {
         template_ids: BTreeSet::new(),
     };
 
-    let merged = merge_layered_desired(Some(control), Some(data)).expect("merged desired");
+    let merged = merge_desired(Some(control), Some(data)).expect("merged desired");
     assert_eq!(
         merged.replicator_collections,
         set(&["AgentNetwork", "NetworkMembership", "AgentRequest"])
@@ -180,7 +201,7 @@ fn data_plane_only_desired_is_replicator_only() {
         template_ids: BTreeSet::new(),
     };
 
-    let merged = merge_layered_desired(None, Some(data)).expect("data-plane desired");
+    let merged = merge_desired(None, Some(data)).expect("data-plane desired");
     assert!(
         merged.collections.is_empty(),
         "data-plane-only desired must not subscribe to conversation collections"
@@ -519,6 +540,7 @@ struct MockAdmin {
     connects: Mutex<Vec<Vec<String>>>,
     /// Filters recorded per `add_replicator` call: (addresses, filters).
     recorded_filters: Mutex<Vec<(Vec<String>, PairingFilters)>>,
+    deleted_replicator_collections: Mutex<Vec<Vec<String>>>,
     /// Entries returned by `active_peers` (bare peer ids or dial addresses,
     /// like the real adapters).
     active: Mutex<Vec<String>>,
@@ -630,8 +652,12 @@ impl RemoteP2pAdmin for MockAdmin {
     async fn delete_replicator(
         &self,
         id: &str,
-        _collections: &[String],
+        collections: &[String],
     ) -> RemoteP2pAdminResult<()> {
+        self.deleted_replicator_collections
+            .lock()
+            .unwrap()
+            .push(collections.to_vec());
         let key = self
             .replicators
             .lock()
@@ -1365,23 +1391,51 @@ async fn changed_endpoint_replaces_same_peer_replicator_teardown_first() {
     );
 }
 
-#[tokio::test]
-async fn empty_persist_forgets_deleted_canonical_document() {
-    let store = MockStore::default();
-    let mut applied = LoadedPairingApplied {
-        canonical_doc_id: Some("deleted-doc".to_string()),
-        ..Default::default()
+#[test]
+fn addressless_replicator_is_not_aliased_across_multiple_applied_routes() {
+    let replicator = RemoteReplicator {
+        id: Some("stable-peer".to_string()),
+        collections: Vec::new(),
+        address: None,
     };
+    let applied = set(&["stable-peer@127.0.0.1:4100", "stable-peer@127.0.0.1:4200"]);
 
-    persist_applied_record(&store, "peer-a", &mut applied)
-        .await
-        .expect("empty persist");
-
-    assert_eq!(applied.canonical_doc_id, None);
+    assert_eq!(
+        canonical_replicator_address(&replicator, &applied),
+        Some("stable-peer".to_string())
+    );
 }
 
 #[tokio::test]
-async fn applied_state_persist_targets_one_canonical_document_when_duplicates_exist() {
+async fn duplicate_remote_routes_merge_their_collection_sets() {
+    let admin = MockAdmin::default();
+    for (key, id, collection) in [
+        ("row-a", "id-a", "AgentRequest"),
+        ("row-b", "id-b", "AgentResponse"),
+    ] {
+        admin.replicators.lock().unwrap().insert(
+            key.to_string(),
+            RemoteReplicator {
+                id: Some(id.to_string()),
+                collections: vec![mock_collection_id(collection)],
+                address: Some("shared-route".to_string()),
+            },
+        );
+    }
+
+    let actual = read_actual(&admin, &BTreeSet::new())
+        .await
+        .expect("read actual routes");
+
+    assert_eq!(
+        actual.state.replicator_collections["shared-route"],
+        set(&["AgentRequest", "AgentResponse"])
+    );
+    assert_eq!(actual.replicator_ids_by_addr["shared-route"], "id-a");
+}
+
+#[tokio::test]
+async fn applied_state_persist_collapses_duplicates_and_recovers_a_missing_row() {
     let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
     node.add_schema(
         r#"
@@ -1442,10 +1496,46 @@ async fn applied_state_persist_targets_one_canonical_document_when_duplicates_ex
             }"#,
         )
         .await;
-    let mut rows = rows::<AppliedStateRow>(&response, "PeerPairingApplied").unwrap();
-    rows.sort_by(|left, right| left.doc_id.cmp(&right.doc_id));
+    let mut persisted_rows = rows::<AppliedStateRow>(&response, "PeerPairingApplied").unwrap();
+    persisted_rows.sort_by(|left, right| left.doc_id.cmp(&right.doc_id));
+    assert_eq!(persisted_rows.len(), 1);
+    assert_eq!(
+        persisted_rows[0].replicator_addresses,
+        Some(vec!["fresh".into()])
+    );
+
+    let mut applied = store.load_applied("peer-a").await.expect("reload applied");
+    let response = node
+        .execute(
+            r#"mutation {
+                delete_PeerPairingApplied(filter: { peer_id: { _eq: "peer-a" } }) { _docID }
+            }"#,
+        )
+        .await;
+    assert!(
+        !response.has_errors(),
+        "delete failed: {:?}",
+        response.errors
+    );
+    applied.state.replicator_addresses = set(&["recovered"]);
+    store
+        .persist_applied("peer-a", &applied)
+        .await
+        .expect("save after concurrent delete");
+
+    let response = node
+        .execute(
+            r#"{
+                PeerPairingApplied(filter: { peer_id: { _eq: "peer-a" } }) {
+                    _docID
+                    replicator_addresses
+                }
+            }"#,
+        )
+        .await;
+    let rows = rows::<AppliedStateRow>(&response, "PeerPairingApplied").unwrap();
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].replicator_addresses, Some(vec!["fresh".into()]));
+    assert_eq!(rows[0].replicator_addresses, Some(vec!["recovered".into()]));
 }
 
 #[tokio::test]
@@ -1480,6 +1570,10 @@ async fn stale_applied_endpoint_absent_from_actual_is_torn_down_once() {
     );
     assert!(second.ops_applied.is_empty());
     assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr2"]]);
+    assert_eq!(
+        *admin.deleted_replicator_collections.lock().unwrap(),
+        vec![vec!["AgentRequest".to_string()]]
+    );
     assert_eq!(
         store.applied.lock().unwrap().replicator_addresses,
         set(&["addr2"])

--- a/crates/gents/src/agent/p2p_reconcile/mod.rs
+++ b/crates/gents/src/agent/p2p_reconcile/mod.rs
@@ -36,8 +36,9 @@ pub use embedded_impl::EmbeddedRemoteP2pAdmin;
 pub use endpoint::{peer_endpoint_upsert_mutation, run_endpoint_heartbeat};
 pub use engine::{
     merge_layered_desired, reconcile_peer_tick, run_pairing_reconciler,
-    update_applied_after_success, GraphqlPairingStateStore, PairingStateStore, PairingTickOutcome,
-    MAX_CONCURRENT_PEER_PREPARATIONS, PAIRING_SWEEP_INTERVAL,
+    update_applied_after_success, GraphqlPairingStateStore, LoadedPairingApplied,
+    PairingStateStore, PairingTickOutcome, MAX_CONCURRENT_PEER_PREPARATIONS,
+    PAIRING_SWEEP_INTERVAL,
 };
 pub use error_class::{classify_remote_admin_error, PairingErrorClass};
 pub use network::{
@@ -58,7 +59,8 @@ pub use registry::{
     UpsertKind, DEFAULT_NETWORK_ID, NETWORK_ID_ENV, REGISTRY_HEARTBEAT_INTERVAL,
 };
 pub use templates::{
-    builtin_templates, conversation_like, resolve_template, scope_filter, Delivery, DidSource,
+    builtin_templates, combine_filters, conversation_like, decode_pairing_filters, equality_filter,
+    filter_conditions, resolve_template, scope_filter, single_string_eq, Delivery, DidSource,
     FilterPredicate, PairingFilters, Scope, ScopeTemplate, AGENT_DIRECTORY_COLLECTION,
 };
 pub use trait_def::{

--- a/crates/gents/src/agent/p2p_reconcile/mod.rs
+++ b/crates/gents/src/agent/p2p_reconcile/mod.rs
@@ -35,7 +35,7 @@ pub use discovery::{
 pub use embedded_impl::EmbeddedRemoteP2pAdmin;
 pub use endpoint::{peer_endpoint_upsert_mutation, run_endpoint_heartbeat};
 pub use engine::{
-    merge_layered_desired, reconcile_peer_tick, run_pairing_reconciler,
+    materialize_base_desired, merge_layered_desired, reconcile_peer_tick, run_pairing_reconciler,
     update_applied_after_success, GraphqlPairingStateStore, LoadedPairingApplied,
     PairingStateStore, PairingTickOutcome, MAX_CONCURRENT_PEER_PREPARATIONS,
     PAIRING_SWEEP_INTERVAL,
@@ -60,8 +60,9 @@ pub use registry::{
 };
 pub use templates::{
     builtin_templates, combine_filters, conversation_like, decode_pairing_filters, equality_filter,
-    filter_conditions, resolve_template, scope_filter, single_string_eq, Delivery, DidSource,
-    FilterPredicate, PairingFilters, Scope, ScopeTemplate, AGENT_DIRECTORY_COLLECTION,
+    filter_conditions, resolve_template, scope_filter, single_string_eq, to_replication_filters,
+    Delivery, DidSource, FilterPredicate, PairingFilters, Scope, ScopeTemplate,
+    AGENT_DIRECTORY_COLLECTION,
 };
 pub use trait_def::{
     RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteP2pDocument, RemoteReplicator,

--- a/crates/gents/src/agent/p2p_reconcile/mod.rs
+++ b/crates/gents/src/agent/p2p_reconcile/mod.rs
@@ -35,7 +35,7 @@ pub use discovery::{
 pub use embedded_impl::EmbeddedRemoteP2pAdmin;
 pub use endpoint::{peer_endpoint_upsert_mutation, run_endpoint_heartbeat};
 pub use engine::{
-    materialize_base_desired, merge_layered_desired, reconcile_peer_tick, run_pairing_reconciler,
+    merge_layered_desired, reconcile_peer_tick, run_pairing_reconciler,
     update_applied_after_success, GraphqlPairingStateStore, LoadedPairingApplied,
     PairingStateStore, PairingTickOutcome, MAX_CONCURRENT_PEER_PREPARATIONS,
     PAIRING_SWEEP_INTERVAL,

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -4,14 +4,14 @@
 //! `Scope` (how per-peer document filtering is derived), and a `Delivery`
 //! (push vs. replicate). The catalog is static and hardcoded here.
 //!
-//! `PairingFilters` is our own seam type around DefraDB's predicate model. It
-//! preserves recursive AND composition so independently derived layers cannot
-//! overwrite each other's tenant fences.
+//! Pairing filters use DefraDB's predicate type directly. Local helpers only
+//! derive, combine, and inspect those predicates.
 
 use std::collections::BTreeMap;
 
-use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
+
+pub use p2p::ReplicationFilter as FilterPredicate;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -82,114 +82,67 @@ pub struct ScopeTemplate {
 }
 
 // ---------------------------------------------------------------------------
-// PairingFilters seam type
+// Pairing filters
 // ---------------------------------------------------------------------------
 
-/// A DefraDB query predicate or an AND-composition of predicates.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FilterPredicate {
-    Predicate(Map<String, Value>),
-    All(Vec<FilterPredicate>),
+pub fn equality_filter(field: impl Into<String>, value: impl Into<String>) -> FilterPredicate {
+    FilterPredicate::eq(field, Value::String(value.into()))
 }
 
-impl FilterPredicate {
-    pub fn eq(field: impl Into<String>, value: impl Into<String>) -> Self {
-        let mut operator = Map::new();
-        operator.insert("_eq".to_string(), Value::String(value.into()));
-        let mut conditions = Map::new();
-        conditions.insert(field.into(), Value::Object(operator));
-        Self::Predicate(conditions)
+pub fn combine_filters(left: FilterPredicate, right: FilterPredicate) -> FilterPredicate {
+    let mut filters = Vec::new();
+    match left {
+        FilterPredicate::All(nested) => filters.extend(nested),
+        predicate => filters.push(predicate),
     }
-
-    pub fn predicate(conditions: Map<String, Value>) -> Self {
-        Self::Predicate(conditions)
+    match right {
+        FilterPredicate::All(nested) => filters.extend(nested),
+        predicate => filters.push(predicate),
     }
-
-    /// Compose two independently derived filters without discarding either.
-    pub fn and(self, other: Self) -> Self {
-        let mut filters = Vec::new();
-        match self {
-            Self::All(nested) => filters.extend(nested),
-            predicate => filters.push(predicate),
-        }
-        match other {
-            Self::All(nested) => filters.extend(nested),
-            predicate => filters.push(predicate),
-        }
-        let mut unique = Vec::with_capacity(filters.len());
-        for filter in filters {
-            if !unique.contains(&filter) {
-                unique.push(filter);
-            }
-        }
-        if unique.len() == 1 {
-            unique.pop().expect("one filter")
-        } else {
-            Self::All(unique)
+    let mut unique = Vec::with_capacity(filters.len());
+    for filter in filters {
+        if !unique.contains(&filter) {
+            unique.push(filter);
         }
     }
-
-    /// Convert recursive `All` nodes into DefraDB query-filter `_and` syntax.
-    pub fn conditions(&self) -> Map<String, Value> {
-        match self {
-            Self::Predicate(conditions) => conditions.clone(),
-            Self::All(filters) => {
-                let mut conditions = Map::new();
-                conditions.insert(
-                    "_and".to_string(),
-                    Value::Array(
-                        filters
-                            .iter()
-                            .map(|filter| Value::Object(filter.conditions()))
-                            .collect(),
-                    ),
-                );
-                conditions
-            }
-        }
-    }
-
-    pub fn single_string_eq(&self) -> Option<(&str, &str)> {
-        let Self::Predicate(conditions) = self else {
-            return None;
-        };
-        let (field, value) = conditions.iter().next()?;
-        if conditions.len() != 1 {
-            return None;
-        }
-        let operators = value.as_object()?;
-        let value = operators.get("_eq")?.as_str()?;
-        (operators.len() == 1).then_some((field.as_str(), value))
+    if unique.len() == 1 {
+        unique.pop().expect("one filter")
+    } else {
+        FilterPredicate::All(unique)
     }
 }
 
-impl<'de> Deserialize<'de> for FilterPredicate {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(rename_all = "snake_case")]
-        enum Tagged {
-            Predicate(Map<String, Value>),
-            All(Vec<FilterPredicate>),
+pub fn filter_conditions(filter: &FilterPredicate) -> Map<String, Value> {
+    match filter {
+        FilterPredicate::Predicate(conditions) => conditions.clone(),
+        FilterPredicate::All(filters) => {
+            let mut conditions = Map::new();
+            conditions.insert(
+                "_and".to_string(),
+                Value::Array(
+                    filters
+                        .iter()
+                        .map(|filter| Value::Object(filter_conditions(filter)))
+                        .collect(),
+                ),
+            );
+            conditions
         }
-
-        let value = Value::deserialize(deserializer)?;
-        if let Some(object) = value.as_object() {
-            if let (Some(field), Some(value)) = (
-                object.get("field").and_then(Value::as_str),
-                object.get("value").and_then(Value::as_str),
-            ) {
-                return Ok(Self::eq(field, value));
-            }
-        }
-        match serde_json::from_value::<Tagged>(value).map_err(D::Error::custom)? {
-            Tagged::Predicate(conditions) => Ok(Self::Predicate(conditions)),
-            Tagged::All(filters) => Ok(Self::All(filters)),
-        }
+        FilterPredicate::Acp { .. } => Map::new(),
     }
+}
+
+pub fn single_string_eq(filter: &FilterPredicate) -> Option<(&str, &str)> {
+    let FilterPredicate::Predicate(conditions) = filter else {
+        return None;
+    };
+    let (field, value) = conditions.iter().next()?;
+    if conditions.len() != 1 {
+        return None;
+    }
+    let operators = value.as_object()?;
+    let value = operators.get("_eq")?.as_str()?;
+    (operators.len() == 1).then_some((field.as_str(), value))
 }
 
 /// Per-collection filter predicates for a concrete pairing.
@@ -200,11 +153,29 @@ impl<'de> Deserialize<'de> for FilterPredicate {
 ///
 pub type PairingFilters = BTreeMap<String, FilterPredicate>;
 
+pub fn decode_pairing_filters(raw: &str) -> serde_json::Result<PairingFilters> {
+    let mut value: Value = serde_json::from_str(raw)?;
+    if let Some(filters) = value.as_object_mut() {
+        for filter in filters.values_mut() {
+            let legacy = filter.as_object().and_then(|object| {
+                Some((
+                    object.get("field")?.as_str()?.to_string(),
+                    object.get("value")?.as_str()?.to_string(),
+                ))
+            });
+            if let Some((field, value)) = legacy {
+                *filter = serde_json::to_value(equality_filter(field, value))?;
+            }
+        }
+    }
+    serde_json::from_value(value)
+}
+
 pub fn merge_pairing_filters(left: &mut PairingFilters, right: PairingFilters) {
     for (collection, predicate) in right {
         match left.remove(&collection) {
             Some(existing) => {
-                left.insert(collection, existing.and(predicate));
+                left.insert(collection, combine_filters(existing, predicate));
             }
             None => {
                 left.insert(collection, predicate);
@@ -590,7 +561,7 @@ pub fn scope_filter(
     match scope {
         Scope::PeerDid { field } => collections
             .iter()
-            .map(|&col| (col.to_string(), FilterPredicate::eq(*field, peer_did)))
+            .map(|&col| (col.to_string(), equality_filter(*field, peer_did)))
             .collect(),
         Scope::Unscoped => BTreeMap::new(),
         Scope::PerCollection(rules) => rules
@@ -603,7 +574,7 @@ pub fn scope_filter(
                 };
                 (
                     rule.collection.to_string(),
-                    FilterPredicate::eq(rule.field, value),
+                    equality_filter(rule.field, value),
                 )
             })
             .collect(),
@@ -661,46 +632,45 @@ mod tests {
         let f = scope_filter(&t.scope, t.collections, "did:key:bob", "did:key:alice");
         assert_eq!(f.len(), 9);
         let p = f.get("AgentRequest").unwrap();
-        assert_eq!(p.single_string_eq(), Some(("requester_did", "did:key:bob")));
+        assert_eq!(single_string_eq(p), Some(("requester_did", "did:key:bob")));
         let ready = f.get("BearerPairingReady").unwrap();
         assert_eq!(
-            ready.single_string_eq(),
+            single_string_eq(ready),
             Some(("claimant_did", "did:key:bob"))
         );
     }
 
     #[test]
-    fn legacy_scalar_filter_deserializes_as_equality() {
-        let filter: FilterPredicate = serde_json::from_value(serde_json::json!({
-            "field": "requester_did",
-            "value": "did:key:phone"
-        }))
-        .expect("legacy filter");
-
-        assert_eq!(
-            filter.single_string_eq(),
-            Some(("requester_did", "did:key:phone"))
-        );
-    }
-
-    #[test]
     fn rich_predicates_and_layered_equalities_keep_both_conditions() {
-        let rich = FilterPredicate::predicate(
+        let rich = FilterPredicate::Predicate(
             serde_json::json!({ "status": { "_in": ["pending", "processing"] } })
                 .as_object()
                 .expect("object")
                 .clone(),
         );
-        let combined = FilterPredicate::eq("requester_did", "did:key:phone").and(rich);
+        let combined = combine_filters(equality_filter("requester_did", "did:key:phone"), rich);
 
         assert_eq!(
-            Value::Object(combined.conditions()),
+            Value::Object(filter_conditions(&combined)),
             serde_json::json!({
                 "_and": [
                     { "requester_did": { "_eq": "did:key:phone" } },
                     { "status": { "_in": ["pending", "processing"] } }
                 ]
             })
+        );
+    }
+
+    #[test]
+    fn legacy_pairing_filter_decodes() {
+        let filters = decode_pairing_filters(
+            r#"{"AgentRequest":{"field":"requester_did","value":"did:key:phone"}}"#,
+        )
+        .expect("legacy filters");
+
+        assert_eq!(
+            filters.get("AgentRequest").and_then(single_string_eq),
+            Some(("requester_did", "did:key:phone"))
         );
     }
 
@@ -755,7 +725,7 @@ mod tests {
                 .get(*collection)
                 .expect("indexed collection is filtered");
             assert_eq!(
-                predicate.single_string_eq(),
+                single_string_eq(predicate),
                 Some(("requester_did", "did:key:phone"))
             );
         }
@@ -822,7 +792,7 @@ mod tests {
         assert!(!f.contains_key("AgentRequest"));
         assert_eq!(
             f.get("AgentToolCall"),
-            Some(&FilterPredicate::eq("spawn_target_did", "did:key:host"))
+            Some(&equality_filter("spawn_target_did", "did:key:host"))
         );
     }
 
@@ -835,12 +805,12 @@ mod tests {
         assert_eq!(f.len(), SUBAGENT_HOST_COLLECTIONS.len());
         assert_eq!(
             f.get("AgentRequest"),
-            Some(&FilterPredicate::eq("requester_did", "did:key:coord"))
+            Some(&equality_filter("requester_did", "did:key:coord"))
         );
         for col in SUBAGENT_HOST_COLLECTIONS {
             assert_eq!(
                 f.get(*col),
-                Some(&FilterPredicate::eq("requester_did", "did:key:coord")),
+                Some(&equality_filter("requester_did", "did:key:coord")),
                 "unexpected subagent-host filter for {col}"
             );
         }
@@ -871,20 +841,20 @@ mod tests {
                 "requester_did"
             };
             assert_eq!(
-                predicate.single_string_eq(),
+                single_string_eq(predicate),
                 Some((expected_field, "did:key:phone"))
             );
         }
         assert_eq!(
             filters.get(AGENT_DIRECTORY_COLLECTION),
-            Some(&FilterPredicate::eq("source_did", "did:key:server"))
+            Some(&equality_filter("source_did", "did:key:server"))
         );
         // Persona request rows carry requester-authored config picks and the
         // server's status_detail; losing this rule would push every
         // requester's rows to every machine peer (the #687 leak class).
         assert_eq!(
             filters.get("PersonaConfigRequest"),
-            Some(&FilterPredicate::eq("requester_did", "did:key:phone"))
+            Some(&equality_filter("requester_did", "did:key:phone"))
         );
     }
 

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -117,7 +117,17 @@ impl FilterPredicate {
             Self::All(nested) => filters.extend(nested),
             predicate => filters.push(predicate),
         }
-        Self::All(filters)
+        let mut unique = Vec::with_capacity(filters.len());
+        for filter in filters {
+            if !unique.contains(&filter) {
+                unique.push(filter);
+            }
+        }
+        if unique.len() == 1 {
+            unique.pop().expect("one filter")
+        } else {
+            Self::All(unique)
+        }
     }
 
     /// Convert recursive `All` nodes into DefraDB query-filter `_and` syntax.

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -2,17 +2,16 @@
 //!
 //! A `ScopeTemplate` is a named pairing intent: a fixed collection set, a
 //! `Scope` (how per-peer document filtering is derived), and a `Delivery`
-//! (push vs. replicate).  The catalog is static and hardcoded here; later
-//! tasks will wire it into the pairing reconciler and defradb.rs #1033.
+//! (push vs. replicate). The catalog is static and hardcoded here.
 //!
-//! `PairingFilters` is our own seam type that decouples this crate from the
-//! unmerged defradb.rs #1033 filter API.  It holds per-collection single-field
-//! equality predicates and can be translated by later tasks into whatever
-//! upstream shape emerges.
+//! `PairingFilters` is our own seam type around DefraDB's predicate model. It
+//! preserves recursive AND composition so independently derived layers cannot
+//! overwrite each other's tenant fences.
 
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use serde_json::{Map, Value};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -83,27 +82,126 @@ pub struct ScopeTemplate {
 }
 
 // ---------------------------------------------------------------------------
-// PairingFilters seam type (#1033-independent)
+// PairingFilters seam type
 // ---------------------------------------------------------------------------
 
-/// A single-field equality predicate for one collection.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct FilterPredicate {
-    /// The field name to filter on.
-    pub field: String,
-    /// The value the field must equal.
-    pub value: String,
+/// A DefraDB query predicate or an AND-composition of predicates.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterPredicate {
+    Predicate(Map<String, Value>),
+    All(Vec<FilterPredicate>),
+}
+
+impl FilterPredicate {
+    pub fn eq(field: impl Into<String>, value: impl Into<String>) -> Self {
+        let mut operator = Map::new();
+        operator.insert("_eq".to_string(), Value::String(value.into()));
+        let mut conditions = Map::new();
+        conditions.insert(field.into(), Value::Object(operator));
+        Self::Predicate(conditions)
+    }
+
+    pub fn predicate(conditions: Map<String, Value>) -> Self {
+        Self::Predicate(conditions)
+    }
+
+    /// Compose two independently derived filters without discarding either.
+    pub fn and(self, other: Self) -> Self {
+        let mut filters = Vec::new();
+        match self {
+            Self::All(nested) => filters.extend(nested),
+            predicate => filters.push(predicate),
+        }
+        match other {
+            Self::All(nested) => filters.extend(nested),
+            predicate => filters.push(predicate),
+        }
+        Self::All(filters)
+    }
+
+    /// Convert recursive `All` nodes into DefraDB query-filter `_and` syntax.
+    pub fn conditions(&self) -> Map<String, Value> {
+        match self {
+            Self::Predicate(conditions) => conditions.clone(),
+            Self::All(filters) => {
+                let mut conditions = Map::new();
+                conditions.insert(
+                    "_and".to_string(),
+                    Value::Array(
+                        filters
+                            .iter()
+                            .map(|filter| Value::Object(filter.conditions()))
+                            .collect(),
+                    ),
+                );
+                conditions
+            }
+        }
+    }
+
+    pub fn single_string_eq(&self) -> Option<(&str, &str)> {
+        let Self::Predicate(conditions) = self else {
+            return None;
+        };
+        let (field, value) = conditions.iter().next()?;
+        if conditions.len() != 1 {
+            return None;
+        }
+        let operators = value.as_object()?;
+        let value = operators.get("_eq")?.as_str()?;
+        (operators.len() == 1).then_some((field.as_str(), value))
+    }
+}
+
+impl<'de> Deserialize<'de> for FilterPredicate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        enum Tagged {
+            Predicate(Map<String, Value>),
+            All(Vec<FilterPredicate>),
+        }
+
+        let value = Value::deserialize(deserializer)?;
+        if let Some(object) = value.as_object() {
+            if let (Some(field), Some(value)) = (
+                object.get("field").and_then(Value::as_str),
+                object.get("value").and_then(Value::as_str),
+            ) {
+                return Ok(Self::eq(field, value));
+            }
+        }
+        match serde_json::from_value::<Tagged>(value).map_err(D::Error::custom)? {
+            Tagged::Predicate(conditions) => Ok(Self::Predicate(conditions)),
+            Tagged::All(filters) => Ok(Self::All(filters)),
+        }
+    }
 }
 
 /// Per-collection filter predicates for a concrete pairing.
 ///
-/// `key` = collection name, `value` = equality predicate to apply when
+/// `key` = collection name, `value` = predicate to apply when
 /// subscribing / pushing documents for that collection.  An empty map means
 /// no filtering (Unscoped).
 ///
-/// This type is our own seam that later tasks will translate into whatever
-/// shape defradb.rs #1033 exposes.
 pub type PairingFilters = BTreeMap<String, FilterPredicate>;
+
+pub fn merge_pairing_filters(left: &mut PairingFilters, right: PairingFilters) {
+    for (collection, predicate) in right {
+        match left.remove(&collection) {
+            Some(existing) => {
+                left.insert(collection, existing.and(predicate));
+            }
+            None => {
+                left.insert(collection, predicate);
+            }
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Built-in template catalog
@@ -482,15 +580,7 @@ pub fn scope_filter(
     match scope {
         Scope::PeerDid { field } => collections
             .iter()
-            .map(|&col| {
-                (
-                    col.to_string(),
-                    FilterPredicate {
-                        field: (*field).to_string(),
-                        value: peer_did.to_string(),
-                    },
-                )
-            })
+            .map(|&col| (col.to_string(), FilterPredicate::eq(*field, peer_did)))
             .collect(),
         Scope::Unscoped => BTreeMap::new(),
         Scope::PerCollection(rules) => rules
@@ -503,10 +593,7 @@ pub fn scope_filter(
                 };
                 (
                     rule.collection.to_string(),
-                    FilterPredicate {
-                        field: rule.field.to_string(),
-                        value: value.to_string(),
-                    },
+                    FilterPredicate::eq(rule.field, value),
                 )
             })
             .collect(),
@@ -564,11 +651,47 @@ mod tests {
         let f = scope_filter(&t.scope, t.collections, "did:key:bob", "did:key:alice");
         assert_eq!(f.len(), 9);
         let p = f.get("AgentRequest").unwrap();
-        assert_eq!(p.field, "requester_did");
-        assert_eq!(p.value, "did:key:bob");
+        assert_eq!(p.single_string_eq(), Some(("requester_did", "did:key:bob")));
         let ready = f.get("BearerPairingReady").unwrap();
-        assert_eq!(ready.field, "claimant_did");
-        assert_eq!(ready.value, "did:key:bob");
+        assert_eq!(
+            ready.single_string_eq(),
+            Some(("claimant_did", "did:key:bob"))
+        );
+    }
+
+    #[test]
+    fn legacy_scalar_filter_deserializes_as_equality() {
+        let filter: FilterPredicate = serde_json::from_value(serde_json::json!({
+            "field": "requester_did",
+            "value": "did:key:phone"
+        }))
+        .expect("legacy filter");
+
+        assert_eq!(
+            filter.single_string_eq(),
+            Some(("requester_did", "did:key:phone"))
+        );
+    }
+
+    #[test]
+    fn rich_predicates_and_layered_equalities_keep_both_conditions() {
+        let rich = FilterPredicate::predicate(
+            serde_json::json!({ "status": { "_in": ["pending", "processing"] } })
+                .as_object()
+                .expect("object")
+                .clone(),
+        );
+        let combined = FilterPredicate::eq("requester_did", "did:key:phone").and(rich);
+
+        assert_eq!(
+            Value::Object(combined.conditions()),
+            serde_json::json!({
+                "_and": [
+                    { "requester_did": { "_eq": "did:key:phone" } },
+                    { "status": { "_in": ["pending", "processing"] } }
+                ]
+            })
+        );
     }
 
     #[test]
@@ -621,8 +744,10 @@ mod tests {
             let predicate = filter
                 .get(*collection)
                 .expect("indexed collection is filtered");
-            assert_eq!(predicate.field, "requester_did");
-            assert_eq!(predicate.value, "did:key:phone");
+            assert_eq!(
+                predicate.single_string_eq(),
+                Some(("requester_did", "did:key:phone"))
+            );
         }
     }
 
@@ -687,10 +812,7 @@ mod tests {
         assert!(!f.contains_key("AgentRequest"));
         assert_eq!(
             f.get("AgentToolCall"),
-            Some(&FilterPredicate {
-                field: "spawn_target_did".to_string(),
-                value: "did:key:host".to_string(),
-            })
+            Some(&FilterPredicate::eq("spawn_target_did", "did:key:host"))
         );
     }
 
@@ -703,18 +825,12 @@ mod tests {
         assert_eq!(f.len(), SUBAGENT_HOST_COLLECTIONS.len());
         assert_eq!(
             f.get("AgentRequest"),
-            Some(&FilterPredicate {
-                field: "requester_did".to_string(),
-                value: "did:key:coord".to_string(),
-            })
+            Some(&FilterPredicate::eq("requester_did", "did:key:coord"))
         );
         for col in SUBAGENT_HOST_COLLECTIONS {
             assert_eq!(
                 f.get(*col),
-                Some(&FilterPredicate {
-                    field: "requester_did".to_string(),
-                    value: "did:key:coord".to_string(),
-                }),
+                Some(&FilterPredicate::eq("requester_did", "did:key:coord")),
                 "unexpected subagent-host filter for {col}"
             );
         }
@@ -744,25 +860,21 @@ mod tests {
             } else {
                 "requester_did"
             };
-            assert_eq!(predicate.field, expected_field);
-            assert_eq!(predicate.value, "did:key:phone");
+            assert_eq!(
+                predicate.single_string_eq(),
+                Some((expected_field, "did:key:phone"))
+            );
         }
         assert_eq!(
             filters.get(AGENT_DIRECTORY_COLLECTION),
-            Some(&FilterPredicate {
-                field: "source_did".to_string(),
-                value: "did:key:server".to_string(),
-            })
+            Some(&FilterPredicate::eq("source_did", "did:key:server"))
         );
         // Persona request rows carry requester-authored config picks and the
         // server's status_detail; losing this rule would push every
         // requester's rows to every machine peer (the #687 leak class).
         assert_eq!(
             filters.get("PersonaConfigRequest"),
-            Some(&FilterPredicate {
-                field: "requester_did".to_string(),
-                value: "did:key:phone".to_string(),
-            })
+            Some(&FilterPredicate::eq("requester_did", "did:key:phone"))
         );
     }
 

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -112,9 +112,9 @@ pub fn combine_filters(left: FilterPredicate, right: FilterPredicate) -> FilterP
     }
 }
 
-pub fn filter_conditions(filter: &FilterPredicate) -> Map<String, Value> {
+pub fn filter_conditions(filter: &FilterPredicate) -> Option<Map<String, Value>> {
     match filter {
-        FilterPredicate::Predicate(conditions) => conditions.clone(),
+        FilterPredicate::Predicate(conditions) => Some(conditions.clone()),
         FilterPredicate::All(filters) => {
             let mut conditions = Map::new();
             conditions.insert(
@@ -122,14 +122,31 @@ pub fn filter_conditions(filter: &FilterPredicate) -> Map<String, Value> {
                 Value::Array(
                     filters
                         .iter()
-                        .map(|filter| Value::Object(filter_conditions(filter)))
-                        .collect(),
+                        .map(|filter| filter_conditions(filter).map(Value::Object))
+                        .collect::<Option<Vec<_>>>()?,
                 ),
             );
-            conditions
+            Some(conditions)
         }
-        FilterPredicate::Acp { .. } => Map::new(),
+        FilterPredicate::Acp { .. } => None,
     }
+}
+
+pub fn to_replication_filters(
+    filters: &PairingFilters,
+) -> Result<defra_p2p_adapter::ReplicationFilters, String> {
+    filters
+        .iter()
+        .map(|(collection, filter)| {
+            let conditions = filter_conditions(filter).ok_or_else(|| {
+                format!("ACP filter for {collection} is not supported by the replication API")
+            })?;
+            Ok((
+                collection.clone(),
+                defra_p2p_adapter::ReplicationFilter::predicate(conditions),
+            ))
+        })
+        .collect()
 }
 
 pub fn single_string_eq(filter: &FilterPredicate) -> Option<(&str, &str)> {
@@ -169,19 +186,6 @@ pub fn decode_pairing_filters(raw: &str) -> serde_json::Result<PairingFilters> {
         }
     }
     serde_json::from_value(value)
-}
-
-pub fn merge_pairing_filters(left: &mut PairingFilters, right: PairingFilters) {
-    for (collection, predicate) in right {
-        match left.remove(&collection) {
-            Some(existing) => {
-                left.insert(collection, combine_filters(existing, predicate));
-            }
-            None => {
-                left.insert(collection, predicate);
-            }
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -651,7 +655,7 @@ mod tests {
         let combined = combine_filters(equality_filter("requester_did", "did:key:phone"), rich);
 
         assert_eq!(
-            Value::Object(filter_conditions(&combined)),
+            Value::Object(filter_conditions(&combined).expect("predicate conditions")),
             serde_json::json!({
                 "_and": [
                     { "requester_did": { "_eq": "did:key:phone" } },
@@ -659,6 +663,20 @@ mod tests {
                 ]
             })
         );
+    }
+
+    #[test]
+    fn unsupported_acp_filter_is_rejected() {
+        let filters = [(
+            "AgentRequest".to_string(),
+            FilterPredicate::Acp {
+                relation: "reader".to_string(),
+            },
+        )]
+        .into_iter()
+        .collect();
+
+        assert!(to_replication_filters(&filters).is_err());
     }
 
     #[test]

--- a/crates/gents/src/agent/reconcile/tests.rs
+++ b/crates/gents/src/agent/reconcile/tests.rs
@@ -292,7 +292,7 @@ fn operator_delete_yields_teardown_diff() -> bool {
 /// store whose desired read errors (the admin is never reached on this path).
 async fn read_failure_is_noop_self_loop(node: Arc<defra_node::EmbeddedNode>) -> bool {
     use crate::agent::p2p_reconcile::{
-        reconcile_peer_tick, EmbeddedRemoteP2pAdmin, PairingApplied, PairingDesired,
+        reconcile_peer_tick, EmbeddedRemoteP2pAdmin, LoadedPairingApplied, PairingDesired,
         PairingStateStore,
     };
 
@@ -302,13 +302,13 @@ async fn read_failure_is_noop_self_loop(node: Arc<defra_node::EmbeddedNode>) -> 
         async fn load_desired(&self, _peer_id: &str) -> anyhow::Result<Option<PairingDesired>> {
             anyhow::bail!("simulated desired-state read failure")
         }
-        async fn load_applied(&self, _peer_id: &str) -> anyhow::Result<PairingApplied> {
-            Ok(PairingApplied::default())
+        async fn load_applied(&self, _peer_id: &str) -> anyhow::Result<LoadedPairingApplied> {
+            Ok(LoadedPairingApplied::default())
         }
         async fn persist_applied(
             &self,
             _peer_id: &str,
-            _applied: &PairingApplied,
+            _applied: &LoadedPairingApplied,
         ) -> anyhow::Result<()> {
             Ok(())
         }

--- a/crates/gents/src/agent/reconcile/tests.rs
+++ b/crates/gents/src/agent/reconcile/tests.rs
@@ -305,14 +305,11 @@ async fn read_failure_is_noop_self_loop(node: Arc<defra_node::EmbeddedNode>) -> 
         async fn load_applied(&self, _peer_id: &str) -> anyhow::Result<PairingApplied> {
             Ok(PairingApplied::default())
         }
-        async fn save_applied(
+        async fn persist_applied(
             &self,
             _peer_id: &str,
             _applied: &PairingApplied,
         ) -> anyhow::Result<()> {
-            Ok(())
-        }
-        async fn delete_applied(&self, _peer_id: &str) -> anyhow::Result<()> {
             Ok(())
         }
         async fn list_peer_ids(&self) -> anyhow::Result<BTreeSet<String>> {

--- a/crates/gents/tests/conformance/cancel_propagation.rs
+++ b/crates/gents/tests/conformance/cancel_propagation.rs
@@ -672,10 +672,7 @@ async fn replay_and_wait_for_bridge(
     let mut filters = PairingFilters::new();
     filters.insert(
         "AgentToolCall".to_string(),
-        FilterPredicate {
-            field: "spawn_target_did".to_string(),
-            value: receiver_did.to_string(),
-        },
+        FilterPredicate::eq("spawn_target_did", receiver_did),
     );
     admin
         .add_replicator(&[receiver_addr.to_string()], &collections, &filters)

--- a/crates/gents/tests/conformance/cancel_propagation.rs
+++ b/crates/gents/tests/conformance/cancel_propagation.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use gents::agent::p2p_reconcile::{
-    resolve_template, EmbeddedRemoteP2pAdmin, FilterPredicate, PairingFilters, RemoteP2pAdmin,
+    equality_filter, resolve_template, EmbeddedRemoteP2pAdmin, PairingFilters, RemoteP2pAdmin,
 };
 use gents::background_completion::{observe_cancel_cascade_ack, CancelAckOutcome};
 use gents::defra_node::EmbeddedNode;
@@ -672,7 +672,7 @@ async fn replay_and_wait_for_bridge(
     let mut filters = PairingFilters::new();
     filters.insert(
         "AgentToolCall".to_string(),
-        FilterPredicate::eq("spawn_target_did", receiver_did),
+        equality_filter("spawn_target_did", receiver_did),
     );
     admin
         .add_replicator(&[receiver_addr.to_string()], &collections, &filters)

--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -29,13 +29,7 @@ fn set(values: &[&str]) -> BTreeSet<String> {
 
 fn one_filter(collection: &str, field: &str, value: &str) -> PairingFilters {
     let mut filters = PairingFilters::new();
-    filters.insert(
-        collection.to_string(),
-        FilterPredicate {
-            field: field.to_string(),
-            value: value.to_string(),
-        },
-    );
+    filters.insert(collection.to_string(), FilterPredicate::eq(field, value));
     filters
 }
 
@@ -155,19 +149,50 @@ fn layered_desired_merge_keeps_data_plane_replicator_only() {
         merged
             .replicator_filter
             .get("AgentRequest")
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("requester_did", "did:key:a"))
     );
     assert_eq!(
         merged
             .replicator_filter
             .get("AgentResponse")
-            .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            .and_then(FilterPredicate::single_string_eq),
         Some(("requester_did", "did:key:a"))
     );
     assert!(
         !merged.replicator_filter.contains_key("AgentNetwork"),
         "network-control collections stay unfiltered inside the mixed replicator"
+    );
+}
+
+/// Mirrors Lean `overlapping_collection_filters_compose`: independently
+/// derived predicates on the same collection are conjunctive, not last-writer-wins.
+#[test]
+fn layered_desired_merge_ands_overlapping_collection_filters() {
+    let base_filter = FilterPredicate::eq("requester_did", "did:key:phone");
+    let data_filter = FilterPredicate::predicate(
+        serde_json::json!({ "status": { "_in": ["pending", "processing"] } })
+            .as_object()
+            .expect("object")
+            .clone(),
+    );
+    let layer = |filter| PairingDesired {
+        collections: BTreeSet::new(),
+        replicator_addresses: set(&["addr"]),
+        replicator_collections: set(&["AgentRequest"]),
+        replicator_filter: [("AgentRequest".to_string(), filter)].into_iter().collect(),
+        template_ids: BTreeSet::new(),
+    };
+
+    let merged = merge_layered_desired(
+        Some(layer(base_filter.clone())),
+        Some(layer(data_filter.clone())),
+    )
+    .expect("merged desired state");
+
+    assert_eq!(
+        merged.replicator_filter.get("AgentRequest"),
+        Some(&FilterPredicate::All(vec![base_filter, data_filter]))
     );
 }
 

--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use gents::agent::p2p_reconcile::{
-    merge_layered_desired, DiffOp, FilterPredicate, PairingDesired, PairingFilters,
-    MAX_CONCURRENT_PEER_PREPARATIONS,
+    equality_filter, merge_layered_desired, single_string_eq, DiffOp, FilterPredicate,
+    PairingDesired, PairingFilters, MAX_CONCURRENT_PEER_PREPARATIONS,
 };
 
 use crate::lean_vocab_test::{
@@ -29,7 +29,7 @@ fn set(values: &[&str]) -> BTreeSet<String> {
 
 fn one_filter(collection: &str, field: &str, value: &str) -> PairingFilters {
     let mut filters = PairingFilters::new();
-    filters.insert(collection.to_string(), FilterPredicate::eq(field, value));
+    filters.insert(collection.to_string(), equality_filter(field, value));
     filters
 }
 
@@ -149,14 +149,14 @@ fn layered_desired_merge_keeps_data_plane_replicator_only() {
         merged
             .replicator_filter
             .get("AgentRequest")
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("requester_did", "did:key:a"))
     );
     assert_eq!(
         merged
             .replicator_filter
             .get("AgentResponse")
-            .and_then(FilterPredicate::single_string_eq),
+            .and_then(single_string_eq),
         Some(("requester_did", "did:key:a"))
     );
     assert!(
@@ -169,7 +169,7 @@ fn layered_desired_merge_keeps_data_plane_replicator_only() {
 /// derived predicates on the same collection are conjunctive, not last-writer-wins.
 #[test]
 fn layered_desired_merge_ands_overlapping_collection_filters() {
-    let base_filter = FilterPredicate::eq("requester_did", "did:key:phone");
+    let base_filter = equality_filter("requester_did", "did:key:phone");
     let data_filter = FilterPredicate::predicate(
         serde_json::json!({ "status": { "_in": ["pending", "processing"] } })
             .as_object()
@@ -193,6 +193,27 @@ fn layered_desired_merge_ands_overlapping_collection_filters() {
     assert_eq!(
         merged.replicator_filter.get("AgentRequest"),
         Some(&FilterPredicate::All(vec![base_filter, data_filter]))
+    );
+}
+
+#[test]
+fn layered_desired_merge_keeps_control_readiness_claimant() {
+    let layer = |claimant| PairingDesired {
+        replicator_filter: one_filter("BearerPairingReady", "claimant_did", claimant),
+        ..Default::default()
+    };
+    let merged = merge_layered_desired(
+        Some(layer("did:key:claimant")),
+        Some(layer("did:key:stale")),
+    )
+    .expect("merged desired state");
+
+    assert_eq!(
+        merged
+            .replicator_filter
+            .get("BearerPairingReady")
+            .and_then(single_string_eq),
+        Some(("claimant_did", "did:key:claimant"))
     );
 }
 

--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use gents::agent::p2p_reconcile::{
-    equality_filter, merge_layered_desired, single_string_eq, DiffOp, FilterPredicate,
-    PairingDesired, PairingFilters, MAX_CONCURRENT_PEER_PREPARATIONS,
+    equality_filter, materialize_base_desired, merge_layered_desired, single_string_eq, DiffOp,
+    FilterPredicate, PairingDesired, PairingFilters, MAX_CONCURRENT_PEER_PREPARATIONS,
 };
 
 use crate::lean_vocab_test::{
@@ -165,10 +165,8 @@ fn layered_desired_merge_keeps_data_plane_replicator_only() {
     );
 }
 
-/// Mirrors Lean `overlapping_collection_filters_compose`: independently
-/// derived predicates on the same collection are conjunctive, not last-writer-wins.
 #[test]
-fn layered_desired_merge_ands_overlapping_collection_filters() {
+fn layered_desired_merge_prefers_signed_data_plane_filter() {
     let base_filter = equality_filter("requester_did", "did:key:phone");
     let data_filter = FilterPredicate::predicate(
         serde_json::json!({ "status": { "_in": ["pending", "processing"] } })
@@ -192,19 +190,19 @@ fn layered_desired_merge_ands_overlapping_collection_filters() {
 
     assert_eq!(
         merged.replicator_filter.get("AgentRequest"),
-        Some(&FilterPredicate::All(vec![base_filter, data_filter]))
+        Some(&data_filter)
     );
 }
 
 #[test]
-fn layered_desired_merge_keeps_control_readiness_claimant() {
+fn layered_desired_merge_uses_signed_readiness_claimant() {
     let layer = |claimant| PairingDesired {
         replicator_filter: one_filter("BearerPairingReady", "claimant_did", claimant),
         ..Default::default()
     };
     let merged = merge_layered_desired(
         Some(layer("did:key:claimant")),
-        Some(layer("did:key:stale")),
+        Some(layer("did:key:signed")),
     )
     .expect("merged desired state");
 
@@ -213,7 +211,15 @@ fn layered_desired_merge_keeps_control_readiness_claimant() {
             .replicator_filter
             .get("BearerPairingReady")
             .and_then(single_string_eq),
-        Some(("claimant_did", "did:key:claimant"))
+        Some(("claimant_did", "did:key:signed"))
+    );
+}
+
+#[test]
+fn self_pairing_base_is_not_materialized() {
+    assert!(
+        materialize_base_desired("did:key:self", "did:key:self", PairingDesired::default())
+            .is_none()
     );
 }
 

--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use gents::agent::p2p_reconcile::{
-    equality_filter, materialize_base_desired, merge_layered_desired, single_string_eq, DiffOp,
-    FilterPredicate, PairingDesired, PairingFilters, MAX_CONCURRENT_PEER_PREPARATIONS,
+    equality_filter, merge_layered_desired, single_string_eq, DiffOp, FilterPredicate,
+    PairingDesired, PairingFilters, MAX_CONCURRENT_PEER_PREPARATIONS,
 };
 
 use crate::lean_vocab_test::{
@@ -31,6 +31,13 @@ fn one_filter(collection: &str, field: &str, value: &str) -> PairingFilters {
     let mut filters = PairingFilters::new();
     filters.insert(collection.to_string(), equality_filter(field, value));
     filters
+}
+
+fn merge_desired(
+    base: Option<PairingDesired>,
+    data_plane: Option<PairingDesired>,
+) -> Option<PairingDesired> {
+    merge_layered_desired("did:key:local", "did:key:peer", base, data_plane)
 }
 
 #[tokio::test]
@@ -126,8 +133,7 @@ fn layered_desired_merge_keeps_data_plane_replicator_only() {
         template_ids: BTreeSet::new(),
     };
 
-    let merged =
-        merge_layered_desired(Some(control), Some(data_plane)).expect("merged desired state");
+    let merged = merge_desired(Some(control), Some(data_plane)).expect("merged desired state");
 
     assert_eq!(
         merged.collections,
@@ -182,7 +188,7 @@ fn layered_desired_merge_prefers_signed_data_plane_filter() {
         template_ids: BTreeSet::new(),
     };
 
-    let merged = merge_layered_desired(
+    let merged = merge_desired(
         Some(layer(base_filter.clone())),
         Some(layer(data_filter.clone())),
     )
@@ -200,7 +206,7 @@ fn layered_desired_merge_uses_signed_readiness_claimant() {
         replicator_filter: one_filter("BearerPairingReady", "claimant_did", claimant),
         ..Default::default()
     };
-    let merged = merge_layered_desired(
+    let merged = merge_desired(
         Some(layer("did:key:claimant")),
         Some(layer("did:key:signed")),
     )
@@ -217,10 +223,13 @@ fn layered_desired_merge_uses_signed_readiness_claimant() {
 
 #[test]
 fn self_pairing_base_is_not_materialized() {
-    assert!(
-        materialize_base_desired("did:key:self", "did:key:self", PairingDesired::default())
-            .is_none()
-    );
+    assert!(merge_layered_desired(
+        "did:key:self",
+        "did:key:self",
+        Some(PairingDesired::default()),
+        None
+    )
+    .is_none());
 }
 
 #[test]
@@ -233,7 +242,7 @@ fn layered_desired_merge_absent_data_plane_preserves_control_only() {
         template_ids: BTreeSet::new(),
     };
 
-    let merged = merge_layered_desired(Some(control.clone()), None).expect("control desired state");
+    let merged = merge_desired(Some(control.clone()), None).expect("control desired state");
 
     assert_eq!(merged, control);
 }
@@ -247,7 +256,7 @@ fn merge_preserves_app_collections_subscription_only() {
         replicator_filter: Default::default(),
         template_ids: set(&["app-collections"]),
     };
-    let merged = merge_layered_desired(None, Some(app_layer)).expect("merged");
+    let merged = merge_desired(None, Some(app_layer)).expect("merged");
     assert!(
         merged.collections.contains("ChangeProposed"),
         "app-collections subscription must survive the merge: {merged:?}"
@@ -260,7 +269,7 @@ fn merge_preserves_app_collections_subscription_only() {
         replicator_filter: Default::default(),
         template_ids: set(&["network-control"]),
     };
-    let merged_nc = merge_layered_desired(None, Some(nc_layer)).expect("merged nc");
+    let merged_nc = merge_desired(None, Some(nc_layer)).expect("merged nc");
     assert!(
         merged_nc.collections.is_empty(),
         "non-app-collections data-plane subscription must be cleared: {merged_nc:?}"
@@ -283,7 +292,7 @@ fn app_collections_coexists_with_control_pairing() {
         replicator_filter: Default::default(),
         template_ids: set(&["app-collections"]),
     };
-    let merged = merge_layered_desired(Some(base), Some(app_layer)).expect("merged");
+    let merged = merge_desired(Some(base), Some(app_layer)).expect("merged");
     assert!(merged.collections.contains("AgentNetwork"));
     assert!(merged.collections.contains("NetworkMembership"));
     assert!(merged.collections.contains("ChangeProposed"));

--- a/crates/gents/tests/conformance/scope_templates.rs
+++ b/crates/gents/tests/conformance/scope_templates.rs
@@ -3,6 +3,10 @@ use gents::agent::p2p_reconcile::templates::{
     AGENT_DIRECTORY_COLLECTION,
 };
 
+fn assert_eq_filter(predicate: &FilterPredicate, field: &str, value: &str) {
+    assert_eq!(predicate.single_string_eq(), Some((field, value)));
+}
+
 #[test]
 fn resolve_template_is_total_over_catalog_and_id_faithful() {
     for t in builtin_templates() {
@@ -52,8 +56,7 @@ fn conversation_scope_filters_transcript_and_grants_unfiltered_config() {
         } else {
             "requester_did"
         };
-        assert_eq!(pred.field, expected_field);
-        assert_eq!(pred.value, "did:key:bob");
+        assert_eq_filter(pred, expected_field, "did:key:bob");
     }
     for col in [
         "AgentBehavior",
@@ -78,9 +81,9 @@ fn conversation_scope_excludes_another_requester_on_the_same_agent() {
 
     let phone_request = ("did:key:amy", Some("did:key:phone"));
     let classifier_request = ("did:key:amy", None);
-    assert_eq!(predicate.field, "requester_did");
-    assert_eq!(phone_request.1, Some(predicate.value.as_str()));
-    assert_ne!(classifier_request.1, Some(predicate.value.as_str()));
+    assert_eq_filter(predicate, "requester_did", "did:key:phone");
+    assert_eq!(phone_request.1, Some("did:key:phone"));
+    assert_ne!(classifier_request.1, Some("did:key:phone"));
 }
 
 /// Mirrors Lean `clientIndex_filter_eq` and
@@ -100,8 +103,7 @@ fn client_index_scope_is_exactly_the_requester_scoped_session_index() {
     assert_eq!(phone.len(), 2);
     for collection in template.collections {
         let predicate = phone.get(*collection).expect("collection filtered");
-        assert_eq!(predicate.field, "requester_did");
-        assert_eq!(predicate.value, "did:key:phone");
+        assert_eq_filter(predicate, "requester_did", "did:key:phone");
     }
 
     let laptop = scope_filter(
@@ -111,8 +113,8 @@ fn client_index_scope_is_exactly_the_requester_scoped_session_index() {
         "did:key:home",
     );
     assert_ne!(
-        phone.get("AgentSession").unwrap().value,
-        laptop.get("AgentSession").unwrap().value
+        phone.get("AgentSession").unwrap(),
+        laptop.get("AgentSession").unwrap()
     );
 }
 
@@ -143,15 +145,11 @@ fn machine_scope_covers_conversation_and_home_owned_directory() {
         } else {
             "requester_did"
         };
-        assert_eq!(predicate.field, expected_field);
-        assert_eq!(predicate.value, "did:key:phone");
+        assert_eq_filter(predicate, expected_field, "did:key:phone");
     }
     assert_eq!(
         filters.get(AGENT_DIRECTORY_COLLECTION),
-        Some(&FilterPredicate {
-            field: "source_did".to_string(),
-            value: "did:key:issuer".to_string(),
-        })
+        Some(&FilterPredicate::eq("source_did", "did:key:issuer"))
     );
 }
 
@@ -189,10 +187,7 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     assert!(!coord_filter.contains_key("AgentRequest"));
     assert_eq!(
         coord_filter.get("AgentToolCall"),
-        Some(&FilterPredicate {
-            field: "spawn_target_did".to_string(),
-            value: "did:key:host".to_string(),
-        })
+        Some(&FilterPredicate::eq("spawn_target_did", "did:key:host"))
     );
 
     let host = resolve_template("subagent-host").expect("host template");
@@ -207,18 +202,12 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     assert_eq!(host_filter.len(), RETURN_PROJECTION.len());
     assert_eq!(
         host_filter.get("AgentRequest"),
-        Some(&FilterPredicate {
-            field: "requester_did".to_string(),
-            value: "did:key:coord".to_string(),
-        })
+        Some(&FilterPredicate::eq("requester_did", "did:key:coord"))
     );
     for collection in RETURN_PROJECTION {
         assert_eq!(
             host_filter.get(*collection),
-            Some(&FilterPredicate {
-                field: "requester_did".to_string(),
-                value: "did:key:coord".to_string(),
-            }),
+            Some(&FilterPredicate::eq("requester_did", "did:key:coord")),
             "unexpected host filter for {collection}"
         );
     }
@@ -233,10 +222,10 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     }
 
     for predicate in coord_filter.values().chain(host_filter.values()) {
-        assert!(
-            predicate.value == "did:key:coord" || predicate.value == "did:key:host",
-            "subagent filters must not include third-party DIDs"
-        );
+        let (_, value) = predicate
+            .single_string_eq()
+            .expect("single equality filter");
+        assert!(value == "did:key:coord" || value == "did:key:host");
     }
 }
 
@@ -253,9 +242,9 @@ fn subagent_host_message_filter_excludes_unrelated_host_history() {
 
     let child_requester_did = Some("did:key:coord");
     let unrelated_requester_did: Option<&str> = None;
-    assert_eq!(predicate.field, "requester_did");
-    assert_eq!(child_requester_did, Some(predicate.value.as_str()));
-    assert_ne!(unrelated_requester_did, Some(predicate.value.as_str()));
+    assert_eq_filter(predicate, "requester_did", "did:key:coord");
+    assert_eq!(child_requester_did, Some("did:key:coord"));
+    assert_ne!(unrelated_requester_did, Some("did:key:coord"));
 }
 
 #[test]
@@ -284,7 +273,7 @@ fn sixteen_peer_request_wave_is_reduced_to_one_target() {
             scope_filter(&host.scope, host.collections, &peer_did, "did:key:host")
                 .get("AgentRequest")
                 .is_some_and(|predicate| {
-                    predicate.field == "requester_did" && predicate.value == requester_did
+                    predicate.single_string_eq() == Some(("requester_did", requester_did))
                 })
         })
         .count();

--- a/crates/gents/tests/conformance/scope_templates.rs
+++ b/crates/gents/tests/conformance/scope_templates.rs
@@ -1,10 +1,10 @@
 use gents::agent::p2p_reconcile::templates::{
-    builtin_templates, resolve_template, scope_filter, Delivery, FilterPredicate, Scope,
-    AGENT_DIRECTORY_COLLECTION,
+    builtin_templates, equality_filter, resolve_template, scope_filter, single_string_eq, Delivery,
+    FilterPredicate, Scope, AGENT_DIRECTORY_COLLECTION,
 };
 
 fn assert_eq_filter(predicate: &FilterPredicate, field: &str, value: &str) {
-    assert_eq!(predicate.single_string_eq(), Some((field, value)));
+    assert_eq!(single_string_eq(predicate), Some((field, value)));
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn machine_scope_covers_conversation_and_home_owned_directory() {
     }
     assert_eq!(
         filters.get(AGENT_DIRECTORY_COLLECTION),
-        Some(&FilterPredicate::eq("source_did", "did:key:issuer"))
+        Some(&equality_filter("source_did", "did:key:issuer"))
     );
 }
 
@@ -187,7 +187,7 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     assert!(!coord_filter.contains_key("AgentRequest"));
     assert_eq!(
         coord_filter.get("AgentToolCall"),
-        Some(&FilterPredicate::eq("spawn_target_did", "did:key:host"))
+        Some(&equality_filter("spawn_target_did", "did:key:host"))
     );
 
     let host = resolve_template("subagent-host").expect("host template");
@@ -202,12 +202,12 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     assert_eq!(host_filter.len(), RETURN_PROJECTION.len());
     assert_eq!(
         host_filter.get("AgentRequest"),
-        Some(&FilterPredicate::eq("requester_did", "did:key:coord"))
+        Some(&equality_filter("requester_did", "did:key:coord"))
     );
     for collection in RETURN_PROJECTION {
         assert_eq!(
             host_filter.get(*collection),
-            Some(&FilterPredicate::eq("requester_did", "did:key:coord")),
+            Some(&equality_filter("requester_did", "did:key:coord")),
             "unexpected host filter for {collection}"
         );
     }
@@ -222,9 +222,7 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     }
 
     for predicate in coord_filter.values().chain(host_filter.values()) {
-        let (_, value) = predicate
-            .single_string_eq()
-            .expect("single equality filter");
+        let (_, value) = single_string_eq(predicate).expect("single equality filter");
         assert!(value == "did:key:coord" || value == "did:key:host");
     }
 }
@@ -273,7 +271,7 @@ fn sixteen_peer_request_wave_is_reduced_to_one_target() {
             scope_filter(&host.scope, host.collections, &peer_did, "did:key:host")
                 .get("AgentRequest")
                 .is_some_and(|predicate| {
-                    predicate.single_string_eq() == Some(("requester_did", requester_did))
+                    single_string_eq(predicate) == Some(("requester_did", requester_did))
                 })
         })
         .count();

--- a/crates/gents/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
+++ b/crates/gents/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
@@ -93,10 +93,7 @@ async fn install_one_way_replicator(
     let mut filters = PairingFilters::new();
     filters.insert(
         "AgentRequest".to_string(),
-        FilterPredicate {
-            field: "requester_did".to_string(),
-            value: PEER_DID.to_string(),
-        },
+        FilterPredicate::eq("requester_did", PEER_DID),
     );
     sender_admin
         .add_replicator(&[receiver_addr], &collection_names, &filters)

--- a/crates/gents/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
+++ b/crates/gents/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use gents::agent::p2p_reconcile::{
-    EmbeddedRemoteP2pAdmin, FilterPredicate, PairingFilters, RemoteP2pAdmin,
+    equality_filter, EmbeddedRemoteP2pAdmin, PairingFilters, RemoteP2pAdmin,
 };
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
@@ -93,7 +93,7 @@ async fn install_one_way_replicator(
     let mut filters = PairingFilters::new();
     filters.insert(
         "AgentRequest".to_string(),
-        FilterPredicate::eq("requester_did", PEER_DID),
+        equality_filter("requester_did", PEER_DID),
     );
     sender_admin
         .add_replicator(&[receiver_addr], &collection_names, &filters)

--- a/crates/gents/tests/support/pairing_conformance/runner.rs
+++ b/crates/gents/tests/support/pairing_conformance/runner.rs
@@ -371,10 +371,7 @@ fn scenario_filter_to_pairing_filters(
         .map(|(collection, predicate)| {
             (
                 collection.clone(),
-                FilterPredicate {
-                    field: predicate.field.clone(),
-                    value: predicate.value.clone(),
-                },
+                FilterPredicate::eq(predicate.field.clone(), predicate.value.clone()),
             )
         })
         .collect()

--- a/crates/gents/tests/support/pairing_conformance/runner.rs
+++ b/crates/gents/tests/support/pairing_conformance/runner.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::{bail, Result};
-use gents::agent::p2p_reconcile::templates::{FilterPredicate, PairingFilters};
+use gents::agent::p2p_reconcile::templates::{equality_filter, PairingFilters};
 use gents::agent::p2p_reconcile::{
     compute_owned_pairing_diff, update_applied_after_success, DiffOp,
     PairingActual as RuntimePairingActual,
@@ -373,7 +373,7 @@ fn scenario_filter_to_pairing_filters(
         .map(|(collection, predicate)| {
             (
                 collection.clone(),
-                FilterPredicate::eq(predicate.field.clone(), predicate.value.clone()),
+                equality_filter(predicate.field.clone(), predicate.value.clone()),
             )
         })
         .collect()

--- a/crates/gents/tests/support/pairing_conformance/runner.rs
+++ b/crates/gents/tests/support/pairing_conformance/runner.rs
@@ -323,6 +323,8 @@ struct DesiredRow {
 
 #[derive(Deserialize)]
 struct AppliedRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
     collections: Option<Vec<String>>,
     replicator_addresses: Option<Vec<String>>,
 }
@@ -455,20 +457,7 @@ async fn delete_peer_pairing_desired(node: &HarnessNode, peer: &str) -> Result<(
 }
 
 async fn read_peer_pairing_applied(node: &HarnessNode, peer: &str) -> Result<PairingApplied> {
-    let peer = escape_graphql_string(peer);
-    let query = format!(
-        r#"{{
-            PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{peer}" }} }}) {{
-                collections
-                replicator_addresses
-            }}
-        }}"#
-    );
-    let resp = node.db.node.execute(&query).await;
-    if resp.has_errors() {
-        bail!("read PeerPairingApplied failed: {:?}", resp.errors);
-    }
-    let row = first_optional_row::<AppliedRow>(&resp, "PeerPairingApplied");
+    let row = read_peer_pairing_applied_row(node, peer).await?;
     Ok(PairingApplied {
         collections: row
             .as_ref()
@@ -485,44 +474,79 @@ async fn read_peer_pairing_applied(node: &HarnessNode, peer: &str) -> Result<Pai
     })
 }
 
+async fn read_peer_pairing_applied_row(
+    node: &HarnessNode,
+    peer: &str,
+) -> Result<Option<AppliedRow>> {
+    let peer = escape_graphql_string(peer);
+    let query = format!(
+        r#"{{
+            PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{peer}" }} }}) {{
+                _docID
+                collections
+                replicator_addresses
+            }}
+        }}"#
+    );
+    let resp = node.db.node.execute(&query).await;
+    if resp.has_errors() {
+        bail!("read PeerPairingApplied failed: {:?}", resp.errors);
+    }
+    Ok(
+        gents::graphql::rows::<AppliedRow>(&resp, "PeerPairingApplied")?
+            .into_iter()
+            .min_by(|left, right| left.doc_id.cmp(&right.doc_id)),
+    )
+}
+
 async fn write_peer_pairing_applied(
     node: &HarnessNode,
     peer: &str,
     applied: &PairingApplied,
 ) -> Result<()> {
-    let peer = escape_graphql_string(peer);
+    let escaped_peer = escape_graphql_string(peer);
     let mutation = if applied.is_empty() {
         format!(
             r#"mutation {{
                 delete_PeerPairingApplied(
-                    filter: {{ peer_id: {{ _eq: "{peer}" }} }}
+                    filter: {{ peer_id: {{ _eq: "{escaped_peer}" }} }}
                 ) {{ _docID }}
             }}"#
         )
     } else {
+        let existing_doc_id = read_peer_pairing_applied_row(node, peer)
+            .await?
+            .map(|row| row.doc_id);
         let collections = graphql_string_set_literal(&applied.collections);
         let replicator_addresses = graphql_string_set_literal(&applied.replicator_addresses);
         let now = chrono::Utc::now().to_rfc3339();
         let now = escape_graphql_string(&now);
-        format!(
-            r#"mutation {{
-                upsert_PeerPairingApplied(
-                    filter: {{ peer_id: {{ _eq: "{peer}" }} }},
-                    add: {{
-                        peer_id: "{peer}",
+        match existing_doc_id {
+            Some(doc_id) => format!(
+                r#"mutation {{
+                    update_PeerPairingApplied(
+                        filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                        input: {{
+                            collections: {collections},
+                            replicator_addresses: {replicator_addresses},
+                            updated_at: "{now}"
+                        }}
+                    ) {{ _docID }}
+                }}"#,
+                doc_id = escape_graphql_string(&doc_id),
+            ),
+            None => format!(
+                r#"mutation {{
+                    create_PeerPairingApplied(input: {{
+                        peer_id: "{escaped_peer}",
                         collections: {collections},
                         replicator_addresses: {replicator_addresses},
                         created_at: "{now}",
                         updated_at: "{now}"
-                    }},
-                    update: {{
-                        collections: {collections},
-                        replicator_addresses: {replicator_addresses},
-                        updated_at: "{now}"
-                    }}
-                ) {{ _docID }}
-            }}"#
-        )
+                    }}) {{ _docID }}
+                }}"#,
+            ),
+        }
     };
     let resp = node.db.node.execute(&mutation).await;
     if resp.has_errors() {


### PR DESCRIPTION
## Summary

- support conjunctive pairing filters while preserving bearer readiness across layered filters
- keep mobile configuration navigation consistent
- treat endpoint rotation for the same stable peer as a route refresh instead of reinstalling replicators
- consolidate `PeerPairingApplied` writes behind one persistence entrypoint and update one canonical `_docID`
- align the runtime, CLI, and conformance runner on canonical applied-row selection

## Root cause

`PeerPairingApplied` was written through multiple paths using a logical-key upsert. Once duplicate physical rows existed, DefraDB rejected the upsert and the reconciler could no longer record convergence. Endpoint ticket rotation also looked like replicator replacement even when the stable peer identity had not changed, causing unnecessary teardown and replay.

## Impact

Pairing reconciliation now survives duplicate applied rows, refreshes rotated routes without replaying collections, and prunes stale endpoints only after they disappear from both desired and observed state.

## Validation

- `cargo test -p gents` — 2,205 passed, 3 ignored
- pairing conformance suite — 10 passed, including Lean rebuild
- CLI pairing tests — 18 passed
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- post-rebase `RUST_MIN_STACK=8388608 cargo test -p gents endpoint_` — 15 passed
