### PR TITLE
feat: declare bounded graph execution contracts

### DIFF
--- a/crates/gents/src/graph_pipeline/compiler.rs
+++ b/crates/gents/src/graph_pipeline/compiler.rs
@@ -5,8 +5,9 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use super::types::{
-    DeliveryMode, Diagnostic, DiagnosticCode, GraphIntent, GraphPlan, PlannedEdge, PlannedEntry,
-    PlannedNode, PortCardinality, PortRef, PortSpec, StageCapability, COMPILER_VERSION,
+    CapabilityManifestEntry, DeliveryMode, Diagnostic, DiagnosticCode, GraphIntent, GraphPlan,
+    GroupCount, PackagePlan, PlannedEdge, PlannedEntry, PlannedNode, PlannedResult,
+    PortCardinality, PortRef, PortSpec, ResultCardinality, StageCapability, COMPILER_VERSION,
 };
 use crate::graphql::{
     validate_collection_identifier, validate_graphql_filter_fragment, validate_graphql_name,
@@ -18,7 +19,10 @@ pub struct CompilerPolicy {
     pub max_edges: u32,
     pub max_depth: u32,
     pub max_fan_out: u32,
+    pub max_total_invocations: u32,
+    pub max_runtime_secs: u64,
     pub max_group_size: u32,
+    pub max_group_timeout_secs: u64,
 }
 
 impl Default for CompilerPolicy {
@@ -28,7 +32,10 @@ impl Default for CompilerPolicy {
             max_edges: 256,
             max_depth: 32,
             max_fan_out: 16,
+            max_total_invocations: 1_024,
+            max_runtime_secs: 86_400,
             max_group_size: 256,
+            max_group_timeout_secs: 86_400,
         }
     }
 }
@@ -63,10 +70,17 @@ fn output_port<'a>(capability: &'a StageCapability, name: &str) -> Option<&'a Po
         .find(|port| port.name == name)
 }
 
-fn delivery_sort_key(delivery: &DeliveryMode) -> (u8, u32) {
+fn delivery_sort_key(delivery: &DeliveryMode) -> (u8, u32, String, u64) {
     match delivery {
-        DeliveryMode::PerDocument => (0, 0),
-        DeliveryMode::PerGroup { expected_count } => (1, *expected_count),
+        DeliveryMode::PerDocument => (0, 0, String::new(), 0),
+        DeliveryMode::PerGroup {
+            expected: GroupCount::Static { count },
+            timeout_secs,
+        } => (1, *count, String::new(), timeout_secs.unwrap_or_default()),
+        DeliveryMode::PerGroup {
+            expected: GroupCount::SourceField { field },
+            timeout_secs,
+        } => (2, 0, field.clone(), timeout_secs.unwrap_or_default()),
     }
 }
 
@@ -97,6 +111,17 @@ fn check_requested_limits(
                 format!("requested {value}, platform ceiling is {ceiling}"),
             );
         }
+    }
+    if requested.max_runtime_secs == 0 || requested.max_runtime_secs > policy.max_runtime_secs {
+        diagnostic(
+            diagnostics,
+            DiagnosticCode::PlatformLimitExceeded,
+            "/limits/max_runtime_secs",
+            format!(
+                "requested {}, platform range is 1..={}",
+                requested.max_runtime_secs, policy.max_runtime_secs
+            ),
+        );
     }
 
     let node_count = intent.nodes.len() as u32;
@@ -387,7 +412,7 @@ pub fn compile_graph(
                     ),
                 );
             }
-            let cardinality_valid = match edge.delivery {
+            let cardinality_valid = match &edge.delivery {
                 DeliveryMode::PerDocument => source_port.cardinality == target_port.cardinality,
                 DeliveryMode::PerGroup { .. } => {
                     source_port.cardinality == PortCardinality::One
@@ -403,15 +428,43 @@ pub fn compile_graph(
                 );
             }
         }
-        if let DeliveryMode::PerGroup { expected_count } = edge.delivery {
-            if expected_count < 2 || expected_count > policy.max_group_size {
+        if let DeliveryMode::PerGroup {
+            expected,
+            timeout_secs,
+        } = &edge.delivery
+        {
+            match expected {
+                GroupCount::Static { count } if *count < 2 || *count > policy.max_group_size => {
+                    diagnostic(
+                        &mut diagnostics,
+                        DiagnosticCode::InvalidGroupSize,
+                        format!("{path}/delivery/expected/count"),
+                        format!(
+                            "per-group size must be between 2 and {}",
+                            policy.max_group_size
+                        ),
+                    );
+                }
+                GroupCount::SourceField { field } if validate_graphql_name(field).is_err() => {
+                    diagnostic(
+                        &mut diagnostics,
+                        DiagnosticCode::InvalidGroupCountField,
+                        format!("{path}/delivery/expected/field"),
+                        "source-field group count must be a GraphQL field identifier",
+                    );
+                }
+                _ => {}
+            }
+            if timeout_secs
+                .is_some_and(|seconds| seconds == 0 || seconds > policy.max_group_timeout_secs)
+            {
                 diagnostic(
                     &mut diagnostics,
-                    DiagnosticCode::InvalidGroupSize,
-                    format!("{path}/delivery/expected_count"),
+                    DiagnosticCode::InvalidGroupTimeout,
+                    format!("{path}/delivery/timeout_secs"),
                     format!(
-                        "per-group size must be between 2 and {}",
-                        policy.max_group_size
+                        "group timeout must be in 1..={} seconds when present",
+                        policy.max_group_timeout_secs
                     ),
                 );
             }
@@ -504,6 +557,61 @@ pub fn compile_graph(
         }
         *incoming.entry(entry.to.clone()).or_default() += 1;
         entry_nodes.insert(entry.to.node_id.as_str());
+    }
+
+    if !intent.results.iter().any(|result| result.terminal) {
+        diagnostic(
+            &mut diagnostics,
+            DiagnosticCode::MissingTerminalResult,
+            "/results",
+            "a graph must declare at least one terminal result so every completed run can reach a durable terminal state",
+        );
+    }
+    let mut result_names = BTreeSet::new();
+    for (index, result) in intent.results.iter().enumerate() {
+        let path = format!("/results/{index}");
+        if !result_names.insert(result.name.as_str()) {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::DuplicateResult,
+                format!("{path}/name"),
+                format!("result {:?} is declared more than once", result.name),
+            );
+        }
+        let source_node = nodes.contains(result.from.node_id.as_str());
+        if !source_node {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownNode,
+                format!("{path}/from/node_id"),
+                format!("unknown result node {:?}", result.from.node_id),
+            );
+        } else if resolved
+            .get(result.from.node_id.as_str())
+            .and_then(|capability| output_port(capability, &result.from.port))
+            .is_none()
+        {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::UnknownPort,
+                format!("{path}/from/port"),
+                format!("unknown result output port {:?}", result.from.port),
+            );
+        }
+        let count = match result.cardinality {
+            ResultCardinality::Exactly { count } | ResultCardinality::AtMost { count } => count,
+        };
+        if count == 0 || count > policy.max_total_invocations {
+            diagnostic(
+                &mut diagnostics,
+                DiagnosticCode::InvalidResultCardinality,
+                format!("{path}/cardinality/count"),
+                format!(
+                    "result cardinality must be in 1..={}, found {count}",
+                    policy.max_total_invocations
+                ),
+            );
+        }
     }
 
     for (node_id, capability) in &resolved {
@@ -650,6 +758,7 @@ pub fn compile_graph(
                 target_task_id: resolved[edge.to.node_id.as_str()].task_id.clone(),
                 correlation_field: source_port.correlation_field.clone(),
                 delivery: edge.delivery.clone(),
+                concurrency: edge.concurrency.clone(),
                 predicate: edge.predicate.clone(),
             }
         })
@@ -679,6 +788,7 @@ pub fn compile_graph(
                 name: entry.name.clone(),
                 collection: target_port.collection.clone(),
                 schema: target_port.schema.clone(),
+                input_contract: entry.input_contract.clone(),
                 to: entry.to.clone(),
                 target_task_id: target_capability.task_id.clone(),
                 correlation_field: target_port.correlation_field.clone(),
@@ -689,6 +799,42 @@ pub fn compile_graph(
         (&left.name, &left.schema, &left.to).cmp(&(&right.name, &right.schema, &right.to))
     });
 
+    let mut results: Vec<PlannedResult> = intent
+        .results
+        .iter()
+        .map(|result| {
+            let source_capability = resolved[result.from.node_id.as_str()];
+            let source_port = output_port(source_capability, &result.from.port)
+                .expect("validated result port must resolve");
+            PlannedResult {
+                name: result.name.clone(),
+                from: result.from.clone(),
+                collection: source_port.collection.clone(),
+                schema: source_port.schema.clone(),
+                correlation_field: source_port.correlation_field.clone(),
+                cardinality: result.cardinality.clone(),
+                terminal: result.terminal,
+            }
+        })
+        .collect();
+    results.sort_by(|left, right| (&left.name, &left.from).cmp(&(&right.name, &right.from)));
+
+    let mut manifest: Vec<CapabilityManifestEntry> = resolved
+        .values()
+        .map(|capability| CapabilityManifestEntry {
+            capability_id: capability.capability_id.clone(),
+            revision: capability.revision.clone(),
+            task_id: capability.task_id.clone(),
+        })
+        .collect();
+    manifest.sort_by(|left, right| {
+        (&left.capability_id, &left.revision, &left.task_id).cmp(&(
+            &right.capability_id,
+            &right.revision,
+            &right.task_id,
+        ))
+    });
+    manifest.dedup();
     let mut plan = GraphPlan {
         compiler_version: COMPILER_VERSION.to_owned(),
         graph_id: intent.graph_id.clone(),
@@ -696,7 +842,10 @@ pub fn compile_graph(
         nodes: planned_nodes,
         edges,
         entries,
+        results,
+        capability_manifest: manifest,
         limits: intent.limits.clone(),
+        package: None,
     };
     plan.digest = graph_plan_digest(&plan);
     Ok(plan)
@@ -713,7 +862,10 @@ pub fn graph_plan_digest(plan: &GraphPlan) -> String {
         nodes: &'a [PlannedNode],
         edges: &'a [PlannedEdge],
         entries: &'a [PlannedEntry],
+        results: &'a [PlannedResult],
+        capability_manifest: &'a [CapabilityManifestEntry],
         limits: &'a super::types::GraphLimits,
+        package: &'a Option<PackagePlan>,
     }
 
     let bytes = serde_json::to_vec(&DigestPayload {
@@ -722,10 +874,25 @@ pub fn graph_plan_digest(plan: &GraphPlan) -> String {
         nodes: &plan.nodes,
         edges: &plan.edges,
         entries: &plan.entries,
+        results: &plan.results,
+        capability_manifest: &plan.capability_manifest,
         limits: &plan.limits,
+        package: &plan.package,
     })
     .expect("GraphPlan contains only infallibly serializable fields");
     format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+/// Bind typed package/configuration provenance to an already validated graph.
+/// Package validation owns uniqueness and digest checks; this function only
+/// canonicalizes order and advances the immutable revision identity.
+pub fn bind_package_plan(mut plan: GraphPlan, mut package: PackagePlan) -> GraphPlan {
+    package.artifacts.sort();
+    package.required_schema_digests.sort();
+    plan.package = Some(package);
+    plan.digest.clear();
+    plan.digest = graph_plan_digest(&plan);
+    plan
 }
 
 pub fn verify_graph_plan_digest(plan: &GraphPlan) -> bool {

--- a/crates/gents/src/graph_pipeline/mod.rs
+++ b/crates/gents/src/graph_pipeline/mod.rs
@@ -10,7 +10,8 @@ mod tools;
 mod types;
 
 pub use compiler::{
-    compile_graph, graph_plan_digest, verify_graph_plan_digest, CompilerPolicy, GraphCompileError,
+    bind_package_plan, compile_graph, graph_plan_digest, verify_graph_plan_digest, CompilerPolicy,
+    GraphCompileError,
 };
 pub use runtime::{publish_graph_plan, PublishedGraph};
 pub use tools::{
@@ -18,9 +19,12 @@ pub use tools::{
     COMPILE_GRAPH_TOOL_NAME, GRAPH_PIPELINE_TOOL_NAMES,
 };
 pub use types::{
-    DeliveryMode, Diagnostic, DiagnosticCode, EntryBinding, GraphEdge, GraphIntent, GraphLimits,
-    GraphNode, GraphPlan, PlannedEdge, PlannedEntry, PlannedNode, PortCardinality, PortRef,
-    PortSpec, StageCapability, COMPILER_VERSION,
+    BundledProvenance, CapabilityManifestEntry, DeliveryConcurrency, DeliveryMode, Diagnostic,
+    DiagnosticCode, EntryBinding, GraphEdge, GraphIntent, GraphLimits, GraphNode, GraphPlan,
+    GroupCount, PackageArtifactKind, PackagePlan, PackageRoleBinding, PlannedEdge, PlannedEntry,
+    PlannedNode, PlannedPackageArtifact, PlannedResult, PortCardinality, PortRef, PortSpec,
+    RequiredSchemaDigest, ResultCardinality, ResultContract, StageCapability,
+    WorkspaceAuthorityCeiling, COMPILER_VERSION,
 };
 
 #[cfg(test)]

--- a/crates/gents/src/graph_pipeline/runtime.rs
+++ b/crates/gents/src/graph_pipeline/runtime.rs
@@ -13,7 +13,9 @@ use sha2::{Digest, Sha256};
 use crate::config_client::{write_event_trigger_document, ConfigApplyTxn};
 use crate::graphql::escape_graphql_string;
 
-use super::{verify_graph_plan_digest, DeliveryMode, GraphPlan};
+use super::{
+    verify_graph_plan_digest, DeliveryConcurrency, DeliveryMode, GraphPlan, GroupCount,
+};
 
 const TRIGGER_PREFIX: &str = "graph-trigger-";
 
@@ -143,12 +145,44 @@ async fn write_trigger(
     source_collection: &str,
     correlation_field: &str,
     delivery: &DeliveryMode,
+    concurrency: &DeliveryConcurrency,
     predicate: Option<&str>,
     now: &str,
 ) -> Result<()> {
-    let (fire_mode, expected_count) = match delivery {
-        DeliveryMode::PerDocument => ("per_document", Value::Null),
-        DeliveryMode::PerGroup { expected_count } => ("per_group", json!(expected_count)),
+    let (fire_mode, expected_count, expected_count_field, group_timeout_secs) = match delivery {
+        DeliveryMode::PerDocument => (
+            "per_document",
+            Value::Null,
+            Value::Null,
+            Value::Null,
+        ),
+        DeliveryMode::PerGroup {
+            expected: GroupCount::Static { count },
+            timeout_secs,
+        } => (
+            "per_group",
+            json!(count),
+            Value::Null,
+            timeout_secs.map(Value::from).unwrap_or(Value::Null),
+        ),
+        DeliveryMode::PerGroup {
+            expected: GroupCount::SourceField { field },
+            timeout_secs,
+        } => (
+            "per_group",
+            Value::Null,
+            json!(field),
+            timeout_secs.map(Value::from).unwrap_or(Value::Null),
+        ),
+    };
+    let concurrency = match concurrency {
+        DeliveryConcurrency::Parallel => "parallel",
+        DeliveryConcurrency::Serial => "serial",
+    };
+    let group_min_count = if group_timeout_secs.is_null() {
+        Value::Null
+    } else {
+        json!(1)
     };
     let add = json!({
         "trigger_id": id,
@@ -157,13 +191,13 @@ async fn write_trigger(
         "event_kind": "created",
         "filter": predicate.map(Value::from).unwrap_or(Value::Null),
         "enabled": true,
-        "concurrency": "parallel",
+        "concurrency": concurrency,
         "correlation_field": correlation_field,
         "fire_mode": fire_mode,
         "expected_count": expected_count,
-        "expected_count_field": Value::Null,
-        "group_timeout_secs": if matches!(delivery, DeliveryMode::PerGroup { .. }) { json!(300) } else { Value::Null },
-        "group_min_count": expected_count,
+        "expected_count_field": expected_count_field,
+        "group_timeout_secs": group_timeout_secs,
+        "group_min_count": group_min_count,
         "workspace_authority": Value::Null,
         "created_at": now,
         "updated_at": now,
@@ -244,6 +278,7 @@ pub async fn publish_graph_plan(
                 &entry.collection,
                 &entry.correlation_field,
                 &DeliveryMode::PerDocument,
+                &DeliveryConcurrency::Parallel,
                 None,
                 &now,
             )
@@ -264,6 +299,7 @@ pub async fn publish_graph_plan(
                 &edge.source_collection,
                 &edge.correlation_field,
                 &edge.delivery,
+                &edge.concurrency,
                 edge.predicate.as_deref(),
                 &now,
             )
@@ -292,7 +328,7 @@ mod tests {
     use super::*;
     use crate::graph_pipeline::{
         compile_graph, CompilerPolicy, EntryBinding, GraphIntent, GraphLimits, GraphNode,
-        PortCardinality, PortRef, PortSpec, StageCapability,
+        PortCardinality, PortRef, PortSpec, ResultCardinality, ResultContract, StageCapability,
     };
 
     fn plan() -> GraphPlan {
@@ -303,6 +339,14 @@ mod tests {
             correlation_field: "run_id".to_owned(),
             cardinality: PortCardinality::One,
             required: true,
+        };
+        let output = PortSpec {
+            name: "result".to_owned(),
+            collection: "PipelineOutput".to_owned(),
+            schema: "PipelineOutput/v1".to_owned(),
+            correlation_field: "run_id".to_owned(),
+            cardinality: PortCardinality::One,
+            required: false,
         };
         let intent = GraphIntent {
             graph_id: "pipeline".to_owned(),
@@ -316,16 +360,28 @@ mod tests {
                 name: "input".to_owned(),
                 collection: input.collection.clone(),
                 schema: input.schema.clone(),
+                input_contract: None,
                 to: PortRef {
                     node_id: "worker".to_owned(),
                     port: input.name.clone(),
                 },
+            }],
+            results: vec![ResultContract {
+                name: "result".to_owned(),
+                from: PortRef {
+                    node_id: "worker".to_owned(),
+                    port: output.name.clone(),
+                },
+                cardinality: ResultCardinality::Exactly { count: 1 },
+                terminal: true,
             }],
             limits: GraphLimits {
                 max_nodes: 2,
                 max_edges: 2,
                 max_depth: 2,
                 max_fan_out: 2,
+                max_total_invocations: 2,
+                max_runtime_secs: 60,
             },
         };
         compile_graph(
@@ -335,7 +391,7 @@ mod tests {
                 revision: "v1".to_owned(),
                 task_id: "existing-worker-task".to_owned(),
                 input_ports: vec![input],
-                output_ports: vec![],
+                output_ports: vec![output],
                 allowed_callers: vec!["did:key:owner".to_owned()],
             }],
             "did:key:owner",

--- a/crates/gents/src/graph_pipeline/tests.rs
+++ b/crates/gents/src/graph_pipeline/tests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use super::*;
 
 fn one_port(name: &str, schema: &str, required: bool) -> PortSpec {
@@ -80,22 +82,35 @@ fn linear_intent() -> GraphIntent {
                 port: "finding".to_owned(),
             },
             delivery: DeliveryMode::PerDocument,
+            concurrency: DeliveryConcurrency::Parallel,
             predicate: None,
         }],
         entries: vec![EntryBinding {
             name: "job".to_owned(),
             collection: "ExperimentJob".to_owned(),
             schema: "ExperimentJob/v1".to_owned(),
+            input_contract: None,
             to: PortRef {
                 node_id: "extract".to_owned(),
                 port: "job".to_owned(),
             },
+        }],
+        results: vec![ResultContract {
+            name: "findings".to_owned(),
+            from: PortRef {
+                node_id: "extract".to_owned(),
+                port: "finding".to_owned(),
+            },
+            cardinality: ResultCardinality::AtMost { count: 8 },
+            terminal: true,
         }],
         limits: GraphLimits {
             max_nodes: 8,
             max_edges: 16,
             max_depth: 8,
             max_fan_out: 4,
+            max_total_invocations: 32,
+            max_runtime_secs: 7_200,
         },
     }
 }
@@ -232,12 +247,154 @@ fn per_group_requires_one_to_many_and_a_bounded_group() {
     let mut capabilities = catalog();
     capabilities[1].input_ports[0] = many_port("finding", "ExperimentFinding/v1", true);
     let mut intent = linear_intent();
-    intent.edges[0].delivery = DeliveryMode::PerGroup { expected_count: 3 };
+    intent.edges[0].delivery = DeliveryMode::PerGroup {
+        expected: GroupCount::Static { count: 3 },
+        timeout_secs: None,
+    };
     assert!(compile(&intent, &capabilities).is_ok());
 
-    intent.edges[0].delivery = DeliveryMode::PerGroup { expected_count: 1 };
+    intent.edges[0].delivery = DeliveryMode::PerGroup {
+        expected: GroupCount::Static { count: 1 },
+        timeout_secs: None,
+    };
     let error = compile(&intent, &capabilities).unwrap_err();
     assert!(has_code(&error, DiagnosticCode::InvalidGroupSize));
+}
+
+#[test]
+fn per_group_accepts_a_bounded_source_field_and_validates_timeout() {
+    let mut capabilities = catalog();
+    capabilities[1].input_ports[0] = many_port("finding", "ExperimentFinding/v1", true);
+    let mut intent = linear_intent();
+    intent.edges[0].delivery = DeliveryMode::PerGroup {
+        expected: GroupCount::SourceField {
+            field: "expected_total".to_owned(),
+        },
+        timeout_secs: Some(60),
+    };
+    intent.edges[0].concurrency = DeliveryConcurrency::Serial;
+
+    let plan = compile(&intent, &capabilities).expect("source-field group is valid");
+    assert_eq!(plan.edges[0].delivery, intent.edges[0].delivery);
+    assert_eq!(plan.edges[0].concurrency, DeliveryConcurrency::Serial);
+
+    if let DeliveryMode::PerGroup {
+        expected: GroupCount::SourceField { field },
+        timeout_secs,
+    } = &mut intent.edges[0].delivery
+    {
+        *field = "not-valid!".to_owned();
+        *timeout_secs = Some(0);
+    }
+    let error = compile(&intent, &capabilities).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::InvalidGroupCountField));
+    assert!(has_code(&error, DiagnosticCode::InvalidGroupTimeout));
+}
+
+#[test]
+fn result_contracts_are_typed_canonical_and_digest_bound() {
+    let mut intent = linear_intent();
+    intent.results = vec![ResultContract {
+        name: "findings".to_owned(),
+        from: PortRef {
+            node_id: "extract".to_owned(),
+            port: "finding".to_owned(),
+        },
+        cardinality: ResultCardinality::AtMost { count: 8 },
+        terminal: true,
+    }];
+
+    let mut plan = compile(&intent, &catalog()).expect("valid result contract");
+    assert_eq!(plan.results[0].collection, "ExperimentFinding");
+    assert!(plan.results[0].terminal);
+    assert!(verify_graph_plan_digest(&plan));
+    plan.results[0].terminal = false;
+    assert!(!verify_graph_plan_digest(&plan));
+
+    intent.results.push(intent.results[0].clone());
+    intent.results[1].cardinality = ResultCardinality::Exactly { count: 0 };
+    let error = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::DuplicateResult));
+    assert!(has_code(&error, DiagnosticCode::InvalidResultCardinality));
+}
+
+#[test]
+fn compilation_requires_a_terminal_result_contract() {
+    let mut intent = linear_intent();
+    intent.results.clear();
+    let error = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::MissingTerminalResult));
+
+    intent.results = vec![ResultContract {
+        name: "observations".to_owned(),
+        from: PortRef {
+            node_id: "extract".to_owned(),
+            port: "finding".to_owned(),
+        },
+        cardinality: ResultCardinality::AtMost { count: 8 },
+        terminal: false,
+    }];
+    let error = compile(&intent, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::MissingTerminalResult));
+}
+
+fn package_plan(artifacts: Vec<PlannedPackageArtifact>) -> PackagePlan {
+    PackagePlan {
+        name: "code-review".to_owned(),
+        version: "1.0.0".to_owned(),
+        package_digest: format!("sha256:{}", "1".repeat(64)),
+        bundled_provenance: BundledProvenance {
+            binary_version: "0.12.0".to_owned(),
+            build_commit: "test".to_owned(),
+        },
+        roles: BTreeMap::new(),
+        workspace_authority: BTreeMap::new(),
+        predecessor_revision_digest: None,
+        artifacts,
+        required_schema_digests: vec![],
+    }
+}
+
+#[test]
+fn package_plan_order_is_canonical_and_configuration_changes_revision_identity() {
+    let artifacts = vec![
+        PlannedPackageArtifact {
+            logical_id: "review".to_owned(),
+            physical_id: "pkg-review".to_owned(),
+            kind: PackageArtifactKind::Task,
+            content_digest: format!("sha256:{}", "b".repeat(64)),
+        },
+        PlannedPackageArtifact {
+            logical_id: "prepare".to_owned(),
+            physical_id: "pkg-prepare".to_owned(),
+            kind: PackageArtifactKind::Behavior,
+            content_digest: format!("sha256:{}", "a".repeat(64)),
+        },
+    ];
+    let first = bind_package_plan(
+        compile(&linear_intent(), &catalog()).unwrap(),
+        package_plan(artifacts.clone()),
+    );
+    let second = bind_package_plan(
+        compile(&linear_intent(), &catalog()).unwrap(),
+        package_plan(artifacts.into_iter().rev().collect()),
+    );
+    assert_eq!(first, second);
+
+    let mut configured = package_plan(first.package.clone().unwrap().artifacts);
+    configured.roles.insert(
+        "reviewer".to_owned(),
+        PackageRoleBinding {
+            principal_did: "did:key:reviewer".to_owned(),
+            deployment_id: "local".to_owned(),
+            backend_id: Some("backend".to_owned()),
+            profile_id: Some("profile".to_owned()),
+            model_name: Some("model".to_owned()),
+        },
+    );
+    let configured = bind_package_plan(compile(&linear_intent(), &catalog()).unwrap(), configured);
+    assert_ne!(first.digest, configured.digest);
+    assert!(verify_graph_plan_digest(&configured));
 }
 
 #[test]
@@ -276,6 +433,7 @@ fn rejects_cycles_and_unreachable_nodes() {
             port: "review".to_owned(),
         },
         delivery: DeliveryMode::PerDocument,
+        concurrency: DeliveryConcurrency::Parallel,
         predicate: None,
     });
     let error = compile(&cyclic, &capabilities).unwrap_err();
@@ -291,6 +449,15 @@ fn rejects_cycles_and_unreachable_nodes() {
 fn rejects_requested_and_actual_resource_limit_violations() {
     let mut requested = linear_intent();
     requested.limits.max_nodes = CompilerPolicy::default().max_nodes + 1;
+    let error = compile(&requested, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::PlatformLimitExceeded));
+
+    requested = linear_intent();
+    requested.limits.max_runtime_secs = 0;
+    let error = compile(&requested, &catalog()).unwrap_err();
+    assert!(has_code(&error, DiagnosticCode::PlatformLimitExceeded));
+
+    requested.limits.max_runtime_secs = CompilerPolicy::default().max_runtime_secs + 1;
     let error = compile(&requested, &catalog()).unwrap_err();
     assert!(has_code(&error, DiagnosticCode::PlatformLimitExceeded));
 

--- a/crates/gents/src/graph_pipeline/tools.rs
+++ b/crates/gents/src/graph_pipeline/tools.rs
@@ -121,6 +121,7 @@ mod tests {
     use super::*;
     use crate::graph_pipeline::{
         EntryBinding, GraphLimits, GraphNode, PortCardinality, PortRef, PortSpec,
+        ResultCardinality, ResultContract,
     };
 
     #[derive(Deserialize)]
@@ -208,16 +209,28 @@ mod tests {
                 name: "input".to_owned(),
                 collection: "PipelineInput".to_owned(),
                 schema: "PipelineInput/v1".to_owned(),
+                input_contract: None,
                 to: PortRef {
                     node_id: "worker".to_owned(),
                     port: "input".to_owned(),
                 },
+            }],
+            results: vec![ResultContract {
+                name: "result".to_owned(),
+                from: PortRef {
+                    node_id: "worker".to_owned(),
+                    port: "result".to_owned(),
+                },
+                cardinality: ResultCardinality::Exactly { count: 1 },
+                terminal: true,
             }],
             limits: GraphLimits {
                 max_nodes: 2,
                 max_edges: 2,
                 max_depth: 2,
                 max_fan_out: 2,
+                max_total_invocations: 2,
+                max_runtime_secs: 60,
             },
         }
     }

--- a/crates/gents/src/graph_pipeline/types.rs
+++ b/crates/gents/src/graph_pipeline/types.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
-pub const COMPILER_VERSION: &str = "graph-intent-v1";
+pub const COMPILER_VERSION: &str = "graph-intent-v3";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -54,9 +56,39 @@ pub struct PortRef {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case", tag = "kind", deny_unknown_fields)]
+pub enum GroupCount {
+    Static { count: u32 },
+    SourceField { field: String },
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryConcurrency {
+    #[default]
+    Parallel,
+    Serial,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case", tag = "kind", deny_unknown_fields)]
 pub enum DeliveryMode {
     PerDocument,
-    PerGroup { expected_count: u32 },
+    PerGroup {
+        expected: GroupCount,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_secs: Option<u64>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -73,6 +105,8 @@ pub struct GraphEdge {
     pub from: PortRef,
     pub to: PortRef,
     pub delivery: DeliveryMode,
+    #[serde(default)]
+    pub concurrency: DeliveryConcurrency,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub predicate: Option<String>,
 }
@@ -83,11 +117,28 @@ pub struct EntryBinding {
     pub name: String,
     pub collection: String,
     pub schema: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_contract: Option<String>,
     pub to: PortRef,
 }
 
-/// Structural compiler limits. These bound authoring work only; execution
-/// limits remain the responsibility of the existing task/trigger runtime.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case", tag = "kind", deny_unknown_fields)]
+pub enum ResultCardinality {
+    Exactly { count: u32 },
+    AtMost { count: u32 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResultContract {
+    pub name: String,
+    pub from: PortRef,
+    pub cardinality: ResultCardinality,
+    #[serde(default)]
+    pub terminal: bool,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GraphLimits {
@@ -95,6 +146,10 @@ pub struct GraphLimits {
     pub max_edges: u32,
     pub max_depth: u32,
     pub max_fan_out: u32,
+    /// Whole-run ceiling enforced by the durable GraphRun reconciler.
+    pub max_total_invocations: u32,
+    /// Wall-clock run bound enforced from the durable `GraphRun.started_at`.
+    pub max_runtime_secs: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -105,6 +160,8 @@ pub struct GraphIntent {
     #[serde(default)]
     pub edges: Vec<GraphEdge>,
     pub entries: Vec<EntryBinding>,
+    #[serde(default)]
+    pub results: Vec<ResultContract>,
     pub limits: GraphLimits,
 }
 
@@ -130,6 +187,11 @@ pub enum DiagnosticCode {
     CorrelationMismatch,
     CardinalityMismatch,
     InvalidGroupSize,
+    InvalidGroupCountField,
+    InvalidGroupTimeout,
+    DuplicateResult,
+    MissingTerminalResult,
+    InvalidResultCardinality,
     MultipleInputBindings,
     MissingInputBinding,
     UnreachableNode,
@@ -168,6 +230,7 @@ pub struct PlannedEdge {
     pub target_task_id: String,
     pub correlation_field: String,
     pub delivery: DeliveryMode,
+    pub concurrency: DeliveryConcurrency,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub predicate: Option<String>,
 }
@@ -178,9 +241,113 @@ pub struct PlannedEntry {
     pub name: String,
     pub collection: String,
     pub schema: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_contract: Option<String>,
     pub to: PortRef,
     pub target_task_id: String,
     pub correlation_field: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlannedResult {
+    pub name: String,
+    pub from: PortRef,
+    pub collection: String,
+    pub schema: String,
+    pub correlation_field: String,
+    pub cardinality: ResultCardinality,
+    pub terminal: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageRoleBinding {
+    pub principal_did: String,
+    pub deployment_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BundledProvenance {
+    pub binary_version: String,
+    pub build_commit: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceAuthorityCeiling {
+    None,
+    ReadOnly,
+    ReadWrite,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PackageArtifactKind {
+    Behavior,
+    ToolSelection,
+    ToolSurface,
+    Task,
+    Trigger,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlannedPackageArtifact {
+    /// Stable package-local identity. The physical document ID is derived
+    /// from this value and the final revision digest.
+    pub logical_id: String,
+    /// Immutable configuration-scoped document identity. This is derived
+    /// before graph compilation from package digest plus typed bindings, so it
+    /// may participate in the final graph digest without a circular hash.
+    pub physical_id: String,
+    pub kind: PackageArtifactKind,
+    pub content_digest: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequiredSchemaDigest {
+    pub namespace: String,
+    pub digest: String,
+    /// Canonical full-contract digest for each collection in the pinned SDL.
+    /// Peers can compare their active DefraDB collection versions without
+    /// needing the originating binary's bundled catalog.
+    pub collection_contract_digests: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackagePlan {
+    pub name: String,
+    pub version: String,
+    pub package_digest: String,
+    pub bundled_provenance: BundledProvenance,
+    #[serde(default)]
+    pub roles: BTreeMap<String, PackageRoleBinding>,
+    #[serde(default)]
+    pub workspace_authority: BTreeMap<String, WorkspaceAuthorityCeiling>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub predecessor_revision_digest: Option<String>,
+    #[serde(default)]
+    pub artifacts: Vec<PlannedPackageArtifact>,
+    #[serde(default)]
+    pub required_schema_digests: Vec<RequiredSchemaDigest>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CapabilityManifestEntry {
+    pub capability_id: String,
+    pub revision: String,
+    pub task_id: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -192,5 +359,10 @@ pub struct GraphPlan {
     pub nodes: Vec<PlannedNode>,
     pub edges: Vec<PlannedEdge>,
     pub entries: Vec<PlannedEntry>,
+    #[serde(default)]
+    pub results: Vec<PlannedResult>,
+    pub capability_manifest: Vec<CapabilityManifestEntry>,
     pub limits: GraphLimits,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<PackagePlan>,
 }

--- a/crates/gents/tests/conformance/graph_pipeline.rs
+++ b/crates/gents/tests/conformance/graph_pipeline.rs
@@ -1,6 +1,6 @@
 use gents::graph_pipeline::{
     compile_graph, CompilerPolicy, EntryBinding, GraphIntent, GraphLimits, GraphNode,
-    PortCardinality, PortRef, PortSpec, StageCapability,
+    PortCardinality, PortRef, PortSpec, ResultCardinality, ResultContract, StageCapability,
 };
 
 use super::lean_contract_snapshot;
@@ -16,6 +16,14 @@ fn valid_fixture() -> (GraphIntent, Vec<StageCapability>) {
         cardinality: PortCardinality::One,
         required: true,
     };
+    let output = PortSpec {
+        name: "result".to_owned(),
+        collection: "ExperimentResult".to_owned(),
+        schema: "ExperimentResult/v1".to_owned(),
+        correlation_field: "graph_run_id".to_owned(),
+        cardinality: PortCardinality::One,
+        required: false,
+    };
     let intent = GraphIntent {
         graph_id: "lean-validation-fixture".to_owned(),
         nodes: vec![GraphNode {
@@ -28,16 +36,28 @@ fn valid_fixture() -> (GraphIntent, Vec<StageCapability>) {
             name: "job".to_owned(),
             collection: input.collection.clone(),
             schema: input.schema.clone(),
+            input_contract: None,
             to: PortRef {
                 node_id: "worker".to_owned(),
                 port: input.name.clone(),
             },
+        }],
+        results: vec![ResultContract {
+            name: "result".to_owned(),
+            from: PortRef {
+                node_id: "worker".to_owned(),
+                port: output.name.clone(),
+            },
+            cardinality: ResultCardinality::Exactly { count: 1 },
+            terminal: true,
         }],
         limits: GraphLimits {
             max_nodes: 2,
             max_edges: 2,
             max_depth: 2,
             max_fan_out: 2,
+            max_total_invocations: 2,
+            max_runtime_secs: 60,
         },
     };
     let capability = StageCapability {
@@ -45,7 +65,7 @@ fn valid_fixture() -> (GraphIntent, Vec<StageCapability>) {
         revision: "v1".to_owned(),
         task_id: "worker-v1-task".to_owned(),
         input_ports: vec![input],
-        output_ports: vec![],
+        output_ports: vec![output],
         allowed_callers: vec![CALLER_DID.to_owned()],
     };
     (intent, vec![capability])

--- a/demo/graph-pipeline/eval_cases.json
+++ b/demo/graph-pipeline/eval_cases.json
@@ -19,11 +19,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "result",
+          "from": { "node_id": "worker", "port": "result" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 2,
         "max_edges": 2,
         "max_depth": 2,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": true,
@@ -49,11 +59,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "result",
+          "from": { "node_id": "worker", "port": "result" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 2,
         "max_edges": 2,
         "max_depth": 2,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": false,
@@ -72,11 +92,21 @@
       ],
       "edges": [],
       "entries": [],
+      "results": [
+        {
+          "name": "result",
+          "from": { "node_id": "worker", "port": "result" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 2,
         "max_edges": 2,
         "max_depth": 2,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": false,
@@ -102,11 +132,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "result",
+          "from": { "node_id": "worker", "port": "result" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 0,
         "max_edges": 2,
         "max_depth": 2,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": false,
@@ -143,11 +183,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "feedback",
+          "from": { "node_id": "reviewer", "port": "feedback" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 3,
         "max_edges": 3,
         "max_depth": 3,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": true,
@@ -173,11 +223,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "result",
+          "from": { "node_id": "worker", "port": "result" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 2,
         "max_edges": 2,
         "max_depth": 2,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": false,
@@ -203,11 +263,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "result",
+          "from": { "node_id": "worker", "port": "result" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 2,
         "max_edges": 2,
         "max_depth": 2,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": false,
@@ -249,11 +319,21 @@
           "to": { "node_id": "worker", "port": "input" }
         }
       ],
+      "results": [
+        {
+          "name": "feedback",
+          "from": { "node_id": "reviewer", "port": "feedback" },
+          "cardinality": { "kind": "exactly", "count": 1 },
+          "terminal": true
+        }
+      ],
       "limits": {
         "max_nodes": 3,
         "max_edges": 3,
         "max_depth": 3,
-        "max_fan_out": 2
+        "max_fan_out": 2,
+        "max_total_invocations": 2,
+        "max_runtime_secs": 60
       }
     },
     "expected_accepted": false,


### PR DESCRIPTION
## Summary

- extend `GraphIntent` with typed entry inputs, declared results, grouped delivery, concurrency, and whole-run bounds
- keep package attribution inside the immutable `GraphPlan` digest
- validate and canonicalize the contract in the existing compiler
- update existing model-callable graph fixtures

## Review boundary

Compiler and types only. No `GraphRun` persistence or package installer.

## Stack

Depends on #1219.

## Verification

- `cargo check -p gents --all-targets`