### PR TITLE
fix: enable embedded schema operations over HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -789,7 +789,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1548,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -1618,7 +1618,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "anyhow",
@@ -1975,7 +1975,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2000,7 +2000,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "async-stream",
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "anyhow",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "async-trait",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "serde",
 ]
@@ -2329,7 +2329,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4242,7 +4242,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -4884,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "async-channel",
@@ -4952,7 +4952,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6181,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "anyhow",
@@ -6966,7 +6966,7 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "acp",
  "async-graphql",
@@ -7363,7 +7363,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "p2p",
  "query",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "cid",
  "defra-core",
@@ -8520,7 +8520,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "tracing",
 ]
@@ -11500,7 +11500,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=54b629b1e1f0f64a83d9b81e2106d963de842d27#54b629b1e1f0f64a83d9b81e2106d963de842d27"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=275b0cd75deb50c73166ba500e5421c1d239b77f#275b0cd75deb50c73166ba500e5421c1d239b77f"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ clap = { version = "4", features = ["derive", "env"] }
 # DefraDB v0.18.0 includes signed explicit transactions and default node query
 # identity. Its iterative parent-DAG replay remains required on iOS:
 # a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-codex-protocol = { path = "crates/gents-codex-protocol" }
@@ -69,12 +69,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -82,8 +82,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "54b629b1e1f0f64a83d9b81e2106d963de842d27" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "275b0cd75deb50c73166ba500e5421c1d239b77f" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/gents-cli/tests/suites/cli_mailbox.rs
+++ b/crates/gents-cli/tests/suites/cli_mailbox.rs
@@ -46,9 +46,8 @@ async fn mailbox_list_scopes_to_caller_and_dismisses_owned_item() -> Result<()> 
         did = escape_graphql_string(&agent_did),
     );
     let created = graphql_query(&graphql, &mutation).await?;
-    let doc_id = created["data"]["create_MailboxItem"]["_docID"]
-        .as_str()
-        .context("created mailbox doc id")?;
+    let doc_id = gents_protocol::graphql::extract_mutation_doc_id(&created, "MailboxItem")
+        .with_context(|| format!("created mailbox doc id: {created}"))?;
 
     let listed = run_cli_json(&home_dir, &["mailbox", "list", "--graphql", &graphql])?;
     let rows = listed.as_array().context("mailbox list array")?;
@@ -58,7 +57,7 @@ async fn mailbox_list_scopes_to_caller_and_dismisses_owned_item() -> Result<()> 
 
     let dismissed = run_cli_json(
         &home_dir,
-        &["mailbox", "dismiss", doc_id, "--graphql", &graphql],
+        &["mailbox", "dismiss", &doc_id, "--graphql", &graphql],
     )?;
     assert_eq!(dismissed["status"], "dismissed");
     let open = run_cli_json(&home_dir, &["mailbox", "list", "--graphql", &graphql])?;


### PR DESCRIPTION
## Summary

- update the pinned DefraDB revision to the reviewed schema-over-HTTP change
- enable schema operations in the embedded Gents HTTP server

This is the minimum prerequisite for installing bundled graph schemas through the same server boundary used by the CLI.

DefraDB dependency: sourcenetwork/defradb.rs#1592

## Review boundary

No graph package or runtime behavior is introduced here.

## Verification

- `cargo test -p gents`
- `cargo check --workspace --all-targets`