### PR TITLE
proofs: model graph pipeline publication

### DIFF
--- a/crates/gents/proofs/Proofs.lean
+++ b/crates/gents/proofs/Proofs.lean
@@ -58,3 +58,4 @@ import Proofs.Skills
 import Proofs.EditMatch
 import Proofs.EventDelivery
 import Proofs.Conformance.EventDelivery
+import Proofs.GraphPipeline

--- a/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
@@ -83,6 +83,9 @@ def boundaryModelNatTypedIdsTimeId : String :=
 def boundaryP2pBackpressureObligationModelId : String :=
   "boundary.p2p-backpressure.obligation-model"
 
+def boundaryGraphPipelineFoundationId : String :=
+  "boundary.graph-pipeline.foundation"
+
 def boundaryRenderedCaptureAssembledRequestArtifactId : String :=
   "boundary.rendered-capture.assembled-request-artifact"
 
@@ -277,6 +280,14 @@ def boundaries : List Boundary :=
         some "A future queue-admission, durable-retry, store-before-ack, or restart-recovery regression can pass this one-wave model; the separate pinned-struct observability and P2P end-to-end tests are implementation fences, not proofs of those properties."
     , acceptedFollowUp :=
         some "Extend the distributed model to bounded multi-wave queue admission plus durable retry and pending-DAG restart recovery, bind its witness rows to the pinned DefraDB adapter, and TLC-check MCP2PBackpressure*. Tracked under #630."
+    }
+  , { id := boundaryGraphPipelineFoundationId
+    , domain := "GraphPipeline"
+    , subject := "foundation model before compiler and persistence refinement"
+    , statement :=
+        "Proofs.GraphPipeline establishes publication readiness, active-pointer alignment, immutable revision identity, and run pinning. This foundation slice has no shipping compiler, GraphRevision/GraphRun storage schema, activation controller, or runtime visibility filter, so it makes no Rust refinement claim yet."
+    , acceptedFollowUp :=
+        some "The immediately stacked compiler and publication/runtime pull requests replace this boundary with pure-compiler conformance and persisted lifecycle end-to-end fences."
     }
   , { id := boundaryRenderedCaptureAssembledRequestArtifactId
     , domain := "RenderedCapture"

--- a/crates/gents/proofs/Proofs/GraphPipeline.lean
+++ b/crates/gents/proofs/Proofs/GraphPipeline.lean
@@ -1,0 +1,125 @@
+import Proofs.Basic
+
+/-!
+# Graph pipeline publication boundary
+
+The model-facing endpoint composes existing Tasks with ordinary EventTriggers;
+it is not a second execution engine. This model fences the semantic change:
+publication is legal only after type, topology, capability-authorization, and
+structural-bound checks all succeed. The compiler is pure and publication is
+one transaction in Rust.
+-/
+
+namespace GraphPipeline
+
+structure Checks where
+  typesValid : Bool
+  topologyValid : Bool
+  capabilitiesAuthorized : Bool
+  withinBounds : Bool
+  deriving DecidableEq, Repr
+
+def Checks.wholeGraphValid (checks : Checks) : Prop :=
+  checks.typesValid = true ∧
+    checks.topologyValid = true ∧
+    checks.capabilitiesAuthorized = true ∧
+    checks.withinBounds = true
+
+instance (checks : Checks) : Decidable checks.wholeGraphValid := by
+  unfold Checks.wholeGraphValid
+  infer_instance
+
+inductive Status where
+  | proposed
+  | published
+  | rejected
+  deriving DecidableEq, Repr
+
+structure State where
+  checks : Checks
+  status : Status
+  deriving DecidableEq, Repr
+
+def State.safe (state : State) : Prop :=
+  state.status = .published → state.checks.wholeGraphValid
+
+def initial (checks : Checks) : State :=
+  { checks, status := .proposed }
+
+inductive Action where
+  | publish
+  | reject
+  deriving DecidableEq, Repr
+
+def step? (state : State) : Action → Option State
+  | .publish =>
+      if state.status = .proposed ∧ state.checks.wholeGraphValid then
+        some { state with status := .published }
+      else
+        none
+  | .reject =>
+      if state.status = .proposed ∧ ¬ state.checks.wholeGraphValid then
+        some { state with status := .rejected }
+      else
+        none
+
+theorem initial_safe (checks : Checks) : (initial checks).safe := by
+  simp [initial, State.safe]
+
+theorem step_preserves_checks
+    {pre post : State} {action : Action}
+    (h : step? pre action = some post) :
+    post.checks = pre.checks := by
+  cases action with
+  | publish =>
+      simp only [step?] at h
+      split at h
+      · injection h with h_state
+        rw [← h_state]
+      · simp at h
+  | reject =>
+      simp only [step?] at h
+      split at h
+      · injection h with h_state
+        rw [← h_state]
+      · simp at h
+
+theorem publish_requires_whole_graph_valid
+    {pre post : State}
+    (h : step? pre .publish = some post) :
+    pre.checks.wholeGraphValid := by
+  simp only [step?] at h
+  split at h <;> simp_all
+
+theorem invalid_graph_cannot_publish
+    (state : State)
+    (h : ¬ state.checks.wholeGraphValid) :
+    step? state .publish = none := by
+  simp [step?, h]
+
+theorem successful_publish_is_safe
+    {pre post : State}
+    (h : step? pre .publish = some post) :
+    post.safe := by
+  have h_valid := publish_requires_whole_graph_valid h
+  simp only [step?] at h
+  split at h
+  · cases h
+    simpa [State.safe] using h_valid
+  · simp at h
+
+theorem safe_preserved
+    {pre post : State} {action : Action}
+    (_h_safe : pre.safe)
+    (h_step : step? pre action = some post) :
+    post.safe := by
+  cases action with
+  | publish => exact successful_publish_is_safe h_step
+  | reject =>
+      simp only [step?] at h_step
+      split at h_step
+      · cases h_step
+        simp [State.safe]
+      · simp at h_step
+
+end GraphPipeline

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -89,7 +89,7 @@ lake env lean --run Proofs/Conformance/Contracts.lean
 
 ## What Is Proven
 
-The current proof suite covers seventeen practical areas:
+The current proof suite covers eighteen practical areas:
 
 1. Request/process/persistence state transitions
 2. Daemon storage-observation assumptions that refine persistence
@@ -121,6 +121,9 @@ The current proof suite covers seventeen practical areas:
 17. Agent self-configuration writes: per-collection writable/protected field
     partitions, patch-merge identity immutability and containment,
     transactional accept/reject totality, and no-lockout recoverability
+18. Graph-pipeline publication: type, topology, capability-authorization, and
+    structural-bound validation must all succeed before existing-task routes
+    may be published
 
 Separately, **obligation models** (no Rust refinement tests yet):
 
@@ -199,6 +202,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/CommandPolicy.lean` | Barrel for command/tool execution policy validation, sandbox, env, and safety proofs |
 | `Proofs/ToolExecution.lean` | MCP/tool preflight and retry eligibility boundary model |
 | `Proofs/ManagedExec.lean` | Barrel for managed native executor state, executable transitions, liveness properties, and tool composition |
+| `Proofs/GraphPipeline.lean` | Model-callable graph publication boundary: whole-graph validation is required before existing-task routes may be published |
 | `Proofs/PromptAssembly/` | Provider-view sanitation and prompt assembly, per-turn context budgeting, and the request-wide aggregate token ledger. Fences: generated cases consumed by `agent::loop_stream::tests`. |
 | `Proofs/P2PBackpressure.lean` | Obligation model (no conformance bridge): success-ack backing, pending-DAG capacity, strict push-slot release on timeout |
 | `Proofs/PeerRegistryDiscovery/DirectoryProjection.lean` | Agent directory projection (machine index v1): source-owned membership, foreign-row preservation, idempotent convergence, write-free settled fixpoint, retraction soundness. Fence: `tests/conformance/directory_projection.rs`. |

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -287,6 +287,7 @@ fn lean_boundary_metadata_is_typed_and_reviewable() {
         "boundary.prompt-assembly.provider-input-sanitization",
         "boundary.model.nat-typed-ids-time",
         "boundary.p2p-backpressure.obligation-model",
+        "boundary.graph-pipeline.foundation",
         "boundary.rendered-capture.assembled-request-artifact",
         "boundary.rendered-capture.key-encoding-injectivity",
     ]

--- a/crates/gents/tests/conformance/structure.rs
+++ b/crates/gents/tests/conformance/structure.rs
@@ -38,6 +38,12 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("EventDelivery", Module("conformance/event_delivery.rs")),
         ("Fleet", Module("conformance/fleet.rs")),
         ("Goals", Module("conformance/goals.rs")),
+        (
+            "GraphPipeline",
+            Boundary(
+                "foundation model only; compiler and persistence refinement land in the immediately stacked PRs (boundary.graph-pipeline.foundation)",
+            ),
+        ),
         ("Identity", Module("conformance/identity.rs")),
         ("InferenceCall", Module("conformance/inference_call.rs")),
         ("ManagedExec", Module("conformance/managed_exec.rs")),

--- a/docs/superpowers/specs/2026-08-25-model-callable-graph-pipeline-design.md
+++ b/docs/superpowers/specs/2026-08-25-model-callable-graph-pipeline-design.md
@@ -1,0 +1,170 @@
+# Model-callable graph compilation over existing automation
+
+**Status:** experimental stacked implementation.
+
+**Supersedes:** the direct model-to-Task/EventTrigger compiler in PR #1176.
+
+## Decision
+
+Ship a small compiler and publication adapter, not a graph runtime.
+
+A model submits topology over operator-approved `StageCapability` revisions.
+Each capability wraps an existing Task and declares its typed ports. The pure
+compiler validates the complete DAG and resolves edges to existing task IDs and
+physical collections. One identity-scoped transaction then writes ordinary
+EventTriggers plus an immutable GraphDefinition audit record.
+
+```text
+model GraphIntent
+      │
+      ▼
+pure validation against approved existing Tasks
+      │
+      ▼
+one transaction: GraphDefinition + EventTriggers
+      │
+      ▼
+existing reconciliation → trigger engine → Task runtime
+```
+
+The endpoint never accepts an executable `GraphPlan` from the model. It never
+creates Tasks or accepts behavior IDs, prompts, tool selections, models, or
+physical collections as authority-bearing model input.
+
+Execution is deliberately separate. After normal reconciliation, an existing
+bounded write tool creates an entry document. The existing trigger/task runtime
+does everything after that point.
+
+## Why this is smaller and safer
+
+The repository already owns execution, recovery, identity, tool resolution,
+lineage, event fan-out/fan-in, and persistence. A revision controller and a new
+GraphRun lifecycle duplicated those responsibilities without actually pinning
+live execution.
+
+Independent reviews found that the larger design:
+
+- allowed a model to forge a self-hashed GraphPlan and bypass capability checks;
+- seeded entries before trigger reconciliation, losing the first event;
+- treated mutable Task/EventTrigger rows as immutable digest-addressed artifacts;
+- retired triggers still needed by supposedly pinned runs;
+- advertised invocation and tool-selection pinning that execution ignored;
+- added node-wide watcher queries and full reloads to every control update.
+
+Removing that layer fixes the defects by removing the false abstraction. The
+only new persisted type is an immutable GraphDefinition containing the accepted
+plan digest and canonical plan JSON. It is audit metadata, not a runtime gate.
+
+## Trust boundary
+
+### Operator-owned capability
+
+`StageCapability` contains:
+
+- stable capability ID and revision;
+- an existing Task ID;
+- typed input/output ports, including physical collection and correlation field;
+- caller DIDs allowed to compose it.
+
+The Task remains the single source of its behavior, prompt, tools, model, and
+output permissions. Editing those existing documents has the same semantics it
+does elsewhere in Gents; v1 makes no runtime-pinning claim.
+
+### Model-owned intent
+
+`GraphIntent` contains only graph/node IDs, capability selections, port edges,
+entry bindings, supported delivery modes, safe predicates, and structural
+bounds. The model does not supply resolved Task IDs or collections.
+
+### Identity-scoped publication
+
+`CompileGraphTool` owns one concrete `Did`; the same DID is used for capability
+authorization and every statement in `ConfigApplyTxn`. There is no independent
+caller string and no `identity=None` path. Operators may put `compile_graph` in
+the existing `approval_required_tools` list when mutation needs human approval.
+
+## Compiler contract
+
+The compiler rejects the full intent without writes unless all of these hold:
+
+1. IDs are unique and all node/port references resolve.
+2. Every node selects an allowed capability revision.
+3. Required inputs have exactly one entry or inbound edge.
+4. Connected collection/schema/correlation/cardinality contracts match.
+5. Collections and correlation fields pass shared GraphQL validators.
+6. Predicates pass the existing safe filter-fragment validator.
+7. Every node is reachable from an entry and the graph is acyclic.
+8. Node, edge, depth, fan-out, and group-size bounds hold.
+9. Two graph nodes do not claim the same output collection.
+
+Rule 9 reflects the actual EventTrigger abstraction: routing is collection-wide,
+not producer-node-specific. Rejecting shared output collections keeps an edge's
+`from.node_id` meaningful instead of pretending the runtime can distinguish
+producers it cannot observe.
+
+Successful output is canonical and digest-stable. The tool compiles the intent
+internally, and the publisher verifies the resulting plan digest immediately
+before writing. The plan never crosses the model boundary, so the digest is
+content identity rather than proof supplied by an untrusted caller.
+
+## Publication contract
+
+Publication verifies that every planned Task currently exists and is enabled,
+then writes all entry/edge EventTriggers and the GraphDefinition in one
+transaction. The existing config writers retain their convergence, GraphQL
+escaping, empty-list, and conflict behavior.
+
+Graph IDs are immutable in v1. Repeating the same plan is idempotent; a changed
+plan must use a new graph ID. This avoids introducing revision activation,
+cleanup, and in-flight migration semantics before there is evidence they are
+needed.
+
+The tool response means the configuration committed, not that every host has
+reconciled it. Entry writes remain a later operation, matching all existing
+document-driven automation.
+
+## Explicit non-goals
+
+- creating or editing Tasks, prompts, behaviors, tools, models, or schemas;
+- starting runs or defining a second run lifecycle;
+- active-revision pointers, hot upgrades, or in-flight revision pinning;
+- enforcing runtime invocation budgets;
+- distinguishing multiple producers that write the same collection;
+- production configuration wiring before the experiment graduates.
+
+## Evaluation gate
+
+The checked-in fixtures cover deterministic acceptance and repair diagnostics.
+Graduation additionally requires a live evaluation that:
+
+1. constructs the custom tool with an operator-owned capability catalog;
+2. compiles linear, fan-out, routing, and fan-in graphs;
+3. waits for ordinary runtime reconciliation;
+4. writes entries through existing bounded write tools;
+5. observes requests, outputs, restart behavior, and authorization failures.
+
+Measure repair turns, token/latency cost, digest stability, publication errors,
+reconciliation latency, and end-to-end task correctness.
+
+## Formal boundary
+
+`Proofs.GraphPipeline` proves that publication requires the conjunction of type,
+topology, capability-authorization, and bound checks, that invalid graphs cannot
+publish, and that the publication transition preserves safety. Lean emits the
+complete four-bit validation matrix consumed by Rust conformance tests. DefraDB
+transaction serializability and runtime reconciliation remain declared platform
+boundaries.
+
+## Stack
+
+1. research, narrowed design, and Lean publication boundary;
+2. pure typed compiler and generated conformance cases;
+3. transactional GraphDefinition/EventTrigger publication over existing Tasks;
+4. one model-facing `compile_graph` custom tool and evaluation fixtures.
+
+## References
+
+- [AFlow: Automating Agentic Workflow Generation](https://arxiv.org/abs/2410.10762)
+- [Automated Design of Agentic Systems](https://arxiv.org/abs/2408.08435)
+- [GPTSwarm: Language Agents as Optimizable Graphs](https://arxiv.org/abs/2402.16823)
+- [CaMeL: Defeating Prompt Injections by Design](https://arxiv.org/abs/2503.18813)


### PR DESCRIPTION
## Summary

- define the narrow publication lifecycle for model-proposed document graphs: proposed, published, or rejected
- model the four whole-graph validation factors used by the compiler: types, topology, capability authorization, and structural bounds
- prove initial safety, publication requires every factor, invalid graphs cannot publish, and safety is preserved, with zero `sorry`s
- document the composition-first architecture: existing Tasks provide execution semantics and existing EventTriggers provide routing

This is PR 1 of the replacement stack for #1176. It intentionally contains no Rust compiler, persistence adapter, or model-facing tool.

## Verification

- `cd crates/gents/proofs && lake build`
- `git diff --check`

## Stack

1. **this PR** — formal publication boundary and architecture
2. #1191 — pure typed compiler and conformance fence
3. #1192 — transactional EventTrigger publication over existing Tasks
4. #1193 — single model-callable compile-and-publish tool