### PR TITLE
feat: expose a model-callable graph compiler

### DIFF
--- a/crates/gents/src/document_config/tool_selection.rs
+++ b/crates/gents/src/document_config/tool_selection.rs
@@ -437,6 +437,7 @@ pub fn is_reserved_builtin_tool_name(name: &str) -> bool {
         || SUBAGENT_TOOL_NAMES.contains(&name)
         || SINGLETON_TOOL_NAMES.contains(&name)
         || crate::self_config::SELF_CONFIG_TOOL_NAMES.contains(&name)
+        || crate::graph_pipeline::GRAPH_PIPELINE_TOOL_NAMES.contains(&name)
 }
 
 /// Deserialize the `write_tools` field from either representation:

--- a/crates/gents/src/graph_pipeline/mod.rs
+++ b/crates/gents/src/graph_pipeline/mod.rs
@@ -6,12 +6,17 @@
 
 mod compiler;
 mod runtime;
+mod tools;
 mod types;
 
 pub use compiler::{
     compile_graph, graph_plan_digest, verify_graph_plan_digest, CompilerPolicy, GraphCompileError,
 };
 pub use runtime::{publish_graph_plan, PublishedGraph};
+pub use tools::{
+    CompileGraphArgs, CompileGraphResponse, CompileGraphTool, GraphPipelineToolError,
+    COMPILE_GRAPH_TOOL_NAME, GRAPH_PIPELINE_TOOL_NAMES,
+};
 pub use types::{
     DeliveryMode, Diagnostic, DiagnosticCode, EntryBinding, GraphEdge, GraphIntent, GraphLimits,
     GraphNode, GraphPlan, PlannedEdge, PlannedEntry, PlannedNode, PortCardinality, PortRef,

--- a/crates/gents/src/graph_pipeline/tools.rs
+++ b/crates/gents/src/graph_pipeline/tools.rs
@@ -1,0 +1,330 @@
+use std::sync::Arc;
+
+use defra_node::EmbeddedNode;
+use identity::Did;
+use serde::{Deserialize, Serialize};
+
+use crate::llm::tool::{Tool, ToolDefinition};
+
+use super::{
+    compile_graph, publish_graph_plan, CompilerPolicy, Diagnostic, GraphIntent, PublishedGraph,
+    StageCapability,
+};
+
+pub const COMPILE_GRAPH_TOOL_NAME: &str = "compile_graph";
+pub const GRAPH_PIPELINE_TOOL_NAMES: [&str; 1] = [COMPILE_GRAPH_TOOL_NAME];
+
+#[derive(Debug)]
+pub struct GraphPipelineToolError(anyhow::Error);
+
+impl std::fmt::Display for GraphPipelineToolError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{:#}", self.0)
+    }
+}
+
+impl std::error::Error for GraphPipelineToolError {}
+
+impl From<anyhow::Error> for GraphPipelineToolError {
+    fn from(error: anyhow::Error) -> Self {
+        Self(error)
+    }
+}
+
+#[derive(Clone)]
+pub struct CompileGraphTool {
+    node: Arc<EmbeddedNode>,
+    identity: Did,
+    capabilities: Arc<Vec<StageCapability>>,
+    policy: CompilerPolicy,
+}
+
+impl CompileGraphTool {
+    pub fn new(
+        node: Arc<EmbeddedNode>,
+        identity: Did,
+        capabilities: Vec<StageCapability>,
+        policy: CompilerPolicy,
+    ) -> Self {
+        Self {
+            node,
+            identity,
+            capabilities: Arc::new(capabilities),
+            policy,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CompileGraphArgs {
+    pub intent: GraphIntent,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CompileGraphResponse {
+    pub accepted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published: Option<PublishedGraph>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl Tool for CompileGraphTool {
+    const NAME: &'static str = COMPILE_GRAPH_TOOL_NAME;
+    type Error = GraphPipelineToolError;
+    type Args = CompileGraphArgs;
+    type Output = CompileGraphResponse;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_owned(),
+            description: "Compile a bounded document DAG from operator-approved existing Task capabilities and publish its EventTriggers atomically. The model cannot author prompts, behaviors, tools, models, executable plans, or arbitrary collections. Invalid graphs return stable repair diagnostics without writes. Execution starts separately through existing bounded document-write tools after normal runtime reconciliation. Configure this tool in approval_required_tools when publication needs human approval.".to_owned(),
+            parameters: schemars::schema_for!(CompileGraphArgs).to_value(),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let caller_did = self.identity.to_string();
+        let plan = match compile_graph(
+            &args.intent,
+            self.capabilities.as_slice(),
+            &caller_did,
+            &self.policy,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => {
+                return Ok(CompileGraphResponse {
+                    accepted: false,
+                    digest: None,
+                    published: None,
+                    diagnostics: error.diagnostics,
+                });
+            }
+        };
+        let digest = plan.digest.clone();
+        let published =
+            publish_graph_plan(self.node.as_ref(), self.identity.clone(), &plan).await?;
+        Ok(CompileGraphResponse {
+            accepted: true,
+            digest: Some(digest),
+            published: Some(published),
+            diagnostics: vec![],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph_pipeline::{
+        EntryBinding, GraphLimits, GraphNode, PortCardinality, PortRef, PortSpec,
+    };
+
+    #[derive(Deserialize)]
+    struct EvalCase {
+        name: String,
+        intent: GraphIntent,
+        expected_accepted: bool,
+        expected_diagnostic_codes: Vec<String>,
+    }
+
+    fn capability() -> StageCapability {
+        StageCapability {
+            capability_id: "worker".to_owned(),
+            revision: "v1".to_owned(),
+            task_id: "existing-worker-task".to_owned(),
+            input_ports: vec![
+                PortSpec {
+                    name: "input".to_owned(),
+                    collection: "PipelineInput".to_owned(),
+                    schema: "PipelineInput/v1".to_owned(),
+                    correlation_field: "run_id".to_owned(),
+                    cardinality: PortCardinality::One,
+                    required: true,
+                },
+                PortSpec {
+                    name: "feedback".to_owned(),
+                    collection: "PipelineFeedback".to_owned(),
+                    schema: "PipelineFeedback/v1".to_owned(),
+                    correlation_field: "run_id".to_owned(),
+                    cardinality: PortCardinality::One,
+                    required: false,
+                },
+            ],
+            output_ports: vec![PortSpec {
+                name: "result".to_owned(),
+                collection: "PipelineIntermediate".to_owned(),
+                schema: "PipelineIntermediate/v1".to_owned(),
+                correlation_field: "run_id".to_owned(),
+                cardinality: PortCardinality::One,
+                required: false,
+            }],
+            allowed_callers: vec!["did:key:owner".to_owned()],
+        }
+    }
+
+    fn review_capability() -> StageCapability {
+        StageCapability {
+            capability_id: "reviewer".to_owned(),
+            revision: "v1".to_owned(),
+            task_id: "existing-reviewer-task".to_owned(),
+            input_ports: vec![PortSpec {
+                name: "input".to_owned(),
+                collection: "PipelineIntermediate".to_owned(),
+                schema: "PipelineIntermediate/v1".to_owned(),
+                correlation_field: "run_id".to_owned(),
+                cardinality: PortCardinality::One,
+                required: true,
+            }],
+            output_ports: vec![PortSpec {
+                name: "feedback".to_owned(),
+                collection: "PipelineFeedback".to_owned(),
+                schema: "PipelineFeedback/v1".to_owned(),
+                correlation_field: "run_id".to_owned(),
+                cardinality: PortCardinality::One,
+                required: false,
+            }],
+            allowed_callers: vec!["did:key:owner".to_owned()],
+        }
+    }
+
+    fn capabilities() -> Vec<StageCapability> {
+        vec![capability(), review_capability()]
+    }
+
+    fn intent(capability_id: &str) -> GraphIntent {
+        GraphIntent {
+            graph_id: "model-pipeline".to_owned(),
+            nodes: vec![GraphNode {
+                node_id: "worker".to_owned(),
+                capability_id: capability_id.to_owned(),
+                capability_revision: "v1".to_owned(),
+            }],
+            edges: vec![],
+            entries: vec![EntryBinding {
+                name: "input".to_owned(),
+                collection: "PipelineInput".to_owned(),
+                schema: "PipelineInput/v1".to_owned(),
+                to: PortRef {
+                    node_id: "worker".to_owned(),
+                    port: "input".to_owned(),
+                },
+            }],
+            limits: GraphLimits {
+                max_nodes: 2,
+                max_edges: 2,
+                max_depth: 2,
+                max_fan_out: 2,
+            },
+        }
+    }
+
+    async fn tool() -> CompileGraphTool {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        for schema in [
+            gents_protocol::schemas::GRAPH_DEFINITION,
+            gents_protocol::schemas::TASK,
+            gents_protocol::schemas::EVENT_TRIGGER,
+        ] {
+            node.add_schema(schema).await.unwrap();
+        }
+        node.execute(
+            r#"mutation { create_Task(input: {
+                task_id: "existing-worker-task",
+                behavior_id: "worker",
+                prompt_template: "operator approved prompt",
+                enabled: true
+            }) { _docID } }"#,
+        )
+        .await;
+        node.execute(
+            r#"mutation { create_Task(input: {
+                task_id: "existing-reviewer-task",
+                behavior_id: "reviewer",
+                prompt_template: "operator approved review prompt",
+                enabled: true
+            }) { _docID } }"#,
+        )
+        .await;
+        CompileGraphTool::new(
+            node,
+            Did::new("did:key:owner".to_owned()).unwrap(),
+            capabilities(),
+            CompilerPolicy::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn invalid_graph_returns_repairable_diagnostics_without_writes() {
+        let tool = tool().await;
+        let response = tool
+            .call(CompileGraphArgs {
+                intent: intent("unapproved"),
+            })
+            .await
+            .unwrap();
+        assert!(!response.accepted);
+        assert!(response.published.is_none());
+        assert!(!response.diagnostics.is_empty());
+        tool.node.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn valid_graph_recompiles_and_publishes_existing_task_routes() {
+        let tool = tool().await;
+        let response = tool
+            .call(CompileGraphArgs {
+                intent: intent("worker"),
+            })
+            .await
+            .unwrap();
+        assert!(response.accepted);
+        assert_eq!(response.published.unwrap().trigger_ids.len(), 1);
+        tool.node.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn checked_in_evaluation_cases_match_compiler_results() {
+        let cases: Vec<EvalCase> = serde_json::from_str(include_str!(
+            "../../../../demo/graph-pipeline/eval_cases.json"
+        ))
+        .unwrap();
+        let caller = "did:key:owner";
+        for test_case in cases {
+            let result = compile_graph(
+                &test_case.intent,
+                &capabilities(),
+                caller,
+                &CompilerPolicy::default(),
+            );
+            assert_eq!(
+                result.is_ok(),
+                test_case.expected_accepted,
+                "{}",
+                test_case.name
+            );
+            let actual_codes = result
+                .err()
+                .into_iter()
+                .flat_map(|error| error.diagnostics)
+                .map(|diagnostic| {
+                    serde_json::to_value(&diagnostic.code)
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_owned()
+                })
+                .collect::<std::collections::BTreeSet<_>>();
+            for expected in test_case.expected_diagnostic_codes {
+                assert!(
+                    actual_codes.contains(&expected),
+                    "{} missing {expected:?}; actual: {actual_codes:?}",
+                    test_case.name
+                );
+            }
+        }
+    }
+}

--- a/demo/graph-pipeline/README.md
+++ b/demo/graph-pipeline/README.md
@@ -1,0 +1,37 @@
+# Model-callable graph compiler evaluation
+
+This is an evaluation pack for a small adapter over the existing Gents
+automation runtime. It does not introduce another graph engine.
+
+`compile_graph` accepts topology over operator-approved capability revisions.
+Each capability points at an existing Task document and declares its typed
+ports. The model cannot author Task prompts, behaviors, tools, models, or
+physical collections. The tool performs pure whole-graph validation first and,
+only on success, writes the entry and edge EventTriggers in one transaction.
+
+Execution remains separate. After normal runtime reconciliation, an existing
+bounded write tool creates an entry document and the ordinary trigger/task
+engine runs the graph. Configure `compile_graph` in
+`approval_required_tools` when publication requires human approval.
+
+```rust,ignore
+let tool = CompileGraphTool::new(
+    node,
+    caller_identity,
+    approved_existing_task_capabilities,
+    CompilerPolicy::default(),
+);
+
+let agent = Agent::builder(provider).custom_tool(tool);
+```
+
+`eval_cases.json` is compiled as part of the `gents` unit suite. It covers
+valid single- and multi-stage proposals plus repair cases for invented or stale
+capabilities, missing inputs, schema mismatch, cycles, and structural bounds.
+Expected diagnostic codes are subsets so cases remain stable when the compiler
+adds another useful diagnostic.
+
+For model evaluation, record proposal acceptance, diagnostic codes per repair
+turn, number of repair turns, final digest, publication errors, reconciliation
+latency, and whether the separately written entry document drives the expected
+existing Tasks. Stage-output quality is a separate evaluation.

--- a/demo/graph-pipeline/eval_cases.json
+++ b/demo/graph-pipeline/eval_cases.json
@@ -1,0 +1,262 @@
+[
+  {
+    "name": "valid_single_stage",
+    "intent": {
+      "graph_id": "document-review",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v1",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 2,
+        "max_edges": 2,
+        "max_depth": 2,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": true,
+    "expected_diagnostic_codes": []
+  },
+  {
+    "name": "unknown_capability_fails_closed",
+    "intent": {
+      "graph_id": "document-review",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "model-invented-stage",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v1",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 2,
+        "max_edges": 2,
+        "max_depth": 2,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": false,
+    "expected_diagnostic_codes": ["unknown_capability"]
+  },
+  {
+    "name": "missing_required_entry_is_repairable",
+    "intent": {
+      "graph_id": "document-review",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [],
+      "entries": [],
+      "limits": {
+        "max_nodes": 2,
+        "max_edges": 2,
+        "max_depth": 2,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": false,
+    "expected_diagnostic_codes": ["missing_input_binding", "unreachable_node"]
+  },
+  {
+    "name": "intent_bound_is_enforced",
+    "intent": {
+      "graph_id": "document-review",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v1",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 0,
+        "max_edges": 2,
+        "max_depth": 2,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": false,
+    "expected_diagnostic_codes": ["node_limit_exceeded"]
+  },
+  {
+    "name": "valid_two_stage_route",
+    "intent": {
+      "graph_id": "document-review-two-stage",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v1"
+        },
+        {
+          "node_id": "reviewer",
+          "capability_id": "reviewer",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [
+        {
+          "from": { "node_id": "worker", "port": "result" },
+          "to": { "node_id": "reviewer", "port": "input" },
+          "delivery": { "kind": "per_document" }
+        }
+      ],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v1",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 3,
+        "max_edges": 3,
+        "max_depth": 3,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": true,
+    "expected_diagnostic_codes": []
+  },
+  {
+    "name": "stale_capability_revision_is_repairable",
+    "intent": {
+      "graph_id": "document-review",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v2"
+        }
+      ],
+      "edges": [],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v1",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 2,
+        "max_edges": 2,
+        "max_depth": 2,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": false,
+    "expected_diagnostic_codes": ["capability_revision_mismatch"]
+  },
+  {
+    "name": "entry_schema_mismatch_is_repairable",
+    "intent": {
+      "graph_id": "document-review",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v2",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 2,
+        "max_edges": 2,
+        "max_depth": 2,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": false,
+    "expected_diagnostic_codes": ["schema_mismatch"]
+  },
+  {
+    "name": "cycle_is_repairable",
+    "intent": {
+      "graph_id": "document-review-cycle",
+      "nodes": [
+        {
+          "node_id": "worker",
+          "capability_id": "worker",
+          "capability_revision": "v1"
+        },
+        {
+          "node_id": "reviewer",
+          "capability_id": "reviewer",
+          "capability_revision": "v1"
+        }
+      ],
+      "edges": [
+        {
+          "from": { "node_id": "worker", "port": "result" },
+          "to": { "node_id": "reviewer", "port": "input" },
+          "delivery": { "kind": "per_document" }
+        },
+        {
+          "from": { "node_id": "reviewer", "port": "feedback" },
+          "to": { "node_id": "worker", "port": "feedback" },
+          "delivery": { "kind": "per_document" }
+        }
+      ],
+      "entries": [
+        {
+          "name": "input",
+          "collection": "PipelineInput",
+          "schema": "PipelineInput/v1",
+          "to": { "node_id": "worker", "port": "input" }
+        }
+      ],
+      "limits": {
+        "max_nodes": 3,
+        "max_edges": 3,
+        "max_depth": 3,
+        "max_fan_out": 2
+      }
+    },
+    "expected_accepted": false,
+    "expected_diagnostic_codes": ["cycle"]
+  }
+]


### PR DESCRIPTION
## Summary

- expose one opt-in `compile_graph` custom tool that accepts only `GraphIntent`, compiles it against the caller DID and operator-owned capability catalog, and publishes the resulting routes atomically
- never accept an executable `GraphPlan`, Task prompt, behavior, tool selection, or arbitrary target collection from the model
- return stable, path-addressed diagnostics with no writes when compilation fails
- use generated `schemars` input schema and register the reserved tool name; operators can place it in `approval_required_tools`
- keep execution separate through existing bounded document writes after ordinary runtime reconciliation
- add checked-in evaluation cases for valid plans, invented capabilities, missing inputs, and structural bounds

The tool is currently an evaluation/programmatic custom tool; production document-config wiring is deliberately deferred until the experiment graduates.

## Review resolution

Claude, Grok, and Sol independently found that the earlier three-tool revision/run design let a model supply a self-hashed plan and raced trigger reconciliation. This stack removes that controller, removes GraphRun/GraphRevision entirely, and reuses existing Tasks, EventTriggers, config transactions, and the owned completion loop. The local GLM-5.2 review covered seven lenses and returned **APPROVE** after one documentation cleanup. A final post-fix GLM-5.2 review on workstation-1 covered eight lenses (authorization, publication, GraphQL safety, compiler correctness, formal conformance, schema migration, architecture reuse, and concurrency/durability) and returned **APPROVE** with zero candidates and zero confirmed defects. The rewritten stack is 2,714 added lines versus 4,372 before the review pass (38% fewer).

## Verification

- `cargo test -p gents` — all package unit, conformance, integration, and E2E suites passed
- `cargo check --workspace --all-targets`
- `cd crates/gents/proofs && lake build`
- `cargo fmt --all -- --check`
- `git diff --check`

## Stack

1. #1190 — formal publication boundary and architecture
2. #1191 — pure typed compiler and conformance fence
3. #1192 — transactional EventTrigger publication over existing Tasks
4. **this PR** — single model-callable compile-and-publish tool and eval pack