### PR TITLE
fix(release): reuse warmed Lean conformance gate

### DIFF
--- a/.github/workflows/release-desktop-packages.yml
+++ b/.github/workflows/release-desktop-packages.yml
@@ -53,15 +53,26 @@ jobs:
               echo "::error::Release tag ${GITHUB_REF_NAME} does not match v${workspace_version}."
               exit 1
             }
+            release_tag="${GITHUB_REF_NAME}"
           elif [[ "${RELEASE_VERSION_INPUT}" != "${workspace_version}" ]]; then
             echo "::error::Requested ${RELEASE_VERSION_INPUT} does not match ${workspace_version}."
             exit 1
+          else
+            release_tag="v${RELEASE_VERSION_INPUT}"
           fi
+          echo "RELEASE_TAG=${release_tag}" >> "${GITHUB_ENV}"
 
       - name: Build, test, pack, and clean-install every package
         run: |
           npm run build:packages
-          npm run test:packages
+          # The chat package's Lean-backed conformance test runs in the
+          # lean-proofs CI job, where the proof cache is already warm. A cold
+          # hosted runner spends roughly 10 minutes rebuilding Mathlib and
+          # exceeds the test's bounded contract-generation timeout.
+          npm run test --workspace @source-inc/gents-desktop-client
+          npm run test --workspace @source-inc/gents-desktop-ui
+          npm run test --workspace @source-inc/gents-desktop-fleet
+          npm run test --workspace @source-inc/gents-desktop-operations
           ./scripts/pack-desktop-packages.sh target/desktop-npm-release
 
       - name: Upload workflow artifact
@@ -72,18 +83,18 @@ jobs:
           if-no-files-found: error
 
       - name: Attach package tarballs to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release create "${GITHUB_REF_NAME}" \
+          if ! gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release create "${RELEASE_TAG}" \
               --verify-tag \
-              --title "${GITHUB_REF_NAME}" \
+              --title "${RELEASE_TAG}" \
               --notes "gents release artifacts." \
-              || gh release view "${GITHUB_REF_NAME}" >/dev/null
+              || gh release view "${RELEASE_TAG}" >/dev/null
           fi
           gh release upload \
-            "${GITHUB_REF_NAME}" \
+            "${RELEASE_TAG}" \
             target/desktop-npm-release/*.tgz \
             --clobber


### PR DESCRIPTION
## Summary

- keep the Lean-backed desktop chat conformance test in the warmed lean-proofs CI job
- mirror the normal hosted desktop-package test subset in the release workflow
- allow an explicit workflow dispatch to attach rebuilt packages to an existing verified release tag

## Root cause

The v0.12.0 tag workflow rebuilt Mathlib on a cold hosted runner for roughly 9.5 minutes. Vitest correctly rejected the generated-contract test after its bounded 120-second timeout. Normal CI already avoids this by running that test after the cached Lean proof build.

## Validation

- npm run build:packages
- hosted-runner package test subset (client, UI, fleet, operations)
- scripts/pack-desktop-packages.sh with clean-install consumer verification
- git diff --check