### PR TITLE
feat(pairing): schema-digest preflight — refuse to pair a mismatched build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ target/npm-pack/
 # Python tooling and Harbor adapter bytecode
 __pycache__/
 *.py[cod]
+
+# macOS Finder metadata (anywhere in the tree)
+.DS_Store

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -2771,6 +2771,12 @@ pub(crate) struct P2pClaimArgs {
     /// The `dabear1-` bearer invite token to claim.
     #[arg(value_name = "TOKEN")]
     pub(crate) token: String,
+    /// Pair even if this build's bundled schemas don't match the digest the
+    /// issuer stamped into the invite (issue #1122). Without this, a schema
+    /// mismatch bails before any pairing row is written, since paired
+    /// writes would otherwise be silently merge-rejected by the server.
+    #[arg(long, default_value_t = false)]
+    pub(crate) allow_schema_mismatch: bool,
 }
 
 #[derive(clap::Args)]

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -501,6 +501,21 @@ fn parse_p2p_join(extra: &[&str]) -> P2pJoinArgs {
     }
 }
 
+fn parse_p2p_claim(extra: &[&str]) -> P2pClaimArgs {
+    let mut argv = vec!["gents", "p2p", "pairings", "claim", "dabear1-token"];
+    argv.extend_from_slice(extra);
+    let cli = Cli::try_parse_from(argv).expect("p2p pairings claim should parse");
+    match cli.command {
+        Command::P2p {
+            command:
+                P2pCommand::Pairings {
+                    command: P2pPairingsCommand::Claim(args),
+                },
+        } => args,
+        _ => panic!("expected `p2p pairings claim`"),
+    }
+}
+
 fn parse_p2p_replicator_add(extra: &[&str]) -> P2pReplicatorAddArgs {
     let mut argv = vec![
         "gents",
@@ -534,6 +549,16 @@ fn p2p_invite_template_defaults_to_conversation() {
     let args = parse_p2p_invite(&[]);
     assert_eq!(args.template, "conversation");
     assert_eq!(args.member_did, None);
+}
+
+#[test]
+fn p2p_claim_allow_schema_mismatch_defaults_false_and_parses() {
+    let args = parse_p2p_claim(&[]);
+    assert_eq!(args.token, "dabear1-token");
+    assert!(!args.allow_schema_mismatch);
+
+    let args = parse_p2p_claim(&["--allow-schema-mismatch"]);
+    assert!(args.allow_schema_mismatch);
 }
 
 #[test]

--- a/crates/gents-cli/src/commands/p2p/claim.rs
+++ b/crates/gents-cli/src/commands/p2p/claim.rs
@@ -392,10 +392,7 @@ mod tests {
         assert!(err.contains("machine"), "unexpected: {err}");
         assert!(err.contains("localDigest1"), "unexpected: {err}");
         assert!(err.contains("remoteDigest2"), "unexpected: {err}");
-        assert!(
-            err.contains("--allow-schema-mismatch"),
-            "unexpected: {err}"
-        );
+        assert!(err.contains("--allow-schema-mismatch"), "unexpected: {err}");
     }
 
     #[test]

--- a/crates/gents-cli/src/commands/p2p/claim.rs
+++ b/crates/gents-cli/src/commands/p2p/claim.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use chrono::{SecondsFormat, Utc};
+use gents::agent::p2p_reconcile::templates::{resolve_template, template_schema_digest};
 use gents::graphql::escape_graphql_string;
 use gents_protocol::bearer_token::{
     bearer_signing_payload, check_bearer_freshness, decode_bearer, BearerClaimRecord,
@@ -73,6 +74,24 @@ pub(super) async fn p2p_claim(args: P2pClaimArgs) -> Result<()> {
         .await
         .context("loading local AgentNetwork before claim")?;
     check_local_network_match(local_network.as_ref(), &token)?;
+
+    // Schema-digest preflight (issue #1122), before any pairing row is
+    // written: a paired client whose bundled SDLs differ from the server's
+    // reads fine but every document it authors is merge-rejected forever
+    // with no signal anywhere the user looks. The issuer stamps a digest of
+    // its template's SDLs into the (signed) invite token — recompute the
+    // same digest from this build's local schema bundle and compare before
+    // committing to the pairing.
+    let scope_template = resolve_template(&template)
+        .with_context(|| format!("resolving scope template {template} for schema digest"))?;
+    let local_schema_digest = template_schema_digest(scope_template)
+        .context("computing local schema digest for bearer claim")?;
+    check_schema_digest(
+        &template,
+        &local_schema_digest,
+        token.schema_digest.as_deref(),
+        args.allow_schema_mismatch,
+    )?;
 
     write_agent_network(&access, &token.network).await?;
 
@@ -216,6 +235,42 @@ fn check_local_network_match(
     Ok(())
 }
 
+/// Compares the local schema-bundle digest against the digest the issuer
+/// stamped into the invite token. `remote_digest` is `None` for invites
+/// minted by a server too old to compute one — back-compat, skip silently.
+/// On a mismatch: bail naming both digests unless `allow_mismatch`, in which
+/// case downgrade to a loud warning and proceed.
+fn check_schema_digest(
+    template_id: &str,
+    local_digest: &str,
+    remote_digest: Option<&str>,
+    allow_mismatch: bool,
+) -> Result<()> {
+    let Some(remote_digest) = remote_digest else {
+        return Ok(());
+    };
+    if remote_digest == local_digest {
+        return Ok(());
+    }
+    if allow_mismatch {
+        let message = format!(
+            "schema mismatch: this build's bundled schemas for template '{template_id}' \
+             (digest {local_digest}) differ from the server's (digest {remote_digest}); \
+             documents you author may be silently rejected. Pairing anyway because \
+             --allow-schema-mismatch was set."
+        );
+        tracing::warn!("{message}");
+        eprintln!("{message}");
+        return Ok(());
+    }
+    anyhow::bail!(
+        "schema mismatch: this build's bundled schemas for template '{template_id}' (digest \
+         {local_digest}) differ from the server's (digest {remote_digest}); documents you \
+         author would be silently rejected. Update this build to match the server, or re-run \
+         with --allow-schema-mismatch to pair anyway."
+    );
+}
+
 fn bearer_claim_create_mutation(record: &BearerClaimRecord) -> String {
     let token = escape_graphql_string(&record.token);
     let claimant_did = escape_graphql_string(&record.claimant_did);
@@ -264,6 +319,7 @@ mod tests {
             issued_at: "2026-07-08T00:00:00Z".into(),
             template: "conversation".into(),
             default_behavior_id: Some("default".into()),
+            schema_digest: None,
             network: network_rec,
             sig: vec![2],
         }
@@ -325,5 +381,38 @@ mod tests {
         assert!(mutation.contains("claimant_did: \"did:key:phone\""));
         assert!(mutation.contains("binding_sig: "));
         assert!(!mutation.contains("[]"));
+    }
+
+    #[test]
+    fn schema_digest_mismatch_bails_naming_both_digests() {
+        let err = check_schema_digest("machine", "localDigest1", Some("remoteDigest2"), false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("schema mismatch"), "unexpected: {err}");
+        assert!(err.contains("machine"), "unexpected: {err}");
+        assert!(err.contains("localDigest1"), "unexpected: {err}");
+        assert!(err.contains("remoteDigest2"), "unexpected: {err}");
+        assert!(
+            err.contains("--allow-schema-mismatch"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn schema_digest_mismatch_with_allow_flag_proceeds() {
+        let result = check_schema_digest("machine", "localDigest1", Some("remoteDigest2"), true);
+        assert!(result.is_ok(), "expected override to proceed: {result:?}");
+    }
+
+    #[test]
+    fn schema_digest_match_proceeds() {
+        let result = check_schema_digest("machine", "sameDigest", Some("sameDigest"), false);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn missing_remote_schema_digest_proceeds_silently_for_back_compat() {
+        let result = check_schema_digest("machine", "localDigest1", None, false);
+        assert!(result.is_ok());
     }
 }

--- a/crates/gents-cli/src/commands/p2p/invite.rs
+++ b/crates/gents-cli/src/commands/p2p/invite.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use chrono::{SecondsFormat, Utc};
 use flate2::{write::GzEncoder, Compression};
+use gents::agent::p2p_reconcile::templates::{resolve_template, template_schema_digest};
 use gents::{graphql::escape_graphql_string, AgentIdentity, KeyIdentity};
 use gents_protocol::bearer_token::{
     bearer_signing_payload, encode_bearer, BearerInviteToken, BEARER_TOKEN_VERSION,
@@ -113,6 +114,24 @@ async fn p2p_invite_bearer(args: P2pInviteArgs) -> Result<()> {
     } else {
         None
     };
+    // Schema-digest preflight (issue #1122): fingerprint the SDLs this
+    // build has compiled in for the exact collections this template pushes,
+    // so a claimant whose bundled schemas have drifted can refuse to pair
+    // loudly instead of silently black-holing every document it authors.
+    // Can't live as a new field on `PairingBearerClaim`/`BearerPairingReady`
+    // — both are in `gents_migration::CLIENT_AUTHORED_COLLECTIONS`
+    // (crates/gents-migration/src/registry.rs:568-610), so an SDL change
+    // there would force a baseline re-pin (fresh_apply_parity.rs) that
+    // breaks exactly the stale clients this feature warns about. The signed,
+    // pre-pairing invite token is the only channel that reaches the
+    // claimant before it authors anything.
+    let scope_template = resolve_template(&template)
+        .with_context(|| format!("resolving scope template {template} for schema digest"))?;
+    let schema_digest = Some(
+        template_schema_digest(scope_template)
+            .context("computing schema digest for bearer invite")?,
+    );
+
     let (peer_id, ticket) = resolve_invite_transport(args.home.as_deref(), &graphql).await?;
     let mut token = BearerInviteToken {
         v: BEARER_TOKEN_VERSION,
@@ -124,6 +143,7 @@ async fn p2p_invite_bearer(args: P2pInviteArgs) -> Result<()> {
         issued_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
         template: template.clone(),
         default_behavior_id,
+        schema_digest,
         network,
         sig: Vec::new(),
     };

--- a/crates/gents-cli/src/commands/p2p/invite.rs
+++ b/crates/gents-cli/src/commands/p2p/invite.rs
@@ -570,6 +570,7 @@ mod tests {
             issued_at: "2026-07-23T21:30:00Z".to_string(),
             template: "conversation".to_string(),
             default_behavior_id: Some("default".to_string()),
+            schema_digest: None,
             network: NetworkRecord {
                 network_id: "net-Euv46XiYtc8knZqM7cJBAE".to_string(),
                 admin_did:

--- a/crates/gents-cli/tests/suites/cli_p2p.rs
+++ b/crates/gents-cli/tests/suites/cli_p2p.rs
@@ -237,6 +237,24 @@ async fn p2p_bearer_claim_grants_membership_and_intent_end_to_end() -> Result<()
         .to_string();
     assert!(token.starts_with("dabear1-"), "unexpected token: {token}");
 
+    // Issue #1122: the invite carries a schema-digest fingerprint of the
+    // template's SDLs, computed the same way the claimant will recompute it
+    // locally. Both processes here share one binary/schema bundle, so the
+    // claim below exercises the ordinary (matching-digest) path end to end.
+    let decoded_token = gents_protocol::bearer_token::decode_bearer(&token)
+        .context("decoding minted bearer invite token")?;
+    let conversation_template =
+        gents::agent::p2p_reconcile::templates::resolve_template("conversation")
+            .context("resolving conversation scope template")?;
+    let expected_digest =
+        gents::agent::p2p_reconcile::templates::template_schema_digest(conversation_template)
+            .context("computing expected schema digest")?;
+    assert_eq!(
+        decoded_token.schema_digest,
+        Some(expected_digest),
+        "bearer invite should carry the conversation template's schema digest"
+    );
+
     let claim = run_cli_json(&home_b, &["p2p", "pairings", "claim", &token])?;
     assert_eq!(
         claim.get("status").and_then(Value::as_str),

--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -7,7 +7,8 @@ use defra_node::{EmbeddedNode, QueryResponse};
 use defra_p2p_adapter::{P2POperations as P2POps, ReplicationFilter, ReplicationFilters};
 use gents::agent::p2p_reconcile::{
     conversation_like, peer_endpoint_upsert_mutation, resolve_template, resolve_template_filters,
-    DidSource, PairingDirection, Scope, AGENT_DIRECTORY_COLLECTION, CLIENT_TEMPLATE,
+    template_schema_digest, DidSource, PairingDirection, Scope, AGENT_DIRECTORY_COLLECTION,
+    CLIENT_TEMPLATE,
 };
 use gents::graphql::escape_graphql_string;
 use gents::identity::AgentIdentity;
@@ -619,6 +620,27 @@ async fn verify_bearer_invite(
         );
     }
 
+    // Schema-digest preflight (issue #1122), before any pairing row is
+    // written (this runs ahead of every write in `pair_with_bearer_invite`):
+    // a paired client whose bundled SDLs differ from the server's reads
+    // fine but every document it authors is merge-rejected forever with no
+    // signal anywhere the user looks. The issuer stamps a digest of its
+    // template's SDLs into the (signed) invite token; recompute the same
+    // digest from this build's local schema bundle and compare. `None`
+    // means an older server minted no digest — skip silently, back-compat.
+    if let Some(remote_digest) = token.schema_digest.as_deref() {
+        let local_digest = template_schema_digest(template)
+            .context("computing local schema digest for bearer invite verification")?;
+        if local_digest != remote_digest {
+            bail!(
+                "schema mismatch: this build's bundled schemas for template '{}' (digest {local_digest}) \
+                 differ from the server's (digest {remote_digest}); documents you author would be \
+                 silently rejected. Update this app to match the server before pairing.",
+                token.template
+            );
+        }
+    }
+
     Ok(VerifiedBearerInvite {
         raw: raw.to_string(),
         token,
@@ -977,7 +999,9 @@ fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::client::{DesktopPaths, PrincipalIdentity};
-    use gents_protocol::bearer_token::{encode_bearer, BearerInviteToken, BEARER_TOKEN_VERSION};
+    use gents_protocol::bearer_token::{
+        decode_bearer, encode_bearer, BearerInviteToken, BEARER_TOKEN_VERSION,
+    };
 
     async fn signed_token(now: DateTime<Utc>) -> (tempfile::TempDir, PrincipalIdentity, String) {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -1005,6 +1029,7 @@ mod tests {
             issued_at: now.to_rfc3339_opts(SecondsFormat::Secs, true),
             template: "conversation".into(),
             default_behavior_id: Some("default".into()),
+            schema_digest: None,
             network,
             sig: Vec::new(),
         };
@@ -1013,6 +1038,46 @@ mod tests {
             .expect("sign invite");
         let encoded = encode_bearer(&token).expect("encode");
         (temp, identity, encoded)
+    }
+
+    fn resign(identity: &PrincipalIdentity, mut token: BearerInviteToken) -> String {
+        token.sig = Vec::new();
+        token.sig = identity
+            .sign(&bearer_signing_payload(&token))
+            .expect("resign");
+        encode_bearer(&token).expect("encode")
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_schema_digest_mismatch_before_any_write() {
+        let now = Utc::now();
+        let (_temp, identity, encoded) = signed_token(now).await;
+        let mut token = decode_bearer(&encoded).expect("decode");
+        token.schema_digest = Some("mismatched-digest".into());
+        let encoded = resign(&identity, token);
+
+        let error = verify_bearer_invite(&identity, &encoded, now)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("schema mismatch"), "unexpected: {error}");
+        assert!(error.contains("mismatched-digest"), "unexpected: {error}");
+    }
+
+    #[tokio::test]
+    async fn verify_accepts_matching_schema_digest() {
+        let now = Utc::now();
+        let (_temp, identity, encoded) = signed_token(now).await;
+        let mut token = decode_bearer(&encoded).expect("decode");
+        let template = resolve_template(&token.template).expect("template registered");
+        let digest = template_schema_digest(template).expect("digest computes");
+        token.schema_digest = Some(digest.clone());
+        let encoded = resign(&identity, token);
+
+        let verified = verify_bearer_invite(&identity, &encoded, now)
+            .await
+            .expect("matching digest verifies");
+        assert_eq!(verified.token.schema_digest, Some(digest));
     }
 
     #[tokio::test]

--- a/crates/gents-protocol/src/bearer_token.rs
+++ b/crates/gents-protocol/src/bearer_token.rs
@@ -46,6 +46,15 @@ pub struct BearerInviteToken {
     pub template: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_behavior_id: Option<String>,
+    /// Fingerprint of the SDLs the invite's template pushes, from
+    /// [`crate::schema_digest::schema_bundle_digest`]. `None` on invites
+    /// from a server too old to mint one (or preserved deliberately for
+    /// legacy signing-payload byte-identity, mirroring `default_behavior_id`
+    /// above) — the claimant skips the schema-mismatch preflight silently in
+    /// that case. See `crate::schema_digest` for why this rides the token
+    /// instead of a new field on a client-authored collection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_digest: Option<String>,
     pub network: NetworkRecord,
     /// Issuer DID's signature over [`bearer_signing_payload`].
     pub sig: Vec<u8>,
@@ -170,6 +179,23 @@ impl BearerPairingReadyRecord {
 mod tests {
     use super::*;
 
+    /// Shape after `default_behavior_id` shipped but before `schema_digest`
+    /// (issue #1122) — mirrors [`LegacyBearerInviteToken`] one field newer.
+    #[derive(Serialize)]
+    struct BearerInviteTokenWithBehaviorHintOnly {
+        v: u8,
+        issuer_did: String,
+        peer_id: String,
+        ticket: String,
+        nonce: String,
+        network_id: String,
+        issued_at: String,
+        template: String,
+        default_behavior_id: Option<String>,
+        network: NetworkRecord,
+        sig: Vec<u8>,
+    }
+
     #[derive(Serialize)]
     struct LegacyBearerInviteToken {
         v: u8,
@@ -206,6 +232,7 @@ mod tests {
             issued_at: "2026-07-08T00:00:00Z".into(),
             template: "conversation".into(),
             default_behavior_id: Some("default".into()),
+            schema_digest: Some("7fH3kq9mZp".into()),
             network: sample_network(),
             sig: vec![1, 2, 3],
         }
@@ -237,6 +264,10 @@ mod tests {
 
         let mut b = a.clone();
         b.default_behavior_id = Some("review".into());
+        assert_ne!(bearer_signing_payload(&a), bearer_signing_payload(&b));
+
+        let mut b = a.clone();
+        b.schema_digest = Some("differentDigest".into());
         assert_ne!(bearer_signing_payload(&a), bearer_signing_payload(&b));
 
         let mut b = a.clone();
@@ -318,6 +349,74 @@ mod tests {
 
         assert_eq!(decoded.default_behavior_id, None);
         assert_eq!(bearer_signing_payload(&decoded), legacy_bytes);
+    }
+
+    #[test]
+    fn missing_schema_digest_preserves_legacy_signing_payload() {
+        let legacy = BearerInviteTokenWithBehaviorHintOnly {
+            v: BEARER_TOKEN_VERSION,
+            issuer_did: "did:key:issuer".into(),
+            peer_id: "peer-issuer".into(),
+            ticket: "/ticket/issuer".into(),
+            nonce: "nonce-a".into(),
+            network_id: "default".into(),
+            issued_at: "2026-07-08T00:00:00Z".into(),
+            template: "conversation".into(),
+            default_behavior_id: Some("default".into()),
+            network: sample_network(),
+            sig: Vec::new(),
+        };
+        let mut legacy_bytes = Vec::new();
+        ciborium::ser::into_writer(&legacy, &mut legacy_bytes).unwrap();
+        let encoded = format!(
+            "{BEARER_TOKEN_PREFIX}{}",
+            bs58::encode(&legacy_bytes).into_string()
+        );
+
+        let decoded = decode_bearer(&encoded).unwrap();
+
+        assert_eq!(decoded.schema_digest, None);
+        assert_eq!(decoded.default_behavior_id, Some("default".into()));
+        assert_eq!(bearer_signing_payload(&decoded), legacy_bytes);
+    }
+
+    #[test]
+    fn schema_digest_round_trips_through_encode_decode() {
+        let mut t = sample_bearer(BEARER_TOKEN_VERSION);
+        t.schema_digest = Some("7fH3kq9mZp".into());
+        let enc = encode_bearer(&t).unwrap();
+        let decoded = decode_bearer(&enc).unwrap();
+        assert_eq!(decoded.schema_digest, Some("7fH3kq9mZp".into()));
+        assert_eq!(decoded, t);
+    }
+
+    #[test]
+    fn token_minted_with_schema_digest_still_verifies_its_signature() {
+        // A stand-in for `AgentIdentity::sign`/`verify` (those live in the
+        // `gents` crate, not here): a signature is just some function of the
+        // signing payload. What this crate must guarantee is that the exact
+        // bytes the issuer signed at mint time are what the claimant
+        // recomputes after decoding the wire token — including when
+        // `schema_digest` is set. If that held, any real signature scheme
+        // verifies; if it didn't, every real scheme would reject.
+        fn fake_sign(payload: &[u8]) -> Vec<u8> {
+            let mut hasher = Sha256::new();
+            hasher.update(b"fake-signing-key\x1f");
+            hasher.update(payload);
+            hasher.finalize().to_vec()
+        }
+        fn fake_verify(payload: &[u8], sig: &[u8]) -> bool {
+            fake_sign(payload) == sig
+        }
+
+        let mut t = sample_bearer(BEARER_TOKEN_VERSION);
+        t.schema_digest = Some("7fH3kq9mZp".into());
+        t.sig = Vec::new();
+        t.sig = fake_sign(&bearer_signing_payload(&t));
+
+        // Re-decode from the wire form, exactly as a claimant would.
+        let decoded = decode_bearer(&encode_bearer(&t).unwrap()).unwrap();
+        assert!(fake_verify(&bearer_signing_payload(&decoded), &decoded.sig));
     }
 
     #[test]

--- a/crates/gents-protocol/src/lib.rs
+++ b/crates/gents-protocol/src/lib.rs
@@ -6,6 +6,7 @@ pub mod network_token;
 pub mod pairing_token;
 pub mod rendered_request;
 pub mod row;
+pub mod schema_digest;
 pub mod schemas;
 pub mod timeline;
 pub mod transcript;

--- a/crates/gents-protocol/src/schema_digest.rs
+++ b/crates/gents-protocol/src/schema_digest.rs
@@ -104,8 +104,7 @@ mod tests {
     #[test]
     fn whitespace_only_edits_do_not_change_the_digest() {
         let original: &[(&str, &str)] = &[("Foo", "type Foo {\n    id: String\n}\n")];
-        let reindented: &[(&str, &str)] =
-            &[("Foo", "type   Foo   {\n\tid:    String\n}\n\n\n")];
+        let reindented: &[(&str, &str)] = &[("Foo", "type   Foo   {\n\tid:    String\n}\n\n\n")];
         assert_eq!(
             schema_bundle_digest(original),
             schema_bundle_digest(reindented)
@@ -115,17 +114,14 @@ mod tests {
     #[test]
     fn a_real_field_change_produces_a_different_digest() {
         let before: &[(&str, &str)] = &[("Foo", "type Foo {\n    id: String\n}\n")];
-        let added: &[(&str, &str)] =
-            &[("Foo", "type Foo {\n    id: String\n    extra: Int\n}\n")];
+        let added: &[(&str, &str)] = &[("Foo", "type Foo {\n    id: String\n    extra: Int\n}\n")];
         assert_ne!(schema_bundle_digest(before), schema_bundle_digest(added));
 
         let removed: &[(&str, &str)] = &[("Foo", "type Foo {\n}\n")];
         assert_ne!(schema_bundle_digest(before), schema_bundle_digest(removed));
 
-        let reordered: &[(&str, &str)] = &[(
-            "Foo",
-            "type Foo {\n    extra: Int\n    id: String\n}\n",
-        )];
+        let reordered: &[(&str, &str)] =
+            &[("Foo", "type Foo {\n    extra: Int\n    id: String\n}\n")];
         assert_ne!(schema_bundle_digest(added), schema_bundle_digest(reordered));
     }
 

--- a/crates/gents-protocol/src/schema_digest.rs
+++ b/crates/gents-protocol/src/schema_digest.rs
@@ -1,0 +1,144 @@
+//! Schema-bundle fingerprint carried in the bearer invite token (issue
+//! #1122).
+//!
+//! A paired client whose bundled SDLs have drifted from the server's admits
+//! cleanly — replicated reads keep flowing — but every document the client
+//! *authors* is merge-rejected forever with `Collection not found for
+//! schema_version_id`, and nothing surfaces that to the operator. The fix is
+//! a pre-pairing handshake: the issuer stamps a short digest of the SDLs its
+//! invite's template will push into the (signed) [`crate::bearer_token::BearerInviteToken`],
+//! and the claimant recomputes the same digest locally before writing any
+//! pairing row.
+//!
+//! This can't be a new field on `PairingBearerClaim` or `BearerPairingReady`:
+//! both are listed in `gents_migration::CLIENT_AUTHORED_COLLECTIONS`
+//! (crates/gents-migration/src/registry.rs:568-610), so adding a field would
+//! force a baseline re-pin (crates/gents-migration/tests/fresh_apply_parity.rs)
+//! that breaks precisely the stale clients this feature exists to warn about.
+//! The invite token is server-minted, signed, and parsed by the claimant
+//! before any document is authored — it is the only channel that reaches the
+//! client pre-pairing without an SDL change.
+//!
+//! Deliberately short (8 bytes / ~11 bs58 chars): it rides a QR-size-
+//! constrained token alongside the rest of the bearer invite payload.
+
+use sha2::{Digest, Sha256};
+
+/// Fingerprint a bundle of `(collection_name, sdl_text)` pairs.
+///
+/// Each SDL is canonicalized before hashing so purely cosmetic edits
+/// (comment wording, re-indentation) don't false-positive a mismatch:
+/// whole-line and trailing `#` comments are stripped, each line is trimmed,
+/// blank lines are dropped, and internal whitespace runs collapse to a
+/// single space. Pairs are sorted by collection name so input order never
+/// affects the result. A real schema change (field added/removed/reordered)
+/// changes the canonical text and therefore the digest.
+pub fn schema_bundle_digest(collections: &[(&str, &str)]) -> String {
+    let mut sorted: Vec<(&str, &str)> = collections.to_vec();
+    sorted.sort_by_key(|(name, _)| *name);
+
+    let mut hasher = Sha256::new();
+    for (name, sdl) in sorted {
+        hasher.update(name.as_bytes());
+        hasher.update(b"\n");
+        hasher.update(canonicalize_sdl(sdl).as_bytes());
+        hasher.update(b"\n");
+    }
+    let digest = hasher.finalize();
+    bs58::encode(&digest[..8]).into_string()
+}
+
+/// Strip comments and normalize whitespace so cosmetic-only SDL edits hash
+/// identically to the original.
+fn canonicalize_sdl(sdl: &str) -> String {
+    sdl.lines()
+        .map(strip_comment)
+        .map(collapse_whitespace)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Drop everything from the first unescaped `#` onward (SDL in this codebase
+/// never quotes a literal `#`, so a naive first-index truncation is safe —
+/// see `every_agent_schema_starts_with_type_declaration` and friends, which
+/// would fail loudly if that assumption ever broke).
+fn strip_comment(line: &str) -> &str {
+    match line.find('#') {
+        Some(idx) => &line[..idx],
+        None => line,
+    }
+}
+
+fn collapse_whitespace(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_inputs_produce_the_same_digest() {
+        let a: &[(&str, &str)] = &[("Foo", "type Foo { id: String }")];
+        let b: &[(&str, &str)] = &[("Foo", "type Foo { id: String }")];
+        assert_eq!(schema_bundle_digest(a), schema_bundle_digest(b));
+    }
+
+    #[test]
+    fn comment_only_edits_do_not_change_the_digest() {
+        let original: &[(&str, &str)] = &[(
+            "Foo",
+            "# a comment\ntype Foo {\n    id: String # inline note\n}\n",
+        )];
+        let recommented: &[(&str, &str)] = &[(
+            "Foo",
+            "# a totally different comment\ntype Foo {\n    id: String # a different inline note\n}\n",
+        )];
+        assert_eq!(
+            schema_bundle_digest(original),
+            schema_bundle_digest(recommented)
+        );
+    }
+
+    #[test]
+    fn whitespace_only_edits_do_not_change_the_digest() {
+        let original: &[(&str, &str)] = &[("Foo", "type Foo {\n    id: String\n}\n")];
+        let reindented: &[(&str, &str)] =
+            &[("Foo", "type   Foo   {\n\tid:    String\n}\n\n\n")];
+        assert_eq!(
+            schema_bundle_digest(original),
+            schema_bundle_digest(reindented)
+        );
+    }
+
+    #[test]
+    fn a_real_field_change_produces_a_different_digest() {
+        let before: &[(&str, &str)] = &[("Foo", "type Foo {\n    id: String\n}\n")];
+        let added: &[(&str, &str)] =
+            &[("Foo", "type Foo {\n    id: String\n    extra: Int\n}\n")];
+        assert_ne!(schema_bundle_digest(before), schema_bundle_digest(added));
+
+        let removed: &[(&str, &str)] = &[("Foo", "type Foo {\n}\n")];
+        assert_ne!(schema_bundle_digest(before), schema_bundle_digest(removed));
+
+        let reordered: &[(&str, &str)] = &[(
+            "Foo",
+            "type Foo {\n    extra: Int\n    id: String\n}\n",
+        )];
+        assert_ne!(schema_bundle_digest(added), schema_bundle_digest(reordered));
+    }
+
+    #[test]
+    fn input_slice_order_does_not_matter() {
+        let a: &[(&str, &str)] = &[
+            ("Foo", "type Foo { id: String }"),
+            ("Bar", "type Bar { id: String }"),
+        ];
+        let b: &[(&str, &str)] = &[
+            ("Bar", "type Bar { id: String }"),
+            ("Foo", "type Foo { id: String }"),
+        ];
+        assert_eq!(schema_bundle_digest(a), schema_bundle_digest(b));
+    }
+}

--- a/crates/gents-protocol/src/schemas.rs
+++ b/crates/gents-protocol/src/schemas.rs
@@ -185,6 +185,27 @@ pub const ALL_COLLECTION_NAMES: &[&str] = &[
 
 pub const BRANCHABLE_COLLECTION_NAMES: &[&str] = BRANCHABLE_AGENT_COLLECTION_NAMES;
 
+/// Look up a registered collection's SDL by name (index-aligned lookup over
+/// [`ALL_COLLECTION_NAMES`]/[`ALL`], falling back to
+/// [`RUNTIME_COLLECTION_NAMES`]/[`RUNTIME_ALL`] — `InferenceBackend` is
+/// registered before reconciliation starts and lives only in the runtime
+/// set, not `ALL`, but templates like `conversation`/`machine` still push
+/// it). Used by the bearer-invite schema-digest preflight (issue #1122) to
+/// map a template's collection set to the exact SDL text this build has
+/// compiled in.
+pub fn sdl_for(name: &str) -> Option<&'static str> {
+    ALL_COLLECTION_NAMES
+        .iter()
+        .position(|candidate| *candidate == name)
+        .map(|index| ALL[index])
+        .or_else(|| {
+            RUNTIME_COLLECTION_NAMES
+                .iter()
+                .position(|candidate| *candidate == name)
+                .map(|index| RUNTIME_ALL[index])
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -220,6 +241,17 @@ mod tests {
     fn collection_names_align_with_sdl_arrays() {
         assert_eq!(ALL.len(), ALL_COLLECTION_NAMES.len());
         assert_eq!(RUNTIME_ALL.len(), RUNTIME_COLLECTION_NAMES.len());
+    }
+
+    #[test]
+    fn sdl_for_resolves_every_registered_collection_and_rejects_unknown() {
+        for (index, name) in ALL_COLLECTION_NAMES.iter().enumerate() {
+            assert_eq!(sdl_for(name), Some(ALL[index]));
+        }
+        for (index, name) in RUNTIME_COLLECTION_NAMES.iter().enumerate() {
+            assert_eq!(sdl_for(name), Some(RUNTIME_ALL[index]));
+        }
+        assert_eq!(sdl_for("NotARealCollection"), None);
     }
 
     #[test]

--- a/crates/gents/src/agent/p2p_reconcile/mod.rs
+++ b/crates/gents/src/agent/p2p_reconcile/mod.rs
@@ -70,10 +70,10 @@ pub use registry::{
 pub use session_hydration_reconcile::run_session_hydration_reconciler;
 pub use templates::{
     builtin_templates, combine_filters, conversation_like, decode_pairing_filters, equality_filter,
-    filter_conditions, resolve_template, scope_filter, single_string_eq, to_replication_filters,
-    Delivery, DidSource, FilterPredicate, PairingFilters, Scope, ScopeTemplate,
-    AGENT_DIRECTORY_COLLECTION, CLIENT_COLLECTIONS, CLIENT_TEMPLATE, CLIENT_TO_RUNTIME_COLLECTIONS,
-    NETWORK_CONTROL_TEMPLATE,
+    filter_conditions, resolve_template, scope_filter, single_string_eq, template_schema_digest,
+    to_replication_filters, Delivery, DidSource, FilterPredicate, PairingFilters, Scope,
+    ScopeTemplate, AGENT_DIRECTORY_COLLECTION, CLIENT_COLLECTIONS, CLIENT_TEMPLATE,
+    CLIENT_TO_RUNTIME_COLLECTIONS, NETWORK_CONTROL_TEMPLATE,
 };
 pub use trait_def::{
     RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteP2pDocument, RemoteReplicator,

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -9,6 +9,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 pub use p2p::ReplicationFilter as FilterPredicate;
@@ -686,6 +688,36 @@ pub fn resolve_template(id: &str) -> Option<&'static ScopeTemplate> {
     BUILTIN_TEMPLATES.iter().find(|t| t.id == id)
 }
 
+/// Fingerprint this build's bundled SDLs for a template's collection set
+/// (issue #1122's bearer-invite schema-digest preflight). Shared by the
+/// mint side (CLI `p2p invite --bearer`) and every claim side (CLI `p2p
+/// claim`, the desktop `verify_bearer_invite` path) so both compute the
+/// digest identically — over the exact collections the template pushes,
+/// mapped to SDL via [`gents_protocol::schemas::sdl_for`].
+///
+/// Errors if the template names a collection this build has no registered
+/// SDL for; that would mean the template catalog and the schema registry
+/// have drifted apart, which is a bug in this build, not a mismatch to
+/// report to the operator.
+pub fn template_schema_digest(template: &ScopeTemplate) -> Result<String> {
+    let pairs: Vec<(&str, &str)> = template
+        .collections
+        .iter()
+        .map(|&name| {
+            gents_protocol::schemas::sdl_for(name)
+                .map(|sdl| (name, sdl))
+                .with_context(|| {
+                    format!(
+                        "template '{}' references collection '{name}' with no registered SDL \
+                         in this build",
+                        template.id
+                    )
+                })
+        })
+        .collect::<Result<_>>()?;
+    Ok(gents_protocol::schema_digest::schema_bundle_digest(&pairs))
+}
+
 /// Build per-collection `PairingFilters` for a template scope against a
 /// concrete peer/local DID pair.
 ///
@@ -1045,6 +1077,37 @@ mod tests {
             filters.get("SessionHydrationRequest"),
             Some(&equality_filter("requester_did", "did:key:phone"))
         );
+    }
+
+    #[test]
+    fn template_schema_digest_resolves_every_builtin_templates_collections() {
+        for template in builtin_templates() {
+            if template.collections.is_empty() {
+                // app-collections brings its own collection set at pairing
+                // time; there is nothing static to fingerprint.
+                continue;
+            }
+            let digest = template_schema_digest(template)
+                .unwrap_or_else(|err| panic!("template '{}': {err}", template.id));
+            assert!(!digest.is_empty());
+        }
+    }
+
+    #[test]
+    fn template_schema_digest_is_stable_and_rejects_unregistered_collections() {
+        let machine = resolve_template("machine").expect("machine template registered");
+        let a = template_schema_digest(machine).unwrap();
+        let b = template_schema_digest(machine).unwrap();
+        assert_eq!(a, b);
+
+        let bogus = ScopeTemplate {
+            id: "bogus",
+            collections: &["NotARealCollection"],
+            scope: Scope::Unscoped,
+            delivery: Delivery::Push,
+        };
+        let err = template_schema_digest(&bogus).unwrap_err().to_string();
+        assert!(err.contains("NotARealCollection"), "unexpected: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1122.

## The problem

A paired client whose bundled SDLs have drifted from the server's admits *cleanly* — replicated reads keep flowing, the pairing looks healthy — but every document the client **authors** is merge-rejected forever with `Collection not found for schema_version_id`, and nothing surfaces it to the operator. This is the failure that black-holed messages during mobile device testing: the phone paired, showed a live conversation, and silently dropped everything it wrote.

## The fix

A pre-pairing handshake. The issuer stamps a short digest of the SDLs its invite's template will push into the (signed) `BearerInviteToken`; the claimant recomputes the same digest from its own bundle and refuses to pair on mismatch, **before writing any pairing row**. `--allow-schema-mismatch` overrides for the deliberate case.

`schema_bundle_digest` canonicalizes each SDL before hashing (strips comments, trims lines, collapses whitespace runs, drops blanks, sorts by collection name) so cosmetic edits don't false-positive, while a real field add/remove/reorder changes the digest. It's truncated to 8 bytes / ~11 bs58 chars because it rides a QR-size-constrained token.

## Why the token, not a collection field

This can't be a new field on `PairingBearerClaim` or `BearerPairingReady`: both are in `gents_migration::CLIENT_AUTHORED_COLLECTIONS`, so adding a field forces a baseline re-pin (`fresh_apply_parity.rs`) that breaks precisely the stale clients this feature exists to warn about. The invite token is server-minted, signed, and parsed by the claimant before any document is authored — the only channel that reaches the client pre-pairing without an SDL change.

The field is `skip_serializing_if = "Option::is_none"`, so the signing payload stays byte-identical for tokens that omit it, and a `None` digest (older server) skips the check silently.

## Gate results

| Target | Result |
|---|---|
| `gents-protocol` (incl. `schema_digest`, `bearer_token`) | 143 passed, 0 failed |
| `gents-cli tests/cli_p2p` | 7 passed, 0 failed |
| ~40 other CLI integration targets | green |
| `cargo fmt --all --check` | clean |
| `cargo check --workspace --all-targets` | clean, 0 errors |

Two failure classes in the local suite are **not** from this branch:

- **3 Lean-contract tests** (`gents-cli` lib ×2, `cli_config_task_run` ×1) fail with `failed to build Lean conformance contract target ... No such file or directory` — `lake`/`elan` aren't installed on this machine. CI's `lean-proofs` job is the authority.
- **`cli_subagent::subagent_list_shows_two_level_dispatch_lineage`** fails deterministically (3/3): expects root + 2 children + grandchild, gets only the root. Pre-existing on main and matching #1182 (children invisible to `list_subagents`); this branch touches no subagent code. Flagged separately — it may mean main is red on that target.

## Blocks #938

⚠️ **Merge-order dependency.** #938's compact v2 QR payload is an 11-field *positional* CBOR array with no slot for `schema_digest`, and its decoder verifies the issuer signature over the **reconstructed** struct. Since `bearer_signing_payload` serializes the whole token, a digest-bearing invite shared as a QR would reconstruct without the digest → signing payload differs → **signature verification fails and QR pairing breaks**. Where it didn't hard-fail, the preflight would silently degrade to "no check" on exactly the QR path — the failure this PR exists to eliminate.

This PR should land first; #938 then rebases onto it and widens the v2 array to 12 fields (Rust encoder/decoder + the TS scanner's `V2_ARRAY_LENGTH`).

## Follow-up

The mobile counterpart — compute the same digest over the app's bundled SDLs, refuse to pair, show a banner — is not in this PR. It needs the pinned digest value from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Arv3YzUJH1oSvYL21kekca