### PR TITLE
fix(p2p): close fleet convergence amplification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1348,7 +1348,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -1618,7 +1618,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -1745,12 +1745,12 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "base64 0.22.1",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "anyhow",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -1981,13 +1981,14 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "datastore",
  "defra-core",
  "document",
  "schema",
+ "serde",
  "storage",
  "thiserror 2.0.18",
  "tracing",
@@ -1996,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-lock",
@@ -2036,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-trait",
@@ -2051,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "anyhow",
  "document",
@@ -2085,7 +2086,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2110,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-stream",
@@ -2145,14 +2146,13 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "anyhow",
  "async-trait",
  "axum",
  "blockstore",
- "cid",
  "db",
  "db-merge",
  "defra-core",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-trait",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "serde",
 ]
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -2917,21 +2917,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2944,12 +2935,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -4195,27 +4180,12 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -4374,7 +4344,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -5016,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-channel",
@@ -5084,7 +5054,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5592,23 +5562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -6209,48 +6162,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6368,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "anyhow",
@@ -6380,7 +6295,6 @@ dependencies = [
  "chrono",
  "ciborium",
  "cid",
- "crdt",
  "crypto",
  "defra-core",
  "document",
@@ -6391,7 +6305,7 @@ dependencies = [
  "iroh",
  "iroh-gossip",
  "iroh-tickets",
- "kms",
+ "lru 0.16.4",
  "multihash-codetable",
  "noq",
  "parking_lot",
@@ -7154,7 +7068,7 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-graphql",
@@ -7183,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "chrono",
  "cid",
@@ -7199,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "acp",
  "async-lock",
@@ -7224,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7604,7 +7518,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "p2p",
  "query",
@@ -7630,23 +7544,21 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -8005,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "cid",
  "defra-core",
@@ -8763,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9314,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "tracing",
 ]
@@ -9517,16 +9429,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -10215,12 +10117,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -11710,7 +11606,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=e28586b08c7962b36d4d8f496676024a9167854e#e28586b08c7962b36d4d8f496676024a9167854e"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -1618,7 +1618,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -1890,13 +1890,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "anyhow",
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "datastore",
@@ -1997,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-lock",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-trait",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "anyhow",
  "document",
@@ -2086,7 +2086,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-stream",
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "anyhow",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-trait",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "serde",
 ]
@@ -2390,7 +2390,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2714,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2741,7 +2741,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3229,8 +3229,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4225,7 +4225,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4344,7 +4344,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -4986,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-channel",
@@ -5054,7 +5054,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5796,7 +5796,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5925,7 +5925,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6283,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "anyhow",
@@ -7068,7 +7068,7 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-graphql",
@@ -7097,7 +7097,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "chrono",
  "cid",
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "acp",
  "async-lock",
@@ -7138,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7219,7 +7219,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7518,7 +7518,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "p2p",
  "query",
@@ -7771,7 +7771,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7830,7 +7830,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7851,7 +7851,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "cid",
  "defra-core",
@@ -8052,7 +8052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "tracing",
 ]
@@ -9241,7 +9241,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10744,7 +10744,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11443,8 +11443,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -11606,7 +11606,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=c340eaf215450f9183f3eb7897b32088c7d991fb#c340eaf215450f9183f3eb7897b32088c7d991fb"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f928b30002c4af77c1ce3900a1e82650fdfefc14#f928b30002c4af77c1ce3900a1e82650fdfefc14"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ clap = { version = "4", features = ["derive", "env"] }
 # DefraDB v0.18.0 includes signed explicit transactions and default node query
 # identity. Its iterative parent-DAG replay remains required on iOS:
 # a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-codex-protocol = { path = "crates/gents-codex-protocol" }
@@ -68,12 +68,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -81,8 +81,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f928b30002c4af77c1ce3900a1e82650fdfefc14" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ clap = { version = "4", features = ["derive", "env"] }
 # DefraDB v0.18.0 includes signed explicit transactions and default node query
 # identity. Its iterative parent-DAG replay remains required on iOS:
 # a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-codex-protocol = { path = "crates/gents-codex-protocol" }
@@ -68,12 +68,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -81,8 +81,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "e28586b08c7962b36d4d8f496676024a9167854e" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "c340eaf215450f9183f3eb7897b32088c7d991fb" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/gents-cli/src/commands/p2p/join.rs
+++ b/crates/gents-cli/src/commands/p2p/join.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, SecondsFormat, Utc};
 use gents::agent::p2p_reconcile::network::{decide_v5_admission, V5AdmissionClaim};
-use gents::agent::p2p_reconcile::resolve_template;
+use gents::agent::p2p_reconcile::{resolve_template, NETWORK_CONTROL_TEMPLATE};
 use gents::graphql::escape_graphql_string;
 use gents::AgentIdentity;
 use gents_protocol::network_token::{derive_network_id, MembershipRecord};
@@ -16,12 +16,10 @@ use crate::request_helpers::parse_duration_suffix;
 use crate::{graphql_rows, print_json, resolve_config_access, resolve_graphql_endpoint};
 
 use super::invite::resolve_home_identity;
-use super::network_admin::{
-    load_membership_record, load_optional_network_record, write_agent_network, write_membership,
-};
+use super::network_admin::{load_membership_record, load_optional_network_record};
 use super::pairings::{
     complement_subagent_template, peer_pairing_exists, resolve_pairing_template,
-    wait_for_pairing_connected, write_pairing_desired,
+    wait_for_pairing_connected, write_layered_join_desired,
 };
 
 pub(super) async fn p2p_join(args: P2pJoinArgs) -> Result<()> {
@@ -55,6 +53,7 @@ pub(super) async fn p2p_join(args: P2pJoinArgs) -> Result<()> {
 
     let template = resolve_join_template(args.template.as_deref(), &remote.template)?;
     let collections = template_collections(&template);
+    let control_collections = template_collections(NETWORK_CONTROL_TEMPLATE);
     let addresses = vec![remote.ticket.clone()];
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let (access, home_dir) =
@@ -72,15 +71,17 @@ pub(super) async fn p2p_join(args: P2pJoinArgs) -> Result<()> {
 
     consume_invite_nonce(&access, &remote.nonce, &remote.issuer_did).await?;
 
-    write_agent_network(&access, &remote.network).await?;
-    write_membership(&access, &remote.grant).await?;
-
+    // The issuer is the single writer for the signed network root and grant.
+    // The network-control pairing below durably pulls those exact documents;
+    // recreating them locally gives the same logical record a second DefraDB
+    // document identity and multiplies every subsequent replication edge.
     let existed = peer_pairing_exists(&access, &remote.peer_id).await?;
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
-    let doc_id = write_pairing_desired(
+    let (doc_id, data_plane_doc_id) = write_layered_join_desired(
         &access,
         &remote.peer_id,
-        Some(&remote.issuer_did),
+        &remote.issuer_did,
+        &control_collections,
         &collections,
         &addresses,
         &template,
@@ -115,6 +116,9 @@ pub(super) async fn p2p_join(args: P2pJoinArgs) -> Result<()> {
     });
     if let Some(p2p) = p2p {
         output["p2p"] = p2p;
+    }
+    if let Some(data_plane_doc_id) = data_plane_doc_id {
+        output["data_plane_doc_id"] = data_plane_doc_id.into();
     }
 
     print_json(&output)?;

--- a/crates/gents-cli/src/commands/p2p/pairings.rs
+++ b/crates/gents-cli/src/commands/p2p/pairings.rs
@@ -246,6 +246,65 @@ pub(super) async fn write_pairing_desired(
         .context("reading PeerPairingDesired mutation doc id")
 }
 
+pub(super) async fn write_layered_join_desired(
+    access: &ConfigAccess,
+    peer_id: &str,
+    agent_did: &str,
+    control_collections: &[String],
+    data_collections: &[String],
+    addresses: &[String],
+    data_template: &str,
+    now: &str,
+) -> Result<(String, Option<String>)> {
+    let control = pairing_upsert_field(
+        "control: upsert_PeerPairingDesired",
+        peer_id,
+        Some(agent_did),
+        control_collections,
+        addresses,
+        "network-control",
+        now,
+        true,
+    );
+    let data = (data_template != "network-control").then(|| {
+        pairing_upsert_field(
+            "data_plane: upsert_DataPlanePairingDesired",
+            peer_id,
+            Some(agent_did),
+            data_collections,
+            addresses,
+            data_template,
+            now,
+            false,
+        )
+    });
+    let mutation = format!(
+        "mutation {{ {control} {} }}",
+        data.as_deref().unwrap_or_default()
+    );
+    let response = access
+        .execute(&mutation)
+        .await
+        .context("writing layered join pairing rows")?;
+    let control_doc_id = aliased_mutation_doc_id(&response, "control")?;
+    let data_doc_id = data
+        .as_ref()
+        .map(|_| aliased_mutation_doc_id(&response, "data_plane"))
+        .transpose()?;
+    Ok((control_doc_id, data_doc_id))
+}
+
+fn aliased_mutation_doc_id(response: &Value, alias: &str) -> Result<String> {
+    let doc_ids = mutation_doc_ids(response, alias);
+    match doc_ids.as_slice() {
+        [doc_id] => Ok(doc_id.clone()),
+        [] => anyhow::bail!("graphql mutation returned no _docID for {alias}: {response}"),
+        _ => anyhow::bail!(
+            "graphql mutation returned multiple _docID values for {alias}: {response}"
+        ),
+    }
+}
+
 pub(super) async fn peer_pairing_exists(access: &ConfigAccess, peer_id: &str) -> Result<bool> {
     let peer_id = escape_graphql_string(peer_id);
     let query = format!(
@@ -274,6 +333,30 @@ pub(super) fn upsert_pairing_mutation(
     template: &str,
     now: &str,
 ) -> String {
+    let field = pairing_upsert_field(
+        "upsert_PeerPairingDesired",
+        peer_id,
+        agent_did,
+        collections,
+        addresses,
+        template,
+        now,
+        true,
+    );
+    format!("mutation {{ {field} }}")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pairing_upsert_field(
+    operation: &str,
+    peer_id: &str,
+    agent_did: Option<&str>,
+    collections: &[String],
+    addresses: &[String],
+    template: &str,
+    now: &str,
+    include_profiles: bool,
+) -> String {
     let peer_id = escape_graphql_string(peer_id);
     let agent_did = graphql_nullable_string_literal(agent_did);
     let agent_did_update = if agent_did == "null" {
@@ -285,17 +368,19 @@ pub(super) fn upsert_pairing_mutation(
     let addresses = graphql_nullable_string_list_literal(addresses);
     let template = escape_graphql_string(template);
     let now = escape_graphql_string(now);
+    let profiles = include_profiles
+        .then_some("profiles: null,")
+        .unwrap_or_default();
 
     format!(
-        r#"mutation {{
-            upsert_PeerPairingDesired(
+        r#"{operation}(
                 filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
                 add: {{
                     peer_id: "{peer_id}",
                     agent_did: {agent_did},
                     collections: {collections},
                     replicator_addresses: {addresses},
-                    profiles: null,
+                    {profiles}
                     template: "{template}",
                     source: "operator",
                     created_at: "{now}",
@@ -305,13 +390,12 @@ pub(super) fn upsert_pairing_mutation(
                     {agent_did_update}
                     collections: {collections},
                     replicator_addresses: {addresses},
-                    profiles: null,
+                    {profiles}
                     template: "{template}",
                     source: "operator",
                     updated_at: "{now}"
                 }}
-            ) {{ _docID }}
-        }}"#
+            ) {{ _docID }}"#
     )
 }
 

--- a/crates/gents-cli/src/http/prometheus.rs
+++ b/crates/gents-cli/src/http/prometheus.rs
@@ -680,11 +680,6 @@ fn render_p2p_sync_metrics(lines: &mut Vec<String>, status: Option<&gents::P2pSy
             backlog.per_peer_active_cap,
         ),
         (
-            "gents_p2p_push_encode_cache_entries",
-            "Encoded DAG payloads currently retained by DefraDB push coalescing.",
-            status.encode_cache_entries,
-        ),
-        (
             "gents_p2p_pending_dags",
             "Live in-memory pending DAG registrations.",
             status.pending_dags,
@@ -773,11 +768,6 @@ fn render_p2p_sync_metrics(lines: &mut Vec<String>, status: Option<&gents::P2pSy
             backlog.peer_capacity_parks_total,
         ),
         (
-            "gents_p2p_push_encode_cache_hits_total",
-            "Outbound pushes that reused a cached encoded DAG payload.",
-            status.encode_cache_hits_total,
-        ),
-        (
             "gents_p2p_broadcast_coalesced_total",
             "Redundant DefraDB broadcast updates coalesced before outbound push.",
             status.broadcast_coalesced_total,
@@ -813,6 +803,16 @@ fn render_p2p_sync_metrics(lines: &mut Vec<String>, status: Option<&gents::P2pSy
             status.pending_dag_capacity_shed,
         ),
         (
+            "gents_p2p_pending_dag_fetch_deferred_unavailable_total",
+            "Due pending DAG fetches deferred because no qualified provider was connected.",
+            status.pending_dag_fetch_deferred_unavailable,
+        ),
+        (
+            "gents_p2p_pending_dag_fetch_deferred_contention_total",
+            "Useful CAR ingests deferred behind an existing local storage owner.",
+            status.pending_dag_fetch_deferred_contention,
+        ),
+        (
             "gents_p2p_single_flight_suppressed_total",
             "Duplicate concurrent receives of the same CID suppressed by DefraDB sync.",
             status.single_flight_suppressed,
@@ -830,20 +830,6 @@ fn render_p2p_sync_metrics(lines: &mut Vec<String>, status: Option<&gents::P2pSy
     ] {
         push_metric_prelude_with_type(lines, name, help, "counter");
         push_metric_sample(lines, name, &[], value);
-    }
-
-    push_metric_prelude(
-        lines,
-        "gents_p2p_push_cid_retry_count",
-        "Current outbound retry count retained for one CID.",
-    );
-    for retry in &backlog.per_cid_retry_counts {
-        push_metric_sample(
-            lines,
-            "gents_p2p_push_cid_retry_count",
-            &[("cid", retry.cid.clone())],
-            retry.retry_count,
-        );
     }
 
     for (name, help) in [
@@ -1540,10 +1526,6 @@ mod tests {
                         failed_total: 4,
                         stale_head_retirements_total: 17,
                         peer_capacity_parks_total: 13,
-                        per_cid_retry_counts: vec![gents::P2pCidRetrySnapshot {
-                            cid: "bafy-retry".to_string(),
-                            retry_count: 19,
-                        }],
                         per_peer: vec![gents::P2pPeerBacklogSnapshot {
                             peer_id: "peer-a".to_string(),
                             queued_items: 4,
@@ -1552,9 +1534,8 @@ mod tests {
                             consecutive_failures: 3,
                             cooldown_remaining_ms: 750,
                         }],
+                        ..Default::default()
                     },
-                    encode_cache_hits_total: 37,
-                    encode_cache_entries: 5,
                     broadcast_coalesced_total: 41,
                     push_updates_coalesced_total: 43,
                     gossip_direction_filtered_total: 47,
@@ -1572,9 +1553,12 @@ mod tests {
                     pending_dag_capacity_shed: 59,
                     pending_dag_retry_dispatched: 61,
                     pending_dag_retry_suppressed: 67,
+                    pending_dag_fetch_deferred_unavailable: 69,
+                    pending_dag_fetch_deferred_contention: 68,
                     next_pending_retry_in_ms: Some(71),
                     pending_dag_terminal_quarantined: 73,
                     quarantined_pending_dags: 79,
+                    ..Default::default()
                 }),
                 stale: false,
             }),
@@ -1593,23 +1577,22 @@ mod tests {
         assert!(rendered.contains("gents_p2p_push_queue_items 7"));
         assert!(rendered.contains("gents_p2p_push_queue_bytes 4096"));
         assert!(rendered.contains("gents_p2p_push_active_jobs 3"));
-        assert!(rendered.contains("gents_p2p_push_encode_cache_entries 5"));
         assert!(rendered.contains("gents_p2p_pending_dags 13"));
         assert!(rendered.contains("gents_p2p_persisted_pending_dags 17"));
         assert!(rendered.contains("gents_p2p_quarantined_pending_dags 79"));
         assert!(rendered.contains("gents_p2p_push_rejected_items_total 5"));
         assert!(rendered.contains("gents_p2p_push_stale_head_retirements_total 17"));
         assert!(rendered.contains("gents_p2p_push_peer_capacity_parks_total 13"));
-        assert!(rendered.contains("gents_p2p_push_encode_cache_hits_total 37"));
         assert!(rendered.contains("gents_p2p_broadcast_coalesced_total 41"));
         assert!(rendered.contains("gents_p2p_push_updates_coalesced_total 43"));
         assert!(rendered.contains("gents_p2p_missing_link_retries_total 23"));
         assert!(rendered.contains("gents_p2p_gossip_direction_filtered_total 47"));
         assert!(rendered.contains("gents_p2p_pending_dag_capacity_shed_total 59"));
+        assert!(rendered.contains("gents_p2p_pending_dag_fetch_deferred_unavailable_total 69"));
+        assert!(rendered.contains("gents_p2p_pending_dag_fetch_deferred_contention_total 68"));
         assert!(rendered.contains("gents_p2p_single_flight_suppressed_total 37"));
         assert!(rendered.contains("gents_p2p_already_merged_fast_path_total 53"));
         assert!(rendered.contains("gents_p2p_pending_dag_terminal_quarantined_total 73"));
-        assert!(rendered.contains(r#"gents_p2p_push_cid_retry_count{cid="bafy-retry"} 19"#));
         assert!(rendered.contains(r#"gents_p2p_peer_consecutive_failures{peer_id="peer-a"} 3"#));
         assert!(rendered
             .contains(r#"gents_p2p_peer_cooldown_remaining_milliseconds{peer_id="peer-a"} 750"#));

--- a/crates/gents-cli/src/http/router.rs
+++ b/crates/gents-cli/src/http/router.rs
@@ -560,10 +560,6 @@ mod tests {
                         "failed_total": 4,
                         "stale_head_retirements_total": 17,
                         "peer_capacity_parks_total": 13,
-                        "per_cid_retry_counts": [{
-                            "cid": "bafy-retry",
-                            "retry_count": 19
-                        }],
                         "per_peer": [{
                             "peer_id": "peer-a",
                             "queued_items": 4,
@@ -573,8 +569,6 @@ mod tests {
                             "cooldown_remaining_ms": 750
                         }]
                     },
-                    "encode_cache_hits_total": 37,
-                    "encode_cache_entries": 5,
                     "broadcast_coalesced_total": 41,
                     "push_updates_coalesced_total": 43,
                     "gossip_direction_filtered_total": 47,
@@ -606,9 +600,7 @@ mod tests {
         assert_eq!(sync.push_backlog.queued_items, 7);
         assert_eq!(sync.push_backlog.stale_head_retirements_total, 17);
         assert_eq!(sync.push_backlog.peer_capacity_parks_total, 13);
-        assert_eq!(sync.push_backlog.per_cid_retry_counts[0].retry_count, 19);
         assert_eq!(sync.push_backlog.per_peer[0].consecutive_failures, 3);
-        assert_eq!(sync.encode_cache_hits_total, 37);
         assert_eq!(sync.push_updates_coalesced_total, 43);
         assert_eq!(sync.persisted_pending_dags, 17);
         assert_eq!(sync.missing_link_retries, 23);

--- a/crates/gents-cli/tests/suites/cli_fleet_delegation_live.rs
+++ b/crates/gents-cli/tests/suites/cli_fleet_delegation_live.rs
@@ -31,7 +31,8 @@
 //!
 //! The release acceptance composes the same primitives into a 19-fresh-store
 //! genesis mesh, a coordinator restart, and a 15-target delegation/readback
-//! sweep. It is intentionally a product E2E across both model instruction
+//! sweep. Its control-plane fence reads DefraDB's effective replicator scope.
+//! It is intentionally a product E2E across both model instruction
 //! following and the mesh; the hermetic two-process demo test isolates the pure
 //! transport/materialization contract. It is separately gated because it is
 //! intentionally expensive:
@@ -44,9 +45,8 @@
 //!     nineteen_process_release_acceptance_live -- --ignored --nocapture
 //! ```
 //!
-//! Known failure: the fresh-store control mesh can saturate DefraDB's pending
-//! DAG admission and fail to materialize an `AgentNetwork` applied scope. The
-//! release exception and removal criteria are tracked in #798.
+//! The fresh-store pending-DAG failure and release exception were tracked in
+//! #798.
 
 use crate::support::*;
 
@@ -99,8 +99,14 @@ const FAST_RECONCILE_ENVS: &[(&str, &str)] = &[
     ("GENTS_PAIRING_SWEEP_MS", "1000"),
     ("GENTS_REGISTRY_STALE_MS", "300000"),
     ("GENTS_ENDPOINT_HEARTBEAT_MS", "1000"),
-    ("RUST_LOG", "warn,gents::agent::p2p_reconcile=debug"),
+    (
+        "RUST_LOG",
+        "warn,gents::agent::p2p_reconcile=debug,gents::graphql=debug",
+    ),
 ];
+
+// Cover DefraDB's 30s, 1m, 2m durable retry ladder plus three quiet samples.
+const RELEASE_P2P_QUIET_TIMEOUT: Duration = Duration::from_secs(240);
 
 const CONVERSATION_COLLECTIONS: &[&str] = &[
     "AgentRequest",
@@ -124,7 +130,10 @@ const RELEASE_BAD_LOG_SIGNATURES: &[&str] = &[
     "Dropping GossipSub message outside accepted replication direction",
     "Collection-commit push failed; document retry ledger cannot replay CID-scoped work",
     "CAR handler: no exact blocks",
+    "skipping unparseable block in replicator push",
 ];
+
+const MAX_CONTROL_LEASE_WRITES_PER_NODE: usize = 16;
 
 struct FleetNode {
     home: PathBuf,
@@ -343,32 +352,55 @@ async fn five_process_filtered_conversation_delegation_live() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-#[ignore = "known failing: fresh-store 19-node mesh storm tracked in #798"]
+#[ignore = "live: set GENTS_RELEASE_ACCEPTANCE=1 and pass --ignored"]
 async fn nineteen_process_release_acceptance_live() -> Result<()> {
     require_live_gate("GENTS_RELEASE_ACCEPTANCE")?;
 
-    let endpoint = std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")
-        .or_else(|_| std::env::var("GENTS_CLI_E2E_MODEL_ENDPOINT"))
-        .unwrap_or_else(|_| DEFAULT_MODEL_ENDPOINT.to_string());
-    let model = std::env::var("GENTS_LIVE_OPENAI_MODEL")
-        .or_else(|_| std::env::var("GENTS_CLI_E2E_MODEL_NAME"))
-        .unwrap_or_else(|_| DEFAULT_MODEL_NAME.to_string());
+    let control_only = std::env::var("GENTS_RELEASE_CONTROL_ONLY").as_deref() == Ok("1");
+    let control_model_name = format!("release-control-only-{}", Uuid::new_v4().simple());
+    let control_model = control_only
+        .then(|| MockModelEndpoint::start(&control_model_name))
+        .transpose()?;
+    let endpoint = control_model
+        .as_ref()
+        .map(|mock| mock.endpoint().to_string())
+        .unwrap_or_else(|| {
+            std::env::var("GENTS_LIVE_OPENAI_ENDPOINT")
+                .or_else(|_| std::env::var("GENTS_CLI_E2E_MODEL_ENDPOINT"))
+                .unwrap_or_else(|_| DEFAULT_MODEL_ENDPOINT.to_string())
+        });
+    let model = control_model
+        .as_ref()
+        .map(|_| control_model_name)
+        .unwrap_or_else(|| {
+            std::env::var("GENTS_LIVE_OPENAI_MODEL")
+                .or_else(|_| std::env::var("GENTS_CLI_E2E_MODEL_NAME"))
+                .unwrap_or_else(|_| DEFAULT_MODEL_NAME.to_string())
+        });
     assert_endpoint_reachable(&endpoint).await?;
 
     let tempdir = tempfile::tempdir().context("creating release acceptance tempdir")?;
     let mut fleet =
         bring_up_fleet(tempdir.path(), RELEASE_FLEET_SIZE, &endpoint, &model, false).await?;
 
-    let result = run_release_acceptance(tempdir.path(), &mut fleet).await;
+    let result = run_release_acceptance(tempdir.path(), &mut fleet, control_only).await;
     if result.is_err() {
         dump_fleet_doc_state(&fleet).await;
         persist_fleet_logs(&fleet, "release-acceptance-fail");
         dump_fleet_logs(&fleet);
     }
+    if result.is_err() && std::env::var("GENTS_RELEASE_PRESERVE_STORES").as_deref() == Ok("1") {
+        let path = tempdir.keep();
+        tracing::warn!(path = %path.display(), "preserved failed release-acceptance stores");
+    }
     result
 }
 
-async fn run_release_acceptance(root: &Path, fleet: &mut [FleetNode]) -> Result<()> {
+async fn run_release_acceptance(
+    root: &Path,
+    fleet: &mut [FleetNode],
+    control_only: bool,
+) -> Result<()> {
     anyhow::ensure!(
         fleet.len() == RELEASE_FLEET_SIZE,
         "release acceptance requires exactly {RELEASE_FLEET_SIZE} fresh stores"
@@ -381,8 +413,9 @@ async fn run_release_acceptance(root: &Path, fleet: &mut [FleetNode]) -> Result<
         establish_control_plane(coord, spokes).await?;
         wait_for_fleet_control_plane(coord, spokes).await?;
     }
-    wait_for_p2p_fleet_quiet(fleet, Duration::from_secs(240)).await?;
+    wait_for_p2p_fleet_quiet(fleet, RELEASE_P2P_QUIET_TIMEOUT).await?;
     assert_no_fleet_log_signatures(fleet)?;
+    assert_bounded_control_lease_writes(fleet)?;
 
     restart_fleet_node(&mut fleet[0]).await?;
     {
@@ -392,8 +425,17 @@ async fn run_release_acceptance(root: &Path, fleet: &mut [FleetNode]) -> Result<
         wait_for_fleet_control_plane(coord, spokes).await?;
         wait_for_fleet_hub_remesh(coord, spokes, Duration::from_secs(120)).await?;
     }
-    wait_for_p2p_fleet_quiet(fleet, Duration::from_secs(240)).await?;
+    wait_for_p2p_fleet_quiet(fleet, RELEASE_P2P_QUIET_TIMEOUT).await?;
     assert_no_fleet_log_signatures(fleet)?;
+    assert_bounded_control_lease_writes(fleet)?;
+
+    if control_only {
+        tracing::info!(
+            fleet_size = fleet.len(),
+            "release control mesh converged across coordinator restart before model/delegation phases"
+        );
+        return Ok(());
+    }
 
     let (coord, spokes) = fleet
         .split_first()
@@ -469,7 +511,7 @@ async fn run_release_acceptance(root: &Path, fleet: &mut [FleetNode]) -> Result<
     assert_subagents_have_no_spawn_targets(delegates).await?;
     assert_no_subagent_data_plane_edges(spokes).await?;
 
-    wait_for_p2p_fleet_quiet(fleet, Duration::from_secs(240)).await?;
+    wait_for_p2p_fleet_quiet(fleet, RELEASE_P2P_QUIET_TIMEOUT).await?;
     assert_no_fleet_log_signatures(fleet)?;
     Ok(())
 }
@@ -497,9 +539,16 @@ struct P2pProgressSignature {
     rejected_bytes: u64,
     peer_capacity_parks: u64,
     missing_link_retries: u64,
+    provider_rotations: u64,
+    car_filtered_cids: u64,
+    pending_dag_registered: u64,
     pending_dag_expired: u64,
     pending_dag_capacity_shed: u64,
     pending_dag_retry_dispatched: u64,
+    pending_dag_fetch_deferred_contention: u64,
+    pending_dag_fetch_exhausted: u64,
+    pending_dag_terminal_merged: u64,
+    non_authoritative_broadcast_rejected: u64,
 }
 
 impl From<&P2pSyncStatusSnapshot> for P2pProgressSignature {
@@ -510,9 +559,17 @@ impl From<&P2pSyncStatusSnapshot> for P2pProgressSignature {
             rejected_bytes: snapshot.push_backlog.rejected_bytes_total,
             peer_capacity_parks: snapshot.push_backlog.peer_capacity_parks_total,
             missing_link_retries: snapshot.missing_link_retries,
+            provider_rotations: snapshot.provider_rotations,
+            car_filtered_cids: snapshot.car_filtered_cids,
+            pending_dag_registered: snapshot.pending_dag_registered,
             pending_dag_expired: snapshot.pending_dag_expired,
             pending_dag_capacity_shed: snapshot.pending_dag_capacity_shed,
             pending_dag_retry_dispatched: snapshot.pending_dag_retry_dispatched,
+            pending_dag_fetch_deferred_contention: snapshot.pending_dag_fetch_deferred_contention,
+            pending_dag_fetch_exhausted: snapshot.pending_dag_fetch_exhausted,
+            pending_dag_terminal_merged: snapshot.pending_dag_terminal_merged,
+            non_authoritative_broadcast_rejected: snapshot
+                .non_authoritative_broadcast_rejected_total,
         }
     }
 }
@@ -571,7 +628,11 @@ async fn fetch_connected_peer_ids(graphql: &str) -> Result<HashSet<String>> {
             row.get("id")
                 .and_then(Value::as_str)
                 .filter(|id| !id.trim().is_empty())
-                .map(ToOwned::to_owned)
+                .map(|id| {
+                    p2p::iroh::parse_public_peer_addr(id)
+                        .map(|(peer_id, _)| peer_id.to_string())
+                        .unwrap_or_else(|_| id.to_owned())
+                })
                 .with_context(|| format!("connected P2P peer row has no id: {row}"))
         })
         .collect()
@@ -660,6 +721,14 @@ fn assert_p2p_snapshot_bounded(label: &str, snapshot: &P2pSyncStatusSnapshot) ->
         snapshot.pending_dag_terminal_quarantined == 0 && snapshot.quarantined_pending_dags == 0,
         "{label} quarantined a deterministic pending-DAG failure: {snapshot:?}"
     );
+    anyhow::ensure!(
+        snapshot.pending_dag_capacity_shed == 0,
+        "{label} shed a pending DAG at its admission capacity: {snapshot:?}"
+    );
+    anyhow::ensure!(
+        snapshot.pending_dag_fetch_exhausted == 0,
+        "{label} exhausted a bounded pending-DAG fetch: {snapshot:?}"
+    );
     for peer in &backlog.per_peer {
         anyhow::ensure!(
             peer.active_jobs <= backlog.per_peer_active_cap,
@@ -681,10 +750,9 @@ fn p2p_snapshot_is_quiet(snapshot: &P2pSyncStatusSnapshot) -> bool {
     backlog.queued_items == 0
         && backlog.queued_bytes == 0
         && backlog.active_jobs == 0
-        && backlog.failed_total == 0
+        // Healed failures may remain cumulative; the progress fence must stabilize.
         && backlog.rejected_items_total == 0
         && backlog.rejected_bytes_total == 0
-        && backlog.per_cid_retry_counts.is_empty()
         && backlog.per_peer.iter().all(|peer| {
             peer.queued_items == 0
                 && peer.queued_bytes == 0
@@ -692,8 +760,16 @@ fn p2p_snapshot_is_quiet(snapshot: &P2pSyncStatusSnapshot) -> bool {
                 && peer.consecutive_failures == 0
                 && peer.cooldown_remaining_ms == 0
         })
+        && snapshot.push_retry_markers.document_markers == 0
+        && snapshot.push_retry_markers.collection_markers == 0
+        && snapshot.push_retry_markers.scheduled_peers == 0
+        && snapshot
+            .push_retry_markers
+            .oldest_scheduled_retry_unix
+            .is_none()
         && snapshot.pending_dags == 0
         && snapshot.persisted_pending_dags == 0
+        && snapshot.non_authoritative_broadcast_tasks == 0
         && !snapshot.pending_resync_in_flight
         && snapshot.next_pending_retry_in_ms.is_none()
         && snapshot.quarantined_pending_dags == 0
@@ -743,7 +819,7 @@ async fn wait_for_p2p_fleet_quiet(fleet: &[FleetNode], timeout: Duration) -> Res
                 .zip(&snapshots)
                 .map(|(node, snapshot)| {
                     format!(
-                        "{}: queued={}/{} active={} pending={}/{} persisted={}/{} retained={} missing_retries={} failed_pushes={} rejected_items={} rejected_bytes={}",
+                        "{}: queued={}/{} active={} pending={}/{} persisted={}/{} retained={} non_authoritative={} missing_retries={} provider_rotations={} car_filtered={} fetch_exhausted={} failed_pushes={} rejected_items={} rejected_bytes={}",
                         node.agent_did,
                         snapshot.push_backlog.queued_items,
                         snapshot.push_backlog.queued_bytes,
@@ -753,7 +829,11 @@ async fn wait_for_p2p_fleet_quiet(fleet: &[FleetNode], timeout: Duration) -> Res
                         snapshot.persisted_pending_dags,
                         snapshot.persisted_pending_dag_capacity,
                         snapshot.retained_background_tasks,
+                        snapshot.non_authoritative_broadcast_tasks,
                         snapshot.missing_link_retries,
+                        snapshot.provider_rotations,
+                        snapshot.car_filtered_cids,
+                        snapshot.pending_dag_fetch_exhausted,
                         snapshot.push_backlog.failed_total,
                         snapshot.push_backlog.rejected_items_total,
                         snapshot.push_backlog.rejected_bytes_total,
@@ -779,6 +859,41 @@ fn assert_no_fleet_log_signatures(fleet: &[FleetNode]) -> Result<()> {
             );
         }
     }
+    Ok(())
+}
+
+fn assert_bounded_control_lease_writes(fleet: &[FleetNode]) -> Result<()> {
+    let mut endpoint_writes = 0;
+    let mut registry_writes = 0;
+    for node in fleet {
+        let (stdout, stderr) = fleet_node_captured_output(node)?;
+        let combined = format!("{stdout}\n{stderr}");
+        let node_endpoint_writes = combined
+            .matches("PeerEndpoint heartbeat: signed endpoint written")
+            .count();
+        let node_registry_writes = combined
+            .matches("registry heartbeat: self-registration written")
+            .count();
+        anyhow::ensure!(
+            node_endpoint_writes <= MAX_CONTROL_LEASE_WRITES_PER_NODE,
+            "fleet node {} emitted {node_endpoint_writes} PeerEndpoint writes; bounded lease ceiling is {MAX_CONTROL_LEASE_WRITES_PER_NODE}",
+            node.agent_did
+        );
+        anyhow::ensure!(
+            node_registry_writes <= MAX_CONTROL_LEASE_WRITES_PER_NODE,
+            "fleet node {} emitted {node_registry_writes} PeerRegistry writes; bounded lease ceiling is {MAX_CONTROL_LEASE_WRITES_PER_NODE}",
+            node.agent_did
+        );
+        endpoint_writes += node_endpoint_writes;
+        registry_writes += node_registry_writes;
+    }
+    tracing::info!(
+        fleet_size = fleet.len(),
+        endpoint_writes,
+        registry_writes,
+        per_node_ceiling = MAX_CONTROL_LEASE_WRITES_PER_NODE,
+        "release control-plane lease-write budget satisfied"
+    );
     Ok(())
 }
 
@@ -3640,12 +3755,12 @@ async fn wait_for_fleet_control_plane_collection(
 
 async fn dump_fleet_doc_state(fleet: &[FleetNode]) {
     let query = r#"{
-        AgentNetwork { network_id admin_did }
-        NetworkMembership { member_did status }
-        PeerEndpoint { did }
-        PeerPairingDesired { peer_id source template replicator_addresses }
-        DataPlanePairingDesired { peer_id template replicator_addresses }
-        PeerPairingApplied { peer_id collections replicator_addresses replicator_filter }
+        AgentNetwork { _docID network_id admin_did }
+        NetworkMembership { _docID membership_key member_did status }
+        PeerEndpoint { _docID did }
+        PeerPairingDesired { _docID peer_id source template replicator_addresses }
+        DataPlanePairingDesired { _docID peer_id template replicator_addresses }
+        PeerPairingApplied { _docID peer_id collections replicator_addresses replicator_filter }
     }"#;
     for node in fleet {
         match graphql_query(&node.graphql, query).await {
@@ -3669,48 +3784,103 @@ async fn wait_for_subscription_replicator_installed(
     required_collection: &str,
     timeout: Duration,
 ) -> Result<()> {
-    let escaped = escape_graphql_string(peer_id);
-    let query = format!(
-        r#"{{ PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{escaped}" }} }}) {{ peer_id collections replicator_addresses }} }}"#
-    );
+    let api_base = graphql
+        .strip_suffix("/graphql")
+        .with_context(|| format!("unexpected GraphQL endpoint shape: {graphql}"))?;
+    let collection_versions_url = format!("{api_base}/collections/versions");
+    let replicators_url = format!("{api_base}/p2p/replicators");
     let deadline = Instant::now() + timeout;
-    let mut last = Value::Null;
+    let mut last_collection_versions = Value::Null;
+    let mut last_replicators = Value::Null;
     loop {
-        let response = graphql_query(graphql, &query).await?;
-        if let Some(rows) = response
-            .pointer("/data/PeerPairingApplied")
-            .and_then(Value::as_array)
-        {
-            last = Value::Array(rows.clone());
-            if rows.iter().any(|row| {
-                let has_address = row
-                    .get("replicator_addresses")
-                    .and_then(Value::as_array)
-                    .is_some_and(|addrs| {
-                        addrs
-                            .iter()
-                            .any(|address| address.as_str().is_some_and(|value| !value.is_empty()))
-                    });
-                let has_collection = row
-                    .get("collections")
-                    .and_then(Value::as_array)
-                    .is_some_and(|collections| {
-                        collections
-                            .iter()
-                            .any(|collection| collection.as_str() == Some(required_collection))
-                    });
-                has_address && has_collection
-            }) {
-                return Ok(());
-            }
+        let fetched = async {
+            let collection_versions = p2p_http_client()?
+                .get(&collection_versions_url)
+                .send()
+                .await
+                .with_context(|| {
+                    format!("fetching collection versions from {collection_versions_url}")
+                })?
+                .error_for_status()
+                .with_context(|| {
+                    format!("collection versions returned an error from {collection_versions_url}")
+                })?
+                .json::<Vec<Value>>()
+                .await
+                .with_context(|| {
+                    format!("decoding collection versions from {collection_versions_url}")
+                })?;
+            let replicators = p2p_http_client()?
+                .get(&replicators_url)
+                .send()
+                .await
+                .with_context(|| format!("fetching effective replicators from {replicators_url}"))?
+                .error_for_status()
+                .with_context(|| {
+                    format!("effective replicators returned an error from {replicators_url}")
+                })?
+                .json::<Vec<Value>>()
+                .await
+                .with_context(|| {
+                    format!("decoding effective replicators from {replicators_url}")
+                })?;
+            Ok::<_, anyhow::Error>((collection_versions, replicators))
         }
+        .await;
+        let last_error = match fetched {
+            Ok((collection_versions, replicators)) => {
+                last_collection_versions = Value::Array(collection_versions.clone());
+                last_replicators = Value::Array(replicators.clone());
+                if let Some(collection_id) =
+                    collection_id_from_versions(&collection_versions, required_collection)
+                {
+                    if effective_replicator_has_collection(&replicators, peer_id, collection_id) {
+                        return Ok(());
+                    }
+                }
+                "effective replicator did not yet contain the required collection".to_string()
+            }
+            Err(error) => error.to_string(),
+        };
         if Instant::now() >= deadline {
             bail!(
-                "timed out waiting for replicator install containing {required_collection} on edge peer={peer_id} (graphql={graphql}); last PeerPairingApplied rows: {last}"
+                "timed out waiting for effective replicator scope containing {required_collection} on edge peer={peer_id} (graphql={graphql}); last error: {last_error}; last collection versions: {last_collection_versions}; last replicators: {last_replicators}"
             );
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
+}
+
+fn collection_id_from_versions<'a>(versions: &'a [Value], collection: &str) -> Option<&'a str> {
+    versions.iter().find_map(|version| {
+        let name = version
+            .get("Name")
+            .or_else(|| version.get("name"))
+            .and_then(Value::as_str)?;
+        (name == collection).then(|| {
+            version
+                .get("CollectionID")
+                .or_else(|| version.get("collection_id"))
+                .and_then(Value::as_str)
+        })?
+    })
+}
+
+fn effective_replicator_has_collection(
+    replicators: &[Value],
+    peer_id: &str,
+    required_collection_id: &str,
+) -> bool {
+    replicators.iter().any(|row| {
+        row.get("ID").and_then(Value::as_str) == Some(peer_id)
+            && row
+                .get("CollectionIDs")
+                .and_then(Value::as_array)
+                .is_some_and(|ids| {
+                    ids.iter()
+                        .any(|id| id.as_str() == Some(required_collection_id))
+                })
+    })
 }
 
 async fn wait_for_conversation_replicator_installed(
@@ -3779,6 +3949,31 @@ fn conversation_pairing_fence_requires_the_local_agent_request_scope() {
     assert!(conversation_filter_matches(filter, "did:key:local"));
     assert!(!conversation_filter_matches(filter, "did:key:other"));
     assert!(!conversation_filter_matches("not-json", "did:key:local"));
+}
+
+#[test]
+fn control_plane_fence_reads_effective_replicator_scope() {
+    let versions = vec![serde_json::json!({
+        "CollectionID": "bafy-agent-network",
+        "Name": "AgentNetwork"
+    })];
+    let replicators = vec![serde_json::json!({
+        "ID": "peer-b",
+        "Addresses": ["endpoint-b"],
+        "CollectionIDs": ["bafy-agent-network"]
+    })];
+
+    let collection_id = collection_id_from_versions(&versions, "AgentNetwork").unwrap();
+    assert!(effective_replicator_has_collection(
+        &replicators,
+        "peer-b",
+        collection_id
+    ));
+    assert!(!effective_replicator_has_collection(
+        &replicators,
+        "peer-c",
+        collection_id
+    ));
 }
 
 fn persist_fleet_logs(fleet: &[FleetNode], suffix: &str) {

--- a/crates/gents-cli/tests/suites/cli_p2p_network.rs
+++ b/crates/gents-cli/tests/suites/cli_p2p_network.rs
@@ -411,6 +411,80 @@ fn pair_via_signed_invite(joiner: &Node, token: &str) -> Result<()> {
     Ok(())
 }
 
+async fn wait_for_replicated_network_bootstrap(
+    node: &Node,
+    issuer: &Node,
+    timeout: Duration,
+) -> Result<()> {
+    let member_did = escape_graphql_string(&node.agent_did);
+    let query = format!(
+        r#"{{
+            AgentNetwork {{ _docID network_id }}
+            NetworkMembership(
+                filter: {{ member_did: {{ _eq: "{member_did}" }} }}
+            ) {{ _docID member_did }}
+            PeerEndpoint {{ did node_id address updated_at }}
+            PeerPairingDesired {{ peer_id source template }}
+            PeerPairingApplied {{ peer_id replicator_addresses }}
+        }}"#
+    );
+    let deadline = Instant::now() + timeout;
+    loop {
+        let response = graphql_query(&node.graphql, &query).await?;
+        let network_count = response
+            .pointer("/data/AgentNetwork")
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or_default();
+        let membership_count = response
+            .pointer("/data/NetworkMembership")
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or_default();
+        anyhow::ensure!(
+            network_count <= 1 && membership_count <= 1,
+            "join created duplicate bootstrap records: {response}"
+        );
+        if network_count == 1 && membership_count == 1 {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            let issuer_state = graphql_query(
+                &issuer.graphql,
+                r#"{
+                    AgentNetwork { network_id admin_did }
+                    NetworkMembership { network_id member_did status }
+                    PeerEndpoint { did node_id address updated_at binding_sig }
+                    PeerPairingDesired { peer_id source template }
+                    PeerPairingApplied { peer_id replicator_addresses }
+                }"#,
+            )
+            .await?;
+            let api_base = node
+                .graphql
+                .strip_suffix("/graphql")
+                .context("joiner GraphQL URL has no /graphql suffix")?;
+            let effective_replicators = reqwest::get(format!("{api_base}/p2p/replicators"))
+                .await?
+                .error_for_status()?
+                .json::<Value>()
+                .await?;
+            let sync_status = reqwest::get(format!("{api_base}/p2p/sync/status"))
+                .await?
+                .error_for_status()?
+                .json::<Value>()
+                .await?;
+            let (issuer_stdout, issuer_stderr) = issuer.serve.captured_output()?;
+            let (joiner_stdout, joiner_stderr) = node.serve.captured_output()?;
+            bail!(
+                "timed out waiting for issuer-owned bootstrap records: joiner_did={}; joiner={response}; effective_replicators={effective_replicators}; sync_status={sync_status}; issuer={issuer_state}; joiner stdout={joiner_stdout}; joiner stderr={joiner_stderr}; issuer stdout={issuer_stdout}; issuer stderr={issuer_stderr}",
+                node.agent_did
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 async fn desired_source(graphql: &str, peer_id: &str) -> Result<Option<String>> {
     let escaped = escape_graphql_string(peer_id);
     let response = graphql_query(
@@ -543,6 +617,8 @@ async fn network_transitive_discovery_auto_pairs_unseen_peer() -> Result<()> {
         Duration::from_secs(90),
     )
     .await?;
+
+    wait_for_replicated_network_bootstrap(&node_a, &seed, Duration::from_secs(120)).await?;
 
     let (collections, addresses) = desired_payload(&node_a.graphql, &peer_b)
         .await?

--- a/crates/gents-cli/tests/suites/cli_status.rs
+++ b/crates/gents-cli/tests/suites/cli_status.rs
@@ -34,6 +34,7 @@ async fn status_reads_local_runtime_context_by_default() -> Result<()> {
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     let output = run_cli_json(&home_dir, &["status"])?;
     assert_eq!(

--- a/crates/gents-desktop-core/tests/client_store.rs
+++ b/crates/gents-desktop-core/tests/client_store.rs
@@ -516,6 +516,7 @@ async fn observer_loads_initial_snapshot_and_ticks_on_update() -> Result<()> {
     let mut updates = core.store_updates();
 
     assert_eq!(store.snapshot().agent_principals.len(), 0);
+    let baseline = *updates.borrow_and_update();
 
     let response = core
         .node()
@@ -534,7 +535,6 @@ async fn observer_loads_initial_snapshot_and_ticks_on_update() -> Result<()> {
         "agent principal mutation should succeed"
     );
 
-    let baseline = *updates.borrow_and_update();
     timeout(Duration::from_secs(5), async {
         loop {
             updates.changed().await.context("watch channel closed")?;
@@ -688,18 +688,20 @@ async fn incremental_observer_handles_long_session() -> Result<()> {
         .await
         .expect("observer running and exposing metrics");
 
-    for i in 1..=100usize {
-        let mutation = format!(
-            r#"mutation {{
-                update_AgentResponse(
+    let updates = (1..=100usize)
+        .map(|i| {
+            format!(
+                r#"update_{i}: update_AgentResponse(
                     filter: {{ response_key: {{ _eq: "long-req" }} }},
                     input: {{ progress_seq: {i} }}
-                ) {{ _docID }}
-            }}"#
-        );
-        let resp = core.node().execute(&mutation).await;
-        assert!(!resp.has_errors(), "update {i}: {:?}", resp.errors);
-    }
+                ) {{ _docID }}"#
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mutation = format!("mutation {{ {updates} }}");
+    let resp = core.node().execute(&mutation).await;
+    assert!(!resp.has_errors(), "streaming updates: {:?}", resp.errors);
 
     timeout(Duration::from_millis(2000), async {
         loop {

--- a/crates/gents/src/agent/p2p_reconcile/endpoint.rs
+++ b/crates/gents/src/agent/p2p_reconcile/endpoint.rs
@@ -6,6 +6,7 @@
 //! network-derived pairings from cryptographically bound reachability.
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use defra_node::EmbeddedNode;
@@ -14,6 +15,18 @@ use tokio_util::sync::CancellationToken;
 
 use crate::graphql::escape_graphql_string;
 use crate::identity::AgentIdentity;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EndpointBinding {
+    peer_id: String,
+    address: String,
+}
+
+#[derive(Clone, Debug)]
+struct PublishedEndpoint {
+    binding: EndpointBinding,
+    at: Instant,
+}
 
 pub async fn run_endpoint_heartbeat(
     node: Arc<EmbeddedNode>,
@@ -28,8 +41,18 @@ pub async fn run_endpoint_heartbeat(
 
     let mut interval = tokio::time::interval(super::intervals::endpoint_interval());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let renewal_interval = super::intervals::lease_renewal_interval();
+    let mut published = None;
 
-    if let Err(error) = tick_endpoint(&node, &p2p, identity.as_ref()).await {
+    if let Err(error) = tick_endpoint(
+        &node,
+        &p2p,
+        identity.as_ref(),
+        &mut published,
+        renewal_interval,
+    )
+    .await
+    {
         tracing::warn!(
             did = %identity.did(),
             error = %error,
@@ -43,7 +66,13 @@ pub async fn run_endpoint_heartbeat(
         tokio::select! {
             _ = cancel.cancelled() => return Ok(()),
             _ = interval.tick() => {
-                if let Err(error) = tick_endpoint(&node, &p2p, identity.as_ref()).await {
+                if let Err(error) = tick_endpoint(
+                    &node,
+                    &p2p,
+                    identity.as_ref(),
+                    &mut published,
+                    renewal_interval,
+                ).await {
                     tracing::warn!(
                         did = %identity.did(),
                         error = %error,
@@ -59,6 +88,8 @@ async fn tick_endpoint(
     node: &EmbeddedNode,
     p2p: &Arc<dyn defra_p2p_adapter::P2POperations>,
     identity: &dyn AgentIdentity,
+    published: &mut Option<PublishedEndpoint>,
+    renewal_interval: Duration,
 ) -> Result<()> {
     let peer_id = p2p
         .local_peer_id()
@@ -69,12 +100,24 @@ async fn tick_endpoint(
         .await
         .map_err(|e| anyhow::anyhow!("shareable_address: {e}"))?
         .context("P2P node reported no shareable address for PeerEndpoint")?;
+    let binding = EndpointBinding { peer_id, address };
+    let observed_at = Instant::now();
+    let Some(publish_reason) =
+        endpoint_publish_reason(published.as_ref(), &binding, observed_at, renewal_interval)
+    else {
+        tracing::trace!(
+            did = %identity.did(),
+            node_id = %binding.peer_id,
+            "PeerEndpoint heartbeat: unchanged signed lease is not yet due for renewal"
+        );
+        return Ok(());
+    };
 
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let mut record = EndpointRecord {
         did: identity.did().to_string(),
-        node_id: peer_id,
-        address,
+        node_id: binding.peer_id.clone(),
+        address: binding.address.clone(),
         updated_at: now,
         sig: Vec::new(),
     };
@@ -89,12 +132,35 @@ async fn tick_endpoint(
         "upsert_peer_endpoint_heartbeat",
     )
     .await?;
+    *published = Some(PublishedEndpoint {
+        binding,
+        at: Instant::now(),
+    });
     tracing::debug!(
         did = %record.did,
         node_id = %record.node_id,
+        reason = publish_reason,
         "PeerEndpoint heartbeat: signed endpoint written"
     );
     Ok(())
+}
+
+fn endpoint_publish_reason(
+    published: Option<&PublishedEndpoint>,
+    binding: &EndpointBinding,
+    now: Instant,
+    renewal_interval: Duration,
+) -> Option<&'static str> {
+    let Some(published) = published else {
+        return Some("initial");
+    };
+    if published.binding != *binding {
+        Some("binding_changed")
+    } else if now.duration_since(published.at) >= renewal_interval {
+        Some("renewal")
+    } else {
+        None
+    }
 }
 
 pub fn peer_endpoint_upsert_mutation(record: &EndpointRecord) -> String {
@@ -128,6 +194,55 @@ pub fn peer_endpoint_upsert_mutation(record: &EndpointRecord) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn endpoint_binding_publishes_only_when_needed() {
+        let now = Instant::now();
+        let original = EndpointBinding {
+            peer_id: "peer-one".into(),
+            address: "endpoint-one".into(),
+        };
+        let published = PublishedEndpoint {
+            binding: original.clone(),
+            at: now,
+        };
+
+        assert_eq!(
+            endpoint_publish_reason(None, &original, now, Duration::from_secs(30)),
+            Some("initial")
+        );
+        assert_eq!(
+            endpoint_publish_reason(
+                Some(&published),
+                &original,
+                now + Duration::from_secs(29),
+                Duration::from_secs(30)
+            ),
+            None
+        );
+        assert_eq!(
+            endpoint_publish_reason(
+                Some(&published),
+                &original,
+                now + Duration::from_secs(30),
+                Duration::from_secs(30)
+            ),
+            Some("renewal")
+        );
+        let changed = EndpointBinding {
+            peer_id: "peer-one".into(),
+            address: "endpoint-two".into(),
+        };
+        assert_eq!(
+            endpoint_publish_reason(
+                Some(&published),
+                &changed,
+                now + Duration::from_secs(1),
+                Duration::from_secs(30)
+            ),
+            Some("binding_changed")
+        );
+    }
 
     #[test]
     fn endpoint_upsert_escapes_and_has_no_empty_lists() {

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -941,6 +941,23 @@ impl GraphqlPairingStateStore {
     async fn delete_bearer_readiness_for_peer(&self, peer_id: &str) -> Result<()> {
         let peer_id = escape_graphql_string(peer_id);
         let issuer_did = escape_graphql_string(self.identity.did());
+        let query = format!(
+            r#"{{
+                BearerPairingReady(
+                    filter: {{
+                        peer_id: {{ _eq: "{peer_id}" }},
+                        issuer_did: {{ _eq: "{issuer_did}" }}
+                    }},
+                    limit: 1
+                ) {{ _docID }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        ensure_no_errors(&response, "query BearerPairingReady for deletion")?;
+        if rows::<DocIdRow>(&response, "BearerPairingReady")?.is_empty() {
+            return Ok(());
+        }
+
         let mutation = format!(
             r#"mutation {{
                 delete_BearerPairingReady(
@@ -1231,6 +1248,12 @@ struct BearerPairingReadyRow {
     template: Option<String>,
     acknowledged_at: Option<String>,
     issuer_sig: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DocIdRow {
+    #[serde(rename = "_docID")]
+    _doc_id: String,
 }
 
 fn desired_from_pairing_row(

--- a/crates/gents/src/agent/p2p_reconcile/intervals.rs
+++ b/crates/gents/src/agent/p2p_reconcile/intervals.rs
@@ -1,7 +1,7 @@
 //! Env-overridable reconciler intervals.
 //!
 //! Production defaults match the historic constants; tests and live e2e runs can
-//! compress convergence by setting the env vars. Lean-neutral: no transition,
+//! compress observation by setting the env vars. Lean-neutral: no transition,
 //! invariant, or provider-input depends on these wall-clock values.
 
 use std::time::Duration;
@@ -36,6 +36,11 @@ pub fn sweep_interval() -> Duration {
 
 pub fn endpoint_interval() -> Duration {
     env_ms("GENTS_ENDPOINT_HEARTBEAT_MS").unwrap_or_else(heartbeat_interval)
+}
+
+/// Renew unchanged leases three times inside the configured freshness window.
+pub fn lease_renewal_interval() -> Duration {
+    (stale_after() / DEFAULT_STALE_MULTIPLE).max(Duration::from_millis(1))
 }
 
 pub fn stale_after() -> Duration {
@@ -107,6 +112,7 @@ mod tests {
         assert_eq!(heartbeat_interval(), Duration::from_secs(30));
         assert_eq!(sweep_interval(), Duration::from_secs(30));
         assert_eq!(endpoint_interval(), Duration::from_secs(30));
+        assert_eq!(lease_renewal_interval(), Duration::from_secs(30));
         assert_eq!(stale_after(), Duration::from_secs(90));
         assert_eq!(reciprocal_stale_after(), Duration::from_secs(24 * 60 * 60));
     }
@@ -123,6 +129,10 @@ mod tests {
         assert_eq!(heartbeat_interval(), Duration::from_millis(1250));
         assert_eq!(sweep_interval(), Duration::from_millis(500));
         assert_eq!(endpoint_interval(), Duration::from_millis(750));
+        assert_eq!(
+            lease_renewal_interval(),
+            Duration::from_millis(2500) / DEFAULT_STALE_MULTIPLE
+        );
         assert_eq!(stale_after(), Duration::from_millis(2500));
         assert_eq!(reciprocal_stale_after(), Duration::from_millis(4500));
     }
@@ -133,6 +143,7 @@ mod tests {
         std::env::set_var("GENTS_REGISTRY_HEARTBEAT_MS", "2000");
 
         assert_eq!(endpoint_interval(), Duration::from_secs(2));
+        assert_eq!(lease_renewal_interval(), Duration::from_secs(2));
         assert_eq!(stale_after(), Duration::from_secs(6));
     }
 

--- a/crates/gents/src/agent/p2p_reconcile/mod.rs
+++ b/crates/gents/src/agent/p2p_reconcile/mod.rs
@@ -62,7 +62,7 @@ pub use templates::{
     builtin_templates, combine_filters, conversation_like, decode_pairing_filters, equality_filter,
     filter_conditions, resolve_template, scope_filter, single_string_eq, to_replication_filters,
     Delivery, DidSource, FilterPredicate, PairingFilters, Scope, ScopeTemplate,
-    AGENT_DIRECTORY_COLLECTION,
+    AGENT_DIRECTORY_COLLECTION, NETWORK_CONTROL_TEMPLATE,
 };
 pub use trait_def::{
     RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteP2pDocument, RemoteReplicator,

--- a/crates/gents/src/agent/p2p_reconcile/registry.rs
+++ b/crates/gents/src/agent/p2p_reconcile/registry.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use defra_node::EmbeddedNode;
@@ -67,6 +67,12 @@ pub struct RegistryEntry {
 pub enum UpsertKind {
     Full,
     Heartbeat,
+}
+
+#[derive(Clone, Debug)]
+struct PublishedRegistryEntry {
+    entry: RegistryEntry,
+    at: Instant,
 }
 
 pub fn registry_upsert_mutation(entry: &RegistryEntry, now: &str, kind: UpsertKind) -> String {
@@ -139,8 +145,20 @@ pub async fn run_registry_heartbeat(
 
     let mut interval = tokio::time::interval(super::intervals::heartbeat_interval());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let renewal_interval = super::intervals::lease_renewal_interval();
+    let mut published = None;
 
-    if let Err(error) = tick_registry(&node, &p2p, &agent_did, &network_id, "online").await {
+    if let Err(error) = tick_registry(
+        &node,
+        &p2p,
+        &agent_did,
+        &network_id,
+        "online",
+        &mut published,
+        renewal_interval,
+    )
+    .await
+    {
         tracing::warn!(
             agent_did = %agent_did,
             network_id = %network_id,
@@ -155,7 +173,15 @@ pub async fn run_registry_heartbeat(
         tokio::select! {
             _ = cancel.cancelled() => {
                 if let Err(error) =
-                    tick_registry(&node, &p2p, &agent_did, &network_id, "offline").await
+                    tick_registry(
+                        &node,
+                        &p2p,
+                        &agent_did,
+                        &network_id,
+                        "offline",
+                        &mut published,
+                        renewal_interval,
+                    ).await
                 {
                     tracing::warn!(
                         agent_did = %agent_did,
@@ -167,7 +193,15 @@ pub async fn run_registry_heartbeat(
             }
             _ = interval.tick() => {
                 if let Err(error) =
-                    tick_registry(&node, &p2p, &agent_did, &network_id, "online").await
+                    tick_registry(
+                        &node,
+                        &p2p,
+                        &agent_did,
+                        &network_id,
+                        "online",
+                        &mut published,
+                        renewal_interval,
+                    ).await
                 {
                     tracing::warn!(
                         agent_did = %agent_did,
@@ -186,6 +220,8 @@ async fn tick_registry(
     agent_did: &str,
     network_id: &str,
     status: &str,
+    published: &mut Option<PublishedRegistryEntry>,
+    renewal_interval: Duration,
 ) -> Result<()> {
     let peer_id = p2p
         .local_peer_id()
@@ -197,7 +233,7 @@ async fn tick_registry(
         .await
         .map_err(|e| anyhow::anyhow!("listen_addresses: {e}"))?;
 
-    let addresses: Vec<String> = raw_addresses
+    let mut addresses: Vec<String> = raw_addresses
         .into_iter()
         .map(|addr| {
             if addr.starts_with('/') {
@@ -207,6 +243,8 @@ async fn tick_registry(
             }
         })
         .collect();
+    addresses.sort();
+    addresses.dedup();
 
     let entry = RegistryEntry {
         peer_id: peer_id.clone(),
@@ -218,6 +256,18 @@ async fn tick_registry(
         network_id: network_id.to_string(),
         invited_by: None,
     };
+    let observed_at = Instant::now();
+    let Some(publish_reason) =
+        registry_publish_reason(published.as_ref(), &entry, observed_at, renewal_interval)
+    else {
+        tracing::trace!(
+            peer_id = %entry.peer_id,
+            agent_did = %agent_did,
+            status = %status,
+            "registry heartbeat: unchanged lease is not yet due for renewal"
+        );
+        return Ok(());
+    };
 
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let mutation = registry_upsert_mutation(&entry, &now, UpsertKind::Heartbeat);
@@ -227,20 +277,107 @@ async fn tick_registry(
         "upsert_peer_registry_heartbeat",
     )
     .await?;
+    *published = Some(PublishedRegistryEntry {
+        entry,
+        at: Instant::now(),
+    });
 
     tracing::debug!(
         peer_id = %peer_id,
         agent_did = %agent_did,
         status = %status,
+        reason = publish_reason,
         "registry heartbeat: self-registration written"
     );
 
     Ok(())
 }
 
+fn registry_publish_reason(
+    published: Option<&PublishedRegistryEntry>,
+    entry: &RegistryEntry,
+    now: Instant,
+    renewal_interval: Duration,
+) -> Option<&'static str> {
+    let Some(published) = published else {
+        return Some("initial");
+    };
+    if published.entry != *entry {
+        Some("binding_changed")
+    } else if now.duration_since(published.at) >= renewal_interval {
+        Some("renewal")
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn registry_entry(address: &str, status: &str) -> RegistryEntry {
+        RegistryEntry {
+            peer_id: "peer-one".into(),
+            agent_did: "did:key:one".into(),
+            addresses: vec![address.into()],
+            templates: vec!["conversation".into()],
+            display_name: None,
+            status: status.into(),
+            network_id: "default".into(),
+            invited_by: None,
+        }
+    }
+
+    #[test]
+    fn registry_entry_publishes_only_when_needed() {
+        let now = Instant::now();
+        let entry = registry_entry("endpoint-one", "online");
+        let published = PublishedRegistryEntry {
+            entry: entry.clone(),
+            at: now,
+        };
+
+        assert_eq!(
+            registry_publish_reason(None, &entry, now, Duration::from_secs(30)),
+            Some("initial")
+        );
+        assert_eq!(
+            registry_publish_reason(
+                Some(&published),
+                &entry,
+                now + Duration::from_secs(29),
+                Duration::from_secs(30)
+            ),
+            None
+        );
+        assert_eq!(
+            registry_publish_reason(
+                Some(&published),
+                &entry,
+                now + Duration::from_secs(30),
+                Duration::from_secs(30)
+            ),
+            Some("renewal")
+        );
+        assert_eq!(
+            registry_publish_reason(
+                Some(&published),
+                &registry_entry("endpoint-two", "online"),
+                now + Duration::from_secs(1),
+                Duration::from_secs(30)
+            ),
+            Some("binding_changed")
+        );
+        assert_eq!(
+            registry_publish_reason(
+                Some(&published),
+                &registry_entry("endpoint-one", "offline"),
+                now + Duration::from_secs(1),
+                Duration::from_secs(30)
+            ),
+            Some("binding_changed")
+        );
+    }
 
     #[test]
     fn registry_upsert_mutation_escapes_and_emits_null_for_empty_templates() {
@@ -266,7 +403,7 @@ mod tests {
 
     /// The heartbeat-variant `update` block must NOT contain `display_name` (it
     /// would clobber the operator-set value), but MUST re-advertise `templates`
-    /// so the offered scope set stays fresh on every tick.
+    /// so the offered scope set stays fresh on every lease renewal.
     #[test]
     fn heartbeat_upsert_update_block_omits_display_name_but_keeps_templates() {
         let entry = RegistryEntry {

--- a/crates/gents/src/agent/runtime/control_watcher.rs
+++ b/crates/gents/src/agent/runtime/control_watcher.rs
@@ -11,7 +11,7 @@ use super::super::document_view;
 use super::super::DocumentResolveContext;
 
 pub(super) const CONTROL_RECONCILE_DEBOUNCE: Duration = Duration::from_secs(5);
-const CONTROL_RECONCILE_SETTLE_RETRY: Duration = Duration::from_secs(1);
+pub(super) const CONTROL_RECONCILE_SETTLE_RETRY: Duration = Duration::from_secs(1);
 const CONTROL_RECONCILE_SETTLE_WINDOW: Duration = Duration::from_secs(60);
 const CONTROL_WATCHER_IDLE_SLEEP: Duration = Duration::from_secs(60 * 60 * 24 * 365);
 
@@ -33,6 +33,7 @@ pub(super) async fn run_control_watcher(
     let mut pending_visibility = false;
     let mut settle_deadline = None;
     let mut last_proposed_fingerprint = None::<String>;
+    let mut phase_transition_pending = false;
 
     loop {
         tokio::select! {
@@ -83,9 +84,13 @@ pub(super) async fn run_control_watcher(
                     sleep.as_mut().reset(tokio::time::Instant::now() + CONTROL_RECONCILE_SETTLE_RETRY);
                     continue;
                 }
-                runtime_status
-                    .set_reconcile_phase(ReconcilePhase::Resolving)
-                    .await;
+                let phase_announced = phase_transition_pending;
+                if phase_announced {
+                    runtime_status
+                        .set_reconcile_phase(ReconcilePhase::Resolving)
+                        .await;
+                    phase_transition_pending = false;
+                }
                 let mut proposed_update = false;
                 match document_view::resolve_document_runtime_snapshot_from_view(
                     node.as_ref(),
@@ -97,6 +102,11 @@ pub(super) async fn run_control_watcher(
                     Ok(snapshot) => {
                         let fingerprint = snapshot.configuration_fingerprint();
                         if last_proposed_fingerprint.as_deref() != Some(fingerprint.as_str()) {
+                            if !phase_announced {
+                                runtime_status
+                                    .set_reconcile_phase(ReconcilePhase::Resolving)
+                                    .await;
+                            }
                             if proposals_tx.send(snapshot).await.is_err() {
                                 return Ok(());
                             }
@@ -133,6 +143,7 @@ pub(super) async fn run_control_watcher(
                     "backend measured-health transition detected; scheduling reconcile"
                 );
                 dirty = true;
+                phase_transition_pending = true;
                 runtime_status
                     .set_reconcile_phase(ReconcilePhase::Debouncing)
                     .await;
@@ -166,6 +177,7 @@ pub(super) async fn run_control_watcher(
                         }
                     }
                     dirty = true;
+                    phase_transition_pending = true;
                     settle_deadline =
                         Some(tokio::time::Instant::now() + CONTROL_RECONCILE_SETTLE_WINDOW);
                     runtime_status
@@ -228,6 +240,7 @@ pub(super) async fn run_control_watcher(
                     "runtime control update detected"
                 );
                 dirty = true;
+                phase_transition_pending = true;
                 settle_deadline =
                     Some(tokio::time::Instant::now() + CONTROL_RECONCILE_SETTLE_WINDOW);
                 runtime_status

--- a/crates/gents/src/agent/runtime/mod.rs
+++ b/crates/gents/src/agent/runtime/mod.rs
@@ -10,7 +10,9 @@ pub(super) use startup::run_agent;
 #[cfg(test)]
 use crate::watcher::Watcher;
 #[cfg(test)]
-use control_watcher::{run_control_watcher, CONTROL_RECONCILE_DEBOUNCE};
+use control_watcher::{
+    run_control_watcher, CONTROL_RECONCILE_DEBOUNCE, CONTROL_RECONCILE_SETTLE_RETRY,
+};
 #[cfg(test)]
 use router::{
     resolve_behavior_for_request, run_router_generation_observer,

--- a/crates/gents/src/agent/runtime/tests/control_watcher.rs
+++ b/crates/gents/src/agent/runtime/tests/control_watcher.rs
@@ -1,5 +1,6 @@
 use super::support::*;
 use super::*;
+use crate::runtime_status::ReconcilePhase;
 use crate::ProcessLifecycleState;
 
 async fn update_agent_principal_enabled(
@@ -100,6 +101,16 @@ async fn control_watcher_publishes_reconciled_snapshot_after_relevant_update() {
     );
     let resolving = fetch_runtime_status(node.as_ref(), agent.agent_did()).await;
     assert_eq!(resolving.reconcile_phase, "resolving");
+
+    runtime_status
+        .set_reconcile_phase(ReconcilePhase::Idle)
+        .await;
+    let settled = fetch_runtime_status(node.as_ref(), agent.agent_did()).await;
+    tokio::time::advance(CONTROL_RECONCILE_SETTLE_RETRY + Duration::from_millis(1)).await;
+    tokio::task::yield_now().await;
+    let retried = fetch_runtime_status(node.as_ref(), agent.agent_did()).await;
+    assert_eq!(retried.reconcile_phase, "idle");
+    assert_eq!(retried.updated_at, settled.updated_at);
 
     let _ = shutdown_tx.send(true);
     watcher_task.await.unwrap().unwrap();

--- a/crates/gents/src/agent/runtime/tests/support.rs
+++ b/crates/gents/src/agent/runtime/tests/support.rs
@@ -73,6 +73,7 @@ pub(super) struct RuntimeStatusRow {
     pub(super) unavailable_behavior_count: i64,
     pub(super) last_reconcile_result: String,
     pub(super) last_reconcile_error: String,
+    pub(super) updated_at: String,
 }
 
 pub(super) async fn fetch_runtime_status(
@@ -90,6 +91,7 @@ pub(super) async fn fetch_runtime_status(
                 unavailable_behavior_count
                 last_reconcile_result
                 last_reconcile_error
+                updated_at
             }}
         }}"#
     );
@@ -128,6 +130,7 @@ pub(super) async fn wait_for_runtime_reconcile_phase(
                     unavailable_behavior_count
                     last_reconcile_result
                     last_reconcile_error
+                    updated_at
                 }}
             }}"#
         );

--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -154,7 +154,34 @@ where
 {
     let gate = mutation_write_gate(node);
     let _write_guard = gate.lock().await;
-    graphql_response_with_policy(executor, graphql, operation, retry_policy).await
+    let response = graphql_response_with_policy(executor, graphql, operation, retry_policy).await;
+    if !response.has_errors() {
+        let affected_documents = mutation_affected_documents(&response);
+        tracing::debug!(
+            operation,
+            affected_documents,
+            "DefraDB GraphQL mutation completed"
+        );
+    }
+    response
+}
+
+fn mutation_affected_documents(response: &QueryResponse) -> usize {
+    response
+        .data
+        .as_ref()
+        .and_then(Value::as_object)
+        .map(|fields| {
+            fields
+                .values()
+                .map(|value| match value {
+                    Value::Array(rows) => rows.len(),
+                    Value::Object(_) => 1,
+                    _ => 0,
+                })
+                .sum()
+        })
+        .unwrap_or_default()
 }
 
 /// Execute an auto-committed GraphQL mutation through the single node-scoped

--- a/crates/gents/src/graphql/tests.rs
+++ b/crates/gents/src/graphql/tests.rs
@@ -83,6 +83,22 @@ fn single_mutation_document_normalizes_create_to_add_response_key() {
 }
 
 #[test]
+fn mutation_write_ledger_counts_returned_documents_not_just_calls() {
+    let response = QueryResponse::success(serde_json::json!({
+        "upsert_One": { "_docID": "doc-1" },
+        "delete_Many": [
+            { "_docID": "doc-2" },
+            { "_docID": "doc-3" }
+        ],
+        "delete_None": []
+    }));
+    assert_eq!(mutation_affected_documents(&response), 3);
+
+    let no_match = QueryResponse::success(serde_json::json!({ "delete_None": [] }));
+    assert_eq!(mutation_affected_documents(&no_match), 0);
+}
+
+#[test]
 fn single_mutation_document_rejects_duplicate_normalized_keys() {
     let response = QueryResponse::success(serde_json::json!({
         "create_AgentRequest": { "_docID": "doc-create" },

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -196,8 +196,9 @@ pub use native_executor_status::{active_native_executors, NativeExecutorStatus};
 pub use oneshot::{run_openai_oneshot, run_openai_oneshot_with_tools, OneshotRunResult};
 pub use openai_wire::OpenAiWireApi;
 pub use p2p_observability::{
-    JsonP2pSyncStatusAdapter, P2pCidRetrySnapshot, P2pPeerBacklogSnapshot, P2pPushBacklogSnapshot,
-    P2pSyncStatusAdapter, P2pSyncStatusSnapshot,
+    JsonP2pSyncStatusAdapter, P2pPeerBacklogSnapshot, P2pPushBacklogSnapshot,
+    P2pPushRetryMarkerSnapshot, P2pRequestDispatchSnapshot, P2pSyncStatusAdapter,
+    P2pSyncStatusSnapshot,
 };
 pub use periodic_recovery::{
     periodic_recovery_sweep_metadata, run_periodic_recovery_sweeps, PeriodicRecoverySweepMetadata,

--- a/crates/gents/src/p2p_observability.rs
+++ b/crates/gents/src/p2p_observability.rs
@@ -9,35 +9,79 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct P2pSyncStatusSnapshot {
     pub push_backlog: P2pPushBacklogSnapshot,
-    pub encode_cache_hits_total: u64,
-    pub encode_cache_entries: usize,
+    pub push_retry_markers: P2pPushRetryMarkerSnapshot,
     pub broadcast_coalesced_total: u64,
     pub push_updates_coalesced_total: u64,
     pub gossip_direction_filtered_total: u64,
     pub pending_dags: usize,
     pub pending_dag_capacity: usize,
+    pub pending_dag_high_water: u64,
     pub persisted_pending_dags: usize,
     pub persisted_pending_dag_capacity: usize,
+    pub persisted_pending_dag_high_water: u64,
     pub pending_resync_in_flight: bool,
     pub retained_background_tasks: usize,
+    pub request_dispatch: P2pRequestDispatchSnapshot,
+    pub non_authoritative_broadcast_tasks: usize,
+    pub non_authoritative_broadcast_high_water: usize,
+    pub non_authoritative_broadcast_rejected_total: u64,
     pub missing_link_retries: u64,
+    pub car_requested_cids: u64,
+    pub car_present_cids: u64,
+    pub car_served_cids: u64,
+    pub car_filtered_cids: u64,
+    pub provider_rotations: u64,
     pub pending_dag_resolved: u64,
+    pub pending_dag_registered: u64,
     pub pending_dag_expired: u64,
     pub single_flight_suppressed: u64,
     pub already_merged_fast_path: u64,
     pub pending_dag_capacity_shed: u64,
     pub pending_dag_retry_dispatched: u64,
     pub pending_dag_retry_suppressed: u64,
+    pub pending_dag_fetch_deferred_unavailable: u64,
+    pub pending_dag_fetch_deferred_contention: u64,
+    pub pending_dag_fetch_exhausted: u64,
+    pub pending_dag_terminal_merged: u64,
     pub next_pending_retry_in_ms: Option<u64>,
     pub pending_dag_terminal_quarantined: u64,
     pub quarantined_pending_dags: usize,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
+pub struct P2pRequestDispatchSnapshot {
+    pub request_capacity: usize,
+    pub active_requests: usize,
+    pub active_requests_high_water: usize,
+    pub recovery_capacity: usize,
+    pub active_recovery: usize,
+    pub active_recovery_high_water: usize,
+    pub rejection_capacity: usize,
+    pub active_rejections: usize,
+    pub active_rejections_high_water: usize,
+    pub completion_capacity: usize,
+    pub active_completions: usize,
+    pub active_completions_high_water: usize,
+    pub saturated_total: u64,
+    pub recovery_saturated_total: u64,
+    pub rejection_dropped_total: u64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct P2pPushRetryMarkerSnapshot {
+    pub document_markers: usize,
+    pub collection_markers: usize,
+    pub scheduled_peers: usize,
+    pub oldest_scheduled_retry_unix: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
 pub struct P2pPushBacklogSnapshot {
     pub queue_item_capacity: usize,
     pub queue_byte_capacity: usize,
@@ -53,16 +97,18 @@ pub struct P2pPushBacklogSnapshot {
     pub completed_total: u64,
     pub failed_total: u64,
     pub stale_head_retirements_total: u64,
+    pub head_hints_enqueued_document: u64,
+    pub head_hints_enqueued_collection: u64,
+    pub head_hints_sent_document: u64,
+    pub head_hints_sent_collection: u64,
+    pub head_hints_acked_document: u64,
+    pub head_hints_acked_collection: u64,
+    pub head_hints_nacked_capacity: u64,
+    pub head_hints_nacked_other: u64,
+    pub head_hints_failed_transport: u64,
+    pub head_hints_failed_local: u64,
     pub peer_capacity_parks_total: u64,
-    pub per_cid_retry_counts: Vec<P2pCidRetrySnapshot>,
     pub per_peer: Vec<P2pPeerBacklogSnapshot>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct P2pCidRetrySnapshot {
-    pub cid: String,
-    pub retry_count: u64,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -90,5 +136,47 @@ impl P2pSyncStatusAdapter for JsonP2pSyncStatusAdapter {
 
     fn adapt(&self, upstream: &Value) -> Result<P2pSyncStatusSnapshot, Self::Error> {
         serde_json::from_value(upstream.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_three_diagnostics_decode_with_legacy_defaults() {
+        let upstream = serde_json::json!({
+            "push_backlog": { "head_hints_acked_document": 13 },
+            "push_retry_markers": {
+                "document_markers": 3,
+                "scheduled_peers": 2
+            },
+            "car_filtered_cids": 2,
+            "provider_rotations": 3,
+            "request_dispatch": {
+                "request_capacity": 32,
+                "active_requests_high_water": 4,
+                "recovery_capacity": 8,
+                "active_recovery_high_water": 2
+            },
+            "pending_dag_fetch_deferred_unavailable": 4,
+            "pending_dag_fetch_deferred_contention": 6,
+            "pending_dag_fetch_exhausted": 5
+        });
+
+        let snapshot = JsonP2pSyncStatusAdapter.adapt(&upstream).unwrap();
+
+        assert_eq!(snapshot.car_filtered_cids, 2);
+        assert_eq!(snapshot.provider_rotations, 3);
+        assert_eq!(snapshot.request_dispatch.request_capacity, 32);
+        assert_eq!(snapshot.request_dispatch.active_requests_high_water, 4);
+        assert_eq!(snapshot.request_dispatch.recovery_capacity, 8);
+        assert_eq!(snapshot.request_dispatch.active_recovery_high_water, 2);
+        assert_eq!(snapshot.pending_dag_fetch_deferred_unavailable, 4);
+        assert_eq!(snapshot.pending_dag_fetch_deferred_contention, 6);
+        assert_eq!(snapshot.pending_dag_fetch_exhausted, 5);
+        assert_eq!(snapshot.push_backlog.head_hints_acked_document, 13);
+        assert_eq!(snapshot.push_retry_markers.document_markers, 3);
+        assert_eq!(snapshot.push_retry_markers.scheduled_peers, 2);
     }
 }

--- a/crates/gents/tests/conformance/p2p_observability.rs
+++ b/crates/gents/tests/conformance/p2p_observability.rs
@@ -1,5 +1,5 @@
 use gents::{JsonP2pSyncStatusAdapter, P2pSyncStatusAdapter};
-use p2p::sync::{CidRetrySnapshot, PeerBacklogSnapshot, PushBacklogSnapshot, SyncStatus};
+use p2p::sync::{DispatchSnapshot, PeerBacklogSnapshot, PushBacklogSnapshot, SyncStatus};
 
 #[test]
 fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
@@ -19,11 +19,17 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
             completed_total: 79,
             failed_total: 4,
             stale_head_retirements_total: 17,
+            head_hints_enqueued_document: 103,
+            head_hints_enqueued_collection: 107,
+            head_hints_sent_document: 109,
+            head_hints_sent_collection: 113,
+            head_hints_acked_document: 127,
+            head_hints_acked_collection: 131,
+            head_hints_nacked_capacity: 137,
+            head_hints_nacked_other: 139,
+            head_hints_failed_transport: 149,
+            head_hints_failed_local: 151,
             peer_capacity_parks_total: 13,
-            per_cid_retry_counts: vec![CidRetrySnapshot {
-                cid: "bafy-retry".to_string(),
-                retry_count: 19,
-            }],
             per_peer: vec![PeerBacklogSnapshot {
                 peer_id: "peer-a".to_string(),
                 queued_items: 4,
@@ -33,25 +39,55 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
                 cooldown_remaining_ms: 750,
             }],
         },
-        encode_cache_hits_total: 37,
-        encode_cache_entries: 5,
         broadcast_coalesced_total: 41,
         push_updates_coalesced_total: 43,
         gossip_direction_filtered_total: 47,
         pending_dags: 13,
         pending_dag_capacity: 1_000,
+        pending_dag_high_water: 14,
         persisted_pending_dags: 17,
         persisted_pending_dag_capacity: 4_000,
+        persisted_pending_dag_high_water: 18,
         pending_resync_in_flight: true,
         retained_background_tasks: 6,
+        request_dispatch: DispatchSnapshot {
+            request_capacity: 32,
+            active_requests: 2,
+            active_requests_high_water: 11,
+            recovery_capacity: 8,
+            active_recovery: 1,
+            active_recovery_high_water: 5,
+            rejection_capacity: 8,
+            active_rejections: 0,
+            active_rejections_high_water: 3,
+            completion_capacity: 16,
+            active_completions: 1,
+            active_completions_high_water: 7,
+            saturated_total: 13,
+            recovery_saturated_total: 17,
+            rejection_dropped_total: 19,
+        },
+        non_authoritative_broadcast_tasks: 7,
+        non_authoritative_broadcast_high_water: 8,
+        non_authoritative_broadcast_rejected_total: 9,
         missing_link_retries: 23,
+        car_requested_cids: 24,
+        car_present_cids: 25,
+        car_served_cids: 26,
+        car_filtered_cids: 27,
+        provider_rotations: 28,
         pending_dag_resolved: 29,
+        pending_dag_registered: 30,
         pending_dag_expired: 31,
         single_flight_suppressed: 37,
         already_merged_fast_path: 53,
         pending_dag_capacity_shed: 59,
         pending_dag_retry_dispatched: 61,
         pending_dag_retry_suppressed: 67,
+        pending_dag_fetch_deferred_unavailable: 69,
+        pending_dag_fetch_deferred_contention: 68,
+        pending_dag_fetch_exhausted: 70,
+        pending_dag_terminal_merged: 72,
         next_pending_retry_in_ms: Some(71),
         pending_dag_terminal_quarantined: 73,
         quarantined_pending_dags: 79,
@@ -69,21 +105,19 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
     assert_eq!(adapted.push_backlog.rejected_items_total, 5);
     assert_eq!(adapted.push_backlog.rejected_bytes_total, 2);
     assert_eq!(adapted.push_backlog.stale_head_retirements_total, 17);
-    assert_eq!(
-        adapted.push_backlog.per_cid_retry_counts[0].cid,
-        "bafy-retry"
-    );
-    assert_eq!(adapted.push_backlog.per_cid_retry_counts[0].retry_count, 19);
     assert_eq!(adapted.push_backlog.per_peer[0].peer_id, "peer-a");
     assert_eq!(adapted.push_backlog.per_peer[0].consecutive_failures, 3);
-    assert_eq!(adapted.encode_cache_hits_total, 37);
-    assert_eq!(adapted.encode_cache_entries, 5);
+    assert_eq!(adapted.push_backlog.head_hints_enqueued_document, 103);
+    assert_eq!(adapted.push_backlog.head_hints_acked_collection, 131);
     assert_eq!(adapted.broadcast_coalesced_total, 41);
     assert_eq!(adapted.push_updates_coalesced_total, 43);
     assert_eq!(adapted.pending_dags, 13);
     assert_eq!(adapted.persisted_pending_dags, 17);
     assert!(adapted.pending_resync_in_flight);
     assert_eq!(adapted.retained_background_tasks, 6);
+    assert_eq!(adapted.request_dispatch.active_requests_high_water, 11);
+    assert_eq!(adapted.request_dispatch.active_recovery_high_water, 5);
+    assert_eq!(adapted.request_dispatch.saturated_total, 13);
     assert_eq!(adapted.missing_link_retries, 23);
     assert_eq!(adapted.push_backlog.peer_capacity_parks_total, 13);
     assert_eq!(adapted.gossip_direction_filtered_total, 47);
@@ -92,6 +126,10 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
     assert_eq!(adapted.pending_dag_capacity_shed, 59);
     assert_eq!(adapted.pending_dag_retry_dispatched, 61);
     assert_eq!(adapted.pending_dag_retry_suppressed, 67);
+    assert_eq!(adapted.pending_dag_fetch_deferred_unavailable, 69);
+    assert_eq!(adapted.pending_dag_fetch_deferred_contention, 68);
+    assert_eq!(adapted.pending_dag_fetch_exhausted, 70);
+    assert_eq!(adapted.pending_dag_terminal_merged, 72);
     assert_eq!(adapted.next_pending_retry_in_ms, Some(71));
     assert_eq!(adapted.pending_dag_terminal_quarantined, 73);
     assert_eq!(adapted.quarantined_pending_dags, 79);

--- a/docs/design-notes/p2p-convergence-630-696-798.md
+++ b/docs/design-notes/p2p-convergence-630-696-798.md
@@ -40,14 +40,17 @@ The final causal split is:
 3. One-second qualification intervals rewrote unchanged `PeerEndpoint` and
    `PeerRegistry` leases every second even though the freshness window was five
    minutes.
-4. The old DefraDB sender expanded every new head into per-peer full-DAG work.
-5. Receiver recovery and terminal cleanup also acted on the same roots, causing
+4. Each relevant runtime-control update opened a 60-second settle window.
+   Unchanged one-second probes toggled `AgentRuntime` from idle to resolving and
+   back, producing roughly 110 status mutations after the initial reconcile.
+5. The old DefraDB sender expanded every new head into per-peer full-DAG work.
+6. Receiver recovery and terminal cleanup also acted on the same roots, causing
    CAR/provider storms and pending-store contention.
 
 DefraDB #1502 removes steps 4 and 5 by transferring one current-head hint into
 one durable receiver obligation, pacing rooted CAR recovery, qualifying
 providers, and serializing the P2P merge owner. This Gents change removes the
-avoidable production in steps 2 and 3 and suppresses a repeated no-match
+avoidable production in steps 2 through 4 and suppresses a repeated no-match
 `BearerPairingReady` delete.
 
 ## Gents changes
@@ -62,6 +65,9 @@ avoidable production in steps 2 and 3 and suppresses a repeated no-match
   sorted and deduplicated before comparison.
 - `BearerPairingReady` deletion first proves an issuer-and-peer row exists, so a
   settled sweep does not open an empty delete mutation.
+- Runtime-control settle probes rederive the snapshot without publishing phase
+  changes when its fingerprint is unchanged. An externally triggered reconcile
+  still publishes the complete phase lifecycle once.
 - Successful GraphQL mutations log their operation and affected-document count
   at debug level, making remaining write sources attributable.
 - The release fence reads DefraDB's effective replicator collection IDs instead
@@ -72,8 +78,8 @@ avoidable production in steps 2 and 3 and suppresses a repeated no-match
 
 The mutation-site audit found no other settled write clock in this bundle.
 Desired/applied pairing, bearer claims, network derivation, reciprocal intent,
-directory projection, and runtime status already converge to write-free
-fixpoints when their inputs are unchanged.
+directory projection, and runtime status now converge to write-free fixpoints
+when their inputs are unchanged.
 
 ## Reproduction and acceptance
 
@@ -115,7 +121,10 @@ used by join is the executable path already modeled and proved in
 `Proofs/PairingReconcile/Layering.lean` by merged PR #1156. The remaining Gents
 changes affect write timing, no-match plumbing, diagnostics, and acceptance
 observation without changing freshness thresholds, legal pairing transitions,
-admission bounds, retry dispositions, or convergence claims.
+admission bounds, retry dispositions, or convergence claims. Suppressing phase
+writes for implementation-internal settle probes does not remove a modeled
+document-observation transition; externally triggered reconciles retain the
+modeled `debouncing` and `resolving` phases.
 
 DefraDB #1502 carries the formal ownership change: TLA models the durable
 receiver obligation, provider qualification, bounded retry/admission, and

--- a/docs/design-notes/p2p-convergence-630-696-798.md
+++ b/docs/design-notes/p2p-convergence-630-696-798.md
@@ -1,0 +1,124 @@
+# P2P convergence diagnosis: #630, #696, and #798
+
+Qualified with Gents based on `7a992d59` and DefraDB PR
+[#1502](https://github.com/sourcenetwork/defradb.rs/pull/1502) at `c340eaf2`.
+
+## Conclusion
+
+The three issues are related mechanisms, not one defect:
+
+- #630 was sender-side amplification: one logical update became an ordered,
+  full-DAG PushLog for every peer. Fan-in made the hub's bounded push workers
+  the visible bottleneck.
+- #696 combined that sender amplification with collection-head identity,
+  gossip-direction, admission, and missing-link recovery defects. A fresh mesh
+  made the interaction look like one runaway pending-DAG failure.
+- #798 was an interaction between Gents control-plane amplification and the
+  remaining DefraDB ownership defects. Gents produced avoidable physical
+  documents and unchanged lease heads; DefraDB admitted overlapping sender,
+  receiver, recovery, and merge owners for the resulting DAGs.
+
+Transport symptoms were consequences. A PushLog timeout, empty selective CAR,
+provider rotation, pending-DAG registration, or retry was not independently the
+root cause. They followed either excess application document production or an
+unfulfilled/duplicated sync ownership obligation.
+
+This was not a CRDT merge-semantics bug. The transaction conflicts observed in
+`pending_store.remove` were ordinary OCC conflicts between concurrent owners of
+the same mutable sync metadata. Duplicate `AgentNetwork` rows were distinct
+DefraDB documents created by Gents for the same signed logical record, not two
+CRDT values incorrectly merged into one document.
+
+## Amplification boundary
+
+The final causal split is:
+
+1. Gents created a large but bounded network-control topology.
+2. Each join also recreated the issuer's signed `AgentNetwork` and
+   `NetworkMembership` locally, assigning the same logical records new physical
+   document identities.
+3. One-second qualification intervals rewrote unchanged `PeerEndpoint` and
+   `PeerRegistry` leases every second even though the freshness window was five
+   minutes.
+4. The old DefraDB sender expanded every new head into per-peer full-DAG work.
+5. Receiver recovery and terminal cleanup also acted on the same roots, causing
+   CAR/provider storms and pending-store contention.
+
+DefraDB #1502 removes steps 4 and 5 by transferring one current-head hint into
+one durable receiver obligation, pacing rooted CAR recovery, qualifying
+providers, and serializing the P2P merge owner. This Gents change removes the
+avoidable production in steps 2 and 3 and suppresses a repeated no-match
+`BearerPairingReady` delete.
+
+## Gents changes
+
+- Join is layered using the pairing model landed in #1156. It writes the
+  `network-control` base pairing plus the requested data-plane pairing in one
+  mutation. The issuer remains the only writer of the signed network root and
+  membership grant; the joiner receives those exact documents through the
+  control replicator.
+- `PeerEndpoint` and `PeerRegistry` publish on initial state, binding/status
+  change, or lease renewal. Failed writes remain due, and registry addresses are
+  sorted and deduplicated before comparison.
+- `BearerPairingReady` deletion first proves an issuer-and-peer row exists, so a
+  settled sweep does not open an empty delete mutation.
+- Successful GraphQL mutations log their operation and affected-document count
+  at debug level, making remaining write sources attributable.
+- The release fence reads DefraDB's effective replicator collection IDs instead
+  of treating desired/applied document fields as installed scope.
+- The release harness exposes stage-3 queue, marker, CAR, provider, admission,
+  and terminal counters; it requires three stable quiet samples before and
+  after coordinator restart.
+
+The mutation-site audit found no other settled write clock in this bundle.
+Desired/applied pairing, bearer claims, network derivation, reciprocal intent,
+directory projection, and runtime status already converge to write-free
+fixpoints when their inputs are unchanged.
+
+## Reproduction and acceptance
+
+```bash
+GENTS_RELEASE_ACCEPTANCE=1 \
+GENTS_RELEASE_CONTROL_ONLY=1 \
+GENTS_RELEASE_PRESERVE_STORES=1 \
+RUST_MIN_STACK=8388608 \
+cargo test -p gents-cli --features live-e2e --test cli_live_suite \
+  cli_fleet_delegation_live::nineteen_process_release_acceptance_live -- \
+  --ignored --nocapture --test-threads=1
+```
+
+The topology is 19 fresh stores: one coordinator and 18 spokes, 18 signed
+invite/join operations, and the derived network-control mesh. Admission remains
+bounded at 1,000 in-memory pending DAGs, 4,000 persisted pending DAGs, eight
+push workers, and four recovery workers. The test accelerates observation to
+one second while unchanged leases renew every 100 seconds.
+
+| Candidate | Result | Runtime | Capacity shed | Fetch exhausted | Quarantine | Missing effective scope | Lease writes |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| pinned baseline | failed | 145.01 s | 14,775 warnings | not observed | not observed | 1 `AgentNetwork` edge | not counted |
+| stage 3 before Gents suppression | failed | 434.88 s | 0 | 0 | 0 | 1 edge | 6,889 endpoint / 6,975 registry |
+| stage 3 after lease suppression | failed upstream recovery | 387.45 s | 0 | 60 | 0 | 0 | 76 endpoint / 76 registry |
+| `c340eaf2` + final Gents, run 1 | passed | 382.13 s | 0 | 0 | 0 | 0 | at most 16 of each per node |
+| `c340eaf2` + final Gents, run 2 | passed | 388.73 s | 0 | 0 | 0 | 0 | at most 16 of each per node |
+
+Both passing runs started from new temporary roots and crossed coordinator
+restart/remesh. At every quiet fence they had empty in-memory and persisted
+pending-DAG sets, no durable retry markers, no pending resync, no
+non-authoritative broadcast tasks, no queued or active push jobs, and stable
+progress counters. The log gate observed no empty selective CAR response,
+unparseable pushed block, or rejected gossip direction.
+
+## Formal boundary
+
+No new Lean or TLA transition is introduced here. The control/data layering
+used by join is the executable path already modeled and proved in
+`Proofs/PairingReconcile/Layering.lean` by merged PR #1156. The remaining Gents
+changes affect write timing, no-match plumbing, diagnostics, and acceptance
+observation without changing freshness thresholds, legal pairing transitions,
+admission bounds, retry dispositions, or convergence claims.
+
+DefraDB #1502 carries the formal ownership change: TLA models the durable
+receiver obligation, provider qualification, bounded retry/admission, and
+single merge owner before conformance and Rust. Its non-gating follow-ups
+#1537, #1538, and #1539 remain separate. Gents #977, #1036, #1049, and #1122
+remain ordered follow-ons and were not absorbed into this bundle.

--- a/docs/design-notes/p2p-convergence-630-696-798.md
+++ b/docs/design-notes/p2p-convergence-630-696-798.md
@@ -1,7 +1,7 @@
 # P2P convergence diagnosis: #630, #696, and #798
 
-Qualified with Gents based on `7a992d59` and DefraDB PR
-[#1502](https://github.com/sourcenetwork/defradb.rs/pull/1502) at `c340eaf2`.
+Qualified with this Gents candidate and merged DefraDB PR
+[#1502](https://github.com/sourcenetwork/defradb.rs/pull/1502) at `f928b300`.
 
 ## Conclusion
 
@@ -106,8 +106,10 @@ one second while unchanged leases renew every 100 seconds.
 | stage 3 after lease suppression | failed upstream recovery | 387.45 s | 0 | 60 | 0 | 0 | 76 endpoint / 76 registry |
 | `c340eaf2` + final Gents, run 1 | passed | 382.13 s | 0 | 0 | 0 | 0 | at most 16 of each per node |
 | `c340eaf2` + final Gents, run 2 | passed | 388.73 s | 0 | 0 | 0 | 0 | at most 16 of each per node |
+| merged `f928b300` + final Gents, run 1 | passed | 383.12 s | 0 | 0 | 0 | 0 | at most 16 of each per node |
+| merged `f928b300` + final Gents, run 2 | passed | 374.34 s | 0 | 0 | 0 | 0 | at most 16 of each per node |
 
-Both passing runs started from new temporary roots and crossed coordinator
+The two merged-revision runs started from new temporary roots and crossed coordinator
 restart/remesh. At every quiet fence they had empty in-memory and persisted
 pending-DAG sets, no durable retry markers, no pending resync, no
 non-authoritative broadcast tasks, no queued or active push jobs, and stable


### PR DESCRIPTION
## Summary

This closes the Gents side of the #630/#696/#798 convergence bundle and pins the merged DefraDB ownership fix from sourcenetwork/defradb.rs#1502 at `f928b300`.

- stop recreating issuer-owned `AgentNetwork` and `NetworkMembership` documents during join;
- install the `network-control` base pairing and requested data-plane pairing atomically;
- suppress unchanged `PeerEndpoint`/`PeerRegistry` writes until lease renewal and skip settled no-match bearer-readiness deletes;
- expose the stage-3 queue, retry-marker, CAR, provider, admission, and terminal counters through Gents;
- make the 19-node gate observe effective DefraDB replicator scope, bounded writes, restart/remesh, and stable quiescence;
- preserve the causal report and historical/final qualification evidence.

## Diagnosis

The three issues are related mechanisms, not one defect. #630 was sender-side full-DAG PushLog amplification. #696 combined that amplification with collection identity, admission, gossip-direction, and missing-link recovery defects. #798 was the interaction of avoidable Gents control-plane document production with overlapping DefraDB sender/receiver/recovery/merge ownership.

The observed `pending_store.remove` conflicts were sync-metadata OCC contention, not incorrect CRDT value semantics. Empty CAR responses, provider rotation, and pending-DAG retries were downstream consequences.

DefraDB #1502 reduces each logical update to one current-head hint, one durable receiver obligation, paced rooted CAR recovery, qualified providers, and one serialized merge owner. This PR removes the application-side amplifiers and makes the operational boundary observable.

## Validation

- `RUST_MIN_STACK=8388608 cargo test -p gents --no-fail-fast`
  - 1,649 unit tests passed, 2 live-only ignored
  - 343 conformance tests passed
  - 236 integration tests passed, 1 external-interop test ignored
- full `cli_p2p_suite`: 16 passed, 1 pre-existing #1033 acceptance test ignored
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- fresh 19-node control acceptance run 1: passed in 383.12s
- fresh 19-node control acceptance run 2: passed in 374.34s

Both 19-node runs used the merged `f928b300` revision and crossed genesis, effective control-scope installation, stable quiescence, coordinator restart/remesh, and a second stable quiescence. They recorded zero capacity shedding, fetch exhaustion, quarantine, missing `AgentNetwork` effective scope, retained retry markers, or release-blocking CAR/gossip log signatures. Endpoint and registry lease writes remained below the 16-per-node ceiling.

## Formal boundary

No new Lean/TLA transition is introduced in Gents. Join now uses the control/data layering already modeled and proved by merged #1156 in `Proofs/PairingReconcile/Layering.lean`. The other changes affect write timing, no-match plumbing, diagnostics, and acceptance observation without changing legal transitions, freshness thresholds, admission bounds, or retry dispositions. DefraDB #1502 contains the upstream TLA → conformance → Rust ownership change.

Closes #630.
Closes #696.
Closes #798.
