### PR TITLE
refactor: share desired-state apply through the runtime

### DIFF
--- a/crates/gents-cli/src/commands/schema.rs
+++ b/crates/gents-cli/src/commands/schema.rs
@@ -268,13 +268,10 @@ async fn apply_sdl_file(access: &ConfigAccess, path: &Path) -> Result<SchemaAppl
         );
     }
 
-    match access {
-        ConfigAccess::Graphql(endpoint) => post_schema_http(endpoint, &sdl).await?,
-        ConfigAccess::Local(node) => node
-            .add_schema(&sdl)
-            .await
-            .with_context(|| format!("adding schema {}", path.display()))?,
-    }
+    access
+        .add_schema(&sdl)
+        .await
+        .with_context(|| format!("adding schema {}", path.display()))?;
 
     Ok(SchemaApplyFileResult {
         path: path.display().to_string(),
@@ -358,51 +355,17 @@ async fn existing_collections(
 }
 
 async fn collection_exists(access: &ConfigAccess, collection: &str) -> Result<bool> {
-    match access {
-        ConfigAccess::Local(node) => Ok(node.get_collection(collection)?.is_some()),
-        ConfigAccess::Graphql(endpoint) => {
-            let api_base = graphql_api_base(endpoint)?;
-            let client = schema_http_client()?;
-            let response: Value = http_get_json(
-                &client,
-                &format!("{api_base}/collections/{collection}/exists"),
-            )
-            .await?;
-            Ok(response
-                .get("exists")
-                .and_then(Value::as_bool)
-                .unwrap_or(false))
-        }
-    }
+    Ok(access.collection_fields(collection).await?.is_some())
 }
 
 async fn collection_field_names(
     access: &ConfigAccess,
     collection: &str,
 ) -> Result<BTreeSet<String>> {
-    match access {
-        ConfigAccess::Local(node) => {
-            let collection = node
-                .get_collection(collection)?
-                .ok_or_else(|| anyhow::anyhow!("collection {collection} does not exist"))?;
-            Ok(collection
-                .fields
-                .into_iter()
-                .map(|field| field.name)
-                .collect())
-        }
-        ConfigAccess::Graphql(endpoint) => {
-            let describe = describe_collection_http(endpoint, collection).await?;
-            Ok(describe
-                .get("Fields")
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(|field| field.get("Name").and_then(Value::as_str))
-                .map(ToOwned::to_owned)
-                .collect())
-        }
-    }
+    access
+        .collection_fields(collection)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("collection {collection} does not exist"))
 }
 
 async fn current_collection_version(
@@ -509,20 +472,6 @@ fn filter_existing_field_adds(
         .map(|(_, op)| op.clone())
         .collect::<Vec<_>>();
     Ok((Value::Array(filtered), applied_fields, skipped_fields))
-}
-
-async fn post_schema_http(endpoint: &str, sdl: &str) -> Result<()> {
-    let api_base = graphql_api_base(endpoint)?;
-    let client = schema_http_client()?;
-    let url = format!("{api_base}/schema");
-    let response = client
-        .post(&url)
-        .header(reqwest::header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .body(sdl.to_string())
-        .send()
-        .await
-        .with_context(|| format!("posting schema SDL to {url}"))?;
-    ensure_success(response, "schema SDL", &url).await
 }
 
 async fn patch_collection_http(endpoint: &str, patch: &Value) -> Result<()> {

--- a/crates/gents-cli/src/config_import.rs
+++ b/crates/gents-cli/src/config_import.rs
@@ -27,21 +27,7 @@ mod lean_vocab_test;
 
 const CONFIG_IMPORT_BATCH_SIZE: usize = 50;
 
-const CONFIG_APPLY_ORDER: [Collection; 13] = [
-    Collection::PeerPairingDesired,
-    Collection::InferenceBackend,
-    Collection::InferenceProfile,
-    Collection::ToolServiceRegistry,
-    Collection::DatastoreToolSurface,
-    Collection::ToolSelection,
-    Collection::Skill,
-    Collection::AgentBehavior,
-    Collection::ProjectionAcpBinding,
-    Collection::Task,
-    Collection::Schedule,
-    Collection::EventTrigger,
-    Collection::AgentPrincipal,
-];
+const CONFIG_APPLY_ORDER: [Collection; 13] = gents::DESIRED_STATE_APPLY_ORDER;
 
 const CONFIG_PRUNE_ORDER: [Collection; 13] = [
     Collection::AgentPrincipal,
@@ -852,14 +838,37 @@ pub(crate) async fn apply_desired_state_changes(
 
     for collection in CONFIG_APPLY_ORDER {
         let docs = select_apply_docs_for_collection(desired_bundle, planned, collection)?;
-        let applied = apply_import_collection(
-            txn,
-            collection.graphql_type(),
-            collection.unique_field(),
-            &docs,
-            true,
-        )
-        .await?;
+        let applied = if collection == Collection::PeerPairingDesired
+            || uses_custom_apply_writer(collection.graphql_type())
+        {
+            // Pairings have compound manifest ownership semantics and remain
+            // in the CLI-specific path. The three custom writers also retain
+            // the existing batched/tombstone-aware CLI behavior; the runtime
+            // API routes package calls through the same dedicated writers.
+            apply_import_collection(
+                txn,
+                collection.graphql_type(),
+                collection.unique_field(),
+                &docs,
+                true,
+            )
+            .await?
+        } else {
+            let documents = docs
+                .iter()
+                .map(|doc| {
+                    Ok(gents::config_client::DesiredStateApplyDocument {
+                        collection,
+                        add: sanitize_import_document(collection.graphql_type(), doc, false)?,
+                        update: sanitize_import_document(collection.graphql_type(), doc, true)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let plan = gents::config_client::DesiredStateApplyPlan::new(documents)?;
+            gents::config_client::apply_desired_state_plan(txn, &plan)
+                .await?
+                .get(collection)
+        };
         counts.set(collection, applied);
 
         if let Some(sleep) = per_collection_sleep {

--- a/crates/gents-cli/src/config_import/lean_apply_write_boundary_tests.rs
+++ b/crates/gents-cli/src/config_import/lean_apply_write_boundary_tests.rs
@@ -700,6 +700,14 @@ fn aliased_mutation_response(query: &str) -> Value {
         let alias = capture[1].to_string();
         data.insert(alias.clone(), json!({ "_docID": format!("{alias}-id") }));
     }
+    if data.is_empty() {
+        let field_re = Regex::new(r"\b((?:add|create|update|upsert)_[A-Za-z]+)\s*\(")
+            .expect("mutation field regex");
+        for capture in field_re.captures_iter(query) {
+            let field = capture[1].to_string();
+            data.insert(field.clone(), json!({ "_docID": format!("{field}-id") }));
+        }
+    }
     Value::Object(data)
 }
 

--- a/crates/gents-cli/tests/suites/cli_config_apply_order.rs
+++ b/crates/gents-cli/tests/suites/cli_config_apply_order.rs
@@ -1,24 +1,12 @@
-use gents::Collection;
+use gents::{Collection, DESIRED_STATE_APPLY_ORDER};
 use std::collections::BTreeSet;
 
 fn config_apply_order_from_source() -> Vec<Collection> {
     let src = include_str!("../../src/config_import.rs");
-    let body_start = src.find("const CONFIG_APPLY_ORDER").unwrap();
-    let body_end = src[body_start..].find("];").unwrap() + body_start;
-    let body = &src[body_start..body_end];
-
-    let re = regex::Regex::new(r"Collection::([A-Za-z]+)").unwrap();
-    re.captures_iter(body)
-        .map(|capture| {
-            let variant_name = capture.get(1).unwrap().as_str();
-            Collection::ALL
-                .into_iter()
-                .find(|collection| collection.graphql_type() == variant_name)
-                .unwrap_or_else(|| {
-                    panic!("unknown Collection variant in CONFIG_APPLY_ORDER: {variant_name}")
-                })
-        })
-        .collect()
+    assert!(src.contains(
+        "const CONFIG_APPLY_ORDER: [Collection; 13] = gents::DESIRED_STATE_APPLY_ORDER;"
+    ));
+    DESIRED_STATE_APPLY_ORDER.to_vec()
 }
 
 #[test]

--- a/crates/gents-cli/tests/suites/cli_config_apply_transactional_rollback.rs
+++ b/crates/gents-cli/tests/suites/cli_config_apply_transactional_rollback.rs
@@ -84,6 +84,19 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
         .context("spawning gents config apply with apply-sleep env")?;
 
     thread::sleep(KILL_DELAY);
+    if let Some(status) = cli
+        .try_wait()
+        .context("checking config apply before SIGKILL")?
+    {
+        let output = cli
+            .wait_with_output()
+            .context("capturing config apply that exited before SIGKILL")?;
+        return Err(anyhow!(
+            "config apply exited before the rollback probe could kill an active transaction ({status})\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
     cli.kill().context("SIGKILL CLI")?;
     cli.wait().context("reap CLI")?;
 

--- a/crates/gents/src/collection.rs
+++ b/crates/gents/src/collection.rs
@@ -27,6 +27,26 @@ pub enum Collection {
     EventTrigger,
 }
 
+/// Canonical dependency order for desired-state writes. Consumers may select
+/// a subset, but must preserve this order. Deletes intentionally have no
+/// equivalent runtime API: pruning is an operator CLI concern, never a package
+/// installation primitive.
+pub const DESIRED_STATE_APPLY_ORDER: [Collection; 13] = [
+    Collection::PeerPairingDesired,
+    Collection::InferenceBackend,
+    Collection::InferenceProfile,
+    Collection::ToolServiceRegistry,
+    Collection::DatastoreToolSurface,
+    Collection::ToolSelection,
+    Collection::Skill,
+    Collection::AgentBehavior,
+    Collection::ProjectionAcpBinding,
+    Collection::Task,
+    Collection::Schedule,
+    Collection::EventTrigger,
+    Collection::AgentPrincipal,
+];
+
 impl Collection {
     // NOTE: `WorkspaceRoot` is intentionally NOT a member of `ALL`. `ALL`
     // drives the full desired-state config CRUD surface (CONFIG_APPLY_ORDER,

--- a/crates/gents/src/config_client/common.rs
+++ b/crates/gents/src/config_client/common.rs
@@ -173,10 +173,45 @@ pub fn mint_recreate_identity(add_doc: &serde_json::Value) -> serde_json::Value 
     doc
 }
 
+/// DefraDB cannot type an empty GraphQL list literal for nillable array
+/// columns. Create inputs omit those fields; update inputs use `null` to clear
+/// them. Every config writer that starts from JSON shares these transforms.
+pub(crate) fn sanitize_create_input(value: &Value) -> Value {
+    let mut value = value.clone();
+    if let Some(object) = value.as_object_mut() {
+        object.retain(|_, value| {
+            !value.is_null() && !matches!(value, Value::Array(items) if items.is_empty())
+        });
+    }
+    value
+}
+
+pub(crate) fn sanitize_update_input(value: &Value) -> Value {
+    let mut value = value.clone();
+    if let Some(object) = value.as_object_mut() {
+        for value in object.values_mut() {
+            if matches!(value, Value::Array(items) if items.is_empty()) {
+                *value = Value::Null;
+            }
+        }
+    }
+    value
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn defra_json_inputs_never_emit_empty_array_literals() {
+        let input = json!({ "keep": ["value"], "empty": [], "nil": null });
+        assert_eq!(sanitize_create_input(&input), json!({ "keep": ["value"] }));
+        assert_eq!(
+            sanitize_update_input(&input),
+            json!({ "keep": ["value"], "empty": null, "nil": null })
+        );
+    }
 
     #[test]
     fn recreate_identity_preserves_content_and_stamps_updated_at() {

--- a/crates/gents/src/config_client/desired_state.rs
+++ b/crates/gents/src/config_client/desired_state.rs
@@ -1,0 +1,368 @@
+//! Runtime-owned desired-state write boundary.
+//!
+//! Loading files, interpolation, and operator-facing diff reports remain CLI
+//! concerns. This module owns the reusable control-plane operation: apply a
+//! validated set of normalized documents in dependency order inside an
+//! existing transaction. There is deliberately no delete or prune operation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result};
+use gents_protocol::graphql::{extract_mutation_doc_id, graphql_input_literal};
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::graphql::escape_graphql_string;
+use crate::{Collection, DESIRED_STATE_APPLY_ORDER};
+
+use super::{
+    common::{sanitize_create_input, sanitize_update_input},
+    mint_recreate_identity, write_event_trigger_document, write_schedule_document,
+    write_task_document, ConfigApplyTxn,
+};
+
+fn normalize_digest_value(value: Value) -> Option<Value> {
+    match value {
+        Value::Null => None,
+        Value::Array(values) => {
+            let values = values
+                .into_iter()
+                .filter_map(|value| match value {
+                    Value::String(raw) => serde_json::from_str::<Value>(&raw)
+                        .ok()
+                        .filter(|parsed| parsed.is_object() || parsed.is_array())
+                        .and_then(normalize_digest_value)
+                        .or(Some(Value::String(raw))),
+                    value => normalize_digest_value(value),
+                })
+                .collect::<Vec<_>>();
+            (!values.is_empty()).then_some(Value::Array(values))
+        }
+        Value::Object(values) => {
+            let values = values
+                .into_iter()
+                .filter(|(key, _)| key != "updated_at")
+                .filter_map(|(key, value)| normalize_digest_value(value).map(|value| (key, value)))
+                .collect::<Map<_, _>>();
+            Some(Value::Object(values))
+        }
+        value => Some(value),
+    }
+}
+
+/// Canonical semantic commitment shared by package planning, retry checks,
+/// runtime visibility, and start readiness. DefraDB null/absent and its
+/// string-encoded object-list representation normalize to one value.
+pub(crate) fn desired_state_document_digest(value: &Value) -> Result<String> {
+    let normalized = normalize_digest_value(value.clone()).unwrap_or(Value::Object(Map::new()));
+    Ok(format!(
+        "sha256:{:x}",
+        Sha256::digest(serde_json::to_vec(&normalized)?)
+    ))
+}
+
+pub(crate) async fn read_desired_state_document_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    collection: Collection,
+    unique_value: &str,
+) -> Result<Option<Value>> {
+    let target = desired_state_read_target(collection)?;
+    if let Some(target) = target {
+        return Ok(super::patch::read_doc_in_txn(txn, target, unique_value)
+            .await?
+            .map(|(_, document)| Value::Object(document)));
+    }
+
+    let collection_name = collection.graphql_type();
+    let unique_field = collection.unique_field();
+    let response = txn
+        .execute(&format!(
+            r#"{{
+                {collection_name}(
+                    filter: {{ {unique_field}: {{ _eq: "{}" }} }}, limit: 2
+                ) {{
+                    _docID surface_id agent_did display_name enabled entries created_at updated_at
+                }}
+            }}"#,
+            escape_graphql_string(unique_value),
+        ))
+        .await?;
+    let rows = response
+        .get("data")
+        .and_then(|data| data.get(collection_name))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if rows.len() > 1 {
+        anyhow::bail!(
+            "multiple live {collection_name} documents share {unique_field}={unique_value}"
+        );
+    }
+    Ok(rows.into_iter().next().map(|mut row| {
+        row.as_object_mut()
+            .expect("GraphQL document row is an object")
+            .remove("_docID");
+        row
+    }))
+}
+
+fn desired_state_read_target(
+    collection: Collection,
+) -> Result<Option<super::patch::SelfConfigTarget>> {
+    let target = match collection {
+        Collection::AgentBehavior => Some(super::patch::SelfConfigTarget::AgentBehavior),
+        Collection::ToolSelection => Some(super::patch::SelfConfigTarget::ToolSelection),
+        Collection::Task => Some(super::patch::SelfConfigTarget::Task),
+        Collection::Schedule => Some(super::patch::SelfConfigTarget::Schedule),
+        Collection::EventTrigger => Some(super::patch::SelfConfigTarget::EventTrigger),
+        Collection::DatastoreToolSurface => None,
+        _ => {
+            return Err(anyhow::anyhow!(
+                "{} is not a package-owned desired-state resource",
+                collection.graphql_type()
+            ))
+        }
+    };
+    Ok(target)
+}
+
+/// Existing revision-owned documents are immutable. Missing rows are
+/// resumable; a present row with different semantic content is drift and is
+/// never overwritten by package retry.
+pub(crate) async fn verify_existing_desired_state_plan(
+    txn: &ConfigApplyTxn<'_>,
+    plan: &DesiredStateApplyPlan,
+) -> Result<()> {
+    for document in plan.documents() {
+        let id = unique_value(document)?;
+        let Some(live) = read_desired_state_document_in_txn(txn, document.collection, id).await?
+        else {
+            continue;
+        };
+        let expected = desired_state_document_digest(&document.add)?;
+        let observed = desired_state_document_digest(&live)?;
+        if observed != expected {
+            anyhow::bail!(
+                "immutable package resource {} {id:?} drifted: expected {expected}, observed {observed}",
+                document.collection.graphql_type()
+            );
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DesiredStateApplyDocument {
+    pub collection: Collection,
+    /// Normalized create shape. It must contain the collection's unique key.
+    pub add: Value,
+    /// Normalized update shape. Omitted fields preserve existing values and
+    /// explicit null clears nullable values.
+    pub update: Value,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DesiredStateApplyPlan {
+    documents: Vec<DesiredStateApplyDocument>,
+}
+
+impl DesiredStateApplyPlan {
+    pub fn new(mut documents: Vec<DesiredStateApplyDocument>) -> Result<Self> {
+        let mut identities = BTreeSet::new();
+        for document in &documents {
+            if document.collection == Collection::PeerPairingDesired {
+                anyhow::bail!(
+                    "PeerPairingDesired uses manifest ownership semantics and is not supported by the non-pruning runtime apply API"
+                );
+            }
+            let collection = document.collection.graphql_type();
+            let unique_field = document.collection.unique_field();
+            let unique_value = unique_value(document)?;
+            if !identities.insert((document.collection, unique_value.to_owned())) {
+                anyhow::bail!(
+                    "desired-state apply plan contains duplicate {collection} {unique_field}={unique_value}"
+                );
+            }
+            if !document.add.is_object() || !document.update.is_object() {
+                anyhow::bail!("desired-state {collection} add/update documents must be objects");
+            }
+        }
+        documents.sort_by(|left, right| {
+            let left_order = apply_order_index(left.collection);
+            let right_order = apply_order_index(right.collection);
+            (left_order, unique_value(left).unwrap_or_default())
+                .cmp(&(right_order, unique_value(right).unwrap_or_default()))
+        });
+        Ok(Self { documents })
+    }
+
+    pub fn documents(&self) -> &[DesiredStateApplyDocument] {
+        &self.documents
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
+pub struct DesiredStateApplyCounts {
+    counts: BTreeMap<String, usize>,
+}
+
+impl DesiredStateApplyCounts {
+    pub fn get(&self, collection: Collection) -> usize {
+        self.counts
+            .get(collection.graphql_type())
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn increment(&mut self, collection: Collection) {
+        *self
+            .counts
+            .entry(collection.graphql_type().to_owned())
+            .or_default() += 1;
+    }
+}
+
+fn apply_order_index(collection: Collection) -> usize {
+    DESIRED_STATE_APPLY_ORDER
+        .iter()
+        .position(|candidate| *candidate == collection)
+        .unwrap_or(usize::MAX)
+}
+
+fn unique_value(document: &DesiredStateApplyDocument) -> Result<&str> {
+    let unique_field = document.collection.unique_field();
+    document
+        .add
+        .get(unique_field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .with_context(|| {
+            format!(
+                "desired-state {} document is missing {}",
+                document.collection.graphql_type(),
+                unique_field
+            )
+        })
+}
+
+/// Apply all documents in the canonical dependency order inside `txn`.
+///
+/// The caller owns schema readiness and transaction commit/discard. Keeping
+/// those boundaries outside this function lets package installation combine
+/// schema checks, config writes, and graph publication without a second
+/// execution engine.
+pub async fn apply_desired_state_plan(
+    txn: &ConfigApplyTxn<'_>,
+    plan: &DesiredStateApplyPlan,
+) -> Result<DesiredStateApplyCounts> {
+    let mut counts = DesiredStateApplyCounts::default();
+    for document in plan.documents() {
+        apply_document(txn, document).await.with_context(|| {
+            format!(
+                "apply desired-state {} {}",
+                document.collection.graphql_type(),
+                unique_value(document).unwrap_or("<missing>")
+            )
+        })?;
+        counts.increment(document.collection);
+    }
+    Ok(counts)
+}
+
+async fn apply_document(
+    txn: &ConfigApplyTxn<'_>,
+    document: &DesiredStateApplyDocument,
+) -> Result<String> {
+    let unique_value = unique_value(document)?;
+    match document.collection {
+        Collection::Task => {
+            write_task_document(txn, unique_value, &document.add, &document.update).await
+        }
+        Collection::Schedule => {
+            write_schedule_document(txn, unique_value, &document.add, &document.update).await
+        }
+        Collection::EventTrigger => {
+            write_event_trigger_document(txn, unique_value, &document.add, &document.update).await
+        }
+        Collection::PeerPairingDesired => unreachable!("rejected by plan validation"),
+        collection => apply_generic_document(txn, collection, unique_value, document).await,
+    }
+}
+
+async fn apply_generic_document(
+    txn: &ConfigApplyTxn<'_>,
+    collection: Collection,
+    unique_value: &str,
+    document: &DesiredStateApplyDocument,
+) -> Result<String> {
+    let collection_name = collection.graphql_type();
+    let unique_field = collection.unique_field();
+    // The existing desired-state path uses an upsert for generic config
+    // collections. Minting recreate identity fields on the add branch keeps
+    // tombstone recovery idempotent while the update branch preserves the
+    // existing document identity.
+    let add = graphql_input_literal(&sanitize_create_input(&mint_recreate_identity(
+        &document.add,
+    )))?;
+    let update = graphql_input_literal(&sanitize_update_input(&document.update))?;
+    let mutation = format!(
+        "mutation {{ upsert_{collection_name}(filter: {{ {unique_field}: {{ _eq: \"{}\" }} }}, add: {add}, update: {update}) {{ _docID }} }}",
+        escape_graphql_string(unique_value),
+    );
+    let response = txn.execute(&mutation).await?;
+    extract_mutation_doc_id(&response, collection_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn doc(collection: Collection, id: &str) -> DesiredStateApplyDocument {
+        let unique = collection.unique_field();
+        DesiredStateApplyDocument {
+            collection,
+            add: json!({ (unique): id }),
+            update: json!({}),
+        }
+    }
+
+    #[test]
+    fn plan_is_dependency_ordered_and_rejects_duplicates_and_prune_owned_docs() {
+        let plan = DesiredStateApplyPlan::new(vec![
+            doc(Collection::EventTrigger, "trigger"),
+            doc(Collection::ToolSelection, "tools"),
+            doc(Collection::Task, "task"),
+        ])
+        .unwrap();
+        assert_eq!(plan.documents[0].collection, Collection::ToolSelection);
+        assert_eq!(plan.documents[1].collection, Collection::Task);
+        assert_eq!(plan.documents[2].collection, Collection::EventTrigger);
+
+        assert!(DesiredStateApplyPlan::new(vec![
+            doc(Collection::Task, "same"),
+            doc(Collection::Task, "same"),
+        ])
+        .is_err());
+        assert!(
+            DesiredStateApplyPlan::new(vec![doc(Collection::PeerPairingDesired, "peer")]).is_err()
+        );
+    }
+
+    #[test]
+    fn every_specialized_desired_state_writer_has_a_verification_reader() {
+        assert_eq!(
+            desired_state_read_target(Collection::Task).unwrap(),
+            Some(super::super::patch::SelfConfigTarget::Task)
+        );
+        assert_eq!(
+            desired_state_read_target(Collection::Schedule).unwrap(),
+            Some(super::super::patch::SelfConfigTarget::Schedule)
+        );
+        assert_eq!(
+            desired_state_read_target(Collection::EventTrigger).unwrap(),
+            Some(super::super::patch::SelfConfigTarget::EventTrigger)
+        );
+    }
+}

--- a/crates/gents/src/config_client/mod.rs
+++ b/crates/gents/src/config_client/mod.rs
@@ -24,6 +24,7 @@
 mod agent_behavior;
 mod approval;
 mod common;
+mod desired_state;
 mod event_trigger;
 mod inference_backend;
 mod schedule;
@@ -35,6 +36,14 @@ pub mod patch;
 pub use agent_behavior::write_agent_behavior_document;
 pub use approval::{list_held_tool_calls, write_tool_approval, HeldToolCall, ToolApprovalVerdict};
 pub use common::{mint_recreate_identity, mint_recreate_identity_timestamp};
+pub use desired_state::{
+    apply_desired_state_plan, DesiredStateApplyCounts, DesiredStateApplyDocument,
+    DesiredStateApplyPlan,
+};
+pub(crate) use desired_state::{
+    desired_state_document_digest, read_desired_state_document_in_txn,
+    verify_existing_desired_state_plan,
+};
 pub use event_trigger::write_event_trigger_document;
 pub use inference_backend::{write_inference_backend_document, InferenceBackendUpsertDocument};
 pub use schedule::write_schedule_document;
@@ -46,9 +55,10 @@ pub use txn::ConfigApplyTxn;
 
 mod tool_selection;
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use defra_node::EmbeddedNode;
 use gents_protocol::graphql::{execute_graphql_async, GraphqlRequestOptions};
 use serde_json::{json, Value};
@@ -94,6 +104,99 @@ impl ConfigAccess {
                 .await?;
                 Ok(json!({
                     "data": response.data.unwrap_or(Value::Null),
+                }))
+            }
+        }
+    }
+
+    /// Apply schema SDL through the same local-or-HTTP control-plane seam as
+    /// configuration writes. Callers must still perform their own structural
+    /// compatibility check before invoking this operation.
+    pub async fn add_schema(&self, sdl: &str) -> Result<()> {
+        match self {
+            Self::Graphql(graphql) => {
+                let api_base = graphql_api_base(graphql)?;
+                let url = format!("{api_base}/schema");
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .post(&url)
+                    .header(reqwest::header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                    .body(sdl.to_owned())
+                    .send()
+                    .await
+                    .with_context(|| format!("posting schema SDL to {url}"))?;
+                let status = response.status();
+                let bytes = response
+                    .bytes()
+                    .await
+                    .with_context(|| format!("reading schema SDL response from {url}"))?;
+                if !status.is_success() {
+                    anyhow::bail!(
+                        "schema SDL request to {url} failed with {status}: {}",
+                        String::from_utf8_lossy(&bytes)
+                    );
+                }
+                Ok(())
+            }
+            Self::Local(node) => node.add_schema(sdl).await.context("adding schema SDL"),
+        }
+    }
+
+    /// Return the declared field shape for one collection. HTTP callers use
+    /// DefraDB's read-only collection-version API, which EmbeddedNode exposes
+    /// without enabling destructive collection management.
+    pub async fn collection_fields(&self, collection: &str) -> Result<Option<BTreeSet<String>>> {
+        Ok(self.collection_version(collection).await?.map(|version| {
+            version
+                .get("Fields")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|field| field.get("Name").and_then(Value::as_str))
+                .map(ToOwned::to_owned)
+                .collect()
+        }))
+    }
+
+    /// Return the active DefraDB collection version so callers that own a
+    /// schema contract can compare field kinds, directives, and indexes—not
+    /// merely the set of field names.
+    pub async fn collection_version(&self, collection: &str) -> Result<Option<Value>> {
+        crate::graphql::validate_collection_identifier(collection)?;
+        match self {
+            Self::Local(node) => node
+                .get_collection(collection)?
+                .map(serde_json::to_value)
+                .transpose()
+                .context("serializing active collection version"),
+            Self::Graphql(graphql) => {
+                let api_base = graphql_api_base(graphql)?;
+                let url = format!("{api_base}/collections/versions");
+                let versions: Value = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?
+                    .get(&url)
+                    .send()
+                    .await
+                    .with_context(|| format!("fetching collection versions from {url}"))?
+                    .error_for_status()
+                    .with_context(|| format!("fetching collection versions from {url}"))?
+                    .json()
+                    .await
+                    .with_context(|| format!("decoding collection versions from {url}"))?;
+                Ok(versions.as_array().and_then(|versions| {
+                    versions
+                        .iter()
+                        .find(|version| {
+                            version.get("Name").and_then(Value::as_str) == Some(collection)
+                                && version
+                                    .get("IsActive")
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(true)
+                        })
+                        .cloned()
                 }))
             }
         }

--- a/crates/gents/src/config_client/patch.rs
+++ b/crates/gents/src/config_client/patch.rs
@@ -22,7 +22,10 @@ use serde_json::{Map, Value};
 use crate::graphql::escape_graphql_string;
 use gents_protocol::graphql::{extract_mutation_doc_id, graphql_input_literal};
 
-use super::ConfigApplyTxn;
+use super::{
+    common::{sanitize_create_input, sanitize_update_input},
+    ConfigApplyTxn,
+};
 
 /// Write targets of the self-config surface. The `automation` tool category
 /// spans `Task`/`Schedule`/`EventTrigger`; targets are per collection.
@@ -633,12 +636,12 @@ pub async fn update_doc_fields_in_txn(
             continue;
         }
         let value = merged.get(field).cloned().unwrap_or(Value::Null);
-        input.insert(field.clone(), sanitize_written_value(value));
+        input.insert(field.clone(), value);
     }
     if input.is_empty() {
         return Ok(doc_id.to_string());
     }
-    let input_literal = graphql_input_literal(&Value::Object(input))?;
+    let input_literal = graphql_input_literal(&sanitize_update_input(&Value::Object(input)))?;
     let mutation = format!(
         r#"mutation {{
             update_{collection}(docID: "{doc_id}", input: {input_literal}) {{ _docID }}
@@ -659,15 +662,9 @@ pub async fn create_doc_in_txn(
     let collection = target.collection_name();
     let mut input = Map::new();
     for (field, value) in merged {
-        if value.is_null() {
-            continue;
-        }
-        if matches!(value, Value::Array(items) if items.is_empty()) {
-            continue;
-        }
         input.insert(field.clone(), value.clone());
     }
-    let input_literal = graphql_input_literal(&Value::Object(input))?;
+    let input_literal = graphql_input_literal(&sanitize_create_input(&Value::Object(input)))?;
     let mutation = format!(
         r#"mutation {{
             create_{collection}(input: {input_literal}) {{ _docID }}
@@ -675,15 +672,6 @@ pub async fn create_doc_in_txn(
     );
     let response = txn.execute(&mutation).await?;
     extract_mutation_doc_id(&response, collection)
-}
-
-/// Empty list values become `null` on update — an empty list literal types as
-/// `JsonArray` in DefraDB and corrupts nillable array columns.
-fn sanitize_written_value(value: Value) -> Value {
-    match value {
-        Value::Array(items) if items.is_empty() => Value::Null,
-        other => other,
-    }
 }
 
 #[cfg(test)]
@@ -769,8 +757,17 @@ mod tests {
 
     #[test]
     fn empty_list_writes_sanitize_to_null() {
-        assert_eq!(sanitize_written_value(json!([])), Value::Null);
-        assert_eq!(sanitize_written_value(json!(["a"])), json!(["a"]));
-        assert_eq!(sanitize_written_value(json!("x")), json!("x"));
+        assert_eq!(
+            sanitize_update_input(&json!({ "field": [] })),
+            json!({ "field": null })
+        );
+        assert_eq!(
+            sanitize_update_input(&json!({ "field": ["a"] })),
+            json!({ "field": ["a"] })
+        );
+        assert_eq!(
+            sanitize_update_input(&json!({ "field": "x" })),
+            json!({ "field": "x" })
+        );
     }
 }

--- a/crates/gents/src/config_client/txn.rs
+++ b/crates/gents/src/config_client/txn.rs
@@ -114,6 +114,51 @@ impl<'a> ConfigApplyTxn<'a> {
         }
     }
 
+    /// Return the active collection version through the same local-or-HTTP
+    /// backend as this transaction. DefraDB schema registration is additive
+    /// and lives outside document transactions, so this is the authoritative
+    /// schema-readiness view for transactional package checks.
+    pub async fn collection_version(&self, collection: &str) -> Result<Option<Value>> {
+        crate::graphql::validate_collection_identifier(collection)?;
+        match &self.backend {
+            TxnBackend::Local { node, .. } => node
+                .get_collection(collection)?
+                .map(serde_json::to_value)
+                .transpose()
+                .context("serializing active collection version"),
+            TxnBackend::Graphql {
+                endpoint,
+                http_client,
+                ..
+            } => {
+                let api_base = graphql_api_base(endpoint)?;
+                let url = format!("{api_base}/collections/versions");
+                let versions: Value = http_client
+                    .get(&url)
+                    .send()
+                    .await
+                    .with_context(|| format!("fetching collection versions from {url}"))?
+                    .error_for_status()
+                    .with_context(|| format!("fetching collection versions from {url}"))?
+                    .json()
+                    .await
+                    .with_context(|| format!("decoding collection versions from {url}"))?;
+                Ok(versions.as_array().and_then(|versions| {
+                    versions
+                        .iter()
+                        .find(|version| {
+                            version.get("Name").and_then(Value::as_str) == Some(collection)
+                                && version
+                                    .get("IsActive")
+                                    .and_then(Value::as_bool)
+                                    .unwrap_or(true)
+                        })
+                        .cloned()
+                }))
+            }
+        }
+    }
+
     /// Execute against an embedded transaction while preserving the native
     /// response envelope, including composite-version metadata. Runtime
     /// lifecycle transitions need that exact commit identity; converting to

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -113,7 +113,7 @@ pub mod watcher;
 pub mod workspace;
 
 pub use callback::reject_secret_bearing_callback_fields;
-pub use collection::Collection;
+pub use collection::{Collection, DESIRED_STATE_APPLY_ORDER};
 
 pub use adapter_projection::{
     adapter_projection_eval_jsonl_record_schema, adapter_projection_eval_jsonl_records,


### PR DESCRIPTION
## Summary

- move desired-state document apply primitives into the runtime crate
- preserve schema-first ordering and reference-safe application
- let later package installation reuse the ordinary configuration control-plane path

## Review boundary

No package model or graph execution behavior is introduced here.

## Stack

Depends on #1218.

## Verification

- `cargo test -p gents`
- `cargo check --workspace --all-targets`