### PR TITLE
feat: add pure graph intent compiler

### DIFF
--- a/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Boundaries.lean
@@ -283,11 +283,11 @@ def boundaries : List Boundary :=
     }
   , { id := boundaryGraphPipelineFoundationId
     , domain := "GraphPipeline"
-    , subject := "foundation model before compiler and persistence refinement"
+    , subject := "pure compiler before persistence refinement"
     , statement :=
-        "Proofs.GraphPipeline establishes publication readiness, active-pointer alignment, immutable revision identity, and run pinning. This foundation slice has no shipping compiler, GraphRevision/GraphRun storage schema, activation controller, or runtime visibility filter, so it makes no Rust refinement claim yet."
+        "Proofs.GraphPipeline establishes publication readiness, active-pointer alignment, immutable revision identity, and run pinning. The pure GraphIntent compiler is fenced against the model's exhaustive validation conjunction, but this slice has no GraphRevision/GraphRun storage schema, activation controller, or runtime visibility filter, so persisted lifecycle refinement remains outside the claim."
     , acceptedFollowUp :=
-        some "The immediately stacked compiler and publication/runtime pull requests replace this boundary with pure-compiler conformance and persisted lifecycle end-to-end fences."
+        some "The immediately stacked publication/runtime pull request replaces the remaining boundary with persisted lifecycle and visibility end-to-end fences."
     }
   , { id := boundaryRenderedCaptureAssembledRequestArtifactId
     , domain := "RenderedCapture"

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -28,6 +28,7 @@ import Proofs.Conformance.Deviations
 import Proofs.Conformance.CoverageLedger
 import Proofs.Identity.Conformance
 import Proofs.Conformance.EventDelivery
+import Proofs.Conformance.GraphPipeline
 
 namespace Conformance.Contracts
 
@@ -40,6 +41,8 @@ def snapshotJson : String :=
       ++ jsonArray (vocabularies.map VocabularyContract.toJson) ++ ","
     ++ "\"state_machines\":"
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
+    ++ "\"graph_pipeline_validation_cases\":"
+      ++ Conformance.GraphPipelineContracts.validationCasesJson ++ ","
     ++ "\"request_transition_cases\":"
       ++ jsonArray (requestTransitionCases.map lifecycleTransitionCaseJson) ++ ","
     ++ "\"process_transition_cases\":"

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -143,6 +143,15 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , required := [Surface.runtimeInternal]
     , deferred := []
     }
+  , { feature := "graph-pipeline"
+    , required := [Surface.runtimeInternal]
+    , deferred :=
+        [ (Surface.agentFacing, "stack slice 4: bounded model tools")
+        , (Surface.operatorCli, "stack slice 3: publication controller")
+        , (Surface.operatorUi, "post-experiment graduation surface")
+        , (Surface.api, "post-experiment graduation surface")
+        ]
+    }
   , { feature := "session-recovery"
     , required := [Surface.runtimeInternal]
     , deferred := []
@@ -699,6 +708,11 @@ def caseCoverage : List CoverageEntry :=
       "RecoverySweepCases"
       "conformance::generated_recovery_sweep_cases_drive_startup_recovery_contract")
       "recovery" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "graph_pipeline_validation_cases"
+      "GraphPipelineValidationCases"
+      "conformance::graph_pipeline::generated_validation_cases_fence_whole_graph_compilation_gate")
+      "graph-pipeline" [Surface.runtimeInternal]
   , tagged (consumerCoverage
       "recovery_equivalence_cases"
       "RecoveryEquivalenceCases"

--- a/crates/gents/proofs/Proofs/Conformance/GraphPipeline.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GraphPipeline.lean
@@ -1,0 +1,55 @@
+import Proofs.GraphPipeline
+import Proofs.Conformance.ContractTypes
+
+namespace Conformance.GraphPipelineContracts
+
+open Conformance.Contracts
+
+structure ValidationCase where
+  name : String
+  typesValid : Bool
+  topologyValid : Bool
+  capabilitiesAuthorized : Bool
+  withinBounds : Bool
+  expectedValid : Bool
+  deriving DecidableEq, Repr
+
+def boolValues : List Bool := [false, true]
+
+def validationCases : List ValidationCase :=
+  boolValues.flatMap fun typesValid =>
+    boolValues.flatMap fun topologyValid =>
+      boolValues.flatMap fun capabilitiesAuthorized =>
+        boolValues.map fun withinBounds =>
+          { name :=
+              "types=" ++ toString typesValid ++
+              ",topology=" ++ toString topologyValid ++
+              ",authorized=" ++ toString capabilitiesAuthorized ++
+              ",bounds=" ++ toString withinBounds
+          , typesValid := typesValid
+          , topologyValid := topologyValid
+          , capabilitiesAuthorized := capabilitiesAuthorized
+          , withinBounds := withinBounds
+          , expectedValid :=
+              typesValid && topologyValid && capabilitiesAuthorized && withinBounds
+          }
+
+theorem validationCases_count : validationCases.length = 16 := by native_decide
+
+private def boolJson (value : Bool) : String :=
+  if value then "true" else "false"
+
+def validationCaseJson (testCase : ValidationCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString testCase.name ++ ","
+    ++ "\"types_valid\":" ++ boolJson testCase.typesValid ++ ","
+    ++ "\"topology_valid\":" ++ boolJson testCase.topologyValid ++ ","
+    ++ "\"capabilities_authorized\":" ++ boolJson testCase.capabilitiesAuthorized ++ ","
+    ++ "\"within_bounds\":" ++ boolJson testCase.withinBounds ++ ","
+    ++ "\"expected_valid\":" ++ boolJson testCase.expectedValid
+    ++ "}"
+
+def validationCasesJson : String :=
+  jsonArray (validationCases.map validationCaseJson)
+
+end Conformance.GraphPipelineContracts

--- a/crates/gents/src/graph_pipeline/compiler.rs
+++ b/crates/gents/src/graph_pipeline/compiler.rs
@@ -1,0 +1,733 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use super::types::{
+    DeliveryMode, Diagnostic, DiagnosticCode, GraphIntent, GraphPlan, PlannedEdge, PlannedEntry,
+    PlannedNode, PortCardinality, PortRef, PortSpec, StageCapability, COMPILER_VERSION,
+};
+use crate::graphql::{
+    validate_collection_identifier, validate_graphql_filter_fragment, validate_graphql_name,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompilerPolicy {
+    pub max_nodes: u32,
+    pub max_edges: u32,
+    pub max_depth: u32,
+    pub max_fan_out: u32,
+    pub max_group_size: u32,
+}
+
+impl Default for CompilerPolicy {
+    fn default() -> Self {
+        Self {
+            max_nodes: 64,
+            max_edges: 256,
+            max_depth: 32,
+            max_fan_out: 16,
+            max_group_size: 256,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[error("graph intent failed whole-graph validation")]
+pub struct GraphCompileError {
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+fn diagnostic(
+    diagnostics: &mut Vec<Diagnostic>,
+    code: DiagnosticCode,
+    path: impl Into<String>,
+    message: impl Into<String>,
+) {
+    diagnostics.push(Diagnostic {
+        code,
+        path: path.into(),
+        message: message.into(),
+    });
+}
+
+fn input_port<'a>(capability: &'a StageCapability, name: &str) -> Option<&'a PortSpec> {
+    capability.input_ports.iter().find(|port| port.name == name)
+}
+
+fn output_port<'a>(capability: &'a StageCapability, name: &str) -> Option<&'a PortSpec> {
+    capability
+        .output_ports
+        .iter()
+        .find(|port| port.name == name)
+}
+
+fn delivery_sort_key(delivery: &DeliveryMode) -> (u8, u32) {
+    match delivery {
+        DeliveryMode::PerDocument => (0, 0),
+        DeliveryMode::PerGroup { expected_count } => (1, *expected_count),
+    }
+}
+
+fn sorted_diagnostics(diagnostics: &mut [Diagnostic]) {
+    diagnostics.sort_by(|left, right| {
+        (&left.path, &left.code, &left.message).cmp(&(&right.path, &right.code, &right.message))
+    });
+}
+
+fn check_requested_limits(
+    intent: &GraphIntent,
+    policy: &CompilerPolicy,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let requested = &intent.limits;
+    let platform = [
+        ("max_nodes", requested.max_nodes, policy.max_nodes),
+        ("max_edges", requested.max_edges, policy.max_edges),
+        ("max_depth", requested.max_depth, policy.max_depth),
+        ("max_fan_out", requested.max_fan_out, policy.max_fan_out),
+    ];
+    for (name, value, ceiling) in platform {
+        if value > ceiling {
+            diagnostic(
+                diagnostics,
+                DiagnosticCode::PlatformLimitExceeded,
+                format!("/limits/{name}"),
+                format!("requested {value}, platform ceiling is {ceiling}"),
+            );
+        }
+    }
+
+    let node_count = intent.nodes.len() as u32;
+    if node_count > requested.max_nodes {
+        diagnostic(
+            diagnostics,
+            DiagnosticCode::NodeLimitExceeded,
+            "/nodes",
+            format!(
+                "graph has {node_count} nodes, limit is {}",
+                requested.max_nodes
+            ),
+        );
+    }
+    let edge_count = intent.edges.len() as u32;
+    if edge_count > requested.max_edges {
+        diagnostic(
+            diagnostics,
+            DiagnosticCode::EdgeLimitExceeded,
+            "/edges",
+            format!(
+                "graph has {edge_count} edges, limit is {}",
+                requested.max_edges
+            ),
+        );
+    }
+}
+
+fn validate_capability_ports(
+    capability: &StageCapability,
+    node_path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for (kind, ports) in [
+        ("input_ports", &capability.input_ports),
+        ("output_ports", &capability.output_ports),
+    ] {
+        let mut seen = BTreeSet::new();
+        for port in ports {
+            if !seen.insert(&port.name) {
+                diagnostic(
+                    diagnostics,
+                    DiagnosticCode::DuplicatePort,
+                    format!("{node_path}/capability/{kind}"),
+                    format!(
+                        "capability {}@{} declares port {:?} more than once",
+                        capability.capability_id, capability.revision, port.name
+                    ),
+                );
+            }
+            if validate_collection_identifier(&port.collection).is_err() {
+                diagnostic(
+                    diagnostics,
+                    DiagnosticCode::InvalidCollection,
+                    format!("{node_path}/capability/{kind}/{}", port.name),
+                    format!(
+                        "capability {}@{} declares invalid collection {:?}",
+                        capability.capability_id, capability.revision, port.collection
+                    ),
+                );
+            }
+            if validate_graphql_name(&port.correlation_field).is_err() {
+                diagnostic(
+                    diagnostics,
+                    DiagnosticCode::InvalidCorrelationField,
+                    format!("{node_path}/capability/{kind}/{}", port.name),
+                    format!(
+                        "capability {}@{} declares invalid correlation field {:?}",
+                        capability.capability_id, capability.revision, port.correlation_field
+                    ),
+                );
+            }
+        }
+    }
+}
+
+/// Compile an untrusted intent without performing I/O.
+///
+/// Capabilities must come from the caller-visible, operator-approved catalog.
+/// Empty `allowed_callers` lists deny access. Every diagnostic is stable-sorted
+/// so a model can repair a proposal deterministically.
+pub fn compile_graph(
+    intent: &GraphIntent,
+    capabilities: &[StageCapability],
+    caller_did: &str,
+    policy: &CompilerPolicy,
+) -> Result<GraphPlan, GraphCompileError> {
+    let mut diagnostics = Vec::new();
+    if intent.graph_id.trim().is_empty() {
+        diagnostic(
+            &mut diagnostics,
+            DiagnosticCode::EmptyGraphId,
+            "/graph_id",
+            "graph_id must not be empty",
+        );
+    }
+    if intent.nodes.is_empty() {
+        diagnostic(
+            &mut diagnostics,
+            DiagnosticCode::EmptyGraph,
+            "/nodes",
+            "a graph must contain at least one node",
+        );
+    }
+    check_requested_limits(intent, policy, &mut diagnostics);
+
+    let mut catalog = BTreeMap::new();
+    for capability in capabilities {
+        let key = (
+            capability.capability_id.as_str(),
+            capability.revision.as_str(),
+        );
+        if catalog.insert(key, capability).is_some() {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::DuplicateCapability,
+                format!(
+                    "/capabilities/{}@{}",
+                    capability.capability_id, capability.revision
+                ),
+                "the capability catalog contains a duplicate id and revision",
+            );
+        }
+    }
+    let capability_ids: BTreeSet<&str> = capabilities
+        .iter()
+        .map(|capability| capability.capability_id.as_str())
+        .collect();
+
+    let mut nodes = BTreeSet::new();
+    let mut resolved = BTreeMap::new();
+    for (index, node) in intent.nodes.iter().enumerate() {
+        let node_path = format!("/nodes/{index}");
+        if !nodes.insert(node.node_id.as_str()) {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::DuplicateNode,
+                format!("{node_path}/node_id"),
+                format!("node {:?} is declared more than once", node.node_id),
+            );
+            continue;
+        }
+        let Some(capability) = catalog.get(&(
+            node.capability_id.as_str(),
+            node.capability_revision.as_str(),
+        )) else {
+            let (code, message) = if capability_ids.contains(node.capability_id.as_str()) {
+                (
+                    DiagnosticCode::CapabilityRevisionMismatch,
+                    format!(
+                        "capability {:?} has no approved revision {:?}",
+                        node.capability_id, node.capability_revision
+                    ),
+                )
+            } else {
+                (
+                    DiagnosticCode::UnknownCapability,
+                    format!(
+                        "capability {:?} is not in the approved catalog",
+                        node.capability_id
+                    ),
+                )
+            };
+            diagnostic(
+                &mut diagnostics,
+                code,
+                format!("{node_path}/capability_id"),
+                message,
+            );
+            continue;
+        };
+        validate_capability_ports(capability, &node_path, &mut diagnostics);
+        if !capability
+            .allowed_callers
+            .iter()
+            .any(|allowed| allowed == caller_did)
+        {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnauthorizedCapability,
+                format!("{node_path}/capability_id"),
+                format!(
+                    "caller {caller_did:?} may not compose capability {:?}",
+                    capability.capability_id
+                ),
+            );
+        }
+        resolved.insert(node.node_id.as_str(), *capability);
+    }
+
+    // EventTrigger routes by physical collection, not producer node. Reusing
+    // one output collection for two graph nodes would make `from.node_id`
+    // decorative, so v1 rejects that ambiguity instead of approximating it.
+    let mut output_collections = BTreeMap::new();
+    for (node_id, capability) in &resolved {
+        for port in &capability.output_ports {
+            if let Some(previous) = output_collections.insert(port.collection.as_str(), *node_id) {
+                if previous != *node_id {
+                    diagnostic(
+                        &mut diagnostics,
+                        DiagnosticCode::DuplicateOutputCollection,
+                        format!("/nodes/{node_id}/outputs/{}", port.name),
+                        format!(
+                            "output collection {:?} is already produced by node {previous:?}",
+                            port.collection
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    let mut incoming: BTreeMap<PortRef, u32> = BTreeMap::new();
+    let mut adjacency: BTreeMap<&str, BTreeSet<&str>> = nodes
+        .iter()
+        .copied()
+        .map(|node_id| (node_id, BTreeSet::new()))
+        .collect();
+    let mut fan_out: BTreeMap<&str, u32> = BTreeMap::new();
+
+    for (index, edge) in intent.edges.iter().enumerate() {
+        let path = format!("/edges/{index}");
+        let source_node = nodes.contains(edge.from.node_id.as_str());
+        let target_node = nodes.contains(edge.to.node_id.as_str());
+        if !source_node {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownNode,
+                format!("{path}/from/node_id"),
+                format!("unknown source node {:?}", edge.from.node_id),
+            );
+        }
+        if !target_node {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownNode,
+                format!("{path}/to/node_id"),
+                format!("unknown target node {:?}", edge.to.node_id),
+            );
+        }
+        let source_port = resolved
+            .get(edge.from.node_id.as_str())
+            .and_then(|capability| output_port(capability, &edge.from.port));
+        let target_port = resolved
+            .get(edge.to.node_id.as_str())
+            .and_then(|capability| input_port(capability, &edge.to.port));
+        if source_node && source_port.is_none() {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownPort,
+                format!("{path}/from/port"),
+                format!("unknown output port {:?}", edge.from.port),
+            );
+        }
+        if target_node && target_port.is_none() {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownPort,
+                format!("{path}/to/port"),
+                format!("unknown input port {:?}", edge.to.port),
+            );
+        }
+        if let (Some(source_port), Some(target_port)) = (source_port, target_port) {
+            if source_port.schema != target_port.schema
+                || source_port.collection != target_port.collection
+            {
+                diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::SchemaMismatch,
+                    path.clone(),
+                    format!(
+                        "source collection/schema {:?}/{:?} does not match target {:?}/{:?}",
+                        source_port.collection,
+                        source_port.schema,
+                        target_port.collection,
+                        target_port.schema
+                    ),
+                );
+            }
+            if source_port.correlation_field != target_port.correlation_field {
+                diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::CorrelationMismatch,
+                    path.clone(),
+                    format!(
+                        "source correlation field {:?} does not match target {:?}",
+                        source_port.correlation_field, target_port.correlation_field
+                    ),
+                );
+            }
+            let cardinality_valid = match edge.delivery {
+                DeliveryMode::PerDocument => source_port.cardinality == target_port.cardinality,
+                DeliveryMode::PerGroup { .. } => {
+                    source_port.cardinality == PortCardinality::One
+                        && target_port.cardinality == PortCardinality::Many
+                }
+            };
+            if !cardinality_valid {
+                diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::CardinalityMismatch,
+                    format!("{path}/delivery"),
+                    "delivery mode is incompatible with the connected port cardinalities",
+                );
+            }
+        }
+        if let DeliveryMode::PerGroup { expected_count } = edge.delivery {
+            if expected_count < 2 || expected_count > policy.max_group_size {
+                diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::InvalidGroupSize,
+                    format!("{path}/delivery/expected_count"),
+                    format!(
+                        "per-group size must be between 2 and {}",
+                        policy.max_group_size
+                    ),
+                );
+            }
+        }
+        if let Some(predicate) = edge.predicate.as_deref() {
+            if validate_graphql_filter_fragment(predicate).is_err() {
+                diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::InvalidPredicate,
+                    format!("{path}/predicate"),
+                    "predicate is not a safe GraphQL filter fragment",
+                );
+            }
+        }
+        if target_port.is_some() {
+            *incoming.entry(edge.to.clone()).or_default() += 1;
+        }
+        if source_node && target_node {
+            adjacency
+                .entry(edge.from.node_id.as_str())
+                .or_default()
+                .insert(edge.to.node_id.as_str());
+            *fan_out.entry(edge.from.node_id.as_str()).or_default() += 1;
+        }
+    }
+
+    let mut entry_names = BTreeSet::new();
+    let mut entry_nodes = BTreeSet::new();
+    for (index, entry) in intent.entries.iter().enumerate() {
+        let path = format!("/entries/{index}");
+        if !entry_names.insert(entry.name.as_str()) {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::DuplicateEntry,
+                format!("{path}/name"),
+                format!("entry {:?} is declared more than once", entry.name),
+            );
+        }
+        let target_node = nodes.contains(entry.to.node_id.as_str());
+        if !target_node {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownNode,
+                format!("{path}/to/node_id"),
+                format!("unknown target node {:?}", entry.to.node_id),
+            );
+            continue;
+        }
+        let target_port = resolved
+            .get(entry.to.node_id.as_str())
+            .and_then(|capability| input_port(capability, &entry.to.port));
+        let Some(target_port) = target_port else {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownPort,
+                format!("{path}/to/port"),
+                format!("unknown input port {:?}", entry.to.port),
+            );
+            continue;
+        };
+        if entry.schema != target_port.schema {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::SchemaMismatch,
+                format!("{path}/schema"),
+                format!(
+                    "entry schema {:?} does not match target schema {:?}",
+                    entry.schema, target_port.schema
+                ),
+            );
+        }
+        if entry.collection != target_port.collection {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::SchemaMismatch,
+                format!("{path}/collection"),
+                format!(
+                    "entry collection {:?} does not match approved target collection {:?}",
+                    entry.collection, target_port.collection
+                ),
+            );
+        }
+        if target_port.cardinality != PortCardinality::One {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::CardinalityMismatch,
+                format!("{path}/to"),
+                "a v1 entry binds exactly one document and requires a one-valued input",
+            );
+        }
+        *incoming.entry(entry.to.clone()).or_default() += 1;
+        entry_nodes.insert(entry.to.node_id.as_str());
+    }
+
+    for (node_id, capability) in &resolved {
+        for port in capability.input_ports.iter().filter(|port| port.required) {
+            let port_ref = PortRef {
+                node_id: (*node_id).to_owned(),
+                port: port.name.clone(),
+            };
+            match incoming.get(&port_ref).copied().unwrap_or_default() {
+                0 => diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::MissingInputBinding,
+                    format!("/nodes/{node_id}/inputs/{}", port.name),
+                    "required input has no entry or inbound edge",
+                ),
+                1 => {}
+                count => diagnostic(
+                    &mut diagnostics,
+                    DiagnosticCode::MultipleInputBindings,
+                    format!("/nodes/{node_id}/inputs/{}", port.name),
+                    format!("required input has {count} bindings; exactly one is allowed"),
+                ),
+            }
+        }
+    }
+
+    for (node_id, count) in fan_out {
+        if count > intent.limits.max_fan_out {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::FanOutLimitExceeded,
+                format!("/nodes/{node_id}/fan_out"),
+                format!(
+                    "node fan-out is {count}, limit is {}",
+                    intent.limits.max_fan_out
+                ),
+            );
+        }
+    }
+
+    let mut reachable = entry_nodes.clone();
+    let mut queue: VecDeque<&str> = entry_nodes.into_iter().collect();
+    while let Some(node_id) = queue.pop_front() {
+        for target in adjacency.get(node_id).into_iter().flatten() {
+            if reachable.insert(target) {
+                queue.push_back(target);
+            }
+        }
+    }
+    for node_id in &nodes {
+        if !reachable.contains(node_id) {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnreachableNode,
+                format!("/nodes/{node_id}"),
+                "node is not reachable from an entry binding",
+            );
+        }
+    }
+
+    let mut indegree: BTreeMap<&str, u32> =
+        nodes.iter().copied().map(|node_id| (node_id, 0)).collect();
+    for targets in adjacency.values() {
+        for target in targets {
+            *indegree.entry(target).or_default() += 1;
+        }
+    }
+    let mut topo_queue: VecDeque<&str> = indegree
+        .iter()
+        .filter_map(|(node_id, degree)| (*degree == 0).then_some(*node_id))
+        .collect();
+    let mut visited = 0_usize;
+    let mut depth: BTreeMap<&str, u32> = indegree
+        .keys()
+        .copied()
+        .map(|node_id| (node_id, 1))
+        .collect();
+    while let Some(node_id) = topo_queue.pop_front() {
+        visited += 1;
+        let source_depth = depth.get(node_id).copied().unwrap_or(1);
+        for target in adjacency.get(node_id).into_iter().flatten() {
+            depth
+                .entry(target)
+                .and_modify(|value| *value = (*value).max(source_depth.saturating_add(1)));
+            let degree = indegree.entry(target).or_default();
+            *degree -= 1;
+            if *degree == 0 {
+                topo_queue.push_back(target);
+            }
+        }
+    }
+    if visited != nodes.len() {
+        diagnostic(
+            &mut diagnostics,
+            DiagnosticCode::Cycle,
+            "/edges",
+            "v1 graph intents must be acyclic",
+        );
+    } else if let Some(actual_depth) = depth.values().max().copied() {
+        if actual_depth > intent.limits.max_depth {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::DepthLimitExceeded,
+                "/limits/max_depth",
+                format!(
+                    "graph depth is {actual_depth}, limit is {}",
+                    intent.limits.max_depth
+                ),
+            );
+        }
+    }
+
+    if !diagnostics.is_empty() {
+        sorted_diagnostics(&mut diagnostics);
+        return Err(GraphCompileError { diagnostics });
+    }
+
+    let mut planned_nodes: Vec<PlannedNode> = intent
+        .nodes
+        .iter()
+        .map(|node| {
+            let capability = resolved[node.node_id.as_str()];
+            PlannedNode {
+                node_id: node.node_id.clone(),
+                capability_id: capability.capability_id.clone(),
+                capability_revision: capability.revision.clone(),
+                task_id: capability.task_id.clone(),
+            }
+        })
+        .collect();
+    planned_nodes.sort_by(|left, right| left.node_id.cmp(&right.node_id));
+
+    let mut edges: Vec<PlannedEdge> = intent
+        .edges
+        .iter()
+        .map(|edge| {
+            let source_capability = resolved[edge.from.node_id.as_str()];
+            let source_port = output_port(source_capability, &edge.from.port)
+                .expect("validated source port must resolve");
+            PlannedEdge {
+                from: edge.from.clone(),
+                to: edge.to.clone(),
+                source_collection: source_port.collection.clone(),
+                target_task_id: resolved[edge.to.node_id.as_str()].task_id.clone(),
+                correlation_field: source_port.correlation_field.clone(),
+                delivery: edge.delivery.clone(),
+                predicate: edge.predicate.clone(),
+            }
+        })
+        .collect();
+    edges.sort_by(|left, right| {
+        (
+            &left.from,
+            &left.to,
+            delivery_sort_key(&left.delivery),
+            &left.predicate,
+        )
+            .cmp(&(
+                &right.from,
+                &right.to,
+                delivery_sort_key(&right.delivery),
+                &right.predicate,
+            ))
+    });
+    let mut entries: Vec<PlannedEntry> = intent
+        .entries
+        .iter()
+        .map(|entry| {
+            let target_capability = resolved[entry.to.node_id.as_str()];
+            let target_port = input_port(target_capability, &entry.to.port)
+                .expect("validated target port must resolve");
+            PlannedEntry {
+                name: entry.name.clone(),
+                collection: target_port.collection.clone(),
+                schema: target_port.schema.clone(),
+                to: entry.to.clone(),
+                target_task_id: target_capability.task_id.clone(),
+                correlation_field: target_port.correlation_field.clone(),
+            }
+        })
+        .collect();
+    entries.sort_by(|left, right| {
+        (&left.name, &left.schema, &left.to).cmp(&(&right.name, &right.schema, &right.to))
+    });
+
+    let mut plan = GraphPlan {
+        compiler_version: COMPILER_VERSION.to_owned(),
+        graph_id: intent.graph_id.clone(),
+        digest: String::new(),
+        nodes: planned_nodes,
+        edges,
+        entries,
+        limits: intent.limits.clone(),
+    };
+    plan.digest = graph_plan_digest(&plan);
+    Ok(plan)
+}
+
+/// Recompute the content identity of a plan while excluding its `digest`
+/// field. Publication controllers use this to reject a tampered plan before
+/// materializing any artifact.
+pub fn graph_plan_digest(plan: &GraphPlan) -> String {
+    #[derive(Serialize)]
+    struct DigestPayload<'a> {
+        compiler_version: &'a str,
+        graph_id: &'a str,
+        nodes: &'a [PlannedNode],
+        edges: &'a [PlannedEdge],
+        entries: &'a [PlannedEntry],
+        limits: &'a super::types::GraphLimits,
+    }
+
+    let bytes = serde_json::to_vec(&DigestPayload {
+        compiler_version: &plan.compiler_version,
+        graph_id: &plan.graph_id,
+        nodes: &plan.nodes,
+        edges: &plan.edges,
+        entries: &plan.entries,
+        limits: &plan.limits,
+    })
+    .expect("GraphPlan contains only infallibly serializable fields");
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+pub fn verify_graph_plan_digest(plan: &GraphPlan) -> bool {
+    plan.digest == graph_plan_digest(plan)
+}

--- a/crates/gents/src/graph_pipeline/mod.rs
+++ b/crates/gents/src/graph_pipeline/mod.rs
@@ -1,0 +1,20 @@
+//! Pure compiler for model-proposed document graphs.
+//!
+//! Inputs to this module are untrusted proposals. Compilation resolves only
+//! operator-approved stage capabilities and performs no I/O. Persistence and
+//! activation live behind a separate controller boundary.
+
+mod compiler;
+mod types;
+
+pub use compiler::{
+    compile_graph, graph_plan_digest, verify_graph_plan_digest, CompilerPolicy, GraphCompileError,
+};
+pub use types::{
+    DeliveryMode, Diagnostic, DiagnosticCode, EntryBinding, GraphEdge, GraphIntent, GraphLimits,
+    GraphNode, GraphPlan, PlannedEdge, PlannedEntry, PlannedNode, PortCardinality, PortRef,
+    PortSpec, StageCapability, COMPILER_VERSION,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/gents/src/graph_pipeline/tests.rs
+++ b/crates/gents/src/graph_pipeline/tests.rs
@@ -1,0 +1,372 @@
+use super::*;
+
+fn one_port(name: &str, schema: &str, required: bool) -> PortSpec {
+    PortSpec {
+        name: name.to_owned(),
+        collection: schema.split('/').next().unwrap_or(schema).to_owned(),
+        schema: schema.to_owned(),
+        correlation_field: "graph_run_id".to_owned(),
+        cardinality: PortCardinality::One,
+        required,
+    }
+}
+
+fn many_port(name: &str, schema: &str, required: bool) -> PortSpec {
+    PortSpec {
+        name: name.to_owned(),
+        collection: schema.split('/').next().unwrap_or(schema).to_owned(),
+        schema: schema.to_owned(),
+        correlation_field: "graph_run_id".to_owned(),
+        cardinality: PortCardinality::Many,
+        required,
+    }
+}
+
+fn capability(
+    id: &str,
+    behavior: &str,
+    inputs: Vec<PortSpec>,
+    outputs: Vec<PortSpec>,
+) -> StageCapability {
+    StageCapability {
+        capability_id: id.to_owned(),
+        revision: "v1".to_owned(),
+        task_id: behavior.to_owned(),
+        input_ports: inputs,
+        output_ports: outputs,
+        allowed_callers: vec!["did:key:composer".to_owned()],
+    }
+}
+
+fn catalog() -> Vec<StageCapability> {
+    vec![
+        capability(
+            "extract",
+            "extract-behavior",
+            vec![one_port("job", "ExperimentJob/v1", true)],
+            vec![one_port("finding", "ExperimentFinding/v1", false)],
+        ),
+        capability(
+            "review",
+            "review-behavior",
+            vec![one_port("finding", "ExperimentFinding/v1", true)],
+            vec![],
+        ),
+    ]
+}
+
+fn linear_intent() -> GraphIntent {
+    GraphIntent {
+        graph_id: "review-pipeline".to_owned(),
+        nodes: vec![
+            GraphNode {
+                node_id: "extract".to_owned(),
+                capability_id: "extract".to_owned(),
+                capability_revision: "v1".to_owned(),
+            },
+            GraphNode {
+                node_id: "review".to_owned(),
+                capability_id: "review".to_owned(),
+                capability_revision: "v1".to_owned(),
+            },
+        ],
+        edges: vec![GraphEdge {
+            from: PortRef {
+                node_id: "extract".to_owned(),
+                port: "finding".to_owned(),
+            },
+            to: PortRef {
+                node_id: "review".to_owned(),
+                port: "finding".to_owned(),
+            },
+            delivery: DeliveryMode::PerDocument,
+            predicate: None,
+        }],
+        entries: vec![EntryBinding {
+            name: "job".to_owned(),
+            collection: "ExperimentJob".to_owned(),
+            schema: "ExperimentJob/v1".to_owned(),
+            to: PortRef {
+                node_id: "extract".to_owned(),
+                port: "job".to_owned(),
+            },
+        }],
+        limits: GraphLimits {
+            max_nodes: 8,
+            max_edges: 16,
+            max_depth: 8,
+            max_fan_out: 4,
+        },
+    }
+}
+
+fn compile(
+    intent: &GraphIntent,
+    capabilities: &[StageCapability],
+) -> Result<GraphPlan, GraphCompileError> {
+    compile_graph(
+        intent,
+        capabilities,
+        "did:key:composer",
+        &CompilerPolicy::default(),
+    )
+}
+
+fn has_code(error: &GraphCompileError, code: DiagnosticCode) -> bool {
+    error
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == code)
+}
+
+#[test]
+fn compiles_typed_linear_graph_and_resolves_existing_tasks() {
+    let plan = compile(&linear_intent(), &catalog()).expect("valid plan");
+
+    assert_eq!(plan.compiler_version, COMPILER_VERSION);
+    assert!(plan.digest.starts_with("sha256:"));
+    assert_eq!(plan.nodes[0].task_id, "extract-behavior");
+    assert_eq!(plan.nodes[1].task_id, "review-behavior");
+    assert_eq!(plan.edges[0].source_collection, "ExperimentFinding");
+    assert_eq!(plan.edges[0].correlation_field, "graph_run_id");
+    assert_eq!(plan.entries[0].correlation_field, "graph_run_id");
+}
+
+#[test]
+fn rejects_collection_and_correlation_mismatches() {
+    let mut capabilities = catalog();
+    capabilities[1].input_ports[0].collection = "OtherFinding".to_owned();
+    capabilities[1].input_ports[0].correlation_field = "other_run_id".to_owned();
+
+    let error = compile(&linear_intent(), &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::SchemaMismatch));
+    assert!(has_code(&error, DiagnosticCode::CorrelationMismatch));
+
+    capabilities[1].input_ports[0].correlation_field = "not-valid!".to_owned();
+    let error = compile(&linear_intent(), &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::InvalidCorrelationField));
+
+    capabilities[1].input_ports[0].collection = "not-valid!".to_owned();
+    let error = compile(&linear_intent(), &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::InvalidCollection));
+}
+
+#[test]
+fn rejects_unsafe_predicates_and_ambiguous_output_collections() {
+    let mut intent = linear_intent();
+    intent.edges[0].predicate = Some("x: { _eq: 1 } }) { Task { task_id } } #".to_owned());
+    let error = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::InvalidPredicate));
+
+    let mut capabilities = catalog();
+    capabilities[1]
+        .output_ports
+        .push(one_port("duplicate", "ExperimentFinding/v1", false));
+    let error = compile(&linear_intent(), &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::DuplicateOutputCollection));
+}
+
+#[test]
+fn canonical_plan_and_digest_ignore_proposal_order() {
+    let first = compile(&linear_intent(), &catalog()).unwrap();
+    let mut reordered = linear_intent();
+    reordered.nodes.reverse();
+    reordered.entries.reverse();
+    reordered.edges.reverse();
+    let second = compile(&reordered, &catalog()).unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(
+        serde_json::to_vec(&first).unwrap(),
+        serde_json::to_vec(&second).unwrap()
+    );
+}
+
+#[test]
+fn plan_digest_verification_rejects_semantic_tampering() {
+    let mut plan = compile(&linear_intent(), &catalog()).unwrap();
+    assert!(verify_graph_plan_digest(&plan));
+
+    plan.nodes[0].task_id = "attacker-selected-task".to_owned();
+    assert!(!verify_graph_plan_digest(&plan));
+}
+
+#[test]
+fn empty_allowlist_denies_capability() {
+    let mut capabilities = catalog();
+    capabilities[0].allowed_callers.clear();
+
+    let error = compile(&linear_intent(), &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::UnauthorizedCapability));
+}
+
+#[test]
+fn unknown_capability_and_unapproved_revision_are_distinct() {
+    let mut intent = linear_intent();
+    intent.nodes[0].capability_id = "missing".to_owned();
+    let unknown = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(&unknown, DiagnosticCode::UnknownCapability));
+
+    intent.nodes[0].capability_id = "extract".to_owned();
+    intent.nodes[0].capability_revision = "v2".to_owned();
+    let revision = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(
+        &revision,
+        DiagnosticCode::CapabilityRevisionMismatch
+    ));
+}
+
+#[test]
+fn rejects_unknown_ports_and_schema_mismatches() {
+    let mut intent = linear_intent();
+    intent.edges[0].from.port = "missing".to_owned();
+    intent.entries[0].schema = "Wrong/v1".to_owned();
+
+    let error = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::UnknownPort));
+    assert!(has_code(&error, DiagnosticCode::SchemaMismatch));
+}
+
+#[test]
+fn per_group_requires_one_to_many_and_a_bounded_group() {
+    let mut capabilities = catalog();
+    capabilities[1].input_ports[0] = many_port("finding", "ExperimentFinding/v1", true);
+    let mut intent = linear_intent();
+    intent.edges[0].delivery = DeliveryMode::PerGroup { expected_count: 3 };
+    assert!(compile(&intent, &capabilities).is_ok());
+
+    intent.edges[0].delivery = DeliveryMode::PerGroup { expected_count: 1 };
+    let error = compile(&intent, &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::InvalidGroupSize));
+}
+
+#[test]
+fn required_input_must_have_exactly_one_binding() {
+    let mut missing = linear_intent();
+    missing.entries.clear();
+    let error = compile(&missing, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::MissingInputBinding));
+
+    let mut duplicate = linear_intent();
+    duplicate.entries.push(EntryBinding {
+        name: "job-again".to_owned(),
+        ..duplicate.entries[0].clone()
+    });
+    let error = compile(&duplicate, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::MultipleInputBindings));
+}
+
+#[test]
+fn rejects_cycles_and_unreachable_nodes() {
+    let mut capabilities = catalog();
+    capabilities[0]
+        .input_ports
+        .push(one_port("review", "Review/v1", false));
+    capabilities[1]
+        .output_ports
+        .push(one_port("review", "Review/v1", false));
+    let mut cyclic = linear_intent();
+    cyclic.edges.push(GraphEdge {
+        from: PortRef {
+            node_id: "review".to_owned(),
+            port: "review".to_owned(),
+        },
+        to: PortRef {
+            node_id: "extract".to_owned(),
+            port: "review".to_owned(),
+        },
+        delivery: DeliveryMode::PerDocument,
+        predicate: None,
+    });
+    let error = compile(&cyclic, &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::Cycle));
+
+    let mut unreachable = linear_intent();
+    unreachable.edges.clear();
+    let error = compile(&unreachable, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::UnreachableNode));
+}
+
+#[test]
+fn rejects_requested_and_actual_resource_limit_violations() {
+    let mut requested = linear_intent();
+    requested.limits.max_nodes = CompilerPolicy::default().max_nodes + 1;
+    let error = compile(&requested, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::PlatformLimitExceeded));
+
+    let mut actual = linear_intent();
+    actual.limits.max_nodes = 1;
+    let error = compile(&actual, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::NodeLimitExceeded));
+}
+
+#[test]
+fn rejects_depth_and_fan_out_over_intent_limits() {
+    let mut depth = linear_intent();
+    depth.limits.max_depth = 1;
+    let error = compile(&depth, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::DepthLimitExceeded));
+
+    let mut fan_out = linear_intent();
+    fan_out.limits.max_fan_out = 0;
+    let error = compile(&fan_out, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::FanOutLimitExceeded));
+}
+
+#[test]
+fn duplicate_nodes_entries_and_capability_ports_fail_closed() {
+    let mut intent = linear_intent();
+    intent.nodes.push(intent.nodes[0].clone());
+    intent.entries.push(intent.entries[0].clone());
+    let mut capabilities = catalog();
+    let duplicate_port = capabilities[0].output_ports[0].clone();
+    capabilities[0].output_ports.push(duplicate_port);
+
+    let error = compile(&intent, &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::DuplicateNode));
+    assert!(has_code(&error, DiagnosticCode::DuplicateEntry));
+    assert!(has_code(&error, DiagnosticCode::DuplicatePort));
+}
+
+#[test]
+fn duplicate_capability_revisions_fail_closed() {
+    let mut capabilities = catalog();
+    capabilities.push(capabilities[0].clone());
+
+    let error = compile(&linear_intent(), &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::DuplicateCapability));
+}
+
+#[test]
+fn diagnostics_are_stably_sorted() {
+    let mut intent = linear_intent();
+    intent.graph_id.clear();
+    intent.entries.clear();
+    let error = compile(&intent, &catalog()).unwrap_err();
+    let keys: Vec<_> = error
+        .diagnostics
+        .iter()
+        .map(|diagnostic| (&diagnostic.path, &diagnostic.code, &diagnostic.message))
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted);
+}
+
+#[test]
+fn intent_schema_rejects_unknown_fields() {
+    let raw = serde_json::json!({
+        "graph_id": "g",
+        "nodes": [],
+        "edges": [],
+        "entries": [],
+        "limits": {
+            "max_nodes": 1,
+            "max_edges": 1,
+            "max_depth": 1,
+            "max_fan_out": 1
+        },
+        "write_directly_to_defradb": true
+    });
+    assert!(serde_json::from_value::<GraphIntent>(raw).is_err());
+}

--- a/crates/gents/src/graph_pipeline/types.rs
+++ b/crates/gents/src/graph_pipeline/types.rs
@@ -1,0 +1,196 @@
+use serde::{Deserialize, Serialize};
+
+pub const COMPILER_VERSION: &str = "graph-intent-v1";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PortCardinality {
+    One,
+    Many,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PortSpec {
+    pub name: String,
+    /// Existing DefraDB collection carried on this port.
+    pub collection: String,
+    /// Stable schema reference used for compile-time compatibility checks.
+    pub schema: String,
+    /// Existing field used by EventTrigger correlation and fan-in.
+    pub correlation_field: String,
+    pub cardinality: PortCardinality,
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Operator-approved interface around an existing Task document.
+///
+/// The model can select a capability revision, but cannot author the Task's
+/// behavior, prompt, tools, model, or output permissions.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StageCapability {
+    pub capability_id: String,
+    pub revision: String,
+    pub task_id: String,
+    #[serde(default)]
+    pub input_ports: Vec<PortSpec>,
+    #[serde(default)]
+    pub output_ports: Vec<PortSpec>,
+    /// Empty means nobody, not everybody.
+    #[serde(default)]
+    pub allowed_callers: Vec<String>,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(deny_unknown_fields)]
+pub struct PortRef {
+    pub node_id: String,
+    pub port: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case", tag = "kind", deny_unknown_fields)]
+pub enum DeliveryMode {
+    PerDocument,
+    PerGroup { expected_count: u32 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GraphNode {
+    pub node_id: String,
+    pub capability_id: String,
+    pub capability_revision: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GraphEdge {
+    pub from: PortRef,
+    pub to: PortRef,
+    pub delivery: DeliveryMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EntryBinding {
+    pub name: String,
+    pub collection: String,
+    pub schema: String,
+    pub to: PortRef,
+}
+
+/// Structural compiler limits. These bound authoring work only; execution
+/// limits remain the responsibility of the existing task/trigger runtime.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GraphLimits {
+    pub max_nodes: u32,
+    pub max_edges: u32,
+    pub max_depth: u32,
+    pub max_fan_out: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GraphIntent {
+    pub graph_id: String,
+    pub nodes: Vec<GraphNode>,
+    #[serde(default)]
+    pub edges: Vec<GraphEdge>,
+    pub entries: Vec<EntryBinding>,
+    pub limits: GraphLimits,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticCode {
+    EmptyGraphId,
+    EmptyGraph,
+    DuplicateNode,
+    DuplicateEntry,
+    DuplicateCapability,
+    DuplicatePort,
+    DuplicateOutputCollection,
+    UnknownCapability,
+    CapabilityRevisionMismatch,
+    UnauthorizedCapability,
+    UnknownNode,
+    UnknownPort,
+    InvalidCollection,
+    InvalidCorrelationField,
+    InvalidPredicate,
+    SchemaMismatch,
+    CorrelationMismatch,
+    CardinalityMismatch,
+    InvalidGroupSize,
+    MultipleInputBindings,
+    MissingInputBinding,
+    UnreachableNode,
+    Cycle,
+    NodeLimitExceeded,
+    EdgeLimitExceeded,
+    DepthLimitExceeded,
+    FanOutLimitExceeded,
+    PlatformLimitExceeded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Diagnostic {
+    pub code: DiagnosticCode,
+    /// Stable JSON-pointer-like location in the submitted intent.
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlannedNode {
+    pub node_id: String,
+    pub capability_id: String,
+    pub capability_revision: String,
+    pub task_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlannedEdge {
+    pub from: PortRef,
+    pub to: PortRef,
+    pub source_collection: String,
+    pub target_task_id: String,
+    pub correlation_field: String,
+    pub delivery: DeliveryMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub predicate: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlannedEntry {
+    pub name: String,
+    pub collection: String,
+    pub schema: String,
+    pub to: PortRef,
+    pub target_task_id: String,
+    pub correlation_field: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GraphPlan {
+    pub compiler_version: String,
+    pub graph_id: String,
+    pub digest: String,
+    pub nodes: Vec<PlannedNode>,
+    pub edges: Vec<PlannedEdge>,
+    pub entries: Vec<PlannedEntry>,
+    pub limits: GraphLimits,
+}

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -28,6 +28,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) generated_by: String,
     pub(crate) vocabularies: Vec<LeanVocabularyContract>,
     pub(crate) state_machines: Vec<LeanStateMachineContract>,
+    #[serde(default)]
+    pub(crate) graph_pipeline_validation_cases: Vec<LeanGraphPipelineValidationCase>,
     pub(crate) request_transition_cases: Vec<LeanLifecycleTransitionCase>,
     pub(crate) process_transition_cases: Vec<LeanLifecycleTransitionCase>,
     pub(crate) trigger_dispatch_case_count: usize,
@@ -192,6 +194,16 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) event_delivery_source_instances: Vec<LeanEventDeliverySourceInstance>,
     #[serde(default)]
     pub(crate) event_delivery_convergence_traces: Vec<LeanEventDeliveryConvergenceTrace>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LeanGraphPipelineValidationCase {
+    pub(crate) name: String,
+    pub(crate) types_valid: bool,
+    pub(crate) topology_valid: bool,
+    pub(crate) capabilities_authorized: bool,
+    pub(crate) within_bounds: bool,
+    pub(crate) expected_valid: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -31,6 +31,7 @@ pub mod error;
 pub mod event_delivery_contract;
 pub mod external_adapter_capture;
 pub mod goal;
+pub mod graph_pipeline;
 pub mod graphql;
 pub mod health_checker;
 pub mod hook;

--- a/crates/gents/tests/conformance.rs
+++ b/crates/gents/tests/conformance.rs
@@ -118,6 +118,8 @@ mod event_delivery;
 mod fleet;
 #[path = "conformance/goals.rs"]
 mod goals;
+#[path = "conformance/graph_pipeline.rs"]
+mod graph_pipeline;
 #[path = "conformance/inference_call.rs"]
 mod inference_call;
 #[path = "conformance/interrupts_manual.rs"]

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -507,6 +507,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "ProcessTransitions".to_string(),
         ));
     }
+    if !snapshot.graph_pipeline_validation_cases.is_empty() {
+        emitted.insert((
+            "graph_pipeline_validation_cases".to_string(),
+            "GraphPipelineValidationCases".to_string(),
+        ));
+    }
     assert_eq!(
         snapshot.trigger_dispatch_case_count,
         snapshot.trigger_dispatch_cases.len(),
@@ -1130,6 +1136,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "descendant_graph_cases",
         "goal_decision_cases",
         "goal_transition_cases",
+        "graph_pipeline_validation_cases",
         "workspace_cases",
         "workspace_binding_cases",
         "callback_cases",

--- a/crates/gents/tests/conformance/graph_pipeline.rs
+++ b/crates/gents/tests/conformance/graph_pipeline.rs
@@ -1,0 +1,106 @@
+use gents::graph_pipeline::{
+    compile_graph, CompilerPolicy, EntryBinding, GraphIntent, GraphLimits, GraphNode,
+    PortCardinality, PortRef, PortSpec, StageCapability,
+};
+
+use super::lean_contract_snapshot;
+
+const CALLER_DID: &str = "did:key:graph-composer";
+
+fn valid_fixture() -> (GraphIntent, Vec<StageCapability>) {
+    let input = PortSpec {
+        name: "job".to_owned(),
+        collection: "ExperimentJob".to_owned(),
+        schema: "ExperimentJob/v1".to_owned(),
+        correlation_field: "graph_run_id".to_owned(),
+        cardinality: PortCardinality::One,
+        required: true,
+    };
+    let intent = GraphIntent {
+        graph_id: "lean-validation-fixture".to_owned(),
+        nodes: vec![GraphNode {
+            node_id: "worker".to_owned(),
+            capability_id: "approved-worker".to_owned(),
+            capability_revision: "v1".to_owned(),
+        }],
+        edges: vec![],
+        entries: vec![EntryBinding {
+            name: "job".to_owned(),
+            collection: input.collection.clone(),
+            schema: input.schema.clone(),
+            to: PortRef {
+                node_id: "worker".to_owned(),
+                port: input.name.clone(),
+            },
+        }],
+        limits: GraphLimits {
+            max_nodes: 2,
+            max_edges: 2,
+            max_depth: 2,
+            max_fan_out: 2,
+        },
+    };
+    let capability = StageCapability {
+        capability_id: "approved-worker".to_owned(),
+        revision: "v1".to_owned(),
+        task_id: "worker-v1-task".to_owned(),
+        input_ports: vec![input],
+        output_ports: vec![],
+        allowed_callers: vec![CALLER_DID.to_owned()],
+    };
+    (intent, vec![capability])
+}
+
+#[test]
+fn generated_validation_cases_fence_whole_graph_compilation_gate() {
+    let cases = &lean_contract_snapshot().graph_pipeline_validation_cases;
+    assert_eq!(cases.len(), 16, "Lean must emit the full four-bit matrix");
+
+    for test_case in cases {
+        let (mut intent, mut capabilities) = valid_fixture();
+        if !test_case.types_valid {
+            intent.entries[0].schema = "WrongSchema/v1".to_owned();
+        }
+        if !test_case.topology_valid {
+            intent.entries.clear();
+        }
+        if !test_case.capabilities_authorized {
+            capabilities[0].allowed_callers.clear();
+        }
+        if !test_case.within_bounds {
+            intent.limits.max_nodes = 0;
+        }
+
+        let accepted = compile_graph(
+            &intent,
+            &capabilities,
+            CALLER_DID,
+            &CompilerPolicy::default(),
+        )
+        .is_ok();
+        assert_eq!(accepted, test_case.expected_valid, "{}", test_case.name);
+    }
+}
+
+#[test]
+fn successful_compilation_supplies_stable_publication_identity() {
+    let (intent, capabilities) = valid_fixture();
+    let first = compile_graph(
+        &intent,
+        &capabilities,
+        CALLER_DID,
+        &CompilerPolicy::default(),
+    )
+    .unwrap();
+    let second = compile_graph(
+        &intent,
+        &capabilities,
+        CALLER_DID,
+        &CompilerPolicy::default(),
+    )
+    .unwrap();
+
+    assert_eq!(first, second);
+    assert!(first.digest.starts_with("sha256:"));
+    assert_eq!(first.nodes[0].task_id, "worker-v1-task");
+}

--- a/crates/gents/tests/conformance/structure.rs
+++ b/crates/gents/tests/conformance/structure.rs
@@ -40,9 +40,7 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("Goals", Module("conformance/goals.rs")),
         (
             "GraphPipeline",
-            Boundary(
-                "foundation model only; compiler and persistence refinement land in the immediately stacked PRs (boundary.graph-pipeline.foundation)",
-            ),
+            Module("conformance/graph_pipeline.rs"),
         ),
         ("Identity", Module("conformance/identity.rs")),
         ("InferenceCall", Module("conformance/inference_call.rs")),

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -56,6 +56,13 @@ impl ConformanceConsumer {
 pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
     &[
         ConformanceConsumer::RustTest {
+            id: "conformance::graph_pipeline::generated_validation_cases_fence_whole_graph_compilation_gate",
+            package: "gents",
+            source_path: "crates/gents/tests/conformance/graph_pipeline.rs",
+            module_path: "conformance::graph_pipeline",
+            function: "generated_validation_cases_fence_whole_graph_compilation_gate",
+        },
+        ConformanceConsumer::RustTest {
             id: "conformance::goals::rust_goal_status_vocabulary_and_machine_match_lean_contract",
             package: "gents",
             source_path: "crates/gents/tests/conformance/goals.rs",


### PR DESCRIPTION
## Summary

- add typed `GraphIntent`, approved `StageCapability` wrappers around existing Task IDs, ports, edges, entries, limits, diagnostics, and canonical `GraphPlan` contracts
- resolve every node against the operator-owned capability catalog and caller DID
- validate references, GraphQL collections and filters, schemas/cardinality, exact input bindings, physical output-collection uniqueness, reachability, cycles, joins, authorization, and structural bounds without I/O
- canonicalize plans and produce a deterministic SHA-256 content digest
- drive the all-or-nothing compiler gate from the Lean-generated 16-case validation matrix

This is PR 2 of the replacement stack for #1176 and is stacked on #1190. It performs no DefraDB writes and exposes no model-facing tool.

## Verification

- `cargo test -p gents` — 1,824 unit tests, 353 conformance tests, and all integration/E2E suites passed
- `cargo check --workspace --all-targets`
- `cd crates/gents/proofs && lake build`
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack

1. #1190 — formal publication boundary and architecture
2. **this PR** — pure typed compiler and conformance fence
3. #1192 — transactional EventTrigger publication over existing Tasks
4. #1193 — single model-callable compile-and-publish tool