### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.12.0"
+        default: "0.13.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.12.0"
+        default: "0.13.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.13.0 - 2026-08-25
+
+### Bridge contract
+
+- Advance the Rust and npm desktop package train together to 0.13.0 and the
+  desktop bridge contract from 0.9 to 1.3.
+- Make client-authored requests the sole session creation path, removing the
+  `desktop_session_fork` projection, and add revisioned live-session deltas,
+  bounded transcript-page evidence, exact-total markers, and observer merge
+  counters (#1160, #1154, #1203).
+
+### Mobile and desktop
+
+- Add request-owned remote session hydration with explicit pending, stalled,
+  schema-skew, and terminal states; keep recovery truthful across mobile
+  backgrounding and reconnects (#1154).
+- Bound long-session work at the database query, bridge payload, and React
+  rendering seams: query transcript pages at the tip and backward cursor,
+  preserve tool-call boundaries, coalesce live response updates, and avoid
+  remounting previously rendered rows (#1184, #1185, #1203).
+- Centralize reliable multi-server pairing and replace repeated full-store
+  replication scans with explicit document-set replay (#1186).
+
+### Runtime and formal foundation
+
+- Add Lean-fenced isolated workspaces, callback planning and execution,
+  request-scoped tool roots, frozen instruction provenance, and explicit
+  cleanup receipts for agent-owned workspace lifecycles (#1164-#1174).
+- Publish the graph pipeline foundation, pure intent compiler, task-backed
+  graph routes, and bounded graph tool surface (#1190-#1193).
+- Discover live `AGENTS.md` instructions for unbound requests and tighten the
+  graph-native defending-code review pack (#1173).
+
+### CLI, testing, and reliability
+
+- Keep explicit transport log filters intact and expand live pairing,
+  hydration, pagination, and inference acceptance coverage (#1188, #1154,
+  #1203).
+- Add repeatable mobile interaction artifacts and structural budgets while
+  keeping noisy wall-clock measurements report-only (#1203).
+
+### Dependencies
+
+- Advance DefraDB to `54b629b1`, including explicit document-set P2P replay;
+  this revision is the direct child of the current DefraDB `main` head.
+
 ## 0.12.0 - 2026-08-20
 
 ### Bridge contract
@@ -187,6 +233,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 | Tag        | Bridge crate | npm packages | contract_version | Notes                                         |
 | ---------- | ------------ | ------------ | ---------------- | --------------------------------------------- |
+| v0.13.0    | 0.13.0       | 0.13.0       | 1.3              | Hydration, bounded mobile transcripts, graph pipeline; DefraDB `54b629b1` |
 | v0.12.0    | 0.12.0       | 0.12.0       | 0.9              | Mobile pairing convergence; eager session index; DefraDB `f928b300` |
 | v0.11.0    | 0.11.0       | 0.11.0       | 0.9              | DefraDB v0.18.0; signed provenance and build metrics |
 | v0.10.1    | 0.10.1       | 0.10.1       | 0.5              | DefraDB v0.17.4; mobile/subagent/migration fixes |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "gents-chatgpt-login"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.2",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "gents-codex-protocol"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.12.0"
+version = "0.13.0"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.12.0",
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-fleet": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0",
+    "@source-inc/gents-desktop-chat": "0.13.0",
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-fleet": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -54,14 +54,14 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-chat": "0.12.0",
-    "@source-inc/gents-desktop-fleet": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0"
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-chat": "0.13.0",
+    "@source-inc/gents-desktop-fleet": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-operations": "0.12.0",
+    "@source-inc/gents-desktop-operations": "0.13.0",
     "@antithesishq/bombadil": "^0.6.0",
     "@playwright/test": "^1.61.0",
     "@tauri-apps/cli": "2.10.1",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.0</string>
+	<string>0.13.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.12.0</string>
+	<string>0.13.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.12.0
-        CFBundleVersion: "0.12.0"
+        CFBundleShortVersionString: 0.13.0
+        CFBundleVersion: "0.13.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/review-demo/package.json
+++ b/apps/review-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/review-demo-ui",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite --strictPort --host 127.0.0.1",
@@ -10,8 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -301,7 +301,7 @@
     "desktop://managed-server-updated",
     "desktop://managed-server-tray-stop"
   ],
-  "packageVersion": "0.12.0",
+  "packageVersion": "0.13.0",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
+++ b/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
@@ -10,7 +10,7 @@
         },
         "model_name": "deepseek-ai/DeepSeek-V4-Flash-0731",
         "name": "terminal-bench",
-        "version": "0.12.0"
+        "version": "0.13.0"
       },
       "extra": {
         "source_projection_id": "run_timeline",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.12.0
-docker run --rm ghcr.io/source-inc/gents:v0.12.0 version
+docker pull ghcr.io/source-inc/gents:v0.13.0
+docker run --rm ghcr.io/source-inc/gents:v0.13.0 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.12.0 \
+  ghcr.io/source-inc/gents:v0.13.0 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.12.0 \
+  ghcr.io/source-inc/gents:v0.13.0 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -19,13 +19,13 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.12.0",
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-fleet": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-chat": "0.13.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-fleet": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,16 +43,16 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.12.0",
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-fleet": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-chat": "0.13.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-fleet": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -64,7 +64,7 @@
       "devDependencies": {
         "@antithesishq/bombadil": "^0.6.0",
         "@playwright/test": "^1.61.0",
-        "@source-inc/gents-desktop-operations": "0.12.0",
+        "@source-inc/gents-desktop-operations": "0.13.0",
         "@tauri-apps/cli": "2.10.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -83,10 +83,10 @@
     },
     "apps/review-demo": {
       "name": "@source-inc/review-demo-ui",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -5110,12 +5110,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5125,9 +5125,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5137,7 +5137,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5149,16 +5149,16 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "^0.8.2",
         "jsqr": "^1.4.0"
       },
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5167,21 +5167,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5190,24 +5190,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.12.0",
-        "@source-inc/gents-desktop-tokens": "0.12.0",
-        "@source-inc/gents-desktop-ui": "0.12.0",
+        "@source-inc/gents-desktop-client": "0.13.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
+        "@source-inc/gents-desktop-ui": "0.13.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5219,7 +5219,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.12.0",
+        "@source-inc/gents-desktop-tokens": "0.13.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0"
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0",
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,7 +15,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.12.0";
+export const PACKAGE_VERSION = "0.13.0";
 export const MINIMUM_BRIDGE_CONTRACT_VERSION = "0.7";
 
 export function assertCompatibleBridgeContract(

--- a/packages/gents-desktop-client/src/store.test.ts
+++ b/packages/gents-desktop-client/src/store.test.ts
@@ -36,7 +36,7 @@ describe("createDesktopStore", () => {
         },
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.12.0",
+          packageVersion: "0.13.0",
           events: [],
           eventReasons: [],
           errorCodes: [],
@@ -66,7 +66,7 @@ describe("createDesktopStore", () => {
         desktop_client_start: () => ({}),
         desktop_bridge_contract: () => ({
           contractVersion: "0.7",
-          packageVersion: "0.12.0",
+          packageVersion: "0.13.0",
           events: [],
           eventReasons: [],
           errorCodes: [],

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "Reusable peer discovery, pairing, health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -40,14 +40,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0"
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0",
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "Focused holds, health, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0"
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.12.0",
-    "@source-inc/gents-desktop-tokens": "0.12.0",
-    "@source-inc/gents-desktop-ui": "0.12.0",
+    "@source-inc/gents-desktop-client": "0.13.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
+    "@source-inc/gents-desktop-ui": "0.13.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.12.0",
+    "@source-inc/gents-desktop-tokens": "0.13.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary

- advance the Rust, Tauri, and npm lockstep train from 0.12.0 to 0.13.0
- publish release notes and compatibility metadata for bridge contract 1.3
- preserve DefraDB `54b629b1`, which is the explicit-document-set replay commit directly atop the current DefraDB main head
- update release workflow defaults, packaged-client fixtures, container examples, and generated Apple version metadata

## Release contents

This train includes request-owned session hydration, query-level transcript pagination and live deltas, long-session rendering bounds, reliable multi-server pairing, isolated workspace/callback foundations, and the graph pipeline/tool surface.

## Validation

- `cargo test -p gents` (full package and integration suites)
- `cargo check --workspace --all-targets`
- `make fmt-check`
- `npm run check:package-boundaries`
- all release npm packages built and their release-workflow tests passed
- `scripts/pack-desktop-packages.sh target/desktop-npm-release-v0.13.0` clean-consumer gate passed
- `git diff --check`
