### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/.github/workflows/desktop-ui-qa.yml
+++ b/.github/workflows/desktop-ui-qa.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Build desktop packages
+        run: npm run build:packages
+
       - name: Install Playwright browser
         working-directory: apps/gents-desktop
         run: npx playwright install chromium

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.11.0"
+        default: "0.12.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.11.0"
+        default: "0.12.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.12.0 - 2026-08-20
+
+### Bridge contract
+
+- Keep the additive desktop bridge contract at 0.9 and advance the Rust and
+  npm desktop package train together to 0.12.0.
+
+### P2P and mobile
+
+- Make mobile pairing converge across reconnects, layered filters, reverse
+  pairings, and repeated reconcile passes; close fleet convergence
+  amplification and pin DefraDB's merged replication-ownership fix (#1145,
+  #1156, #1157).
+- Eagerly replicate the requester-scoped session index to paired mobile peers
+  and retry index synchronization from the P2P supervisor (#1141, #1148).
+- Clarify mobile configuration back-navigation and skip disabled P2P metrics
+  polling (#1146, #1130).
+
+### Runtime and formal foundation
+
+- Add correlated event-trigger fan-in, reliable background subagent
+  continuations, and an optional native LSP tool for coding behaviors (#1113,
+  #1117, #1115).
+- Unify durable descendant authorization and projections, bound terminal
+  GraphQL persistence retries, and centralize GraphQL validation and run
+  provenance (#1124, #1132, #1136).
+- Add bounded datastore query surfaces and keep client-authored conversation
+  collections compatible with fresh stores (#1125, #1151, #1155).
+
+### Agents, demos, and tooling
+
+- Add the repository review harness plus executable maintenance, security-scan,
+  and live code-review demo surfaces (#1121, #1135, #1151, #1155).
+- Replace cluster triage labels with program milestones and enforce roadmap
+  horizons through the issue-hygiene automation (#1107).
+
+### Build and reliability
+
+- Replace RocksDB with Lark, narrow DefraDB feature consumption, and improve
+  release build attribution and artifact measurement (#1101, #1109, #1119).
+- Consolidate integration-test binaries, make live gates explicit, and repair
+  the post-merge conformance and migration fences (#1140, #1149, #1150).
+
+### Dependencies
+
+- Advance DefraDB to the ownership-corrected `f928b300` revision.
+
 ## 0.11.0 - 2026-08-11
 
 ### Bridge contract
@@ -140,6 +187,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 | Tag        | Bridge crate | npm packages | contract_version | Notes                                         |
 | ---------- | ------------ | ------------ | ---------------- | --------------------------------------------- |
+| v0.12.0    | 0.12.0       | 0.12.0       | 0.9              | Mobile pairing convergence; eager session index; DefraDB `f928b300` |
 | v0.11.0    | 0.11.0       | 0.11.0       | 0.9              | DefraDB v0.18.0; signed provenance and build metrics |
 | v0.10.1    | 0.10.1       | 0.10.1       | 0.5              | DefraDB v0.17.4; mobile/subagent/migration fixes |
 | v0.10.0    | 0.10.0       | 0.10.0       | 0.5              | Reusable desktop packages implemented in #878 |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "gents-chatgpt-login"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.2",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "gents-codex-protocol"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -3506,7 +3506,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.11.0",
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-fleet": "0.11.0",
-    "@source-inc/gents-desktop-operations": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0",
+    "@source-inc/gents-desktop-chat": "0.12.0",
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-fleet": "0.12.0",
+    "@source-inc/gents-desktop-operations": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -52,12 +52,12 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-chat": "0.11.0",
-    "@source-inc/gents-desktop-fleet": "0.11.0",
-    "@source-inc/gents-desktop-operations": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0"
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-chat": "0.12.0",
+    "@source-inc/gents-desktop-fleet": "0.12.0",
+    "@source-inc/gents-desktop-operations": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0"
   },
   "devDependencies": {
     "@antithesishq/bombadil": "^0.6.0",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.12.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.11.0</string>
+	<string>0.12.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.11.0
-        CFBundleVersion: "0.11.0"
+        CFBundleShortVersionString: 0.12.0
+        CFBundleVersion: "0.12.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/review-demo/package.json
+++ b/apps/review-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/review-demo-ui",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite --strictPort --host 127.0.0.1",
@@ -10,8 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -301,7 +301,7 @@
     "desktop://managed-server-updated",
     "desktop://managed-server-tray-stop"
   ],
-  "packageVersion": "0.11.0",
+  "packageVersion": "0.12.0",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/crates/gents-cli/tests/suites/cli_config_apply_running.rs
+++ b/crates/gents-cli/tests/suites/cli_config_apply_running.rs
@@ -45,6 +45,7 @@ async fn config_apply_reconciles_running_runtime_without_restart() -> Result<()>
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     let behaviors_dir = root.join("agent-behaviors");
     let behavior_entry = fs::read_dir(&behaviors_dir)

--- a/crates/gents-cli/tests/suites/cli_config_read.rs
+++ b/crates/gents-cli/tests/suites/cli_config_read.rs
@@ -34,6 +34,7 @@ async fn config_read_commands_list_and_show_trigger_schedule_and_mcp() -> Result
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     run_cli_text(
         &home_dir,

--- a/crates/gents-cli/tests/suites/cli_session.rs
+++ b/crates/gents-cli/tests/suites/cli_session.rs
@@ -34,6 +34,7 @@ async fn session_list_and_show_include_request_count() -> Result<()> {
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    wait_for_runtime_state_graphql(&home_dir, &graphql, Duration::from_secs(30)).await?;
 
     run_cli_text(
         &home_dir,

--- a/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
+++ b/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
@@ -10,7 +10,7 @@
         },
         "model_name": "deepseek-ai/DeepSeek-V4-Flash-0731",
         "name": "terminal-bench",
-        "version": "0.11.0"
+        "version": "0.12.0"
       },
       "extra": {
         "source_projection_id": "run_timeline",

--- a/crates/gents/tests/support/interrupt.rs
+++ b/crates/gents/tests/support/interrupt.rs
@@ -17,6 +17,10 @@ const TEST_MUTATION_INITIAL_BACKOFF_MS: u64 = 100;
 // busy CI host, a healthy runtime can spend more than 60 seconds waiting for
 // startup and recovery I/O before it publishes its ready status row.
 pub const TEST_RUNTIME_READY_TIMEOUT: Duration = Duration::from_secs(120);
+// Shutdown also performs bounded watcher and subsystem cleanup. Keep this
+// comfortably above the 5-second control-settle windows exercised by the
+// runtime while preserving a hard failure for a genuinely stuck agent.
+const TEST_RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct BootedAgent {
     shutdown_tx: tokio::sync::watch::Sender<bool>,
@@ -42,9 +46,11 @@ impl BootedAgent {
         let Some(handle) = self.handle.take() else {
             return;
         };
-        tokio::time::timeout(Duration::from_secs(5), handle)
+        tokio::time::timeout(TEST_RUNTIME_SHUTDOWN_TIMEOUT, handle)
             .await
-            .expect("agent did not shut down within 5s")
+            .unwrap_or_else(|error| {
+                panic!("agent did not shut down within {TEST_RUNTIME_SHUTDOWN_TIMEOUT:?}: {error}")
+            })
             .expect("agent task should join")
             .expect("agent run should return ok");
     }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.11.0
-docker run --rm ghcr.io/source-inc/gents:v0.11.0 version
+docker pull ghcr.io/source-inc/gents:v0.12.0
+docker run --rm ghcr.io/source-inc/gents:v0.12.0 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.11.0 \
+  ghcr.io/source-inc/gents:v0.12.0 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.11.0 \
+  ghcr.io/source-inc/gents:v0.12.0 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -19,14 +19,14 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.11.0",
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-fleet": "0.11.0",
-        "@source-inc/gents-desktop-operations": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-chat": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-fleet": "0.12.0",
+        "@source-inc/gents-desktop-operations": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -44,17 +44,17 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.11.0",
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-fleet": "0.11.0",
-        "@source-inc/gents-desktop-operations": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-chat": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-fleet": "0.12.0",
+        "@source-inc/gents-desktop-operations": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -84,10 +84,10 @@
     },
     "apps/review-demo": {
       "name": "@source-inc/review-demo-ui",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -5111,12 +5111,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5126,9 +5126,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5138,7 +5138,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5150,16 +5150,16 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
         "jsqr": "^1.4.0"
       },
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5168,21 +5168,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5191,24 +5191,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.11.0",
-        "@source-inc/gents-desktop-tokens": "0.11.0",
-        "@source-inc/gents-desktop-ui": "0.11.0",
+        "@source-inc/gents-desktop-client": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-ui": "0.12.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5220,7 +5220,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.11.0",
+        "@source-inc/gents-desktop-tokens": "0.12.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0"
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0",
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,7 +15,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.11.0";
+export const PACKAGE_VERSION = "0.12.0";
 export const MINIMUM_BRIDGE_CONTRACT_VERSION = "0.7";
 
 export function assertCompatibleBridgeContract(

--- a/packages/gents-desktop-client/src/store.test.ts
+++ b/packages/gents-desktop-client/src/store.test.ts
@@ -36,7 +36,7 @@ describe("createDesktopStore", () => {
         },
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.11.0",
+          packageVersion: "0.12.0",
           events: [],
           eventReasons: [],
           errorCodes: [],
@@ -66,7 +66,7 @@ describe("createDesktopStore", () => {
         desktop_client_start: () => ({}),
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.11.0",
+          packageVersion: "0.12.0",
           events: [],
           eventReasons: [],
           errorCodes: [],

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Reusable peer discovery, pairing, health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -40,14 +40,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0"
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0",
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Reusable operations rail, liveness, health, lineage, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0"
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.11.0",
-    "@source-inc/gents-desktop-tokens": "0.11.0",
-    "@source-inc/gents-desktop-ui": "0.11.0",
+    "@source-inc/gents-desktop-client": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-ui": "0.12.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.11.0",
+    "@source-inc/gents-desktop-tokens": "0.12.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary

- advance the Rust and npm package train to 0.12.0 while retaining desktop bridge contract 0.9
- document the P2P/mobile convergence release and DefraDB ownership fix
- repair deterministic post-merge CLI/conformance timing gates and the desktop UI QA package build

## Validation

- cargo fmt --all -- --check
- RUST_MIN_STACK=16777216 cargo test -p gents
- cargo test -p gents-cli
- cargo check --workspace --all-targets
- npm run check:package-boundaries
- npm ci
- npm run build:packages
- npm run test:packages
- npm run build --workspace=@source-inc/gents-desktop-app

PR #1154 remains deferred and is not included in this release.