### PR TITLE
refactor(runtime): centralize conversation continuations

### DIFF
--- a/crates/gents-cli/src/commands/codex_shim/history_projection.rs
+++ b/crates/gents-cli/src/commands/codex_shim/history_projection.rs
@@ -92,6 +92,10 @@ struct CompactionRow {
 #[derive(Debug, Clone, Deserialize)]
 struct MessageRow {
     sequence: i64,
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
+    message_key: String,
     #[serde(default, deserialize_with = "deserialize_nullable_string")]
     role: String,
     #[serde(default, deserialize_with = "deserialize_nullable_string")]
@@ -172,6 +176,8 @@ pub(super) async fn load_thread_turns(
                 order: {{ sequence: ASC }}
             ) {{
                 sequence
+                request_id
+                message_key
                 role
                 content
                 reasoning
@@ -228,9 +234,13 @@ pub(super) async fn load_thread_turns(
         .map(|message| (message.sequence, message))
         .collect::<BTreeMap<_, _>>();
 
+    let requests_by_id = requests
+        .iter()
+        .map(|request| (request.request_id.as_str(), request))
+        .collect::<BTreeMap<_, _>>();
     let turns = project_request_turns(
         record,
-        requests,
+        &requests,
         &responses_by_request,
         &tools_by_request,
         &compactions_by_request,
@@ -238,7 +248,7 @@ pub(super) async fn load_thread_turns(
     )?;
 
     if turns.is_empty() && !messages.is_empty() {
-        return Ok(project_message_turns(messages));
+        return Ok(project_message_turns(messages, &requests_by_id));
     }
 
     Ok(turns)
@@ -283,7 +293,10 @@ async fn load_completed_compactions(
         .context("decoding completed InferenceCall compaction history rows")
 }
 
-fn project_message_turns(messages: Vec<MessageRow>) -> Vec<codex::Turn> {
+fn project_message_turns(
+    messages: Vec<MessageRow>,
+    requests_by_id: &BTreeMap<&str, &RequestRow>,
+) -> Vec<codex::Turn> {
     let mut turns = Vec::new();
     let mut current_id = None::<String>;
     let mut current_items = Vec::<codex::ThreadItem>::new();
@@ -292,6 +305,21 @@ fn project_message_turns(messages: Vec<MessageRow>) -> Vec<codex::Turn> {
     for message in messages {
         let role = message.role.trim();
         if role.eq_ignore_ascii_case("user") {
+            let request = message
+                .request_id
+                .as_ref()
+                .and_then(|request_id| requests_by_id.get(request_id.as_str()).copied());
+            if gents::lifecycle::classify_continuation_message(
+                request.map(|request| request.metadata.as_str()),
+                message.request_id.as_deref(),
+                request.map(|request| request.content.as_str()),
+                &message.role,
+                &message.content,
+                &message.message_key,
+            ) == gents::lifecycle::ConversationProjection::RuntimeControl
+            {
+                continue;
+            }
             finish_message_turn(
                 &mut turns,
                 current_id.take(),
@@ -345,15 +373,16 @@ fn finish_message_turn(
 
 fn project_request_turns(
     record: &CodexThreadRecord,
-    requests: Vec<RequestRow>,
+    requests: &[RequestRow],
     responses_by_request: &BTreeMap<String, ResponseRow>,
     tools_by_request: &BTreeMap<String, Vec<ToolRow>>,
     compactions_by_request: &BTreeMap<String, Vec<CompactionRow>>,
     messages_by_sequence: &BTreeMap<i64, MessageRow>,
 ) -> Result<Vec<codex::Turn>> {
     let requests = requests
-        .into_iter()
+        .iter()
         .filter(|request| record.is_subagent() || is_codex_visible_request(request))
+        .cloned()
         .collect::<Vec<_>>();
     let requests_by_id = requests
         .iter()
@@ -606,8 +635,33 @@ fn append_request_items(
             .then_with(|| left.started_at.cmp(&right.started_at))
     });
 
-    if !request.content.trim().is_empty()
-        && !is_background_completion_metadata(Some(&request.metadata))
+    let continuation_input = messages_by_sequence.values().find(|message| {
+        message.request_id.as_deref() == Some(request.request_id.as_str())
+            && gents::lifecycle::classify_continuation_message(
+                Some(&request.metadata),
+                message.request_id.as_deref(),
+                Some(&request.content),
+                &message.role,
+                &message.content,
+                &message.message_key,
+            ) == gents::lifecycle::ConversationProjection::VisibleInput
+    });
+    if let Some(message) = continuation_input {
+        let presentation = present_persisted_message(&message.role, &message.content);
+        if !presentation.body_markdown.trim().is_empty() {
+            items.push(codex::ThreadItem::UserMessage {
+                id: format!("gents-user-message-{}", message.sequence),
+                content: vec![codex::UserInput::Text {
+                    text: presentation.body_markdown,
+                    text_elements: Vec::new(),
+                }],
+            });
+        }
+    } else if !request.content.trim().is_empty()
+        && gents::lifecycle::classify_continuation_request(
+            Some(&request.metadata),
+            &request.content,
+        ) != gents::lifecycle::ConversationProjection::RuntimeControl
     {
         items.push(codex::ThreadItem::UserMessage {
             id: format!("gents-user-{}", request.request_id),
@@ -1020,6 +1074,129 @@ mod tests {
     }
 
     #[test]
+    fn steering_projection_uses_versioned_input_and_preserves_legacy_input() {
+        let record = CodexThreadRecord {
+            session_id: "thread-1".to_string(),
+            cwd: PathBuf::from("/tmp/project"),
+            archived: false,
+            loaded: true,
+            memory_mode: "disabled".to_string(),
+            name: String::new(),
+            settings_json: "{}".to_string(),
+            git_info: None,
+            projection_started: None,
+            conversation: None,
+            subagent: None,
+        };
+        let mut request = RequestRow {
+            request_id: "steering-1".to_string(),
+            content: "also check the staging config".to_string(),
+            status: "completed".to_string(),
+            lifecycle_state: "completed".to_string(),
+            failure_reason: String::new(),
+            created_at: None,
+            terminalized_at: None,
+            metadata: r#"{"continuation_version":1,"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":"root-1"}}"#.to_string(),
+            execution_origin: "interactive".to_string(),
+        };
+        let messages = BTreeMap::from([
+            (
+                6,
+                MessageRow {
+                    sequence: 6,
+                    request_id: Some("steering-1".to_string()),
+                    message_key: "request-context:steering-1".to_string(),
+                    role: "user".to_string(),
+                    content: "<context>internal request context</context>".to_string(),
+                    reasoning: String::new(),
+                },
+            ),
+            (
+                7,
+                MessageRow {
+                sequence: 7,
+                request_id: Some("steering-1".to_string()),
+                message_key: "steering-input:steering-1".to_string(),
+                role: "user".to_string(),
+                content: r#"{"role":"user","content":[{"type":"text","text":"also check the staging config"}]}"#.to_string(),
+                reasoning: String::new(),
+                },
+            ),
+        ]);
+        let mut items = Vec::new();
+        append_request_items(
+            &record,
+            &mut items,
+            &request,
+            None,
+            Vec::new(),
+            &[],
+            &messages,
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| matches!(item, codex::ThreadItem::UserMessage { .. }))
+                .count(),
+            1
+        );
+        assert!(items.iter().any(|item| matches!(
+            item,
+            codex::ThreadItem::UserMessage { content, .. }
+                if content.iter().any(|input| matches!(
+                    input,
+                    codex::UserInput::Text { text, .. }
+                        if text == "also check the staging config"
+                ))
+        )));
+
+        request.metadata = r#"{"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":"root-1"}}"#.to_string();
+        let legacy_messages = BTreeMap::from([
+            (
+                6,
+                MessageRow {
+                    sequence: 6,
+                    request_id: Some("steering-1".to_string()),
+                    message_key: String::new(),
+                    role: "user".to_string(),
+                    content: "<context>internal request context</context>".to_string(),
+                    reasoning: String::new(),
+                },
+            ),
+            (
+                7,
+                MessageRow {
+                    sequence: 7,
+                    request_id: Some("steering-1".to_string()),
+                    message_key: String::new(),
+                    role: "user".to_string(),
+                    content: r#"{"role":"user","content":[{"type":"text","text":"also check the staging config"}]}"#.to_string(),
+                    reasoning: String::new(),
+                },
+            ),
+        ]);
+        items.clear();
+        append_request_items(
+            &record,
+            &mut items,
+            &request,
+            None,
+            Vec::new(),
+            &[],
+            &legacy_messages,
+        );
+        assert!(items.iter().any(|item| matches!(
+            item,
+            codex::ThreadItem::UserMessage { content, .. }
+                if content.iter().any(|input| matches!(
+                    input,
+                    codex::UserInput::Text { text, .. }
+                        if text == "also check the staging config"
+                ))
+        )));
+    }
+
+    #[test]
     fn turn_completion_timing_prefers_response_then_request_terminalization() {
         let request = RequestRow {
             request_id: "request-1".to_string(),
@@ -1136,6 +1313,8 @@ mod tests {
                 2,
                 MessageRow {
                     sequence: 2,
+                    request_id: None,
+                    message_key: String::new(),
                     role: "assistant".to_string(),
                     content: r#"{"role":"assistant","id":null,"content":[{"id":"call-1","call_id":null,"function":{"name":"list_files","arguments":{"path":"."}},"signature":null,"additional_params":null},{"text":"Before the tool call."}]}"#.to_string(),
                     reasoning: String::new(),
@@ -1145,6 +1324,8 @@ mod tests {
                 4,
                 MessageRow {
                     sequence: 4,
+                    request_id: None,
+                    message_key: String::new(),
                     role: "assistant".to_string(),
                     content: r#"{"role":"assistant","id":null,"content":[{"text":"Final answer after tools."}]}"#.to_string(),
                     reasoning: String::new(),
@@ -1266,9 +1447,11 @@ mod tests {
 
     #[test]
     fn project_message_turns_renders_structured_persisted_messages() {
-        let turns = project_message_turns(vec![
-            MessageRow {
+        let turns = project_message_turns(
+            vec![MessageRow {
                 sequence: 1,
+                request_id: None,
+                message_key: String::new(),
                 role: "user".to_string(),
                 content: r#"{"role":"user","content":[{"type":"text","text":"Hello from stored user JSON."}]}"#
                     .to_string(),
@@ -1276,12 +1459,15 @@ mod tests {
             },
             MessageRow {
                 sequence: 2,
+                request_id: None,
+                message_key: String::new(),
                 role: "assistant".to_string(),
                 content: r#"{"role":"assistant","id":null,"content":[{"text":"Hello from stored assistant JSON."}]}"#
                     .to_string(),
                 reasoning: String::new(),
-            },
-        ]);
+            }],
+            &BTreeMap::new(),
+        );
 
         assert_eq!(turns.len(), 1);
         let turn = &turns[0];
@@ -1303,6 +1489,34 @@ mod tests {
     }
 
     #[test]
+    fn messages_only_fallback_hides_goal_controller_prompts() {
+        let request = RequestRow {
+            request_id: "goal-request-1".to_string(),
+            content: "Continue pursuing the active goal.".to_string(),
+            status: "completed".to_string(),
+            lifecycle_state: "completed".to_string(),
+            failure_reason: String::new(),
+            created_at: None,
+            terminalized_at: None,
+            metadata: r#"{"continuation_version":1,"queue":{"source":"goal","policy":"coalesce","key":"goal:1","queued_after_request_id":"root-1"}}"#.to_string(),
+            execution_origin: "scheduled".to_string(),
+        };
+        let requests = BTreeMap::from([(request.request_id.as_str(), &request)]);
+        let turns = project_message_turns(
+            vec![MessageRow {
+                sequence: 1,
+                request_id: Some("goal-request-1".to_string()),
+                message_key: String::new(),
+                role: "user".to_string(),
+                content: "Continue pursuing the active goal.".to_string(),
+                reasoning: String::new(),
+            }],
+            &requests,
+        );
+        assert!(turns.is_empty());
+    }
+
+    #[test]
     fn persisted_reasoning_field_is_the_authoritative_replay_source() {
         let mut items = Vec::new();
         let appended = append_assistant_message_items(
@@ -1310,6 +1524,8 @@ mod tests {
             4,
             &MessageRow {
                 sequence: 4,
+                request_id: None,
+                message_key: String::new(),
                 role: "assistant".to_string(),
                 content: r#"{"role":"assistant","id":null,"content":[{"reasoning":"legacy embedded reasoning"},{"text":"answer"}]}"#
                     .to_string(),

--- a/crates/gents-desktop-bridge/src/snapshot/session.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/session.rs
@@ -19,30 +19,23 @@ use super::{request_matches_agent, source_matches_agent};
 fn message_is_runtime_control(
     message: &AgentMessageRow,
     requests_by_id: &HashMap<&str, &AgentRequestRow>,
-    keyed_steering_request_ids: &std::collections::BTreeSet<String>,
 ) -> bool {
-    let request_metadata = message
+    let request = message
         .request_id
         .as_deref()
         .and_then(|request_id| requests_by_id.get(request_id))
-        .and_then(|request| request.metadata.as_deref());
-    let has_keyed_input = message
-        .request_id
-        .as_deref()
-        .is_some_and(|request_id| keyed_steering_request_ids.contains(request_id));
-    gents::lifecycle::is_runtime_control_message(
-        request_metadata,
-        &message.message_key,
-        has_keyed_input,
+        .copied();
+    matches!(
+        gents::lifecycle::classify_continuation_message(
+            request.and_then(|request| request.metadata.as_deref()),
+            message.request_id.as_deref(),
+            request.and_then(|request| request.content.as_deref()),
+            message.role.as_deref().unwrap_or_default(),
+            message.content.as_deref().unwrap_or_default(),
+            &message.message_key,
+        ),
+        gents::lifecycle::ConversationProjection::RuntimeControl
     )
-}
-
-fn keyed_steering_request_ids(messages: &[&AgentMessageRow]) -> std::collections::BTreeSet<String> {
-    messages
-        .iter()
-        .filter(|message| gents::lifecycle::is_steering_input_message_key(&message.message_key))
-        .filter_map(|message| normalize_optional(message.request_id.as_deref()))
-        .collect()
 }
 
 fn request_is_deprecated_background_completion(request: &AgentRequestRow) -> bool {
@@ -317,7 +310,6 @@ pub fn build_session_snapshot_from_store_for_agent(
         .iter()
         .map(|request| (request.request_id.as_str(), *request))
         .collect();
-    let keyed_steering_request_ids = keyed_steering_request_ids(&transcript.messages);
     let messages = transcript
         .messages
         .into_iter()
@@ -353,11 +345,7 @@ pub fn build_session_snapshot_from_store_for_agent(
                 has_tool_results: presentation
                     .as_ref()
                     .is_some_and(|presentation| presentation.has_tool_results),
-                runtime_control: message_is_runtime_control(
-                    row,
-                    &requests_by_id,
-                    &keyed_steering_request_ids,
-                ),
+                runtime_control: message_is_runtime_control(row, &requests_by_id),
                 timestamp: normalize_optional(row.timestamp.as_deref()),
             }
         })
@@ -590,12 +578,14 @@ fn build_pending_turn(
             && row.session_id.as_deref() == Some(session_id)
             && agent_did.is_none_or(|agent_did| request_matches_agent(row, agent_did, false))
     })?;
-    if !gents::lifecycle::request_content_owns_user_projection(request.metadata.as_deref()) {
-        return None;
-    }
-
     let lifecycle_state = normalize_optional(request.lifecycle_state.as_deref());
     let content = normalize_optional(request.content.as_deref())?;
+    if matches!(
+        gents::lifecycle::classify_continuation_request(request.metadata.as_deref(), &content,),
+        gents::lifecycle::ConversationProjection::RuntimeControl
+    ) {
+        return None;
+    }
     let transcript = agent_did.map_or_else(
         || store.transcript(session_id),
         |agent_did| store.transcript_for_agent(session_id, agent_did),
@@ -605,7 +595,6 @@ fn build_pending_turn(
         .iter()
         .map(|request| (request.request_id.as_str(), request))
         .collect::<HashMap<_, _>>();
-    let keyed_steering_request_ids = keyed_steering_request_ids(&transcript.messages);
     let messages = transcript
         .messages
         .into_iter()
@@ -632,11 +621,7 @@ fn build_pending_turn(
                 reasoning: None,
                 has_tool_calls: false,
                 has_tool_results: false,
-                runtime_control: message_is_runtime_control(
-                    row,
-                    &requests_by_id,
-                    &keyed_steering_request_ids,
-                ),
+                runtime_control: message_is_runtime_control(row, &requests_by_id),
                 timestamp: normalize_optional(row.timestamp.as_deref()),
             }
         })

--- a/crates/gents-desktop-bridge/src/snapshot/tests/session_timeline.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/tests/session_timeline.rs
@@ -186,7 +186,7 @@ fn steering_projects_the_input_once_without_rendering_its_control_prompt() {
     rows.responses.clear();
     rows.requests[0].content = Some("also check the staging config".to_string());
     rows.requests[0].metadata = Some(
-        r#"{"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":"parent-1"}}"#
+        r#"{"continuation_version":1,"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":"parent-1"}}"#
             .to_string(),
     );
     rows.messages[0].message_key = "steering-input:req-1".to_string();
@@ -208,6 +208,53 @@ fn steering_projects_the_input_once_without_rendering_its_control_prompt() {
             })
             .collect::<Vec<_>>(),
         vec!["also check the staging config"]
+    );
+}
+
+#[test]
+fn continuation_assistant_reply_owns_the_live_overlay() {
+    let mut rows = make_streaming_store_with_response_content("working on it").to_rows();
+    rows.requests[0].content = Some("also check the staging config".to_string());
+    rows.requests[0].metadata = Some(
+        r#"{"continuation_version":1,"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":"parent-1"}}"#
+            .to_string(),
+    );
+    rows.messages[0].role = Some("assistant".to_string());
+    rows.messages[0].content = Some(assistant_message_json("working on it"));
+
+    let store = ClientStore::from_rows(rows);
+    let snapshot = build_session_snapshot_from_store(&store, "sess-1", Some("req-1"))
+        .expect("session snapshot");
+
+    assert!(!snapshot.messages[0].runtime_control);
+    assert!(snapshot
+        .timeline_items
+        .iter()
+        .all(|item| !matches!(item, RenderedTimelineItem::LiveAssistant { .. })));
+}
+
+#[test]
+fn legacy_steering_content_remains_visible_during_projection() {
+    let mut rows = make_streaming_store_with_response_content("").to_rows();
+    rows.responses.clear();
+    rows.requests[0].content = Some("also check the staging config".to_string());
+    rows.requests[0].metadata = Some(
+        r#"{"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":"parent-1"}}"#
+            .to_string(),
+    );
+    rows.messages.clear();
+
+    let store = ClientStore::from_rows(rows);
+    let snapshot = build_session_snapshot_from_store(&store, "sess-1", Some("req-1"))
+        .expect("session snapshot");
+
+    assert!(snapshot.messages.is_empty());
+    assert_eq!(
+        snapshot
+            .pending_turn
+            .as_ref()
+            .map(|turn| turn.content.as_str()),
+        Some("also check the staging config")
     );
 }
 

--- a/crates/gents/proofs/Proofs.lean
+++ b/crates/gents/proofs/Proofs.lean
@@ -14,6 +14,7 @@ import Proofs.Compaction
 import Proofs.PromptAssembly
 import Proofs.RenderedCapture
 import Proofs.DurableLineage
+import Proofs.ConversationContinuation
 import Proofs.RuntimeReconcile
 import Proofs.PairingReconcile
 import Proofs.PeerRegistryDiscovery

--- a/crates/gents/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/gents/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -544,6 +544,21 @@ structure SteerInterruptComposes where
   queueInterruptedRequestId : String
   deriving Repr
 
+structure ConversationContinuationPolicy where
+  version : Nat
+  steeringPolicy : String
+  backgroundCompletionPolicy : String
+  goalPolicy : String
+  steeringLineageAdmissible : Bool
+  backgroundLineageAdmissible : Bool
+  goalLineageAdmissible : Bool
+  allControlPromptsInternal : Bool
+  durableInputMatchesMessageBackedKinds : Bool
+  steeringProviderInput : String
+  steeringInputAppearsExactlyOnce : Bool
+  steeringControlPromptAbsent : Bool
+  deriving Repr
+
 structure UnmaterializedChildVisible where
   callerRequestId : String
   bridgeToolCallId : String

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
@@ -1,6 +1,7 @@
 import Proofs.Conformance.Contracts.Json.Helpers
 import Proofs.Conformance.ContractCases
 import Proofs.DurableLineage
+import Proofs.ConversationContinuation
 
 /-!
 # Background Work JSON
@@ -140,6 +141,33 @@ def r4cSteerInterruptComposesJson
       ++ jsonString witness.queueInterruptedRequestId
     ++ "}"
 
+def conversationContinuationPolicyJson
+    (witness : R4cWitnesses.ConversationContinuationPolicy) : String :=
+  "{"
+    ++ "\"witness\":" ++ jsonString "conversation.continuation.policy" ++ ","
+    ++ "\"version\":" ++ toString witness.version ++ ","
+    ++ "\"steering_policy\":" ++ jsonString witness.steeringPolicy ++ ","
+    ++ "\"background_completion_policy\":"
+      ++ jsonString witness.backgroundCompletionPolicy ++ ","
+    ++ "\"goal_policy\":" ++ jsonString witness.goalPolicy ++ ","
+    ++ "\"steering_lineage_admissible\":"
+      ++ boolString witness.steeringLineageAdmissible ++ ","
+    ++ "\"background_lineage_admissible\":"
+      ++ boolString witness.backgroundLineageAdmissible ++ ","
+    ++ "\"goal_lineage_admissible\":"
+      ++ boolString witness.goalLineageAdmissible ++ ","
+    ++ "\"all_control_prompts_internal\":"
+      ++ boolString witness.allControlPromptsInternal ++ ","
+    ++ "\"durable_input_matches_message_backed_kinds\":"
+      ++ boolString witness.durableInputMatchesMessageBackedKinds ++ ","
+    ++ "\"steering_provider_input\":"
+      ++ jsonString witness.steeringProviderInput ++ ","
+    ++ "\"steering_input_appears_exactly_once\":"
+      ++ boolString witness.steeringInputAppearsExactlyOnce ++ ","
+    ++ "\"steering_control_prompt_absent\":"
+      ++ boolString witness.steeringControlPromptAbsent
+    ++ "}"
+
 def r4cListSubagentsLineageRejects :
     R4cWitnesses.ListSubagentsLineageRejects :=
   { callerRequestId := "r4c-w1-caller"
@@ -258,6 +286,42 @@ def r4cSteerInterruptComposes :
   , queueInterruptedRequestId := "r4c-w6-interrupted"
   }
 
+def conversationContinuationPolicy :
+    R4cWitnesses.ConversationContinuationPolicy :=
+  { version := ConversationContinuation.version
+  , steeringPolicy :=
+      ConversationContinuation.Kind.steering.policy.toContract
+  , backgroundCompletionPolicy :=
+      ConversationContinuation.Kind.backgroundCompletion.policy.toContract
+  , goalPolicy := ConversationContinuation.Kind.goal.policy.toContract
+  , steeringLineageAdmissible :=
+      DurableLineage.admissible
+        (ConversationContinuation.Kind.steering.lineage 1)
+  , backgroundLineageAdmissible :=
+      DurableLineage.admissible
+        (ConversationContinuation.Kind.backgroundCompletion.lineage 1)
+  , goalLineageAdmissible :=
+      DurableLineage.admissible (ConversationContinuation.Kind.goal.lineage 0)
+  , allControlPromptsInternal := decide (
+      ConversationContinuation.Kind.steering.policy.controlVisibility = .runtimeControl ∧
+      ConversationContinuation.Kind.backgroundCompletion.policy.controlVisibility = .runtimeControl ∧
+      ConversationContinuation.Kind.goal.policy.controlVisibility = .runtimeControl)
+  , durableInputMatchesMessageBackedKinds := decide (
+      ConversationContinuation.Kind.steering.policy.requiresDurableInput =
+          ConversationContinuation.Kind.steering.policy.inputVisibility.isSome ∧
+      ConversationContinuation.Kind.backgroundCompletion.policy.requiresDurableInput =
+          ConversationContinuation.Kind.backgroundCompletion.policy.inputVisibility.isSome ∧
+      ConversationContinuation.Kind.goal.policy.requiresDurableInput =
+          ConversationContinuation.Kind.goal.policy.inputVisibility.isSome)
+  , steeringProviderInput := ConversationContinuation.steeringProviderInputContract
+  , steeringInputAppearsExactlyOnce := decide (
+      ConversationContinuation.providerItemCount .steeringInput
+        ConversationContinuation.steeringProviderInput = 1)
+  , steeringControlPromptAbsent := decide (
+      ConversationContinuation.providerItemCount .steeringControl
+        ConversationContinuation.steeringProviderInput = 0)
+  }
+
 def r4cBackgroundWorkCasesJson : List String :=
   [ r4cListSubagentsLineageRejectsJson r4cListSubagentsLineageRejects
   , r4cReadTranscriptCursorAdvancesJson r4cReadTranscriptCursorAdvances
@@ -265,6 +329,7 @@ def r4cBackgroundWorkCasesJson : List String :=
   , r4cReadToolOutputDispatchesByStateJson r4cReadToolOutputDispatchesByState
   , r4cSteerAppendPreservesLineageJson r4cSteerAppendPreservesLineage
   , r4cSteerInterruptComposesJson r4cSteerInterruptComposes
+  , conversationContinuationPolicyJson conversationContinuationPolicy
   , r4cUnmaterializedChildVisibleJson r4cUnmaterializedChildVisible
   ]
 

--- a/crates/gents/proofs/Proofs/ConversationContinuation.lean
+++ b/crates/gents/proofs/Proofs/ConversationContinuation.lean
@@ -1,0 +1,189 @@
+import Proofs.DurableLineage
+import Proofs.Session.State
+
+/-!
+# Conversation continuation policy
+
+Runtime-authored turns in an existing conversation share one vocabulary while
+retaining the distinctions that matter for durability and projection.  This
+module is the policy table consumed by conformance tests and mirrored by Rust.
+-/
+
+namespace ConversationContinuation
+
+inductive Kind where
+  | steering
+  | backgroundCompletion
+  | goal
+  deriving DecidableEq, Repr
+
+inductive ExecutionOrigin where
+  | interactive
+  | scheduled
+  deriving DecidableEq, Repr
+
+inductive Visibility where
+  | visibleInput
+  | runtimeControl
+  deriving DecidableEq, Repr
+
+inductive ParentStrategy where
+  | generationOwner
+  | previousRequest
+  deriving DecidableEq, Repr
+
+inductive ProviderInputStrategy where
+  | promptOnce
+  | historyThenControl
+  | controlOnly
+  deriving DecidableEq, Repr
+
+def ExecutionOrigin.toContract : ExecutionOrigin → String
+  | .interactive => "interactive"
+  | .scheduled => "scheduled"
+
+def Visibility.toContract : Visibility → String
+  | .visibleInput => "visible_input"
+  | .runtimeControl => "runtime_control"
+
+def ParentStrategy.toContract : ParentStrategy → String
+  | .generationOwner => "generation_owner"
+  | .previousRequest => "previous_request"
+
+def ProviderInputStrategy.toContract : ProviderInputStrategy → String
+  | .promptOnce => "prompt_once"
+  | .historyThenControl => "history_then_control"
+  | .controlOnly => "control_only"
+
+structure Policy where
+  source : SessionQueue.QueueSource
+  queuePolicy : SessionQueue.QueuePolicy
+  origin : ExecutionOrigin
+  inputVisibility : Option Visibility
+  controlVisibility : Visibility
+  parentStrategy : ParentStrategy
+  requiresDurableInput : Bool
+  providerInputStrategy : ProviderInputStrategy
+  deriving DecidableEq, Repr
+
+def version : Nat := 1
+
+def Kind.policy : Kind → Policy
+  | .steering =>
+      { source := .steering
+      , queuePolicy := .append
+      , origin := .interactive
+      , inputVisibility := some .visibleInput
+      , controlVisibility := .runtimeControl
+      , parentStrategy := .generationOwner
+      , requiresDurableInput := true
+      , providerInputStrategy := .promptOnce
+      }
+  | .backgroundCompletion =>
+      { source := .backgroundCompletion
+      , queuePolicy := .coalesce
+      , origin := .scheduled
+      , inputVisibility := some .runtimeControl
+      , controlVisibility := .runtimeControl
+      , parentStrategy := .generationOwner
+      , requiresDurableInput := true
+      , providerInputStrategy := .historyThenControl
+      }
+  | .goal =>
+      { source := .goal
+      , queuePolicy := .coalesce
+      , origin := .scheduled
+      , inputVisibility := none
+      , controlVisibility := .runtimeControl
+      , parentStrategy := .previousRequest
+      , requiresDurableInput := false
+      , providerInputStrategy := .controlOnly
+      }
+
+def Kind.lineage : Kind → Nat → DurableLineage.RawLineage
+  | .steering, depth => DurableLineage.steeringContinuation depth
+  | .backgroundCompletion, depth => DurableLineage.backgroundCompletionContinuation depth
+  | .goal, _ => DurableLineage.goalContinuation
+
+def Policy.toContract (policy : Policy) : String :=
+  policy.source.toDefraDB ++ "|" ++ policy.queuePolicy.toDefraDB ++ "|" ++
+    policy.origin.toContract ++ "|" ++
+    (policy.inputVisibility.map Visibility.toContract).getD "none" ++ "|" ++
+    policy.controlVisibility.toContract ++ "|" ++ policy.parentStrategy.toContract ++ "|" ++
+    (if policy.requiresDurableInput then "durable_input" else "request_only") ++ "|" ++
+    policy.providerInputStrategy.toContract
+
+theorem every_control_prompt_is_internal (kind : Kind) :
+    kind.policy.controlVisibility = .runtimeControl := by
+  cases kind <;> rfl
+
+theorem durable_input_exactly_for_message_backed_kinds (kind : Kind) :
+    kind.policy.requiresDurableInput = kind.policy.inputVisibility.isSome := by
+  cases kind <;> rfl
+
+theorem every_continuation_lineage_is_admissible (kind : Kind) (depth : Nat) :
+    DurableLineage.admissible (kind.lineage depth) = true := by
+  cases kind
+  · exact DurableLineage.steering_continuation_is_admissible depth
+  · exact DurableLineage.background_completion_continuation_is_admissible depth
+  · exact DurableLineage.goal_continuation_is_admissible
+
+theorem steering_input_is_visible :
+    Kind.steering.policy.inputVisibility = some .visibleInput := by
+  rfl
+
+inductive ProviderItem where
+  | priorMessage
+  | steeringInput
+  | steeringControl
+  deriving DecidableEq, Repr
+
+def ProviderItem.toContract : ProviderItem → String
+  | .priorMessage => "prior_message"
+  | .steeringInput => "steering_input"
+  | .steeringControl => "steering_control"
+
+structure SequencedProviderItem where
+  sequence : Nat
+  item : ProviderItem
+  deriving DecidableEq, Repr
+
+def historyBefore (inputSequence : Nat) (rows : List SequencedProviderItem) :
+    List ProviderItem :=
+  (rows.filter fun row => row.sequence < inputSequence).map SequencedProviderItem.item
+
+def assemblePromptOnce (inputSequence : Nat) (rows : List SequencedProviderItem)
+    (currentPrompt : ProviderItem) : List ProviderItem :=
+  historyBefore inputSequence rows ++ [currentPrompt]
+
+def steeringProviderRows : List SequencedProviderItem :=
+  [ { sequence := 1, item := .priorMessage }
+  , { sequence := 2, item := .steeringInput }
+  ]
+
+def steeringProviderInput : List ProviderItem :=
+  assemblePromptOnce 2 steeringProviderRows .steeringInput
+
+def providerItemCount (needle : ProviderItem) (items : List ProviderItem) : Nat :=
+  (items.filter (· = needle)).length
+
+def steeringProviderInputContract : String :=
+  String.intercalate "|" (steeringProviderInput.map ProviderItem.toContract)
+
+theorem steering_visible_input_appears_exactly_once_at_provider_boundary :
+    providerItemCount .steeringInput steeringProviderInput = 1 := by
+  native_decide
+
+theorem steering_control_prompt_is_absent_at_provider_boundary :
+    providerItemCount .steeringControl steeringProviderInput = 0 := by
+  native_decide
+
+theorem background_input_is_internal :
+    Kind.backgroundCompletion.policy.inputVisibility = some .runtimeControl := by
+  rfl
+
+theorem goal_has_no_separate_input :
+    Kind.goal.policy.inputVisibility = none := by
+  rfl
+
+end ConversationContinuation

--- a/crates/gents/proofs/Proofs/DurableLineage.lean
+++ b/crates/gents/proofs/Proofs/DurableLineage.lean
@@ -100,6 +100,21 @@ theorem background_completion_continuation_is_admissible
   simp [admissible, edgePairsCoherent, pairCoherent, parentShapeCoherent,
     depthCoherent, backgroundCompletionContinuation]
 
+def goalContinuation : RawLineage :=
+  { hasParentRequestId := true
+  , hasParentRequestDocId := true
+  , hasParentToolCallId := false
+  , hasParentToolCallDocId := false
+  , subagentDepth := 0
+  , requestOnlyControl := true
+  , controlAllowedAtDepthZero := true
+  }
+
+/-- A goal continuation is an explicitly linked depth-zero controller turn. -/
+theorem goal_continuation_is_admissible :
+    admissible goalContinuation = true := by
+  rfl
+
 namespace SteeringPersistence
 
 inductive Stage where

--- a/crates/gents/proofs/Proofs/Session/State.lean
+++ b/crates/gents/proofs/Proofs/Session/State.lean
@@ -10,6 +10,7 @@ inductive QueueSource where
   | user
   | backgroundCompletion
   | steering
+  | goal
   deriving DecidableEq, Repr
 
 namespace QueueSource
@@ -18,12 +19,14 @@ def toDefraDB : QueueSource → String
   | .user => "user"
   | .backgroundCompletion => "background_completion"
   | .steering => "steering"
+  | .goal => "goal"
 
 def fromDefraDB? : String → Option QueueSource
   | "user" => some .user
   | "background_completion" => some .backgroundCompletion
   | "subagent_completion" => some .backgroundCompletion
   | "steering" => some .steering
+  | "goal" => some .goal
   | _ => none
 
 theorem fromDefraDB_toDefraDB (source : QueueSource) :
@@ -34,12 +37,14 @@ def automatedWakeup : QueueSource → Prop
   | .user => False
   | .backgroundCompletion => True
   | .steering => False
+  | .goal => False
 
 instance (source : QueueSource) : Decidable source.automatedWakeup :=
   match source with
   | .user => isFalse (by intro h; exact h)
   | .backgroundCompletion => isTrue trivial
   | .steering => isFalse (by intro h; exact h)
+  | .goal => isFalse (by intro h; exact h)
 
 end QueueSource
 

--- a/crates/gents/src/agent/daemon/request.rs
+++ b/crates/gents/src/agent/daemon/request.rs
@@ -89,7 +89,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 let full_history = session::load_history_for_request(
                     &self.node,
                     &request,
-                    lifecycle.background_completion_input_through_sequence(),
+                    lifecycle.provider_history_through_sequence(),
                 )
                     .instrument(tracing::info_span!(
                         "request.load_history",

--- a/crates/gents/src/agent/daemon/title.rs
+++ b/crates/gents/src/agent/daemon/title.rs
@@ -24,6 +24,17 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
         admission_context: AdmissionCallContext,
         capture_context: crate::rendered_request::RenderedRequestContext,
     ) {
+        if crate::lifecycle::classify_continuation_request(
+            request.metadata.as_deref(),
+            &request.content,
+        ) == crate::lifecycle::ConversationProjection::RuntimeControl
+        {
+            tracing::debug!(
+                request_id = %request.request_id,
+                "skipping generated title for runtime continuation request"
+            );
+            return;
+        }
         // A generated title is optional presentation metadata, not part of the
         // requested agent result. Budgeted requests therefore skip this
         // out-of-band provider call instead of giving it a second allowance or

--- a/crates/gents/src/background_completion.rs
+++ b/crates/gents/src/background_completion.rs
@@ -22,11 +22,7 @@ use crate::background_tools::{
     project_child_terminal, subagent_tool_not_allowed_payload, ChildEdge,
 };
 use crate::graphql::escape_graphql_string;
-use crate::lifecycle::queue::{
-    enqueue_background_completion_with_message, enqueue_session_request, parse_queue_hints,
-    QueueHints, QueuePolicy, QueueSource,
-};
-use crate::lifecycle::ExecutionOrigin;
+use crate::lifecycle::queue::{enqueue_conversation_continuation, ConversationContinuation};
 use crate::session;
 use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass, ToolCallLifecycle};
 
@@ -42,6 +38,34 @@ fn background_completion_notification_message_key(stable_id: &str, kind: &str) -
 
 pub fn is_background_completion_notification_message_key(message_key: &str) -> bool {
     message_key.starts_with(BACKGROUND_COMPLETION_NOTIFICATION_MESSAGE_PREFIX)
+}
+
+pub(crate) fn background_completion_notification_identity(
+    message_key: &str,
+) -> Option<(&str, &str)> {
+    message_key
+        .strip_prefix(BACKGROUND_COMPLETION_NOTIFICATION_MESSAGE_PREFIX)?
+        .rsplit_once(':')
+}
+
+pub(crate) fn is_legacy_background_completion_notification(
+    message_key: &str,
+    content: &str,
+    stable_id: &str,
+    kind: &str,
+) -> bool {
+    if message_key == format!("{stable_id}:{kind}") {
+        return true;
+    }
+    let stable_id = rendering::xml_escape_attr(stable_id);
+    match kind {
+        "subagent" => {
+            content.contains("<subagent-notification")
+                && content.contains(&format!(r#"child_request_id="{stable_id}""#))
+        }
+        "tool" => content.contains(&format!(r#"<tool-completion tool_call_id="{stable_id}""#)),
+        _ => false,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -115,12 +139,9 @@ use queries::{load_child_linkage, load_request_id_by_doc_id, load_terminal_child
 use reconciliation::request_is_locally_owned;
 use rendering::{
     child_terminal_status, child_terminal_summary, compact_summary, first_row, non_empty,
-    render_notification, render_tool_completion, xml_escape_attr,
+    render_notification, render_tool_completion,
 };
-use side_effects::{
-    bound_background_wake_request, bridge_state_is_terminal, ensure_projection_side_effects,
-    existing_tool_completion_notification, existing_wakeup_after,
-};
+use side_effects::{bridge_state_is_terminal, ensure_projection_side_effects};
 
 #[cfg(test)]
 mod tests;

--- a/crates/gents/src/background_completion/notification_delivery.rs
+++ b/crates/gents/src/background_completion/notification_delivery.rs
@@ -23,103 +23,16 @@ pub(crate) async fn append_background_tool_completion(
         .await?
         .ok_or_else(|| anyhow!("parent AgentRequest {parent_request_id} not found"))?;
 
-    let queue_key = format!("background_completion:{parent_session_id}");
-    let (notification_timestamp, created_notification) =
-        match existing_tool_completion_notification(node, parent_session_id, tool_call_id).await? {
-            Some(existing) => {
-                if bound_background_wake_request(node, &existing, &queue_key)
-                    .await?
-                    .is_some()
-                {
-                    mark_background_tool_notification_delivered(
-                        node,
-                        &parent_request.agent_did,
-                        parent_request_id,
-                        tool_call_id,
-                    )
-                    .await?;
-                    mark_background_tool_completion_side_effects_done(
-                        node,
-                        parent_session_id,
-                        tool_call_id,
-                    )
-                    .await?;
-                    return Ok(());
-                }
-                (existing.timestamp, false)
-            }
-            None => {
-                let notification =
-                    render_tool_completion(tool_call_id, tool_name, status, result, reason);
-                let notification_message_key =
-                    background_completion_notification_message_key(tool_call_id, "tool");
-                let enqueued = enqueue_background_completion_with_message(
-                    node,
-                    &parent_request,
-                    &notification,
-                    &notification_message_key,
-                    BACKGROUND_COMPLETION_WAKE_PROMPT,
-                    QueueHints {
-                        source: QueueSource::BackgroundCompletion,
-                        policy: QueuePolicy::Coalesce,
-                        key: Some(queue_key.clone()),
-                        queued_after_request_id: Some(parent_request_id.to_string()),
-                        interrupted_request_id: None,
-                    },
-                )
-                .await?;
-                mark_background_tool_notification_delivered(
-                    node,
-                    &parent_request.agent_did,
-                    parent_request_id,
-                    tool_call_id,
-                )
-                .await?;
-                mark_background_tool_completion_side_effects_done(
-                    node,
-                    parent_session_id,
-                    tool_call_id,
-                )
-                .await?;
-                tracing::debug!(
-                    parent_session_id,
-                    parent_request_id,
-                    tool_call_id,
-                    wake_request_id = %enqueued.request.request_id,
-                    created_wake = enqueued.created_request,
-                    "persisted background tool notification and consuming wake atomically"
-                );
-                return Ok(());
-            }
-        };
-
-    if existing_wakeup_after(node, parent_session_id, &queue_key, &notification_timestamp)
-        .await?
-        .is_some()
-    {
-        mark_background_tool_notification_delivered(
-            node,
-            &parent_request.agent_did,
-            parent_request_id,
-            tool_call_id,
-        )
-        .await?;
-        mark_background_tool_completion_side_effects_done(node, parent_session_id, tool_call_id)
-            .await?;
-        return Ok(());
-    }
-
-    let _wake = enqueue_session_request(
+    let notification = render_tool_completion(tool_call_id, tool_name, status, result, reason);
+    let notification_message_key =
+        background_completion_notification_message_key(tool_call_id, "tool");
+    let enqueued = enqueue_conversation_continuation(
         node,
         &parent_request,
-        BACKGROUND_COMPLETION_WAKE_PROMPT,
-        ExecutionOrigin::Scheduled,
-        QueueHints {
-            source: QueueSource::BackgroundCompletion,
-            policy: QueuePolicy::Coalesce,
-            key: Some(queue_key),
-            queued_after_request_id: Some(parent_request_id.to_string()),
-            interrupted_request_id: None,
+        ConversationContinuation::BackgroundCompletion {
+            notification: &notification,
+            notification_key: &notification_message_key,
+            queued_after_request_id: parent_request_id,
         },
     )
     .await?;
@@ -133,14 +46,15 @@ pub(crate) async fn append_background_tool_completion(
     mark_background_tool_completion_side_effects_done(node, parent_session_id, tool_call_id)
         .await?;
 
-    if created_notification {
-        tracing::debug!(
-            parent_session_id,
-            parent_request_id,
-            tool_call_id,
-            "appended background tool completion notification"
-        );
-    }
+    tracing::debug!(
+        parent_session_id,
+        parent_request_id,
+        tool_call_id,
+        wake_request_id = %enqueued.request.request_id,
+        created_notification = enqueued.created_input,
+        created_wake = enqueued.created_request,
+        "ensured background tool notification and consuming wake atomically"
+    );
     Ok(())
 }
 

--- a/crates/gents/src/background_completion/side_effects.rs
+++ b/crates/gents/src/background_completion/side_effects.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub(super) async fn ensure_projection_side_effects(
     node: &EmbeddedNode,
-    parent_session_id: &str,
+    _parent_session_id: &str,
     parent_request_id: &str,
     edge: &ChildEdge,
     status: &str,
@@ -14,324 +14,31 @@ pub(super) async fn ensure_projection_side_effects(
         .await?
         .ok_or_else(|| anyhow!("parent AgentRequest {parent_request_id} not found"))?;
 
-    let queue_key = format!("background_completion:{parent_session_id}");
-    let (notification_sequence, notification_timestamp, created_notification) =
-        match existing_notification(node, parent_session_id, &edge.child_request_id).await? {
-            Some(existing) => {
-                if let Some(wake_request_id) =
-                    bound_background_wake_request(node, &existing, &queue_key).await?
-                {
-                    return Ok(SideEffects {
-                        notification_sequence: existing.sequence,
-                        wake_request_id,
-                        created_notification: false,
-                        created_wake: false,
-                    });
-                }
-                (existing.sequence, existing.timestamp, false)
-            }
-            None => {
-                let notification = render_notification(edge, status, summary);
-                let notification_message_key = background_completion_notification_message_key(
-                    &edge.child_request_id,
-                    "subagent",
-                );
-                let enqueued = enqueue_background_completion_with_message(
-                    node,
-                    &parent_request,
-                    &notification,
-                    &notification_message_key,
-                    BACKGROUND_COMPLETION_WAKE_PROMPT,
-                    QueueHints {
-                        source: QueueSource::BackgroundCompletion,
-                        policy: QueuePolicy::Coalesce,
-                        key: Some(queue_key.clone()),
-                        queued_after_request_id: Some(parent_request_id.to_string()),
-                        interrupted_request_id: None,
-                    },
-                )
-                .await?;
-                return Ok(SideEffects {
-                    notification_sequence: enqueued.message_sequence,
-                    wake_request_id: enqueued.request.request_id,
-                    created_notification: true,
-                    created_wake: enqueued.created_request,
-                });
-            }
-        };
-
-    if let Some(wake_request_id) =
-        existing_wakeup_after(node, parent_session_id, &queue_key, &notification_timestamp).await?
-    {
-        return Ok(SideEffects {
-            notification_sequence,
-            wake_request_id,
-            created_notification,
-            created_wake: false,
-        });
-    }
-
-    let wake = enqueue_session_request(
+    let notification = render_notification(edge, status, summary);
+    let notification_message_key =
+        background_completion_notification_message_key(&edge.child_request_id, "subagent");
+    let enqueued = enqueue_conversation_continuation(
         node,
         &parent_request,
-        BACKGROUND_COMPLETION_WAKE_PROMPT,
-        ExecutionOrigin::Scheduled,
-        QueueHints {
-            source: QueueSource::BackgroundCompletion,
-            policy: QueuePolicy::Coalesce,
-            key: Some(queue_key),
-            queued_after_request_id: Some(parent_request_id.to_string()),
-            interrupted_request_id: None,
+        ConversationContinuation::BackgroundCompletion {
+            notification: &notification,
+            notification_key: &notification_message_key,
+            queued_after_request_id: parent_request_id,
         },
     )
     .await?;
 
+    let notification_sequence = enqueued.input_sequence.ok_or_else(|| {
+        anyhow!("background completion continuation returned no notification sequence")
+    })?;
     Ok(SideEffects {
         notification_sequence,
-        wake_request_id: wake.request_id,
-        created_notification,
-        created_wake: true,
+        wake_request_id: enqueued.request.request_id,
+        created_notification: enqueued.created_input,
+        created_wake: enqueued.created_request,
     })
 }
 
 pub(super) fn bridge_state_is_terminal(state: &str) -> bool {
     matches!(state, "completed" | "failed" | "timedOut" | "cancelled")
-}
-
-pub(super) struct ExistingNotification {
-    pub(super) sequence: u32,
-    pub(super) timestamp: DateTime<Utc>,
-    pub(super) request_id: Option<String>,
-    pub(super) request_doc_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct NotificationMessageRow {
-    sequence: u32,
-    content: String,
-    timestamp: String,
-    request_id: Option<String>,
-    request_doc_id: Option<String>,
-}
-
-async fn existing_notification(
-    node: &EmbeddedNode,
-    parent_session_id: &str,
-    child_request_id: &str,
-) -> Result<Option<ExistingNotification>> {
-    let escaped_session_id = escape_graphql_string(parent_session_id);
-    let query = format!(
-        r#"{{
-            AgentMessage(
-                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
-                order: {{ sequence: ASC }}
-            ) {{
-                sequence
-                content
-                timestamp
-                request_id
-                request_doc_id
-            }}
-        }}"#
-    );
-    let response = node.execute(&query).await;
-    if response.has_errors() {
-        anyhow::bail!(
-            "query parent AgentMessage notifications for session {parent_session_id} failed: {:?}",
-            response.errors
-        );
-    }
-
-    let marker = format!(
-        r#"child_request_id="{}""#,
-        xml_escape_attr(child_request_id)
-    );
-    let rows: Vec<NotificationMessageRow> = response
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentMessage"))
-        .and_then(|value| serde_json::from_value(value.clone()).ok())
-        .unwrap_or_default();
-    for row in rows {
-        if row.content.contains("<subagent-notification") && row.content.contains(&marker) {
-            return Ok(Some(ExistingNotification {
-                sequence: row.sequence,
-                timestamp: parse_utc_timestamp(&row.timestamp, "AgentMessage.timestamp")?,
-                request_id: row.request_id,
-                request_doc_id: row.request_doc_id,
-            }));
-        }
-    }
-
-    Ok(None)
-}
-
-pub(super) async fn existing_tool_completion_notification(
-    node: &EmbeddedNode,
-    parent_session_id: &str,
-    tool_call_id: &str,
-) -> Result<Option<ExistingNotification>> {
-    let escaped_session_id = escape_graphql_string(parent_session_id);
-    let query = format!(
-        r#"{{
-            AgentMessage(
-                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
-                order: {{ sequence: ASC }}
-            ) {{
-                sequence
-                content
-                timestamp
-                request_id
-                request_doc_id
-            }}
-        }}"#
-    );
-    let response = node.execute(&query).await;
-    if response.has_errors() {
-        anyhow::bail!(
-            "query AgentMessage for background tool completion session={parent_session_id} failed: {:?}",
-            response.errors
-        );
-    }
-    let rows: Vec<NotificationMessageRow> = response
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentMessage"))
-        .and_then(|value| serde_json::from_value(value.clone()).ok())
-        .unwrap_or_default();
-    let needle = format!(
-        r#"<tool-completion tool_call_id="{}""#,
-        xml_escape_attr(tool_call_id)
-    );
-    for row in rows {
-        if row.content.contains(&needle) {
-            return Ok(Some(ExistingNotification {
-                sequence: row.sequence,
-                timestamp: parse_utc_timestamp(&row.timestamp, "AgentMessage.timestamp")?,
-                request_id: row.request_id,
-                request_doc_id: row.request_doc_id,
-            }));
-        }
-    }
-    Ok(None)
-}
-
-#[derive(Debug, Deserialize)]
-struct BoundWakeRow {
-    request_id: String,
-    metadata: Option<String>,
-}
-
-pub(super) async fn bound_background_wake_request(
-    node: &EmbeddedNode,
-    notification: &ExistingNotification,
-    queue_key: &str,
-) -> Result<Option<String>> {
-    let (Some(request_id), Some(request_doc_id)) = (
-        notification
-            .request_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty()),
-        notification
-            .request_doc_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty()),
-    ) else {
-        return Ok(None);
-    };
-    let escaped_doc_id = escape_graphql_string(request_doc_id);
-    let query = format!(
-        r#"{{
-            AgentRequest(filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }}, limit: 1) {{
-                request_id
-                metadata
-            }}
-        }}"#
-    );
-    let response = node.execute(&query).await;
-    if response.has_errors() {
-        anyhow::bail!(
-            "query notification-bound AgentRequest {request_doc_id} failed: {:?}",
-            response.errors
-        );
-    }
-    let Some(row) = first_row::<BoundWakeRow>(response.data.as_ref(), "AgentRequest") else {
-        return Ok(None);
-    };
-    let matches = row.request_id == request_id
-        && parse_queue_hints(row.metadata.as_deref()).is_some_and(|hints| {
-            hints.source == QueueSource::BackgroundCompletion
-                && hints.policy == QueuePolicy::Coalesce
-                && hints.key.as_deref() == Some(queue_key)
-        });
-    Ok(matches.then_some(row.request_id))
-}
-
-#[derive(Debug, Deserialize)]
-struct WakeupRow {
-    request_id: String,
-    metadata: Option<String>,
-    created_at: String,
-}
-
-pub(super) async fn existing_wakeup_after(
-    node: &EmbeddedNode,
-    parent_session_id: &str,
-    queue_key: &str,
-    notification_timestamp: &DateTime<Utc>,
-) -> Result<Option<String>> {
-    let escaped_session_id = escape_graphql_string(parent_session_id);
-    let query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{
-                    session_id: {{ _eq: "{escaped_session_id}" }},
-                    execution_origin: {{ _eq: "scheduled" }}
-                }},
-                order: {{ created_at: ASC }}
-            ) {{
-                request_id
-                metadata
-                created_at
-            }}
-        }}"#
-    );
-    let response = node.execute(&query).await;
-    if response.has_errors() {
-        anyhow::bail!(
-            "query scheduled wake-ups for session {parent_session_id} failed: {:?}",
-            response.errors
-        );
-    }
-
-    let rows: Vec<WakeupRow> = response
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentRequest"))
-        .and_then(|value| serde_json::from_value(value.clone()).ok())
-        .unwrap_or_default();
-    for row in rows {
-        let matches_key = parse_queue_hints(row.metadata.as_deref()).is_some_and(|hints| {
-            hints.source == QueueSource::BackgroundCompletion
-                && hints.policy == QueuePolicy::Coalesce
-                && hints.key.as_deref() == Some(queue_key)
-        });
-        if !matches_key {
-            continue;
-        }
-
-        let created_at = parse_utc_timestamp(&row.created_at, "AgentRequest.created_at")?;
-        if created_at >= *notification_timestamp {
-            return Ok(Some(row.request_id));
-        }
-    }
-    Ok(None)
-}
-
-fn parse_utc_timestamp(value: &str, field: &str) -> Result<DateTime<Utc>> {
-    Ok(DateTime::parse_from_rfc3339(value)
-        .map_err(|error| anyhow!("{field} is not RFC3339: {error}"))?
-        .with_timezone(&Utc))
 }

--- a/crates/gents/src/background_tools.rs
+++ b/crates/gents/src/background_tools.rs
@@ -22,8 +22,8 @@ pub use crate::descendant_graph::{AWAITING_CHILD_MATERIALIZATION, PENDING_CHILD_
 use crate::document_config::SubagentTarget;
 use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::lifecycle::queue::{
-    drain_automated_wakeups, enqueue_steering_request_with_message, is_automated_wakeup,
-    QueueHints, QueuePolicy, QueueSource,
+    drain_automated_wakeups, enqueue_conversation_continuation, is_automated_wakeup,
+    ConversationContinuation,
 };
 use crate::session::execute_mutation_with_retry;
 use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
@@ -1265,15 +1265,11 @@ pub(crate) async fn append_steering_request(
     child_request.caused_by_parent_request_doc_id = Some(caller_request_doc_id);
     child_request.caused_by_parent_tool_call_id = None;
     child_request.caused_by_parent_tool_call_doc_id = None;
-    let enqueued = enqueue_steering_request_with_message(
+    let enqueued = enqueue_conversation_continuation(
         node,
         &child_request,
-        message,
-        QueueHints {
-            source: QueueSource::Steering,
-            policy: QueuePolicy::Append,
-            key: None,
-            queued_after_request_id: None,
+        ConversationContinuation::Steering {
+            message,
             interrupted_request_id: interrupted_request_id.clone(),
         },
     )
@@ -1282,7 +1278,7 @@ pub(crate) async fn append_steering_request(
     Ok(SteerSubagentResponse {
         child_request_id: edge.child_request_id.clone(),
         child_session_id: edge.child_session_id.clone(),
-        queued_request_id: enqueued.request_id,
+        queued_request_id: enqueued.request.request_id,
         interrupted_active_request_id: interrupted_request_id,
         drained_wake_up_request_ids,
     })

--- a/crates/gents/src/lean_vocab_test/background_transcript.rs
+++ b/crates/gents/src/lean_vocab_test/background_transcript.rs
@@ -69,6 +69,21 @@ pub(crate) enum LeanR4cBackgroundWorkCase {
         queued_request_id: String,
         queue_interrupted_request_id: String,
     },
+    #[serde(rename = "conversation.continuation.policy")]
+    ConversationContinuationPolicy {
+        version: u32,
+        steering_policy: String,
+        background_completion_policy: String,
+        goal_policy: String,
+        steering_lineage_admissible: bool,
+        background_lineage_admissible: bool,
+        goal_lineage_admissible: bool,
+        all_control_prompts_internal: bool,
+        durable_input_matches_message_backed_kinds: bool,
+        steering_provider_input: String,
+        steering_input_appears_exactly_once: bool,
+        steering_control_prompt_absent: bool,
+    },
     #[serde(rename = "r4c.list_subagents.unmaterialized_child_visible")]
     UnmaterializedChildVisible {
         caller_request_id: String,
@@ -102,6 +117,7 @@ impl LeanR4cBackgroundWorkCase {
                 "r4c.steer_subagent.append_preserves_lineage"
             }
             Self::SteerInterruptComposes { .. } => "r4c.steer_subagent.interrupt_composes",
+            Self::ConversationContinuationPolicy { .. } => "conversation.continuation.policy",
             Self::UnmaterializedChildVisible { .. } => {
                 "r4c.list_subagents.unmaterialized_child_visible"
             }

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -271,7 +271,8 @@ pub mod __test_internals {
     };
     pub use crate::lifecycle::materialize::EnqueuedAgentRequest;
     pub use crate::lifecycle::queue::{
-        drain_automated_wakeups, reconcile_coalesced_pending_request, QueueSource,
+        continuation_policy_contract, drain_automated_wakeups, reconcile_coalesced_pending_request,
+        QueueSource,
     };
     pub use crate::trigger_engine::run_subagent_source_for_test;
 }

--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -26,6 +26,9 @@ pub(crate) use materialize::{
     write_pending_agent_request_with_lineage_and_conversation_title,
     write_pending_agent_request_with_lineage_workspace_and_conversation_title,
 };
+pub use queue::{
+    classify_continuation_message, classify_continuation_request, ConversationProjection,
+};
 pub use task_title::task_run_conversation_title;
 
 pub const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
@@ -51,35 +54,6 @@ pub fn request_owns_user_turn(metadata: Option<&str>) -> bool {
         )
     })
 }
-
-pub fn is_steering_input_message_key(message_key: &str) -> bool {
-    queue::is_steering_input_message_key(message_key)
-}
-
-/// Classify a transcript row with the sibling-message context needed to read
-/// both current and pre-key steering transcripts. Current runtimes persist one
-/// keyed user input plus a non-keyed control prompt. Older runtimes persisted
-/// only the non-keyed user input, which must remain visible after upgrade.
-/// Background-completion notifications and durable-goal controller prompts
-/// are entirely internal.
-pub fn is_runtime_control_message(
-    metadata: Option<&str>,
-    message_key: &str,
-    request_has_keyed_steering_input: bool,
-) -> bool {
-    if crate::background_completion::is_background_completion_notification_message_key(message_key)
-    {
-        return true;
-    }
-    queue::parse_queue_hints(metadata).is_some_and(|hints| match hints.source {
-        queue::QueueSource::BackgroundCompletion | queue::QueueSource::Goal => true,
-        queue::QueueSource::Steering => {
-            request_has_keyed_steering_input && !queue::is_steering_input_message_key(message_key)
-        }
-        queue::QueueSource::User => false,
-    })
-}
-
 /// Legacy runtimes persisted unversioned background-completion wakeups as
 /// scheduled requests. They remain durable audit rows but must be ignored;
 /// current versioned completion wakes are authoritative continuation turns.
@@ -537,7 +511,7 @@ pub struct RequestLifecycle {
     progress_seq: u32,
     deadline_duration_secs: u64,
     claimed_deadline_at: Option<chrono::DateTime<chrono::Utc>>,
-    background_completion_input_through_sequence: Option<u32>,
+    provider_history_through_sequence: Option<u32>,
     state: LocalLifecycleState,
     valid_until_at_claim: Option<chrono::DateTime<chrono::Utc>>,
 }
@@ -557,11 +531,11 @@ impl RequestLifecycle {
         self.valid_until_at_claim
     }
 
-    /// Last transcript sequence owned by this background-completion attempt
-    /// at its atomic claim boundary. Messages appended for a successor epoch
-    /// must not enter this attempt's provider input.
-    pub(crate) fn background_completion_input_through_sequence(&self) -> Option<u32> {
-        self.background_completion_input_through_sequence
+    /// Last transcript sequence visible to this request's provider input.
+    /// Background wakes snapshot the current epoch; steering stops immediately
+    /// before its durable input because that same text is the loop prompt.
+    pub(crate) fn provider_history_through_sequence(&self) -> Option<u32> {
+        self.provider_history_through_sequence
     }
 }
 

--- a/crates/gents/src/lifecycle/claim.rs
+++ b/crates/gents/src/lifecycle/claim.rs
@@ -22,10 +22,24 @@ impl BackgroundCompletionClaimSnapshot {
     }
 }
 
+fn steering_input_sequence(rows: &[serde_json::Value]) -> Result<u32> {
+    anyhow::ensure!(
+        rows.len() == 1,
+        "steering continuation must resolve exactly one durable input row"
+    );
+    let input_sequence = rows[0]
+        .get("sequence")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| anyhow::anyhow!("steering continuation input has invalid sequence"))?;
+    u32::try_from(input_sequence)
+        .map_err(|_| anyhow::anyhow!("steering continuation input sequence exceeds u32"))
+}
+
 async fn claim_request_with_projection<F>(
     node: &EmbeddedNode,
     session_id: &str,
     capture_background_snapshot: bool,
+    steering_input_key: Option<&str>,
     projection: &super::materialize::RequestSessionProjection,
     build_mutation: F,
 ) -> Result<(defra_node::QueryResponse, BackgroundCompletionClaimSnapshot)>
@@ -33,6 +47,7 @@ where
     F: Fn(&str) -> String,
 {
     let session_id = escape_graphql_string(session_id);
+    let steering_input_key = escape_graphql_string(steering_input_key.unwrap_or_default());
     let snapshot_query = format!(
         r#"{{
             all_messages: AgentMessage(
@@ -47,23 +62,42 @@ where
                 }},
                 order: {{ sequence: ASC }}
             ) {{ sequence message_key }}
+            steering_input: AgentMessage(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    message_key: {{ _eq: "{steering_input_key}" }}
+                }},
+                limit: 2
+            ) {{ sequence }}
         }}"#
     );
     let mut last_error = None;
     for retry_index in 0..=crate::graphql::DEFRA_DB_CONFLICT_MAX_RETRIES {
         let txn = crate::config_client::ConfigApplyTxn::begin_local(node, None).await?;
         let attempt = async {
-            let snapshot = if capture_background_snapshot {
+            let snapshot = if capture_background_snapshot || !steering_input_key.is_empty() {
                 let response = txn.execute_local_response(&snapshot_query).await?;
-                let through_sequence = response
-                    .data
-                    .as_ref()
-                    .and_then(|data| data.get("all_messages"))
-                    .and_then(serde_json::Value::as_array)
-                    .and_then(|rows| rows.first())
-                    .and_then(|row| row.get("sequence"))
-                    .and_then(serde_json::Value::as_u64)
-                    .and_then(|sequence| u32::try_from(sequence).ok());
+                let through_sequence = if capture_background_snapshot {
+                    response
+                        .data
+                        .as_ref()
+                        .and_then(|data| data.get("all_messages"))
+                        .and_then(serde_json::Value::as_array)
+                        .and_then(|rows| rows.first())
+                        .and_then(|row| row.get("sequence"))
+                        .and_then(serde_json::Value::as_u64)
+                        .and_then(|sequence| u32::try_from(sequence).ok())
+                } else {
+                    let rows = response
+                        .data
+                        .as_ref()
+                        .and_then(|data| data.get("steering_input"))
+                        .and_then(serde_json::Value::as_array)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default();
+                    let input_sequence = steering_input_sequence(rows)?;
+                    Some(input_sequence.saturating_sub(1))
+                };
                 let notification_keys = response
                     .data
                     .as_ref()
@@ -538,6 +572,10 @@ impl RequestLifecycle {
 
         let is_background_completion =
             crate::lifecycle::is_background_completion_request(self.request.metadata.as_deref());
+        let steering_input_key = crate::lifecycle::queue::request_uses_durable_input_as_prompt(
+            self.request.metadata.as_deref(),
+        )
+        .then(|| crate::lifecycle::queue::steering_input_message_key(&self.request.request_id));
         let projection = super::materialize::request_session_projection(
             &self.request,
             &self.agent_name,
@@ -549,11 +587,12 @@ impl RequestLifecycle {
             self.node.as_ref(),
             &self.request.session_id,
             is_background_completion,
+            steering_input_key.as_deref(),
             &projection,
             &build_mutation,
         )
         .await?;
-        let background_completion_input_through_sequence = snapshot.through_sequence;
+        let provider_history_through_sequence = snapshot.through_sequence;
 
         // The mutation response is the only response that can carry the exact
         // commit produced by this claim. Do not fall back to a post-update
@@ -592,8 +631,7 @@ impl RequestLifecycle {
 
         self.state = LocalLifecycleState::Claimed;
         self.claimed_deadline_at = Some(deadline_at);
-        self.background_completion_input_through_sequence =
-            background_completion_input_through_sequence;
+        self.provider_history_through_sequence = provider_history_through_sequence;
         self.valid_until_at_claim = valid_until_at_claim;
 
         Ok(ClaimOutcome::Claimed)
@@ -609,6 +647,25 @@ mod tests {
     const TEST_AGENT_DID: &str = "did:test:claim-order-test";
     const TEST_BEHAVIOR_ID: &str = "general";
     const TEST_BACKEND_ID: &str = "backend-order";
+
+    #[test]
+    fn steering_input_snapshot_requires_exactly_one_row() {
+        for rows in [
+            serde_json::json!([]),
+            serde_json::json!([{ "sequence": 1 }, { "sequence": 2 }]),
+        ] {
+            let error = steering_input_sequence(rows.as_array().unwrap())
+                .expect_err("zero or duplicate steering inputs must fail closed");
+            assert!(error
+                .to_string()
+                .contains("must resolve exactly one durable input row"));
+        }
+        assert_eq!(
+            steering_input_sequence(serde_json::json!([{ "sequence": 7 }]).as_array().unwrap())
+                .unwrap(),
+            7
+        );
+    }
 
     async fn test_node() -> Arc<EmbeddedNode> {
         let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
@@ -921,10 +978,7 @@ mod tests {
             lifecycle.claim_with_identity().await.unwrap(),
             ClaimOutcome::Claimed
         );
-        assert_eq!(
-            lifecycle.background_completion_input_through_sequence(),
-            Some(2)
-        );
+        assert_eq!(lifecycle.provider_history_through_sequence(), Some(2));
         let snapshot = node
             .execute(&format!(
                 r#"{{ AgentRequest(filter: {{ _docID: {{ _eq: "{}" }} }}) {{
@@ -968,7 +1022,7 @@ mod tests {
         let history = session::load_history_through_sequence(
             node.as_ref(),
             session_id,
-            lifecycle.background_completion_input_through_sequence(),
+            lifecycle.provider_history_through_sequence(),
         )
         .await
         .unwrap();

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -353,7 +353,7 @@ impl RequestLifecycle {
             progress_seq: 0,
             deadline_duration_secs,
             claimed_deadline_at: None,
-            background_completion_input_through_sequence: None,
+            provider_history_through_sequence: None,
             state: LocalLifecycleState::Pending,
             valid_until_at_claim: None,
         }
@@ -495,7 +495,7 @@ impl RequestLifecycle {
             progress_seq: 0,
             deadline_duration_secs,
             claimed_deadline_at: Some(deadline_at),
-            background_completion_input_through_sequence: None,
+            provider_history_through_sequence: None,
             state: LocalLifecycleState::Claimed,
             valid_until_at_claim: None,
         })
@@ -577,7 +577,14 @@ pub(super) fn request_session_projection(
         }}"#
     );
     let title = conversation_title_from_metadata(request.metadata.as_deref());
-    let preview = session::derive_conversation_preview(&request.content);
+    let preview_content = (crate::lifecycle::classify_continuation_request(
+        request.metadata.as_deref(),
+        &request.content,
+    ) != crate::lifecycle::ConversationProjection::RuntimeControl)
+        .then_some(request.content.as_str());
+    let preview = preview_content
+        .map(session::derive_conversation_preview)
+        .unwrap_or_default();
     let (title, title_source) = title
         .as_deref()
         .map(|title| (title, session::CONVERSATION_TITLE_SOURCE_TASK))
@@ -585,6 +592,10 @@ pub(super) fn request_session_projection(
     let escaped_title = escape_graphql_string(title);
     let escaped_title_source = escape_graphql_string(title_source);
     let escaped_preview = escape_graphql_string(&preview);
+    let preview_update = preview_content
+        .is_some()
+        .then(|| format!(r#"preview_text: "{escaped_preview}","#))
+        .unwrap_or_default();
     let escaped_request_id = escape_graphql_string(&request.request_id);
     let conversation_update = format!(
         r#"mutation {{
@@ -592,7 +603,7 @@ pub(super) fn request_session_projection(
                 filter: {{ session_id: {{ _eq: "{session_id}" }} }},
                 input: {{
                     agent_name: "{escaped_agent_name}",
-                    preview_text: "{escaped_preview}",
+                    {preview_update}
                     status: "processing",
                     updated_at: "{escaped_started}",
                     latest_request_id: "{escaped_request_id}"
@@ -730,4 +741,64 @@ async fn materialize_claimed_request_with_projection(
     }
     Err(last_error
         .unwrap_or_else(|| anyhow::anyhow!("materialize claimed request transaction exhausted")))
+}
+
+#[cfg(test)]
+mod projection_tests {
+    use super::*;
+
+    #[test]
+    fn runtime_control_projection_preserves_existing_conversation_preview() {
+        let request = AgentRequest {
+            doc_id: "continuation-doc".to_string(),
+            request_id: "continuation-1".to_string(),
+            agent_did: "did:test:amy".to_string(),
+            requester_did: None,
+            behavior_id: Some("general".to_string()),
+            session_id: "session-1".to_string(),
+            content: "Continue with the new steering message.".to_string(),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            seed: None,
+            max_tokens: None,
+            max_total_tokens: None,
+            metadata: Some(
+                r#"{"continuation_version":1,"queue":{"source":"steering","policy":"append"}}"#
+                    .to_string(),
+            ),
+            execution_origin: Some("interactive".to_string()),
+            created_at: "2026-08-24T00:00:00Z".to_string(),
+            deadline: None,
+            subagent_depth: 0,
+            caused_by_parent_request_id: None,
+            caused_by_parent_request_doc_id: None,
+            caused_by_parent_tool_call_id: None,
+            caused_by_parent_tool_call_doc_id: None,
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            caused_by_source_doc_id: None,
+            caused_by_correlation: None,
+            caused_by_trigger_context: None,
+            workspace_id: None,
+            workspace_authority: None,
+            workspace_owner_deployment_id: None,
+            workspace_seal_hash: None,
+        };
+
+        let projection = request_session_projection(
+            &request,
+            "Amy",
+            "did:test:amy",
+            "general",
+            "2026-08-24T00:00:00Z",
+        );
+        assert!(!projection.conversation_update.contains("preview_text"));
+        assert!(projection
+            .conversation_update
+            .contains("latest_request_id: \"continuation-1\""));
+        assert!(projection
+            .conversation_create
+            .contains("preview_text: \"\""));
+    }
 }

--- a/crates/gents/src/lifecycle/queue.rs
+++ b/crates/gents/src/lifecycle/queue.rs
@@ -18,6 +18,7 @@ use super::{extract_single_doc_id, ExecutionOrigin, DEFAULT_REQUEST_MAX_RETRIES}
 
 mod atomic_inputs;
 mod coalescing;
+mod continuation;
 mod draining;
 mod enqueue;
 mod goal_continuation;
@@ -37,15 +38,25 @@ use coalescing::{
     parent_linkage_graphql_fields, queue_row_to_enqueued_request, queue_source_and_key_match,
     request_only_parent_linkage_graphql_fields, PendingQueueRow,
 };
+pub use continuation::{
+    classify_continuation_message, classify_continuation_request, continuation_policy_contract,
+    ConversationProjection,
+};
+pub(crate) use continuation::{
+    enqueue_conversation_continuation, metadata_is_request_only_control,
+    request_uses_durable_input_as_prompt, ContinuationKind, ConversationContinuation,
+};
 pub use draining::drain_automated_wakeups;
 pub(crate) use draining::drain_subagent_owned_queue;
-pub(crate) use enqueue::{enqueue_session_request, enqueue_steering_request_with_message};
+#[cfg(test)]
+use enqueue::enqueue_session_request;
+pub(crate) use enqueue::enqueue_steering_request_with_message;
 pub(crate) use goal_continuation::enqueue_goal_continuation;
 pub use metadata::QueueSource;
 pub(crate) use metadata::{
-    is_automated_wakeup, is_deprecated_background_completion_wakeup, is_goal_queue,
+    continuation_version, is_automated_wakeup, is_deprecated_background_completion_wakeup,
     is_steering_input_message_key, is_subagent_owned_queue, parse_queue_hints, queue_metadata_json,
-    steering_input_message_key, QueueHints, QueuePolicy,
+    request_is_steering_continuation, steering_input_message_key, QueueHints, QueuePolicy,
 };
 use mutation::session_request_create_mutation;
 
@@ -53,6 +64,12 @@ pub(crate) struct EnqueuedBackgroundCompletionInput {
     pub(crate) request: EnqueuedAgentRequest,
     pub(crate) message_sequence: u32,
     pub(crate) created_request: bool,
+    pub(crate) created_message: bool,
+}
+
+pub(crate) struct EnqueuedSteeringInput {
+    pub(crate) request: EnqueuedAgentRequest,
+    pub(crate) message_sequence: u32,
 }
 
 #[cfg(test)]

--- a/crates/gents/src/lifecycle/queue/atomic_inputs.rs
+++ b/crates/gents/src/lifecycle/queue/atomic_inputs.rs
@@ -98,7 +98,6 @@ pub(crate) async fn enqueue_background_completion_with_message(
         .await?
         .unwrap_or_else(|| enqueued.request.clone());
         enqueued.created_request = active_request.doc_id == created_request_doc_id;
-
         enqueued.request = active_request;
     }
 
@@ -119,7 +118,7 @@ async fn background_completion_transaction_attempt(
     let response = txn
         .execute(&format!(
             r#"{{
-                AgentRequest(
+                pending_requests: AgentRequest(
                     filter: {{
                         session_id: {{ _eq: "{escaped_session_id}" }},
                         agent_did: {{ _eq: "{escaped_agent_did}" }},
@@ -133,10 +132,78 @@ async fn background_completion_transaction_attempt(
                     session_id
                     metadata
                 }}
+                AgentMessage(
+                    filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
+                    order: {{ sequence: ASC }}
+                ) {{
+                    _docID sequence request_id request_doc_id message_key content timestamp
+                }}
+                background_wakes: AgentRequest(
+                    filter: {{
+                        session_id: {{ _eq: "{escaped_session_id}" }},
+                        agent_did: {{ _eq: "{escaped_agent_did}" }}
+                    }},
+                    order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
+                ) {{
+                    _docID request_id session_id metadata status lifecycle_state created_at
+                }}
             }}"#
         ))
         .await?;
-    let pending = response["data"]["AgentRequest"]
+    let message_rows = response["data"]["AgentMessage"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let existing_message = select_existing_background_input(message_rows, message_key)?;
+    let wake_rows = response["data"]["background_wakes"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    if let Some(existing) = existing_message.as_ref() {
+        if let Some(request) =
+            bound_background_request_from_rows(wake_rows, existing, &parent.session_id, queue_key)?
+        {
+            let message_sequence = existing["sequence"]
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .context("bound background completion input has invalid sequence")?;
+            return Ok(EnqueuedBackgroundCompletionInput {
+                request,
+                message_sequence,
+                created_request: false,
+                created_message: false,
+            });
+        }
+        if let Some(request) =
+            background_wakeup_after_message(wake_rows, existing, &parent.session_id, queue_key)?
+        {
+            if existing["request_doc_id"]
+                .as_str()
+                .is_none_or(|value| value.trim().is_empty())
+            {
+                let message_doc_id = existing["_docID"]
+                    .as_str()
+                    .context("existing background completion input has no _docID")?;
+                txn.execute(&bind_legacy_background_input_mutation(
+                    message_doc_id,
+                    &parent.session_id,
+                    &request,
+                )?)
+                .await?;
+            }
+            let message_sequence = existing["sequence"]
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .context("existing background completion input has invalid sequence")?;
+            return Ok(EnqueuedBackgroundCompletionInput {
+                request,
+                message_sequence,
+                created_request: false,
+                created_message: false,
+            });
+        }
+    }
+    let pending = response["data"]["pending_requests"]
         .as_array()
         .cloned()
         .unwrap_or_default()
@@ -166,26 +233,223 @@ async fn background_completion_transaction_attempt(
             )
         }
     };
-    let message_sequence = next_append_sequence_in_transaction(txn, &parent.session_id).await?;
-    let message_mutation = session::create_message_mutation(
-        &parent.session_id,
-        &parent.agent_did,
-        parent.requester_did.as_deref(),
-        message_sequence,
-        "user",
-        content,
-        None,
-        Some(&request.request_id),
-        Some(&request.doc_id),
-        Some(message_key),
-    );
-    txn.execute(&message_mutation).await?;
+    let (message_sequence, created_message, message_mutation) = if let Some(existing) =
+        existing_message
+    {
+        let message_sequence = existing["sequence"]
+            .as_u64()
+            .and_then(|value| u32::try_from(value).ok())
+            .context("existing background completion input has invalid sequence")?;
+        let message_doc_id = existing["_docID"]
+            .as_str()
+            .context("existing background completion input has no _docID")?;
+        // request_doc_id is immutable. Only logical-only legacy rows may be
+        // associated with a request; a physically bound row is never rebound.
+        let mutation = existing["request_doc_id"]
+            .as_str()
+            .filter(|value| !value.trim().is_empty())
+            .map(|_| String::new())
+            .map_or_else(
+                || {
+                    bind_legacy_background_input_mutation(
+                        message_doc_id,
+                        &parent.session_id,
+                        &request,
+                    )
+                },
+                Ok,
+            )?;
+        (message_sequence, false, mutation)
+    } else {
+        let message_sequence = next_append_sequence_in_transaction(txn, &parent.session_id).await?;
+        (
+            message_sequence,
+            true,
+            session::create_message_mutation(
+                &parent.session_id,
+                &parent.agent_did,
+                parent.requester_did.as_deref(),
+                message_sequence,
+                "user",
+                content,
+                None,
+                Some(&request.request_id),
+                Some(&request.doc_id),
+                Some(message_key),
+            ),
+        )
+    };
+    if !message_mutation.is_empty() {
+        txn.execute(&message_mutation).await?;
+    }
 
     Ok(EnqueuedBackgroundCompletionInput {
         request,
         message_sequence,
         created_request,
+        created_message,
     })
+}
+
+fn select_existing_background_input(rows: &[Value], message_key: &str) -> Result<Option<Value>> {
+    let exact = rows
+        .iter()
+        .filter(|row| row["message_key"].as_str() == Some(message_key))
+        .collect::<Vec<_>>();
+    if exact.len() > 1 {
+        anyhow::bail!(
+            "background completion input key {message_key} resolved to multiple AgentMessage rows"
+        );
+    }
+    if let Some(row) = exact.first() {
+        return Ok(Some((*row).clone()));
+    }
+
+    let Some((stable_id, kind)) =
+        crate::background_completion::background_completion_notification_identity(message_key)
+    else {
+        return Ok(None);
+    };
+    Ok(rows
+        .iter()
+        .find(|row| {
+            crate::background_completion::is_legacy_background_completion_notification(
+                row["message_key"].as_str().unwrap_or_default(),
+                row["content"].as_str().unwrap_or_default(),
+                stable_id,
+                kind,
+            )
+        })
+        .cloned())
+}
+
+fn background_wakeup_after_message(
+    rows: &[Value],
+    message: &Value,
+    session_id: &str,
+    queue_key: &str,
+) -> Result<Option<EnqueuedAgentRequest>> {
+    let timestamp = message["timestamp"]
+        .as_str()
+        .context("existing background completion input has no timestamp")?;
+    let timestamp = chrono::DateTime::parse_from_rfc3339(timestamp)
+        .context("existing background completion input timestamp is not RFC3339")?
+        .with_timezone(&chrono::Utc);
+    for row in rows {
+        if row["session_id"].as_str() != Some(session_id)
+            || !queue_source_and_key_match(
+                row["metadata"].as_str(),
+                QueueSource::BackgroundCompletion,
+                queue_key,
+            )
+        {
+            continue;
+        }
+        let Some(created_at) = row["created_at"].as_str() else {
+            continue;
+        };
+        let created_at = chrono::DateTime::parse_from_rfc3339(created_at)
+            .context("background completion wake created_at is not RFC3339")?
+            .with_timezone(&chrono::Utc);
+        if created_at < timestamp {
+            continue;
+        }
+        let (Some(doc_id), Some(request_id)) = (row["_docID"].as_str(), row["request_id"].as_str())
+        else {
+            continue;
+        };
+        return Ok(Some(EnqueuedAgentRequest {
+            doc_id: doc_id.to_string(),
+            request_id: request_id.to_string(),
+            session_id: session_id.to_string(),
+        }));
+    }
+    Ok(None)
+}
+
+fn bound_background_request_from_rows(
+    rows: &[Value],
+    message: &Value,
+    session_id: &str,
+    queue_key: &str,
+) -> Result<Option<EnqueuedAgentRequest>> {
+    let Some(request_id) = message["request_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    let request_doc_id = message["request_doc_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let row = if let Some(request_doc_id) = request_doc_id {
+        rows.iter()
+            .find(|row| row["_docID"].as_str() == Some(request_doc_id))
+    } else {
+        let matches = rows
+            .iter()
+            .filter(|row| {
+                row["request_id"].as_str() == Some(request_id)
+                    && row["session_id"].as_str() == Some(session_id)
+            })
+            .collect::<Vec<_>>();
+        if matches.len() > 1 {
+            anyhow::bail!(
+                "background completion input request {request_id} resolved to multiple AgentRequest rows"
+            );
+        }
+        matches.first().copied()
+    };
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let Some(resolved_request_doc_id) = row["_docID"].as_str() else {
+        return Ok(None);
+    };
+    let Some(resolved_request_id) = row["request_id"].as_str() else {
+        return Ok(None);
+    };
+    let matches = row["session_id"].as_str() == Some(session_id)
+        && queue_source_and_key_match(
+            row["metadata"].as_str(),
+            QueueSource::BackgroundCompletion,
+            queue_key,
+        );
+    Ok(matches.then(|| EnqueuedAgentRequest {
+        doc_id: resolved_request_doc_id.to_string(),
+        request_id: resolved_request_id.to_string(),
+        session_id: session_id.to_string(),
+    }))
+}
+
+fn bind_legacy_background_input_mutation(
+    message_doc_id: &str,
+    session_id: &str,
+    request: &EnqueuedAgentRequest,
+) -> Result<String> {
+    let message_doc_id = message_doc_id.trim();
+    anyhow::ensure!(
+        !message_doc_id.is_empty(),
+        "cannot bind a legacy background completion input without an AgentMessage _docID"
+    );
+    Ok(format!(
+        r#"mutation {{
+            update_AgentMessage(
+                filter: {{
+                    _docID: {{ _eq: "{}" }},
+                    session_id: {{ _eq: "{}" }}
+                }},
+                input: {{
+                    request_id: "{}"
+                }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(message_doc_id),
+        escape_graphql_string(session_id),
+        escape_graphql_string(&request.request_id),
+    ))
 }
 
 pub(super) async fn normalize_request_only_control_parent(
@@ -222,7 +486,7 @@ pub(super) async fn steering_transaction_attempt(
     content: &str,
     request_id: &str,
     request_mutation: &str,
-) -> Result<EnqueuedAgentRequest> {
+) -> Result<EnqueuedSteeringInput> {
     let request_response = txn.execute(request_mutation).await?;
     let request_doc_id = transaction_created_doc_id(&request_response, "AgentRequest")?;
     let sequence = next_append_sequence_in_transaction(txn, &parent.session_id).await?;
@@ -241,11 +505,35 @@ pub(super) async fn steering_transaction_attempt(
     );
     txn.execute(&message_mutation).await?;
 
-    Ok(EnqueuedAgentRequest {
-        doc_id: request_doc_id,
-        request_id: request_id.to_string(),
-        session_id: parent.session_id.clone(),
+    Ok(EnqueuedSteeringInput {
+        request: EnqueuedAgentRequest {
+            doc_id: request_doc_id,
+            request_id: request_id.to_string(),
+            session_id: parent.session_id.clone(),
+        },
+        message_sequence: sequence,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_background_binding_requires_a_physical_message_id() {
+        let request = EnqueuedAgentRequest {
+            doc_id: "request-doc".to_string(),
+            request_id: "request-id".to_string(),
+            session_id: "session-id".to_string(),
+        };
+        let error = bind_legacy_background_input_mutation("  ", "session-id", &request)
+            .expect_err("blank message IDs must not produce a session-wide mutation");
+        assert!(error.to_string().contains("AgentMessage _docID"));
+
+        let mutation =
+            bind_legacy_background_input_mutation("message-doc", "session-id", &request).unwrap();
+        assert!(mutation.contains(r#"_docID: { _eq: "message-doc" }"#));
+    }
 }
 
 async fn next_append_sequence_in_transaction(

--- a/crates/gents/src/lifecycle/queue/continuation.rs
+++ b/crates/gents/src/lifecycle/queue/continuation.rs
@@ -1,0 +1,407 @@
+//! Runtime-authored turns must use this entry point so persistence and visibility follow policy.
+
+use super::*;
+
+pub(crate) const STEERING_WAKE_PROMPT: &str = "Continue with the new steering message.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContinuationKind {
+    Steering,
+    BackgroundCompletion,
+    Goal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContinuationInputVisibility {
+    VisibleInput,
+    RuntimeControl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContinuationParentStrategy {
+    GenerationOwner,
+    PreviousRequest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContinuationProviderInputStrategy {
+    PromptOnce,
+    HistoryThenControl,
+    ControlOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ContinuationPolicy {
+    pub(crate) source: QueueSource,
+    pub(crate) queue_policy: QueuePolicy,
+    pub(crate) execution_origin: ExecutionOrigin,
+    pub(crate) input_visibility: Option<ContinuationInputVisibility>,
+    pub(crate) control_visibility: ContinuationInputVisibility,
+    pub(crate) parent_strategy: ContinuationParentStrategy,
+    pub(crate) requires_durable_input: bool,
+    pub(crate) provider_input_strategy: ContinuationProviderInputStrategy,
+}
+
+impl ContinuationKind {
+    pub(crate) const fn from_source(source: QueueSource) -> Option<Self> {
+        match source {
+            QueueSource::Steering => Some(Self::Steering),
+            QueueSource::BackgroundCompletion => Some(Self::BackgroundCompletion),
+            QueueSource::Goal => Some(Self::Goal),
+            QueueSource::User => None,
+        }
+    }
+
+    pub(crate) fn from_metadata(metadata: Option<&str>) -> Option<Self> {
+        Self::from_source(parse_queue_hints(metadata)?.source)
+    }
+
+    pub(crate) const fn policy(self) -> ContinuationPolicy {
+        match self {
+            Self::Steering => ContinuationPolicy {
+                source: QueueSource::Steering,
+                queue_policy: QueuePolicy::Append,
+                execution_origin: ExecutionOrigin::Interactive,
+                input_visibility: Some(ContinuationInputVisibility::VisibleInput),
+                control_visibility: ContinuationInputVisibility::RuntimeControl,
+                parent_strategy: ContinuationParentStrategy::GenerationOwner,
+                requires_durable_input: true,
+                provider_input_strategy: ContinuationProviderInputStrategy::PromptOnce,
+            },
+            Self::BackgroundCompletion => ContinuationPolicy {
+                source: QueueSource::BackgroundCompletion,
+                queue_policy: QueuePolicy::Coalesce,
+                execution_origin: ExecutionOrigin::Scheduled,
+                input_visibility: Some(ContinuationInputVisibility::RuntimeControl),
+                control_visibility: ContinuationInputVisibility::RuntimeControl,
+                parent_strategy: ContinuationParentStrategy::GenerationOwner,
+                requires_durable_input: true,
+                provider_input_strategy: ContinuationProviderInputStrategy::HistoryThenControl,
+            },
+            Self::Goal => ContinuationPolicy {
+                source: QueueSource::Goal,
+                queue_policy: QueuePolicy::Coalesce,
+                execution_origin: ExecutionOrigin::Scheduled,
+                input_visibility: None,
+                control_visibility: ContinuationInputVisibility::RuntimeControl,
+                parent_strategy: ContinuationParentStrategy::PreviousRequest,
+                requires_durable_input: false,
+                provider_input_strategy: ContinuationProviderInputStrategy::ControlOnly,
+            },
+        }
+    }
+
+    pub(crate) fn contract_signature(self) -> String {
+        let policy = self.policy();
+        format!(
+            "{}|{}|{}|{}|{}|{}|{}|{}",
+            queue_source_contract_name(policy.source),
+            queue_policy_contract_name(policy.queue_policy),
+            execution_origin_contract_name(policy.execution_origin),
+            policy
+                .input_visibility
+                .map_or("none", ContinuationInputVisibility::contract_name),
+            policy.control_visibility.contract_name(),
+            policy.parent_strategy.contract_name(),
+            if policy.requires_durable_input {
+                "durable_input"
+            } else {
+                "request_only"
+            },
+            policy.provider_input_strategy.contract_name(),
+        )
+    }
+
+    pub(crate) fn is_automated_wakeup(self, hints: &QueueHints) -> bool {
+        self == Self::BackgroundCompletion
+            && hints.policy == QueuePolicy::Coalesce
+            && hints
+                .key
+                .as_deref()
+                .is_some_and(|key| !key.trim().is_empty())
+    }
+
+    pub(crate) fn is_subagent_owned(self, hints: &QueueHints) -> bool {
+        self == Self::Steering || self.is_automated_wakeup(hints)
+    }
+
+    pub(crate) fn is_request_only_control(self, hints: &QueueHints) -> bool {
+        matches!(self, Self::Steering | Self::Goal) || self.is_automated_wakeup(hints)
+    }
+}
+
+impl ContinuationInputVisibility {
+    const fn projection(self) -> ConversationProjection {
+        match self {
+            Self::VisibleInput => ConversationProjection::VisibleInput,
+            Self::RuntimeControl => ConversationProjection::RuntimeControl,
+        }
+    }
+
+    const fn contract_name(self) -> &'static str {
+        match self {
+            Self::VisibleInput => "visible_input",
+            Self::RuntimeControl => "runtime_control",
+        }
+    }
+}
+
+impl ContinuationParentStrategy {
+    const fn contract_name(self) -> &'static str {
+        match self {
+            Self::GenerationOwner => "generation_owner",
+            Self::PreviousRequest => "previous_request",
+        }
+    }
+}
+
+impl ContinuationProviderInputStrategy {
+    const fn contract_name(self) -> &'static str {
+        match self {
+            Self::PromptOnce => "prompt_once",
+            Self::HistoryThenControl => "history_then_control",
+            Self::ControlOnly => "control_only",
+        }
+    }
+}
+
+const fn queue_source_contract_name(source: QueueSource) -> &'static str {
+    match source {
+        QueueSource::User => "user",
+        QueueSource::BackgroundCompletion => "background_completion",
+        QueueSource::Steering => "steering",
+        QueueSource::Goal => "goal",
+    }
+}
+
+const fn queue_policy_contract_name(policy: QueuePolicy) -> &'static str {
+    match policy {
+        QueuePolicy::Append => "append",
+        QueuePolicy::Coalesce => "coalesce",
+    }
+}
+
+const fn execution_origin_contract_name(origin: ExecutionOrigin) -> &'static str {
+    match origin {
+        ExecutionOrigin::Interactive => "interactive",
+        ExecutionOrigin::Scheduled => "scheduled",
+    }
+}
+
+#[doc(hidden)]
+pub fn continuation_policy_contract(kind: &str) -> Option<String> {
+    match kind {
+        "steering" => Some(ContinuationKind::Steering.contract_signature()),
+        "background_completion" => {
+            Some(ContinuationKind::BackgroundCompletion.contract_signature())
+        }
+        "goal" => Some(ContinuationKind::Goal.contract_signature()),
+        _ => None,
+    }
+}
+
+pub(crate) fn metadata_is_request_only_control(metadata: Option<&str>) -> bool {
+    let Some(hints) = parse_queue_hints(metadata) else {
+        return super::request_is_steering_continuation(metadata);
+    };
+    ContinuationKind::from_source(hints.source)
+        .is_some_and(|kind| kind.is_request_only_control(&hints))
+}
+
+pub(crate) fn request_uses_durable_input_as_prompt(metadata: Option<&str>) -> bool {
+    super::continuation_version(metadata).is_some()
+        && ContinuationKind::from_metadata(metadata).is_some_and(|kind| {
+            kind.policy().provider_input_strategy == ContinuationProviderInputStrategy::PromptOnce
+        })
+}
+
+/// Payloads that may cause the runtime to continue an existing conversation.
+pub(crate) enum ConversationContinuation<'a> {
+    Steering {
+        message: &'a str,
+        interrupted_request_id: Option<String>,
+    },
+    BackgroundCompletion {
+        notification: &'a str,
+        notification_key: &'a str,
+        queued_after_request_id: &'a str,
+    },
+    Goal {
+        goal_id: &'a str,
+        prompt: &'a str,
+        continuation_sequence: i64,
+        wrapup: bool,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct EnqueuedConversationContinuation {
+    pub(crate) request: EnqueuedAgentRequest,
+    pub(crate) input_sequence: Option<u32>,
+    pub(crate) created_request: bool,
+    pub(crate) created_input: bool,
+}
+
+/// Persist a continuation according to its policy, including any input row
+/// that must become durable atomically with the consuming request.
+pub(crate) async fn enqueue_conversation_continuation(
+    node: &EmbeddedNode,
+    parent: &AgentRequest,
+    continuation: ConversationContinuation<'_>,
+) -> Result<EnqueuedConversationContinuation> {
+    match continuation {
+        ConversationContinuation::Steering {
+            message,
+            interrupted_request_id,
+        } => {
+            let policy = ContinuationKind::Steering.policy();
+            let enqueued = enqueue_steering_request_with_message(
+                node,
+                parent,
+                message,
+                QueueHints {
+                    source: policy.source,
+                    policy: policy.queue_policy,
+                    key: None,
+                    queued_after_request_id: None,
+                    interrupted_request_id,
+                },
+            )
+            .await?;
+            Ok(EnqueuedConversationContinuation {
+                request: enqueued.request,
+                input_sequence: Some(enqueued.message_sequence),
+                created_request: true,
+                created_input: true,
+            })
+        }
+        ConversationContinuation::BackgroundCompletion {
+            notification,
+            notification_key,
+            queued_after_request_id,
+        } => {
+            let policy = ContinuationKind::BackgroundCompletion.policy();
+            let enqueued = enqueue_background_completion_with_message(
+                node,
+                parent,
+                notification,
+                notification_key,
+                crate::background_completion::BACKGROUND_COMPLETION_WAKE_PROMPT,
+                QueueHints {
+                    source: policy.source,
+                    policy: policy.queue_policy,
+                    key: Some(format!("background_completion:{}", parent.session_id)),
+                    queued_after_request_id: Some(queued_after_request_id.to_string()),
+                    interrupted_request_id: None,
+                },
+            )
+            .await?;
+            Ok(EnqueuedConversationContinuation {
+                request: enqueued.request,
+                input_sequence: Some(enqueued.message_sequence),
+                created_request: enqueued.created_request,
+                created_input: enqueued.created_message,
+            })
+        }
+        ConversationContinuation::Goal {
+            goal_id,
+            prompt,
+            continuation_sequence,
+            wrapup,
+        } => {
+            let (request, created_request) = enqueue_goal_continuation(
+                node,
+                parent,
+                goal_id,
+                prompt,
+                continuation_sequence,
+                wrapup,
+            )
+            .await?;
+            Ok(EnqueuedConversationContinuation {
+                request,
+                input_sequence: None,
+                created_request,
+                created_input: false,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationProjection {
+    Ordinary,
+    VisibleInput,
+    RuntimeControl,
+}
+
+pub fn classify_continuation_request(
+    metadata: Option<&str>,
+    request_content: &str,
+) -> ConversationProjection {
+    let Some(kind) = ContinuationKind::from_metadata(metadata) else {
+        return ConversationProjection::Ordinary;
+    };
+    if kind == ContinuationKind::Steering
+        && super::continuation_version(metadata).is_none()
+        && request_content != STEERING_WAKE_PROMPT
+    {
+        return ConversationProjection::VisibleInput;
+    }
+    kind.policy().control_visibility.projection()
+}
+
+pub fn classify_continuation_message(
+    metadata: Option<&str>,
+    request_id: Option<&str>,
+    request_content: Option<&str>,
+    message_role: &str,
+    message_content: &str,
+    message_key: &str,
+) -> ConversationProjection {
+    if !message_role.trim().eq_ignore_ascii_case("user") {
+        return ConversationProjection::Ordinary;
+    }
+    if crate::background_completion::is_background_completion_notification_message_key(message_key)
+    {
+        return ConversationProjection::RuntimeControl;
+    }
+    let Some(kind) = ContinuationKind::from_metadata(metadata) else {
+        return ConversationProjection::Ordinary;
+    };
+    match kind {
+        ContinuationKind::Steering => {
+            let exact_key = request_id.map(steering_input_message_key);
+            if exact_key.as_deref() == Some(message_key) {
+                kind.policy()
+                    .input_visibility
+                    .expect("steering has a durable input")
+                    .projection()
+            } else if super::continuation_version(metadata).is_none()
+                && request_content.is_some_and(|content| {
+                    content != STEERING_WAKE_PROMPT
+                        && (content == message_content
+                            || gents_protocol::transcript::present_persisted_message(
+                                message_role,
+                                message_content,
+                            )
+                            .body_markdown
+                                == content)
+                })
+            {
+                kind.policy()
+                    .input_visibility
+                    .expect("steering has a durable input")
+                    .projection()
+            } else {
+                kind.policy().control_visibility.projection()
+            }
+        }
+        ContinuationKind::BackgroundCompletion => kind
+            .policy()
+            .input_visibility
+            .expect("background completions have a durable input")
+            .projection(),
+        ContinuationKind::Goal => kind.policy().control_visibility.projection(),
+    }
+}

--- a/crates/gents/src/lifecycle/queue/enqueue.rs
+++ b/crates/gents/src/lifecycle/queue/enqueue.rs
@@ -7,10 +7,21 @@ pub(crate) async fn enqueue_session_request(
     execution_origin: ExecutionOrigin,
     queue_hints: QueueHints,
 ) -> Result<EnqueuedAgentRequest> {
-    let request_only_control = matches!(
-        queue_hints.source,
-        QueueSource::Steering | QueueSource::BackgroundCompletion
-    );
+    let continuation_kind = ContinuationKind::from_source(queue_hints.source);
+    if let Some(kind) = continuation_kind {
+        anyhow::ensure!(
+            queue_hints.policy == kind.policy().queue_policy,
+            "continuation queue policy does not match {:?}",
+            kind
+        );
+        anyhow::ensure!(
+            execution_origin == kind.policy().execution_origin,
+            "continuation execution origin does not match {:?}",
+            kind
+        );
+    }
+    let request_only_control =
+        continuation_kind.is_some_and(|kind| kind.is_request_only_control(&queue_hints));
     let normalized_parent = if request_only_control {
         Some(normalize_request_only_control_parent(node, parent).await?)
     } else {
@@ -90,7 +101,7 @@ pub(crate) async fn enqueue_steering_request_with_message(
     parent: &AgentRequest,
     content: &str,
     queue_hints: QueueHints,
-) -> Result<EnqueuedAgentRequest> {
+) -> Result<EnqueuedSteeringInput> {
     anyhow::ensure!(
         queue_hints.source == QueueSource::Steering
             && queue_hints.policy == QueuePolicy::Append

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -7,7 +7,7 @@ pub(crate) async fn enqueue_goal_continuation(
     content: &str,
     continuation_sequence: i64,
     wrapup: bool,
-) -> Result<EnqueuedAgentRequest> {
+) -> Result<(EnqueuedAgentRequest, bool)> {
     use sha2::{Digest, Sha256};
 
     let behavior_id = parent_behavior_id(node, parent).await?;
@@ -20,11 +20,14 @@ pub(crate) async fn enqueue_goal_continuation(
             .collect::<String>()
     );
     if let Some(doc_id) = lookup_request_doc_id_optional(node, &request_id).await? {
-        return Ok(EnqueuedAgentRequest {
-            doc_id,
-            request_id,
-            session_id: parent.session_id.clone(),
-        });
+        return Ok((
+            EnqueuedAgentRequest {
+                doc_id,
+                request_id,
+                session_id: parent.session_id.clone(),
+            },
+            false,
+        ));
     }
 
     let now = chrono::Utc::now().to_rfc3339();
@@ -35,16 +38,15 @@ pub(crate) async fn enqueue_goal_continuation(
         queued_after_request_id: Some(parent.request_id.clone()),
         interrupted_request_id: None,
     };
-    let metadata = serde_json::json!({
-        "queue": queue_hints,
-        "goal": {
-            "goal_id": goal_id,
-            "parent_request_id": parent.request_id,
-            "continuation_sequence": continuation_sequence,
-            "wrapup": wrapup,
-        }
-    })
-    .to_string();
+    let mut metadata: serde_json::Value = serde_json::from_str(&queue_metadata_json(&queue_hints))
+        .context("canonical continuation metadata must be valid JSON")?;
+    metadata["goal"] = serde_json::json!({
+        "goal_id": goal_id,
+        "parent_request_id": parent.request_id,
+        "continuation_sequence": continuation_sequence,
+        "wrapup": wrapup,
+    });
+    let metadata = metadata.to_string();
 
     let escaped_request_id = escape_graphql_string(&request_id);
     let escaped_agent_did = escape_graphql_string(&parent.agent_did);
@@ -98,11 +100,14 @@ pub(crate) async fn enqueue_goal_continuation(
         .or(lookup_request_doc_id_optional(node, &request_id).await?)
         .context("goal continuation create returned no _docID")?;
 
-    Ok(EnqueuedAgentRequest {
-        doc_id,
-        request_id,
-        session_id: parent.session_id.clone(),
-    })
+    Ok((
+        EnqueuedAgentRequest {
+            doc_id,
+            request_id,
+            session_id: parent.session_id.clone(),
+        },
+        true,
+    ))
 }
 
 // SAFETY (#664): `agent_did` scopes the candidate query AND the supersede

--- a/crates/gents/src/lifecycle/queue/metadata.rs
+++ b/crates/gents/src/lifecycle/queue/metadata.rs
@@ -2,10 +2,13 @@
 pub(crate) struct RequestQueueMetadata {
     pub queue: QueueHints,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub continuation_version: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub background_completion_wake_version: Option<u32>,
 }
 
 const BACKGROUND_COMPLETION_WAKE_VERSION: u32 = 1;
+pub(crate) const CONTINUATION_VERSION: u32 = 1;
 const STEERING_INPUT_MESSAGE_PREFIX: &str = "steering-input:";
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -58,9 +61,31 @@ pub(crate) fn queue_metadata_json(hints: &QueueHints) -> String {
         queue_hints_are_automated_wakeup(hints).then_some(BACKGROUND_COMPLETION_WAKE_VERSION);
     serde_json::to_string(&RequestQueueMetadata {
         queue: hints.clone(),
+        continuation_version: (!matches!(hints.source, QueueSource::User))
+            .then_some(CONTINUATION_VERSION),
         background_completion_wake_version,
     })
     .expect("queue metadata serialization should not fail")
+}
+
+pub(crate) fn continuation_version(metadata: Option<&str>) -> Option<u32> {
+    parse_queue_metadata(metadata).and_then(|metadata| metadata.continuation_version)
+}
+
+/// Compatibility predicate for steering rows authored before queue policy was
+/// required. Parent-link validation historically accepted the source alone,
+/// so a malformed or missing policy must not turn a replicated steering
+/// continuation into incoherent lineage during an upgrade.
+pub(crate) fn request_is_steering_continuation(metadata: Option<&str>) -> bool {
+    if parse_queue_hints(metadata).is_some_and(|hints| hints.source == QueueSource::Steering) {
+        return true;
+    }
+    metadata
+        .and_then(|metadata| serde_json::from_str::<serde_json::Value>(metadata).ok())
+        .and_then(|metadata| metadata.get("queue").cloned())
+        .and_then(|queue| queue.get("source").cloned())
+        .and_then(|source| source.as_str().map(ToOwned::to_owned))
+        .is_some_and(|source| source == "steering")
 }
 
 pub(crate) fn is_automated_wakeup(metadata: Option<&str>) -> bool {
@@ -68,12 +93,8 @@ pub(crate) fn is_automated_wakeup(metadata: Option<&str>) -> bool {
 }
 
 fn queue_hints_are_automated_wakeup(hints: &QueueHints) -> bool {
-    matches!(hints.source, QueueSource::BackgroundCompletion)
-        && hints.policy == QueuePolicy::Coalesce
-        && hints
-            .key
-            .as_deref()
-            .is_some_and(|key| !key.trim().is_empty())
+    super::ContinuationKind::from_source(hints.source)
+        .is_some_and(|kind| kind.is_automated_wakeup(hints))
 }
 
 pub(crate) fn is_deprecated_background_completion_wakeup(
@@ -92,18 +113,9 @@ pub(crate) fn is_deprecated_background_completion_wakeup(
 
 pub(crate) fn is_subagent_owned_queue(metadata: Option<&str>) -> bool {
     parse_queue_hints(metadata).is_some_and(|hints| {
-        matches!(hints.source, QueueSource::Steering)
-            || (matches!(hints.source, QueueSource::BackgroundCompletion)
-                && hints.policy == QueuePolicy::Coalesce
-                && hints
-                    .key
-                    .as_deref()
-                    .is_some_and(|key| !key.trim().is_empty()))
+        super::ContinuationKind::from_source(hints.source)
+            .is_some_and(|kind| kind.is_subagent_owned(&hints))
     })
-}
-
-pub(crate) fn is_goal_queue(metadata: Option<&str>) -> bool {
-    parse_queue_hints(metadata).is_some_and(|hints| matches!(hints.source, QueueSource::Goal))
 }
 
 pub(crate) fn steering_input_message_key(request_id: &str) -> String {

--- a/crates/gents/src/lifecycle/queue/tests.rs
+++ b/crates/gents/src/lifecycle/queue/tests.rs
@@ -248,3 +248,4 @@ async fn control_parent_normalization_recovers_legacy_logical_request_edge() {
 mod background_completion;
 mod coalescing;
 mod metadata;
+mod steering;

--- a/crates/gents/src/lifecycle/queue/tests/background_completion.rs
+++ b/crates/gents/src/lifecycle/queue/tests/background_completion.rs
@@ -146,6 +146,277 @@ async fn notification_is_atomically_bound_to_coalesced_wake() {
 }
 
 #[tokio::test]
+async fn existing_unbound_notification_is_atomically_rebound_to_its_wake() {
+    let db = test_db("atomic-background-rebind").await;
+    let parent = root_parent("atomic-background-rebind-session");
+    let message_key = "background-completion-notification:rebind:tool";
+    let (original_sequence, created) = session::append_message_once_with_key_and_requester_did(
+        &db.node,
+        &parent.session_id,
+        &parent.agent_did,
+        parent.requester_did.as_deref(),
+        "user",
+        "notification persisted before its wake",
+        None,
+        None,
+        None,
+        message_key,
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(created);
+
+    let first = enqueue_background_completion_with_message(
+        &db.node,
+        &parent,
+        "notification persisted before its wake",
+        message_key,
+        "review notifications",
+        background_hints(&parent),
+    )
+    .await
+    .unwrap();
+    assert!(first.created_request);
+    assert!(!first.created_message);
+    assert_eq!(first.message_sequence, original_sequence);
+
+    let second = enqueue_background_completion_with_message(
+        &db.node,
+        &parent,
+        "notification persisted before its wake",
+        message_key,
+        "review notifications",
+        background_hints(&parent),
+    )
+    .await
+    .unwrap();
+    assert!(!second.created_request);
+    assert!(!second.created_message);
+    assert_eq!(second.request.doc_id, first.request.doc_id);
+    assert_eq!(second.message_sequence, original_sequence);
+
+    let query = format!(
+        r#"{{
+            AgentMessage(filter: {{
+                session_id: {{ _eq: "{}" }},
+                message_key: {{ _eq: "{}" }}
+            }}) {{ request_id request_doc_id sequence }}
+        }}"#,
+        escape_graphql_string(&parent.session_id),
+        escape_graphql_string(message_key),
+    );
+    let response = db.node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "message query: {:?}",
+        response.errors
+    );
+    let rows = response.data.as_ref().unwrap()["AgentMessage"]
+        .as_array()
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["request_id"], first.request.request_id);
+    assert!(rows[0]["request_doc_id"].as_str().is_none_or(str::is_empty));
+    assert_eq!(rows[0]["sequence"], original_sequence);
+}
+
+#[tokio::test]
+async fn interrupted_physically_bound_notification_never_mints_successor_wakes() {
+    let db = test_db("atomic-background-interrupted-binding").await;
+    let parent = root_parent("atomic-background-interrupted-binding-session");
+    let message_key = "background-completion-notification:interrupted:tool";
+    let first = enqueue_background_completion_with_message(
+        &db.node,
+        &parent,
+        r#"<tool-completion tool_call_id="interrupted" status="completed" />"#,
+        message_key,
+        "review notifications",
+        background_hints(&parent),
+    )
+    .await
+    .unwrap();
+
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ _docID: {{ _eq: "{}" }} }},
+                input: {{ status: "interrupted", lifecycle_state: "interrupted" }}
+            ) {{ _docID }}
+            update_AgentMessage(
+                filter: {{ session_id: {{ _eq: "{}" }}, message_key: {{ _eq: "{}" }} }},
+                input: {{ request_id: "stale-logical-successor" }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(&first.request.doc_id),
+        escape_graphql_string(&parent.session_id),
+        escape_graphql_string(message_key),
+    );
+    let response = db.node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "seed mismatch: {:?}",
+        response.errors
+    );
+    let seeded = db
+        .node
+        .execute(&format!(
+            r#"{{
+                AgentMessage(filter: {{ message_key: {{ _eq: "{}" }} }}) {{
+                    request_id request_doc_id
+                }}
+                AgentRequest(filter: {{ _docID: {{ _eq: "{}" }} }}) {{
+                    request_id session_id metadata status lifecycle_state
+                }}
+            }}"#,
+            escape_graphql_string(message_key),
+            escape_graphql_string(&first.request.doc_id),
+        ))
+        .await;
+    assert!(!seeded.has_errors(), "seed query: {:?}", seeded.errors);
+    let seeded_data = seeded.data.as_ref().unwrap();
+    assert_eq!(
+        seeded_data["AgentMessage"][0]["request_doc_id"].as_str(),
+        Some(first.request.doc_id.as_str()),
+        "seeded rows: {seeded_data:?}"
+    );
+
+    for _ in 0..2 {
+        let replay = enqueue_background_completion_with_message(
+            &db.node,
+            &parent,
+            r#"<tool-completion tool_call_id="interrupted" status="completed" />"#,
+            message_key,
+            "review notifications",
+            background_hints(&parent),
+        )
+        .await
+        .unwrap();
+        assert!(!replay.created_request);
+        assert!(!replay.created_message);
+        assert_eq!(replay.request.doc_id, first.request.doc_id);
+        assert_eq!(replay.request.request_id, first.request.request_id);
+    }
+
+    let query = format!(
+        r#"{{ AgentRequest(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+        escape_graphql_string(&parent.session_id)
+    );
+    let response = db.node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "request count: {:?}",
+        response.errors
+    );
+    assert_eq!(
+        response.data.as_ref().unwrap()["AgentRequest"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn keyless_legacy_notification_dedups_by_stable_content_marker() {
+    let db = test_db("atomic-background-keyless-legacy").await;
+    let parent = root_parent("atomic-background-keyless-legacy-session");
+    let content = r#"<subagent-notification child_request_id="legacy-child" status="completed"><summary>done</summary></subagent-notification>"#;
+    let sequence = session::append_message_with_requester_did(
+        &db.node,
+        &parent.session_id,
+        &parent.agent_did,
+        parent.requester_did.as_deref(),
+        "user",
+        content,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let first = enqueue_background_completion_with_message(
+        &db.node,
+        &parent,
+        content,
+        "background-completion-notification:legacy-child:subagent",
+        "review notifications",
+        background_hints(&parent),
+    )
+    .await
+    .unwrap();
+    assert!(!first.created_message);
+    assert_eq!(first.message_sequence, sequence);
+
+    let second = enqueue_background_completion_with_message(
+        &db.node,
+        &parent,
+        content,
+        "background-completion-notification:legacy-child:subagent",
+        "review notifications",
+        background_hints(&parent),
+    )
+    .await
+    .unwrap();
+    assert!(!second.created_request);
+    assert!(!second.created_message);
+    assert_eq!(second.request.doc_id, first.request.doc_id);
+
+    let query = format!(
+        r#"{{ AgentMessage(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+        escape_graphql_string(&parent.session_id)
+    );
+    let response = db.node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "message count: {:?}",
+        response.errors
+    );
+    assert_eq!(
+        response.data.as_ref().unwrap()["AgentMessage"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn unrelated_exact_content_does_not_rebind_as_a_background_input() {
+    let db = test_db("atomic-background-content-collision").await;
+    let parent = root_parent("atomic-background-content-collision-session");
+    let content = "plain text that happens to equal a notification payload";
+    let unrelated_sequence = session::append_message_with_requester_did(
+        &db.node,
+        &parent.session_id,
+        &parent.agent_did,
+        parent.requester_did.as_deref(),
+        "assistant",
+        content,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let enqueued = enqueue_background_completion_with_message(
+        &db.node,
+        &parent,
+        content,
+        "background-completion-notification:content-collision:tool",
+        "review notifications",
+        background_hints(&parent),
+    )
+    .await
+    .unwrap();
+
+    assert!(enqueued.created_message);
+    assert_ne!(enqueued.message_sequence, unrelated_sequence);
+}
+
+#[tokio::test]
 async fn concurrent_notifications_converge_to_one_pending_wake() {
     let db = test_db("atomic-background-race").await;
     let parent = root_parent("atomic-background-race-session");

--- a/crates/gents/src/lifecycle/queue/tests/metadata.rs
+++ b/crates/gents/src/lifecycle/queue/tests/metadata.rs
@@ -95,6 +95,7 @@ fn serializes_queue_metadata_json() {
     assert_eq!(
         value,
         serde_json::json!({
+            "continuation_version": 1,
             "queue": {
                 "source": "steering",
                 "policy": "coalesce",
@@ -102,6 +103,43 @@ fn serializes_queue_metadata_json() {
                 "queued_after_request_id": null
             }
         })
+    );
+}
+
+#[test]
+fn continuation_policy_matches_the_formal_contract_signatures() {
+    assert_eq!(
+        ContinuationKind::Steering.contract_signature(),
+        "steering|append|interactive|visible_input|runtime_control|generation_owner|durable_input|prompt_once"
+    );
+    assert_eq!(
+        ContinuationKind::BackgroundCompletion.contract_signature(),
+        "background_completion|coalesce|scheduled|runtime_control|runtime_control|generation_owner|durable_input|history_then_control"
+    );
+    assert_eq!(
+        ContinuationKind::Goal.contract_signature(),
+        "goal|coalesce|scheduled|none|runtime_control|previous_request|request_only|control_only"
+    );
+}
+
+#[test]
+fn legacy_steering_request_projects_as_input_but_versioned_request_is_control() {
+    let legacy = r#"{"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":null}}"#;
+    let versioned = queue_metadata_json(&QueueHints {
+        source: QueueSource::Steering,
+        policy: QueuePolicy::Append,
+        key: None,
+        queued_after_request_id: None,
+        interrupted_request_id: None,
+    });
+
+    assert_eq!(
+        classify_continuation_request(Some(legacy), "legacy steering input"),
+        ConversationProjection::VisibleInput
+    );
+    assert_eq!(
+        classify_continuation_request(Some(&versioned), "legacy steering input"),
+        ConversationProjection::RuntimeControl
     );
 }
 
@@ -169,36 +207,72 @@ fn runtime_control_projection_keeps_only_the_steering_input_visible() {
     let steering = metadata(QueueSource::Steering);
     let steering_input = steering_input_message_key("request-1");
 
-    assert!(!crate::lifecycle::is_runtime_control_message(
-        Some(&steering),
-        &steering_input,
-        true,
-    ));
-    assert!(crate::lifecycle::is_runtime_control_message(
-        Some(&steering),
-        "",
-        true,
-    ));
-    assert!(crate::lifecycle::is_runtime_control_message(
-        Some(&metadata(QueueSource::Goal)),
-        "",
-        false,
-    ));
-    assert!(crate::lifecycle::is_runtime_control_message(
-        None,
-        "background-completion-notification:child-1:subagent",
-        false,
-    ));
-    assert!(!crate::lifecycle::is_runtime_control_message(
-        Some(&metadata(QueueSource::User)),
-        "",
-        false,
-    ));
-    assert!(!crate::lifecycle::is_runtime_control_message(
-        Some(&steering),
-        "session-1:4",
-        false,
-    ));
+    assert_eq!(
+        classify_continuation_message(
+            Some(&steering),
+            Some("request-1"),
+            Some("steer now"),
+            "user",
+            "steer now",
+            &steering_input
+        ),
+        ConversationProjection::VisibleInput
+    );
+    assert_eq!(
+        classify_continuation_message(
+            Some(&steering),
+            Some("request-1"),
+            Some("steer now"),
+            "user",
+            "<context>internal</context>",
+            ""
+        ),
+        ConversationProjection::RuntimeControl
+    );
+    assert_eq!(
+        classify_continuation_message(
+            Some(&steering),
+            Some("request-1"),
+            Some("steer now"),
+            "assistant",
+            "done",
+            "",
+        ),
+        ConversationProjection::Ordinary
+    );
+    assert_eq!(
+        classify_continuation_message(
+            Some(&metadata(QueueSource::Goal)),
+            Some("request-2"),
+            Some("goal control"),
+            "user",
+            "goal control",
+            ""
+        ),
+        ConversationProjection::RuntimeControl
+    );
+    assert_eq!(
+        classify_continuation_message(
+            None,
+            None,
+            None,
+            "user",
+            "notification",
+            "background-completion-notification:child-1:subagent"
+        ),
+        ConversationProjection::RuntimeControl
+    );
+    assert_eq!(
+        classify_continuation_message(
+            Some(&metadata(QueueSource::User)),
+            Some("request-3"),
+            Some("hello"),
+            "user",
+            "hello",
+            ""
+        ),
+        ConversationProjection::Ordinary
+    );
     assert!(!crate::lifecycle::request_content_owns_user_projection(
         Some(&steering)
     ));
@@ -207,4 +281,10 @@ fn runtime_control_projection_keeps_only_the_steering_input_visible() {
     assert!(!crate::lifecycle::request_owns_user_turn(Some(&metadata(
         QueueSource::Goal
     ))));
+}
+
+#[test]
+fn malformed_legacy_steering_policy_remains_request_only_control() {
+    let metadata = r#"{"queue":{"source":"steering"}}"#;
+    assert!(metadata_is_request_only_control(Some(metadata)));
 }

--- a/crates/gents/src/lifecycle/queue/tests/steering.rs
+++ b/crates/gents/src/lifecycle/queue/tests/steering.rs
@@ -1,0 +1,162 @@
+use super::*;
+
+#[tokio::test]
+async fn steering_claim_uses_durable_input_once_as_the_loop_prompt() {
+    let TestDb { node, _tempdir } = test_db("steering-provider-input-once").await;
+    let node = std::sync::Arc::new(node);
+    let parent = {
+        let mut parent = parent_request("steering-provider-input-once-session");
+        parent.subagent_depth = 0;
+        parent.caused_by_parent_request_id = None;
+        parent.caused_by_parent_request_doc_id = None;
+        parent.caused_by_parent_tool_call_id = None;
+        parent.caused_by_parent_tool_call_doc_id = None;
+        parent
+    };
+    let notification_key = "background-completion-notification:prior-child:subagent";
+    let (notification_sequence, created_notification) =
+        session::append_message_once_with_key_and_requester_did(
+        node.as_ref(),
+        &parent.session_id,
+        &parent.agent_did,
+        parent.requester_did.as_deref(),
+        "user",
+        r#"<subagent-notification child_request_id="prior-child" status="completed"><summary>done</summary></subagent-notification>"#,
+        None,
+        None,
+        None,
+        notification_key,
+        None,
+    )
+    .await
+        .unwrap();
+    assert!(created_notification);
+    let steering_text = "also inspect the staging configuration";
+    let enqueued = enqueue_conversation_continuation(
+        node.as_ref(),
+        &parent,
+        ConversationContinuation::Steering {
+            message: steering_text,
+            interrupted_request_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    let input_sequence = enqueued.input_sequence.unwrap();
+    assert_eq!(input_sequence, notification_sequence + 1);
+    let request =
+        crate::request_binding::load_agent_request(node.as_ref(), &enqueued.request.request_id)
+            .await
+            .unwrap()
+            .unwrap();
+    assert_eq!(request.content, steering_text);
+
+    let mut lifecycle = crate::RequestLifecycle::new_with_execution_binding(
+        node.clone(),
+        TEST_BEHAVIOR_ID,
+        TEST_AGENT_DID,
+        request,
+        60,
+        ExecutionOrigin::Interactive,
+        "backend-test",
+    );
+    assert_eq!(
+        lifecycle.claim_with_identity().await.unwrap(),
+        crate::lifecycle::ClaimOutcome::Claimed
+    );
+    assert_eq!(
+        lifecycle.provider_history_through_sequence(),
+        Some(input_sequence.saturating_sub(1))
+    );
+    let history = session::load_history_through_sequence(
+        node.as_ref(),
+        &parent.session_id,
+        lifecycle.provider_history_through_sequence(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(history.len(), 1);
+
+    let response = node
+        .execute(&format!(
+            r#"{{ AgentMessage(filter: {{ session_id: {{ _eq: "{}" }} }}) {{ sequence message_key }} }}"#,
+            escape_graphql_string(&parent.session_id)
+        ))
+        .await;
+    assert!(
+        !response.has_errors(),
+        "message rows: {:?}",
+        response.errors
+    );
+    let rows = response.data.as_ref().unwrap()["AgentMessage"]
+        .as_array()
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().any(|row| {
+        row["sequence"].as_u64() == Some(u64::from(notification_sequence))
+            && row["message_key"].as_str() == Some(notification_key)
+    }));
+    assert!(rows.iter().any(|row| {
+        row["sequence"].as_u64() == Some(u64::from(input_sequence))
+            && row["message_key"].as_str()
+                == Some(steering_input_message_key(&enqueued.request.request_id).as_str())
+    }));
+}
+
+async fn pending_versioned_steering_request(
+    node: &EmbeddedNode,
+    session_id: &str,
+    request_id: &str,
+) -> (String, AgentRequest) {
+    let metadata = queue_metadata_json(&QueueHints {
+        source: QueueSource::Steering,
+        policy: QueuePolicy::Append,
+        key: None,
+        queued_after_request_id: None,
+        interrupted_request_id: None,
+    });
+    let doc_id = insert_raw_queue_request(node, request_id, session_id, &metadata).await;
+    let request = crate::request_binding::load_agent_request(node, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    (doc_id, request)
+}
+
+async fn assert_request_remains_pending(node: &EmbeddedNode, session_id: &str, request_id: &str) {
+    let row = queue_rows(node, session_id)
+        .await
+        .into_iter()
+        .find(|row| row.request_id == request_id)
+        .unwrap();
+    assert_eq!(row.status, "pending");
+    assert_eq!(row.lifecycle_state.as_deref(), Some("pending"));
+}
+
+#[tokio::test]
+async fn steering_claim_fails_closed_without_its_keyed_input() {
+    let TestDb { node, _tempdir } = test_db("steering-missing-input").await;
+    let node = std::sync::Arc::new(node);
+    let session_id = "steering-missing-input-session";
+    let request_id = "steering-missing-input-request";
+    let (_, request) =
+        pending_versioned_steering_request(node.as_ref(), session_id, request_id).await;
+    let mut lifecycle = crate::RequestLifecycle::new_with_execution_binding(
+        node.clone(),
+        TEST_BEHAVIOR_ID,
+        TEST_AGENT_DID,
+        request,
+        60,
+        ExecutionOrigin::Interactive,
+        "backend-test",
+    );
+
+    let error = lifecycle
+        .claim_with_identity()
+        .await
+        .expect_err("a steering request without its durable input must not be claimed");
+    assert!(error
+        .to_string()
+        .contains("must resolve exactly one durable input row"));
+    assert_request_remains_pending(node.as_ref(), session_id, request_id).await;
+}

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -1259,16 +1259,7 @@ fn request_only_control_link_is_corroborated(request: &TimelineRequestRow) -> bo
     {
         return false;
     }
-    if crate::lifecycle::is_background_completion_request(request.metadata.as_deref()) {
-        return true;
-    }
-    crate::lifecycle::queue::parse_queue_hints(request.metadata.as_deref()).is_some_and(|hints| {
-        matches!(
-            hints.source,
-            crate::lifecycle::queue::QueueSource::Steering
-                | crate::lifecycle::queue::QueueSource::Goal
-        )
-    })
+    crate::lifecycle::queue::metadata_is_request_only_control(request.metadata.as_deref())
 }
 
 fn sorted_inference_calls(

--- a/crates/gents/src/trigger_engine/goal_source.rs
+++ b/crates/gents/src/trigger_engine/goal_source.rs
@@ -22,7 +22,7 @@ use crate::goal::{
     GoalRequestTerminal, GoalStatus, GOAL_TRIGGER_KIND, MAX_INFRASTRUCTURE_RETRIES,
 };
 use crate::graphql::escape_graphql_string;
-use crate::lifecycle::queue::enqueue_goal_continuation;
+use crate::lifecycle::queue::{enqueue_conversation_continuation, ConversationContinuation};
 use crate::runtime_snapshot::{ActiveRuntimeSnapshot, ConcurrencyMode, ResolvedTask};
 use crate::watcher::AgentRequest;
 use crate::UpdateSubscriptionSource;
@@ -495,13 +495,15 @@ impl GoalSource {
         };
         let prompt = continuation_prompt(&goal, retry_prefix.as_deref(), wrapup);
         let parent = latest.into_agent_request();
-        let child = enqueue_goal_continuation(
+        let child = enqueue_conversation_continuation(
             &self.node,
             &parent,
-            &goal.goal_id,
-            &prompt,
-            sequence,
-            wrapup,
+            ConversationContinuation::Goal {
+                goal_id: &goal.goal_id,
+                prompt: &prompt,
+                continuation_sequence: sequence,
+                wrapup,
+            },
         )
         .await?;
         let task = ResolvedTask {
@@ -532,7 +534,7 @@ impl GoalSource {
             group_vars: None,
             trigger_context: parent.caused_by_trigger_context.clone(),
             args_vars: None,
-            pre_materialized_request_id: Some(child.request_id),
+            pre_materialized_request_id: Some(child.request.request_id),
             on_result: Box::new(move |result| match result {
                 FireResult::Fired { request_id } => tracing::info!(
                     %request_id,

--- a/crates/gents/src/watcher.rs
+++ b/crates/gents/src/watcher.rs
@@ -82,9 +82,7 @@ pub fn validate_agent_request(req: &AgentRequest) -> Result<()> {
     let has_parent_tc_doc = req.caused_by_parent_tool_call_doc_id.is_some();
     let request_only_control_link = has_parent_req
         && !has_parent_tc
-        && (is_steering_queue(req)
-            || is_goal_queue(req)
-            || crate::lifecycle::is_background_completion_request(req.metadata.as_deref()));
+        && crate::lifecycle::queue::metadata_is_request_only_control(req.metadata.as_deref());
     if has_parent_req != has_parent_req_doc || has_parent_tc != has_parent_tc_doc {
         return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
     }
@@ -105,29 +103,6 @@ pub fn validate_agent_request(req: &AgentRequest) -> Result<()> {
         return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
     }
     Ok(())
-}
-
-fn is_steering_queue(req: &AgentRequest) -> bool {
-    let Some(metadata) = req
-        .metadata
-        .as_deref()
-        .map(str::trim)
-        .filter(|m| !m.is_empty())
-    else {
-        return false;
-    };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata) else {
-        return false;
-    };
-    value
-        .get("queue")
-        .and_then(|queue| queue.get("source"))
-        .and_then(serde_json::Value::as_str)
-        == Some("steering")
-}
-
-fn is_goal_queue(req: &AgentRequest) -> bool {
-    crate::lifecycle::queue::is_goal_queue(req.metadata.as_deref())
 }
 
 pub trait Watcher: Send + Sync {

--- a/crates/gents/tests/conformance/background.rs
+++ b/crates/gents/tests/conformance/background.rs
@@ -1451,7 +1451,7 @@ pub(super) fn generated_subagent_delegation_graph_cases_pin_gap2_contract() {
 
 pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
     let cases = lean_r4c_background_work_cases();
-    assert_eq!(cases.len(), 7);
+    assert_eq!(cases.len(), 8);
 
     let names = cases
         .iter()
@@ -1460,6 +1460,7 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
     assert_eq!(
         names,
         [
+            "conversation.continuation.policy",
             "r4c.list_subagents.lineage_rejects",
             "r4c.list_subagents.unmaterialized_child_visible",
             "r4c.read_subagent_transcript.cursor_advances",
@@ -1471,6 +1472,46 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
         .into_iter()
         .collect::<BTreeSet<_>>()
     );
+
+    match lean_r4c_background_work_case("conversation.continuation.policy") {
+        LeanR4cBackgroundWorkCase::ConversationContinuationPolicy {
+            version,
+            steering_policy,
+            background_completion_policy,
+            goal_policy,
+            steering_lineage_admissible,
+            background_lineage_admissible,
+            goal_lineage_admissible,
+            all_control_prompts_internal,
+            durable_input_matches_message_backed_kinds,
+            steering_provider_input,
+            steering_input_appears_exactly_once,
+            steering_control_prompt_absent,
+        } => {
+            assert_eq!(*version, 1);
+            assert_eq!(
+                Some(steering_policy.clone()),
+                gents::__test_internals::continuation_policy_contract("steering")
+            );
+            assert_eq!(
+                Some(background_completion_policy.clone()),
+                gents::__test_internals::continuation_policy_contract("background_completion")
+            );
+            assert_eq!(
+                Some(goal_policy.clone()),
+                gents::__test_internals::continuation_policy_contract("goal")
+            );
+            assert!(*steering_lineage_admissible);
+            assert!(*background_lineage_admissible);
+            assert!(*goal_lineage_admissible);
+            assert!(*all_control_prompts_internal);
+            assert!(*durable_input_matches_message_backed_kinds);
+            assert_eq!(steering_provider_input, "prior_message|steering_input");
+            assert!(*steering_input_appears_exactly_once);
+            assert!(*steering_control_prompt_absent);
+        }
+        other => panic!("unexpected continuation policy variant: {other:?}"),
+    }
 
     match lean_r4c_background_work_case("r4c.list_subagents.lineage_rejects") {
         LeanR4cBackgroundWorkCase::ListSubagentsLineageRejects {

--- a/crates/gents/tests/conformance/structure.rs
+++ b/crates/gents/tests/conformance/structure.rs
@@ -25,6 +25,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("Compaction", Module("conformance/streaming_compaction.rs")),
         ("CompletionRetry", Module("conformance/completion_retry.rs")),
         (
+            "ConversationContinuation",
+            Module("conformance/background.rs"),
+        ),
+        (
             "CancelPropagation",
             Module("conformance/cancel_propagation.rs"),
         ),


### PR DESCRIPTION
## Summary

- define one policy-driven runtime interface for steering, background-completion, and goal continuations
- persist message-backed continuations atomically and make background notification recovery idempotent across legacy and interrupted rows
- classify continuation inputs and control prompts consistently in provider history, conversation projection, Codex replay, and desktop timelines
- add an executable Lean continuation model and Rust conformance fence for queue policy, lineage, and prompt-once provider assembly

This is a stacked PR on #1160 so it can reuse the request-owned, replication-safe session projection foundation.

## Correctness coverage

- steering returns its committed input sequence from the enqueue transaction; there is no fallible post-commit lookup
- legacy background rebinds require a nonblank physical document ID and never fall back to session-wide content matching
- steering claim fails closed without exactly one keyed durable input and keeps prior transcript rows before the cutoff
- runtime control rows cannot seed conversation previews/titles or duplicate persisted/live assistant output

## Local validation

- lake build (996 targets; no sorrys)
- cargo test -p gents
- cargo test -p gents-cli history_projection::tests::
- cargo test -p gents-desktop-bridge snapshot::tests::session_timeline
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check

The only warning is the existing unused description field in the CLI secscan matcher.