### PR TITLE
feat: add the code review graph quickstart

### DIFF
--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -143,6 +143,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: TaskCommand,
     },
+    #[command(about = "Discover, install, run, and observe bundled graphs")]
+    Graph {
+        #[command(subcommand)]
+        command: GraphCommand,
+    },
     #[command(about = "Run local configuration and runtime diagnostics", after_help = DIAGNOSE_AFTER_HELP)]
     Diagnose(DiagnoseArgs),
     #[command(about = "Explain resolved behavior tool surfaces", after_help = TOOLS_AFTER_HELP)]
@@ -190,6 +195,110 @@ pub(crate) enum Command {
     },
     #[command(about = "Interactive, self-contained fleet demo (single node -> paired fleet)")]
     Demo(DemoArgs),
+}
+
+#[derive(clap::Subcommand)]
+pub(crate) enum GraphCommand {
+    #[command(about = "Inspect immutable graph packages bundled in this binary")]
+    Catalog(GraphCatalogArgs),
+    #[command(about = "Materialize a bundled package into an initialized home")]
+    Install(GraphInstallArgs),
+    #[command(about = "Start a run of an installed active graph")]
+    Run(GraphRunArgs),
+    #[command(about = "Watch durable graph progress until terminal")]
+    Watch(GraphWatchArgs),
+    #[command(about = "Read named durable outputs for a graph run")]
+    Result(GraphResultArgs),
+    #[command(about = "Request cancellation of a running graph")]
+    Cancel(GraphCancelArgs),
+    #[command(about = "Block new runs without interrupting pinned work")]
+    Disable(GraphToggleArgs),
+    #[command(about = "Allow new runs of an active graph")]
+    Enable(GraphToggleArgs),
+}
+
+#[derive(clap::Args, Clone)]
+pub(crate) struct GraphScopeArgs {
+    #[arg(long)]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long)]
+    pub(crate) graphql: Option<String>,
+    #[arg(long)]
+    pub(crate) agent_did: Option<String>,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphCatalogArgs {
+    pub(crate) package: Option<String>,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphInstallArgs {
+    pub(crate) package: String,
+    #[arg(
+        long,
+        help = "JSON file containing explicit owner, role, deployment, and model bindings"
+    )]
+    pub(crate) bindings: Option<PathBuf>,
+    #[command(flatten)]
+    pub(crate) scope: GraphScopeArgs,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(crate) output: OutputFormat,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphRunArgs {
+    pub(crate) package: String,
+    #[arg(long, default_value = ".")]
+    pub(crate) repo: PathBuf,
+    #[arg(long, default_value = "origin/main")]
+    pub(crate) base: String,
+    #[arg(long, default_value = "HEAD")]
+    pub(crate) head: String,
+    #[arg(long)]
+    pub(crate) focus: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) watch: bool,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(crate) output: OutputFormat,
+    #[command(flatten)]
+    pub(crate) scope: GraphScopeArgs,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphWatchArgs {
+    pub(crate) run_id: String,
+    #[arg(long, default_value_t = 1_000)]
+    pub(crate) interval_ms: u64,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(crate) output: OutputFormat,
+    #[command(flatten)]
+    pub(crate) scope: GraphScopeArgs,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphResultArgs {
+    pub(crate) run_id: String,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub(crate) output: OutputFormat,
+    #[command(flatten)]
+    pub(crate) scope: GraphScopeArgs,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphCancelArgs {
+    pub(crate) run_id: String,
+    #[arg(long)]
+    pub(crate) reason: Option<String>,
+    #[command(flatten)]
+    pub(crate) scope: GraphScopeArgs,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GraphToggleArgs {
+    pub(crate) package: String,
+    #[command(flatten)]
+    pub(crate) scope: GraphScopeArgs,
 }
 
 #[derive(clap::Args)]
@@ -287,10 +396,7 @@ pub(crate) struct DemoInitArgs {
 pub(crate) struct DemoSeedArgs {
     #[arg(help = "Pack directory, or a name resolved under demo/")]
     pub(crate) pack: String,
-    #[arg(
-        long,
-        help = "Pack node home; used to refuse a stale review-root stamp"
-    )]
+    #[arg(long, help = "Pack node home used to resolve the initialized identity")]
     pub(crate) home: Option<PathBuf>,
     #[arg(long, help = "Seed prompt. Defaults to the pack's default_prompt")]
     pub(crate) prompt: Option<String>,

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -633,6 +633,98 @@ fn p2p_replicator_add_no_filter_is_empty() {
     assert!(args.filters.is_empty());
 }
 
+fn parse_graph(argv: &[&str]) -> GraphCommand {
+    let mut args = vec!["gents", "graph"];
+    args.extend_from_slice(argv);
+    let cli = Cli::try_parse_from(args).expect("graph command should parse");
+    match cli.command {
+        Command::Graph { command } => command,
+        _ => panic!("expected `graph`"),
+    }
+}
+
+#[test]
+fn graph_catalog_and_install_parse() {
+    assert!(matches!(
+        parse_graph(&["catalog", "code-review"]),
+        GraphCommand::Catalog(GraphCatalogArgs { package: Some(package) }) if package == "code-review"
+    ));
+
+    match parse_graph(&[
+        "install",
+        "code-review",
+        "--bindings",
+        "/tmp/bindings.json",
+        "--home",
+        "/tmp/gents-home",
+    ]) {
+        GraphCommand::Install(args) => {
+            assert_eq!(args.package, "code-review");
+            assert_eq!(
+                args.bindings.as_deref(),
+                Some(std::path::Path::new("/tmp/bindings.json"))
+            );
+            assert_eq!(
+                args.scope.home.as_deref(),
+                Some(std::path::Path::new("/tmp/gents-home"))
+            );
+        }
+        _ => panic!("expected graph install"),
+    }
+}
+
+#[test]
+fn graph_run_defaults_to_current_checkout() {
+    match parse_graph(&["run", "code-review"]) {
+        GraphCommand::Run(args) => {
+            assert_eq!(args.repo, std::path::PathBuf::from("."));
+            assert_eq!(args.base, "origin/main");
+            assert_eq!(args.head, "HEAD");
+        }
+        _ => panic!("expected graph run"),
+    }
+}
+
+#[test]
+fn graph_run_watch_result_cancel_and_toggle_parse() {
+    match parse_graph(&[
+        "run",
+        "code-review",
+        "--repo",
+        "/tmp/repo",
+        "--base",
+        "origin/main",
+        "--head",
+        "HEAD",
+        "--watch",
+    ]) {
+        GraphCommand::Run(args) => {
+            assert_eq!(args.package, "code-review");
+            assert_eq!(args.repo, std::path::PathBuf::from("/tmp/repo"));
+            assert_eq!(args.base, "origin/main");
+            assert_eq!(args.head, "HEAD");
+            assert!(args.watch);
+        }
+        _ => panic!("expected graph run"),
+    }
+
+    assert!(
+        matches!(parse_graph(&["watch", "run-1"]), GraphCommand::Watch(args) if args.run_id == "run-1")
+    );
+    assert!(
+        matches!(parse_graph(&["result", "run-1"]), GraphCommand::Result(args) if args.run_id == "run-1")
+    );
+    assert!(
+        matches!(parse_graph(&["cancel", "run-1", "--reason", "operator"]), GraphCommand::Cancel(args) if args.run_id == "run-1" && args.reason.as_deref() == Some("operator"))
+    );
+    assert!(
+        matches!(parse_graph(&["disable", "code-review"]), GraphCommand::Disable(args) if args.package == "code-review")
+    );
+    assert!(
+        matches!(parse_graph(&["enable", "code-review"]), GraphCommand::Enable(args) if args.package == "code-review")
+    );
+}
+
 fn parse_demo(argv: &[&str]) -> DemoArgs {
     let mut args = vec!["gents", "demo"];
     args.extend_from_slice(argv);
@@ -647,7 +739,7 @@ fn parse_demo(argv: &[&str]) -> DemoArgs {
 fn demo_seed_parses_pack_port_home_and_page() {
     let args = parse_demo(&[
         "seed",
-        "demo/code-review",
+        "demo/pipeline",
         "--http-port",
         "19191",
         "--home",
@@ -661,7 +753,7 @@ fn demo_seed_parses_pack_port_home_and_page() {
     ]);
     match args.command {
         Some(DemoCommand::Seed(seed)) => {
-            assert_eq!(seed.pack, "demo/code-review");
+            assert_eq!(seed.pack, "demo/pipeline");
             assert_eq!(seed.http_port, 19191);
             assert_eq!(
                 seed.home.as_deref(),
@@ -677,10 +769,10 @@ fn demo_seed_parses_pack_port_home_and_page() {
 
 #[test]
 fn demo_init_parses_pack_and_home() {
-    let args = parse_demo(&["init", "demo/code-review", "--home", "/tmp/review-home"]);
+    let args = parse_demo(&["init", "demo/pipeline", "--home", "/tmp/review-home"]);
     match args.command {
         Some(DemoCommand::Init(init)) => {
-            assert_eq!(init.pack, "demo/code-review");
+            assert_eq!(init.pack, "demo/pipeline");
             assert_eq!(init.home, std::path::PathBuf::from("/tmp/review-home"));
             assert!(!init.overwrite);
         }

--- a/crates/gents-cli/src/commands/graph.rs
+++ b/crates/gents-cli/src/commands/graph.rs
@@ -1,0 +1,852 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+use std::{io, io::IsTerminal as _, io::Write as _};
+
+use anyhow::{Context, Result};
+use gents::config_client::ConfigAccess;
+use gents::graph_package::{
+    bundled_graph_id, default_bundled_graph_package_install_bindings, graph_package_catalog,
+    install_bundled_graph_package, load_bundled_graph_package, GraphPackageInstallBindings,
+};
+use gents::graph_pipeline::{
+    activate_graph_revision_with_access, load_active_graph_plan_with_access,
+    load_graph_run_result_view_with_access, load_graph_run_view_with_access,
+    request_graph_run_cancellation_with_access, set_graph_enabled_with_access,
+    start_graph_run_with_access, GraphRunView,
+};
+use gents::run_timeline::{RunActivityRows, TimelineInferenceCallRow, TimelineToolCallRow};
+use gents::run_timeline_fetch::load_run_activity_rows;
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::cli::output_format::OutputFormat;
+use crate::cli::{
+    GraphCancelArgs, GraphCatalogArgs, GraphCommand, GraphInstallArgs, GraphResultArgs,
+    GraphRunArgs, GraphScopeArgs, GraphToggleArgs, GraphWatchArgs,
+};
+use crate::{print_json, resolve_agent_did, resolve_config_access};
+
+pub(crate) async fn dispatch(command: GraphCommand) -> Result<()> {
+    match command {
+        GraphCommand::Catalog(args) => catalog(args),
+        GraphCommand::Install(args) => install(args).await,
+        GraphCommand::Run(args) => run(args).await,
+        GraphCommand::Watch(args) => watch(args).await,
+        GraphCommand::Result(args) => result(args).await,
+        GraphCommand::Cancel(args) => cancel(args).await,
+        GraphCommand::Disable(args) => toggle(args, false).await,
+        GraphCommand::Enable(args) => toggle(args, true).await,
+    }
+}
+
+fn catalog(args: GraphCatalogArgs) -> Result<()> {
+    let mut entries = graph_package_catalog()?;
+    if let Some(package) = args.package.as_deref() {
+        entries.retain(|entry| entry.name == package);
+        if entries.is_empty() {
+            anyhow::bail!("unknown bundled graph package {package:?}");
+        }
+    }
+    print_json(&json!({ "packages": entries }))
+}
+
+async fn install(args: GraphInstallArgs) -> Result<()> {
+    load_bundled_graph_package(&args.package)?;
+    let (access, owner_did) = access_and_actor(&args.scope).await?;
+    let bindings = if let Some(path) = args.bindings.as_deref() {
+        let bindings: GraphPackageInstallBindings = serde_json::from_slice(
+            &std::fs::read(path)
+                .with_context(|| format!("reading graph package bindings {}", path.display()))?,
+        )
+        .with_context(|| format!("parsing graph package bindings {}", path.display()))?;
+        if bindings.owner_did != owner_did {
+            anyhow::bail!(
+                "binding owner {} does not match selected package owner {}",
+                bindings.owner_did,
+                owner_did
+            );
+        }
+        bindings
+    } else {
+        default_bundled_graph_package_install_bindings(&access, &args.package, &owner_did).await?
+    };
+    let receipt =
+        install_bundled_graph_package(&access, &owner_did, &args.package, &bindings).await?;
+    let previous = load_active_graph_plan_with_access(&access, &owner_did, &receipt.graph_id)
+        .await?
+        .map(|plan| plan.digest);
+    let activation = activate_graph_revision_with_access(
+        &access,
+        &owner_did,
+        &receipt.graph_id,
+        &receipt.revision_digest,
+        previous.as_deref(),
+    )
+    .await?;
+    match args
+        .output
+        .ensure_supported("graph install", &[OutputFormat::Text, OutputFormat::Json])?
+    {
+        OutputFormat::Json => print_json(&json!({
+            "install": receipt,
+            "activation": activation,
+            "bindings": bindings,
+        })),
+        OutputFormat::Text => {
+            let mut out = io::stdout().lock();
+            writeln!(
+                out,
+                "Installed and activated {} {}",
+                receipt.package_name, receipt.package_version
+            )?;
+            writeln!(out, "Backend: inherited from your default behavior")?;
+            writeln!(out, "Run: gents graph run {}", receipt.package_name)?;
+            Ok(())
+        }
+        _ => unreachable!("validated output format"),
+    }
+}
+
+async fn access_and_actor(scope: &GraphScopeArgs) -> Result<(ConfigAccess, String)> {
+    let actor = resolve_agent_did(scope.home.as_deref(), scope.agent_did.as_deref())?;
+    let (access, _) =
+        resolve_config_access(scope.home.as_deref(), scope.graphql.as_deref()).await?;
+    Ok((access, actor))
+}
+
+fn git_output(repo: &Path, arguments: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(arguments)
+        .output()
+        .with_context(|| format!("running git in {}", repo.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {} failed in {}: {}",
+            arguments.join(" "),
+            repo.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+fn resolve_repository(
+    repo: &Path,
+    base: &str,
+    head: &str,
+) -> Result<(std::path::PathBuf, String, String)> {
+    let canonical = std::fs::canonicalize(repo)
+        .with_context(|| format!("canonicalizing repository {}", repo.display()))?;
+    if git_output(&canonical, &["rev-parse", "--is-inside-work-tree"])? != "true" {
+        anyhow::bail!("{} is not a Git work tree", canonical.display());
+    }
+    let base_sha = git_output(
+        &canonical,
+        &["rev-parse", "--verify", &format!("{base}^{{commit}}")],
+    )?;
+    let head_sha = git_output(
+        &canonical,
+        &["rev-parse", "--verify", &format!("{head}^{{commit}}")],
+    )?;
+    Ok((canonical, base_sha, head_sha))
+}
+
+async fn run(args: GraphRunArgs) -> Result<()> {
+    if args.package != "code-review" {
+        anyhow::bail!(
+            "graph run currently supports the local code-review quickstart; package-specific entry bindings are not available for {:?}",
+            args.package
+        );
+    }
+    let (access, actor) = access_and_actor(&args.scope).await?;
+    let ConfigAccess::Graphql(endpoint) = &access else {
+        anyhow::bail!(
+            "graph run requires the local Gents server to be running so workspace and request recovery remain active"
+        );
+    };
+    let endpoint_url = url::Url::parse(endpoint).context("parsing graph GraphQL endpoint")?;
+    let local_endpoint = endpoint_url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    });
+    if !local_endpoint {
+        anyhow::bail!(
+            "the local-repository quickstart requires a loopback GraphQL endpoint; remote repository placement is not inferred from a client path"
+        );
+    }
+    let graph_id = bundled_graph_id(&args.package, &actor)?;
+    let plan = load_active_graph_plan_with_access(&access, &actor, &graph_id)
+        .await?
+        .context("graph is not installed; run `gents graph install code-review` first")?;
+    if plan.package.as_ref().map(|package| package.name.as_str()) != Some(args.package.as_str()) {
+        anyhow::bail!(
+            "active revision does not belong to bundled package {:?}",
+            args.package
+        );
+    }
+    let digest = plan.digest.clone();
+    let deployments = plan
+        .package
+        .as_ref()
+        .context("active revision has no package attribution")?
+        .roles
+        .values()
+        .map(|role| role.deployment_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if deployments.len() != 1 {
+        anyhow::bail!("the local code-review quickstart requires all roles on one deployment");
+    }
+    let deployment_id = deployments.into_iter().next().expect("one deployment");
+    let (repository_path, base_ref, head_ref) =
+        resolve_repository(&args.repo, &args.base, &args.head)?;
+    let workspace = gents::workspace::provision_read_only_workspace(
+        &access,
+        &repository_path,
+        &head_ref,
+        deployment_id,
+        &actor,
+    )
+    .await?;
+    let receipt = start_graph_run_with_access(
+        &access,
+        &actor,
+        &graph_id,
+        Some(&digest),
+        "review",
+        json!({
+            "repository_path": ".",
+            "base_ref": base_ref,
+            "head_ref": head_ref,
+            "workspace_id": workspace.workspace.workspace_id,
+            "workspace_authority": "readOnly",
+            "workspace_owner_deployment_id": workspace.workspace.owner_deployment_id,
+            "lens_count": "4",
+            "lens_min": "4",
+            "lens_max": "4",
+            "pr_number": "",
+            "focus": args.focus.unwrap_or_else(|| "Review the diff for material correctness, safety, durability, and maintainability defects.".to_owned()),
+        }),
+    )
+    .await?;
+    if args.watch {
+        watch_run(
+            &access,
+            &actor,
+            &receipt.run_id,
+            Duration::from_secs(1),
+            args.output,
+        )
+        .await
+    } else {
+        match args
+            .output
+            .ensure_supported("graph run", &[OutputFormat::Text, OutputFormat::Json])?
+        {
+            OutputFormat::Json => print_json(&serde_json::to_value(receipt)?),
+            OutputFormat::Text => {
+                let mut out = io::stdout().lock();
+                writeln!(out, "Started {}", receipt.run_id)?;
+                writeln!(out, "Watch: gents graph watch {}", receipt.run_id)?;
+                Ok(())
+            }
+            _ => unreachable!("validated output format"),
+        }
+    }
+}
+
+fn effective_error(view: &GraphRunView) -> Option<&Value> {
+    view.error.as_ref().or(view.failure_evidence.as_ref())
+}
+
+fn progress(view: &GraphRunView) -> Value {
+    json!({
+        "run_id": view.run_id,
+        "status": view.status,
+        "revision_digest": view.revision_digest,
+        "deadline_at": view.deadline_at,
+        "active_requests": view.active_request_count,
+        "terminal_requests": view.terminal_request_count,
+        "stages": view.stages,
+        "groups": view.groups,
+        "results": view.results,
+        "error": effective_error(view),
+    })
+}
+
+fn compact_count(value: i64) -> String {
+    match value.max(0) {
+        value if value >= 1_000_000 => format!("{:.1}m", value as f64 / 1_000_000.0),
+        value if value >= 1_000 => format!("{:.1}k", value as f64 / 1_000.0),
+        value => value.to_string(),
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Serialize)]
+struct RunUsageSummary {
+    reported_input_tokens: i64,
+    reported_cached_input_tokens: i64,
+    reported_output_tokens: i64,
+    estimated_input_tokens: i64,
+    unreported_completed_calls: usize,
+}
+
+fn context_input_estimate(call: &TimelineInferenceCallRow) -> Option<i64> {
+    let value: Value = serde_json::from_str(call.context_accounting_json.as_deref()?).ok()?;
+    let estimate = value.get("estimated_input_tokens")?.as_u64()?;
+    Some(i64::try_from(estimate).unwrap_or(i64::MAX))
+}
+
+fn run_usage_summary(calls: &[TimelineInferenceCallRow]) -> RunUsageSummary {
+    let mut summary = RunUsageSummary::default();
+    for call in calls {
+        let input = call.prompt_tokens.unwrap_or_default().max(0);
+        let cached = call.cached_input_tokens.unwrap_or_default().max(0);
+        let output = call.completion_tokens.unwrap_or_default().max(0);
+        if input > 0 || cached > 0 || output > 0 {
+            summary.reported_input_tokens = summary.reported_input_tokens.saturating_add(input);
+            summary.reported_cached_input_tokens =
+                summary.reported_cached_input_tokens.saturating_add(cached);
+            summary.reported_output_tokens = summary.reported_output_tokens.saturating_add(output);
+        } else if call.call_state == "completed" {
+            summary.unreported_completed_calls += 1;
+            summary.estimated_input_tokens = summary
+                .estimated_input_tokens
+                .saturating_add(context_input_estimate(call).unwrap_or_default());
+        }
+    }
+    summary
+}
+
+fn usage_detail(summary: &RunUsageSummary) -> String {
+    if summary.unreported_completed_calls == 0 {
+        return format!(
+            "{} input · {} cached · {} output",
+            compact_count(summary.reported_input_tokens),
+            compact_count(summary.reported_cached_input_tokens),
+            compact_count(summary.reported_output_tokens),
+        );
+    }
+    let suffix = if summary.unreported_completed_calls == 1 {
+        "1 completed call unreported".to_owned()
+    } else {
+        format!(
+            "{} completed calls unreported",
+            summary.unreported_completed_calls
+        )
+    };
+    let estimate = if summary.estimated_input_tokens > 0 {
+        format!(
+            "~{} input estimated",
+            compact_count(summary.estimated_input_tokens)
+        )
+    } else {
+        "input unavailable".to_owned()
+    };
+    if summary.reported_input_tokens > 0
+        || summary.reported_cached_input_tokens > 0
+        || summary.reported_output_tokens > 0
+    {
+        format!(
+            "{} input reported · {} cached · {} output · {estimate} · {suffix}",
+            compact_count(summary.reported_input_tokens),
+            compact_count(summary.reported_cached_input_tokens),
+            compact_count(summary.reported_output_tokens),
+        )
+    } else {
+        format!("{estimate} · output unavailable · {suffix}")
+    }
+}
+
+fn tool_state(tool: &TimelineToolCallRow) -> (&'static str, &str) {
+    let state = tool
+        .lifecycle_state
+        .as_deref()
+        .unwrap_or(tool.status.as_str());
+    let marker = match state {
+        "completed" => "✓",
+        "failed" | "timedOut" | "cancelled" => "×",
+        _ => "●",
+    };
+    (marker, state)
+}
+
+fn print_progress_text(
+    view: &GraphRunView,
+    activity: &RunActivityRows,
+    redraw: bool,
+) -> Result<()> {
+    let usage = run_usage_summary(&activity.inference_calls);
+    let active_models = activity
+        .inference_calls
+        .iter()
+        .filter(|call| {
+            !matches!(
+                call.call_state.as_str(),
+                "completed" | "failed" | "cancelled"
+            )
+        })
+        .count();
+    let mut tool_counts = BTreeMap::new();
+    let mut completed_tools = 0;
+    let mut failed_tools = 0;
+    for tool in &activity.tool_calls {
+        *tool_counts.entry(tool.tool_name.as_str()).or_insert(0usize) += 1;
+        match tool_state(tool).1 {
+            "completed" => completed_tools += 1,
+            "failed" | "timedOut" | "cancelled" => failed_tools += 1,
+            _ => {}
+        }
+    }
+    let active_tools = activity
+        .tool_calls
+        .len()
+        .saturating_sub(completed_tools + failed_tools);
+    let mut out = io::stdout().lock();
+    if redraw {
+        write!(out, "\x1b[2J\x1b[H")?;
+    }
+    writeln!(out, "Graph run {} · {}", view.run_id, view.status)?;
+    writeln!(
+        out,
+        "Models  {} calls ({} active) · {}",
+        activity.inference_calls.len(),
+        active_models,
+        usage_detail(&usage),
+    )?;
+    writeln!(
+        out,
+        "Tools   {} calls · {} completed · {} active · {} failed",
+        activity.tool_calls.len(),
+        completed_tools,
+        active_tools,
+        failed_tools,
+    )?;
+    writeln!(out)?;
+    writeln!(out, "Stages")?;
+    for stage in &view.stages {
+        let completed = stage.succeeded + stage.failed;
+        let marker = if stage.failed > 0 {
+            "×"
+        } else if stage.active > 0 {
+            "●"
+        } else if stage.total > 0 && completed == stage.total {
+            "✓"
+        } else {
+            "○"
+        };
+        writeln!(
+            out,
+            "  {marker} {:<12} {completed}/{} · {} active · {} failed",
+            stage.node_id, stage.total, stage.active, stage.failed
+        )?;
+    }
+    writeln!(out)?;
+    writeln!(out, "Agent sessions")?;
+    if view.requests.is_empty() {
+        writeln!(out, "  Waiting for the entry request")?;
+    }
+    for request in &view.requests {
+        let session = request.session_id.as_deref().and_then(|session_id| {
+            activity
+                .sessions
+                .iter()
+                .find(|session| session.session_id == session_id)
+        });
+        let session_id = request.session_id.as_deref().unwrap_or("pending");
+        let status = request
+            .lifecycle_state
+            .as_deref()
+            .or_else(|| session.and_then(|session| session.status.as_deref()))
+            .unwrap_or(request.status.as_str());
+        let node = request.node_id.as_deref().unwrap_or("unknown");
+        let calls = activity
+            .inference_calls
+            .iter()
+            .filter(|call| call.request_id == request.request_id)
+            .count();
+        let tools = activity
+            .tool_calls
+            .iter()
+            .filter(|tool| tool.request_id.as_deref() == Some(request.request_id.as_str()))
+            .count();
+        writeln!(
+            out,
+            "  {node:<12} {status:<12} · {calls} model calls · {tools} tools"
+        )?;
+        writeln!(
+            out,
+            "    session {session_id} · request {}",
+            request.request_id
+        )?;
+    }
+    if !tool_counts.is_empty() {
+        writeln!(out)?;
+        writeln!(
+            out,
+            "Tool usage  {}",
+            tool_counts
+                .into_iter()
+                .map(|(name, count)| format!("{name} {count}"))
+                .collect::<Vec<_>>()
+                .join(" · ")
+        )?;
+    }
+    if !activity.tool_calls.is_empty() {
+        writeln!(out)?;
+        writeln!(out, "Recent tool calls")?;
+        for tool in activity.tool_calls.iter().rev().take(8).rev() {
+            let (marker, state) = tool_state(tool);
+            let latency = tool
+                .latency_ms
+                .map(|value| format!(" · {value}ms"))
+                .unwrap_or_default();
+            let failure = tool
+                .tool_failure_class
+                .as_deref()
+                .map(|value| format!(" · {value}"))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "  {marker} {:<24} {state}{latency}{failure}",
+                tool.tool_name
+            )?;
+        }
+    }
+    if activity.truncated {
+        writeln!(
+            out,
+            "\nWarning: activity counts exceeded the bounded observation window"
+        )?;
+    }
+    if let Some(error) = effective_error(view) {
+        writeln!(out, "\nError: {}", serde_json::to_string(error)?)?;
+    }
+    out.flush()?;
+    Ok(())
+}
+
+fn display_value(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        Value::Null => "null".to_owned(),
+        other => other.to_string(),
+    }
+}
+
+fn write_result_text(out: &mut impl io::Write, view: &GraphRunView) -> Result<()> {
+    writeln!(out, "Run: {}", view.run_id)?;
+    writeln!(out, "Status: {}", view.status)?;
+    if let Some(error) = effective_error(view) {
+        writeln!(out, "Error: {}", serde_json::to_string_pretty(error)?)?;
+    }
+    let outputs = view
+        .results
+        .iter()
+        .filter(|result| result.terminal)
+        .collect::<Vec<_>>();
+    if outputs.is_empty() {
+        writeln!(out, "Outputs: none declared")?;
+        return Ok(());
+    }
+    for result in outputs {
+        writeln!(out)?;
+        writeln!(out, "{} ({})", result.name, result.documents.len())?;
+        if let Some(violation) = result.violation.as_deref() {
+            writeln!(out, "  Contract violation: {violation}")?;
+        }
+        for (index, document) in result.documents.iter().enumerate() {
+            if result.documents.len() > 1 {
+                writeln!(out, "  #{}", index + 1)?;
+            }
+            let Some(fields) = document.as_object() else {
+                writeln!(out, "  {}", display_value(document))?;
+                continue;
+            };
+            for (field, value) in fields {
+                if field.starts_with('_') || field == "run_id" {
+                    continue;
+                }
+                let rendered = display_value(value);
+                if rendered.contains('\n') {
+                    writeln!(out, "  {field}:")?;
+                    for line in rendered.lines() {
+                        writeln!(out, "    {line}")?;
+                    }
+                } else {
+                    writeln!(out, "  {field}: {rendered}")?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_result_text(view: &GraphRunView) -> Result<()> {
+    write_result_text(&mut io::stdout().lock(), view)
+}
+
+async fn watch_run(
+    access: &ConfigAccess,
+    actor: &str,
+    run_id: &str,
+    interval: Duration,
+    output: OutputFormat,
+) -> Result<()> {
+    let output =
+        output.ensure_supported("graph watch", &[OutputFormat::Text, OutputFormat::Json])?;
+    let mut last = Value::Null;
+    let redraw = output == OutputFormat::Text && io::stdout().is_terminal();
+    loop {
+        let view = load_graph_run_view_with_access(access, actor, run_id).await?;
+        let request_ids = view
+            .requests
+            .iter()
+            .map(|request| request.request_id.clone())
+            .collect::<Vec<_>>();
+        let session_ids = view
+            .requests
+            .iter()
+            .filter_map(|request| request.session_id.clone())
+            .collect::<Vec<_>>();
+        let activity = load_run_activity_rows(access, &request_ids, &session_ids).await?;
+        let usage = run_usage_summary(&activity.inference_calls);
+        let current = json!({ "run": progress(&view), "activity": activity, "usage": usage });
+        if current != last {
+            match output {
+                OutputFormat::Json => print_json(&current)?,
+                OutputFormat::Text => print_progress_text(&view, &activity, redraw)?,
+                _ => unreachable!("validated output format"),
+            }
+            last = current;
+        }
+        if view.is_terminal() {
+            if view.status == "succeeded" {
+                return Ok(());
+            }
+            anyhow::bail!("graph run {} ended {}", view.run_id, view.status);
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+async fn watch(args: GraphWatchArgs) -> Result<()> {
+    let (access, actor) = access_and_actor(&args.scope).await?;
+    watch_run(
+        &access,
+        &actor,
+        &args.run_id,
+        Duration::from_millis(args.interval_ms.max(100)),
+        args.output,
+    )
+    .await
+}
+
+async fn result(args: GraphResultArgs) -> Result<()> {
+    let (access, actor) = access_and_actor(&args.scope).await?;
+    let view = load_graph_run_result_view_with_access(&access, &actor, &args.run_id).await?;
+    match args
+        .output
+        .ensure_supported("graph result", &[OutputFormat::Text, OutputFormat::Json])?
+    {
+        OutputFormat::Json => print_json(&json!({
+            "run_id": view.run_id,
+            "status": view.status,
+            "revision_digest": view.revision_digest,
+            "results": view.results,
+            "result_refs": view.persisted_result_refs,
+            "error": effective_error(&view),
+        })),
+        OutputFormat::Text => print_result_text(&view),
+        _ => unreachable!("validated output format"),
+    }
+}
+
+async fn cancel(args: GraphCancelArgs) -> Result<()> {
+    let (access, actor) = access_and_actor(&args.scope).await?;
+    let view = request_graph_run_cancellation_with_access(
+        &access,
+        &actor,
+        &args.run_id,
+        args.reason.as_deref(),
+    )
+    .await?;
+    print_json(&progress(&view))
+}
+
+async fn toggle(args: GraphToggleArgs, enabled: bool) -> Result<()> {
+    let (access, actor) = access_and_actor(&args.scope).await?;
+    let graph_id = bundled_graph_id(&args.package, &actor)?;
+    set_graph_enabled_with_access(&access, &actor, &graph_id, enabled).await?;
+    print_json(&json!({ "graph_id": graph_id, "enabled": enabled }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result_view() -> GraphRunView {
+        serde_json::from_str(
+            r#"{
+            "view_version": 1,
+            "run_id": "run-1",
+            "graph_id": "review",
+            "revision_digest": "sha256:revision",
+            "owner_did": "did:key:owner",
+            "caller_did": "did:key:owner",
+            "entry_name": "review",
+            "correlation": "run-1",
+            "status": "succeeded",
+            "input": {},
+            "cancellation_requested_at": null,
+            "cancellation_requested_by": null,
+            "cancellation_reason": null,
+            "error": null,
+            "created_at": "2026-08-26T00:00:00Z",
+            "started_at": "2026-08-26T00:00:00Z",
+            "deadline_at": "2026-08-26T02:00:00Z",
+            "completed_at": "2026-08-26T01:00:00Z",
+            "update_generation": 2,
+            "requests": [],
+            "stages": [],
+            "groups": [],
+            "results": [{
+                "name": "findings",
+                "terminal": true,
+                "satisfied": true,
+                "observed_count": 1,
+                "violation": null,
+                "refs": [],
+                "documents": [{
+                    "_docID": "finding-doc",
+                    "run_id": "run-1",
+                    "severity": "Major",
+                    "path": "src/main.rs",
+                    "line": "42",
+                    "title": "Actionable defect",
+                    "detail": "The complete explanation.",
+                    "evidence": "Exact source evidence.",
+                    "verification": "Independently confirmed."
+                }]
+            }, {
+                "name": "report",
+                "terminal": true,
+                "satisfied": true,
+                "observed_count": 1,
+                "violation": null,
+                "refs": [],
+                "documents": [{
+                    "_docID": "report-doc",
+                    "run_id": "run-1",
+                    "summary": "Block until the confirmed defect is fixed."
+                }]
+            }],
+            "persisted_result_refs": [],
+            "active_request_count": 0,
+            "terminal_request_count": 1,
+            "result_contract_satisfied": true,
+            "failure_evidence": null
+        }"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn result_text_is_a_complete_actionable_handoff() {
+        let mut output = Vec::new();
+        write_result_text(&mut output, &result_view()).unwrap();
+        let output = String::from_utf8(output).unwrap();
+        for expected in [
+            "Status: succeeded",
+            "severity: Major",
+            "path: src/main.rs",
+            "line: 42",
+            "title: Actionable defect",
+            "detail: The complete explanation.",
+            "evidence: Exact source evidence.",
+            "verification: Independently confirmed.",
+            "summary: Block until the confirmed defect is fixed.",
+        ] {
+            assert!(output.contains(expected), "missing {expected:?}:\n{output}");
+        }
+        assert!(!output.contains("_docID"));
+        assert!(!output.contains("run_id:"));
+    }
+
+    #[test]
+    fn progress_json_exposes_derived_failure_evidence_as_error() {
+        let mut view = result_view();
+        view.status = "running".to_owned();
+        view.error = None;
+        view.failure_evidence = Some(json!({
+            "code": "result_contract_unsatisfied",
+            "message": "terminal contract failed"
+        }));
+        assert_eq!(
+            progress(&view)["error"]["code"],
+            "result_contract_unsatisfied"
+        );
+    }
+
+    #[test]
+    fn live_usage_uses_durable_context_estimates_only_for_unreported_completed_calls() {
+        let calls = vec![
+            TimelineInferenceCallRow {
+                call_state: "completed".to_owned(),
+                prompt_tokens: Some(120),
+                completion_tokens: Some(30),
+                cached_input_tokens: Some(40),
+                ..TimelineInferenceCallRow::default()
+            },
+            TimelineInferenceCallRow {
+                call_state: "completed".to_owned(),
+                prompt_tokens: Some(0),
+                completion_tokens: Some(0),
+                cached_input_tokens: Some(0),
+                context_accounting_json: Some(r#"{"estimated_input_tokens":6310}"#.to_owned()),
+                ..TimelineInferenceCallRow::default()
+            },
+            TimelineInferenceCallRow {
+                call_state: "running".to_owned(),
+                context_accounting_json: Some(r#"{"estimated_input_tokens":9999}"#.to_owned()),
+                ..TimelineInferenceCallRow::default()
+            },
+        ];
+        let summary = run_usage_summary(&calls);
+        assert_eq!(
+            summary,
+            RunUsageSummary {
+                reported_input_tokens: 120,
+                reported_cached_input_tokens: 40,
+                reported_output_tokens: 30,
+                estimated_input_tokens: 6310,
+                unreported_completed_calls: 1,
+            }
+        );
+        assert_eq!(
+            usage_detail(&summary),
+            "120 input reported · 40 cached · 30 output · ~6.3k input estimated · 1 completed call unreported"
+        );
+    }
+
+    #[test]
+    fn live_usage_does_not_render_missing_provider_usage_as_zero() {
+        let summary = run_usage_summary(&[TimelineInferenceCallRow {
+            call_state: "completed".to_owned(),
+            prompt_tokens: Some(0),
+            completion_tokens: Some(0),
+            cached_input_tokens: Some(0),
+            context_accounting_json: Some(r#"{"estimated_input_tokens":8900000}"#.to_owned()),
+            ..TimelineInferenceCallRow::default()
+        }]);
+        assert_eq!(
+            usage_detail(&summary),
+            "~8.9m input estimated · output unavailable · 1 completed call unreported"
+        );
+    }
+}

--- a/crates/gents-cli/src/commands/mod.rs
+++ b/crates/gents-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod demo;
 pub(crate) mod diagnose;
 pub(crate) mod fleet;
 pub(crate) mod goal;
+pub(crate) mod graph;
 pub(crate) mod grok_auth_probe;
 pub(crate) mod grok_login;
 pub(crate) mod init;

--- a/crates/gents-cli/src/interactive_backend.rs
+++ b/crates/gents-cli/src/interactive_backend.rs
@@ -70,8 +70,8 @@ async fn pick_backend() -> Result<BackendSelection> {
         None => eprintln!("  2) local server     (e.g. ollama / llama-server)"),
     }
     eprintln!("  3) custom URL");
-    eprintln!("  4) ChatGPT / Codex subscription   (uses your ChatGPT plan; log in after init)");
-    eprintln!("  5) Grok subscription (SuperGrok / X Premium+)   (log in after init)");
+    eprintln!("  4) ChatGPT / Codex subscription   (uses your ChatGPT plan; OAuth setup included)");
+    eprintln!("  5) Grok subscription (SuperGrok / X Premium+)   (OAuth setup included)");
     let choice = prompt_line("> ").await?;
     match choice.trim() {
         "1" | "" => {
@@ -133,32 +133,20 @@ async fn pick_backend() -> Result<BackendSelection> {
                 api_key: None,
             })
         }
-        "4" => {
-            eprintln!(
-                "\nAfter init, run `gents codex-login` to store the subscription\n\
-                 credential for this agent. `gents init` only seeds the backend."
-            );
-            Ok(BackendSelection {
-                inference_url: None,
-                backend_preset: Some(BackendPresetArg::ChatGptCodex),
-                model_name: None,
-                api_key: None,
-                label: "ChatGPT / Codex subscription".to_string(),
-            })
-        }
-        "5" => {
-            eprintln!(
-                "\nAfter init, run `gents grok-login` to store the SuperGrok / X Premium+\n\
-                 OAuth credential for this agent. `gents init` only seeds the backend."
-            );
-            Ok(BackendSelection {
-                inference_url: None,
-                backend_preset: Some(BackendPresetArg::XaiGrokOAuth),
-                model_name: None,
-                api_key: None,
-                label: "Grok subscription (SuperGrok / X Premium+)".to_string(),
-            })
-        }
+        "4" => Ok(BackendSelection {
+            inference_url: None,
+            backend_preset: Some(BackendPresetArg::ChatGptCodex),
+            model_name: None,
+            api_key: None,
+            label: "ChatGPT / Codex subscription".to_string(),
+        }),
+        "5" => Ok(BackendSelection {
+            inference_url: None,
+            backend_preset: Some(BackendPresetArg::XaiGrokOAuth),
+            model_name: None,
+            api_key: None,
+            label: "Grok subscription (SuperGrok / X Premium+)".to_string(),
+        }),
         other => bail!("unrecognized choice: {other}"),
     }
 }

--- a/crates/gents-cli/src/lib.rs
+++ b/crates/gents-cli/src/lib.rs
@@ -452,6 +452,7 @@ async fn async_main() -> Result<()> {
         Command::Mcp { command } => commands::mcp::dispatch(command).await,
         Command::Fleet { command } => commands::fleet::dispatch(command).await,
         Command::Task { command } => commands::task::dispatch(command).await,
+        Command::Graph { command } => commands::graph::dispatch(command).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
         Command::Tools { command } => commands::tools::dispatch(command).await,
         Command::Config { command } => commands::config::dispatch(command).await,

--- a/crates/gents-cli/tests/cli_graph.rs
+++ b/crates/gents-cli/tests/cli_graph.rs
@@ -1,0 +1,131 @@
+//! Checkout-independent binary acceptance for bundled graph discovery and
+//! revision-backed installation. Runtime/model execution has its own live
+//! fixture; these cases keep the package boundary honest in the ordinary CLI.
+
+mod support;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use support::{
+    agent_did_from_init, allocate_port, run_cli_failure_stderr, run_cli_json, run_init_json,
+    spawn_server_with_ready_json,
+};
+
+fn required_str<'a>(value: &'a Value, path: &[&str]) -> Result<&'a str> {
+    let mut current = value;
+    for segment in path {
+        current = current
+            .get(*segment)
+            .with_context(|| format!("missing JSON path {} in {value}", path.join(".")))?;
+    }
+    current
+        .as_str()
+        .with_context(|| format!("JSON path {} is not a string", path.join(".")))
+}
+
+#[test]
+fn bundled_catalog_is_read_only_outside_a_source_checkout() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating graph catalog tempdir")?;
+    let catalog = run_cli_json(tempdir.path(), &["graph", "catalog", "code-review"])?;
+    let packages = catalog
+        .get("packages")
+        .and_then(Value::as_array)
+        .context("catalog output is missing packages")?;
+    anyhow::ensure!(packages.len() == 1, "unexpected catalog output: {catalog}");
+    anyhow::ensure!(
+        packages[0].get("name").and_then(Value::as_str) == Some("code-review"),
+        "catalog did not return code-review: {catalog}"
+    );
+    anyhow::ensure!(
+        std::fs::read_dir(tempdir.path())?.next().is_none(),
+        "read-only catalog created files in a clean working directory"
+    );
+    Ok(())
+}
+
+#[test]
+fn clean_binary_install_is_idempotent_activates_and_is_owner_fenced() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating graph install tempdir")?;
+    let home = tempdir.path().join("agent-home");
+    let home_arg = home.to_str().context("graph home path is not UTF-8")?;
+    let initialized = run_init_json(
+        tempdir.path(),
+        &["--agent-name", "graph-reviewer", "--home", home_arg],
+    )?;
+    let owner_did = agent_did_from_init(&initialized)?;
+    let port = allocate_port()?;
+    let (_server, readiness) =
+        spawn_server_with_ready_json(&home, port, &["--home", home_arg], &[])?;
+    anyhow::ensure!(
+        readiness.get("status").and_then(Value::as_str) == Some("serving"),
+        "server did not become ready: {readiness}"
+    );
+
+    let install_args = [
+        "graph",
+        "install",
+        "code-review",
+        "--home",
+        home_arg,
+        "--output",
+        "json",
+    ];
+    let first = run_cli_json(tempdir.path(), &install_args)?;
+    let second = run_cli_json(tempdir.path(), &install_args)?;
+    anyhow::ensure!(
+        first.get("install") == second.get("install"),
+        "repeated install changed its durable receipt\nfirst: {first}\nsecond: {second}"
+    );
+    let revision = required_str(&first, &["install", "revision_digest"])?;
+    anyhow::ensure!(
+        required_str(&first, &["activation", "active_digest"])? == revision,
+        "install did not activate its exact immutable revision: {first}"
+    );
+
+    let wrong_actor = "did:key:z6MkvGraphPackageIntruder";
+    let denial = run_cli_failure_stderr(
+        tempdir.path(),
+        &[
+            "graph",
+            "install",
+            "code-review",
+            "--home",
+            home_arg,
+            "--agent-did",
+            wrong_actor,
+        ],
+    )?;
+    anyhow::ensure!(
+        denial.contains("package owner principal is missing"),
+        "wrong-owner install did not fail at the identity boundary: {denial}"
+    );
+
+    let disabled = run_cli_json(
+        tempdir.path(),
+        &[
+            "graph",
+            "disable",
+            "code-review",
+            "--home",
+            home_arg,
+            "--agent-did",
+            &owner_did,
+        ],
+    )?;
+    anyhow::ensure!(disabled.get("enabled") == Some(&Value::Bool(false)));
+    let enabled = run_cli_json(
+        tempdir.path(),
+        &[
+            "graph",
+            "enable",
+            "code-review",
+            "--home",
+            home_arg,
+            "--agent-did",
+            &owner_did,
+        ],
+    )?;
+    anyhow::ensure!(enabled.get("enabled") == Some(&Value::Bool(true)));
+    Ok(())
+}

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -37,6 +37,20 @@ pub struct RunTimelineRows {
     pub rendered_request_refs: Vec<TimelineRenderedRequestRef>,
 }
 
+/// Bounded, prompt-free activity rows for a live observer. These reuse the
+/// same durable row vocabulary as [`RunTimelineRows`] without loading message
+/// bodies, tool arguments/results, or full request timelines on every poll.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct RunActivityRows {
+    #[serde(default)]
+    pub sessions: Vec<TimelineSessionRow>,
+    #[serde(default)]
+    pub inference_calls: Vec<TimelineInferenceCallRow>,
+    #[serde(default)]
+    pub tool_calls: Vec<TimelineToolCallRow>,
+    pub truncated: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunTimeline {
     pub request_id: String,

--- a/crates/gents/src/run_timeline_fetch.rs
+++ b/crates/gents/src/run_timeline_fetch.rs
@@ -16,13 +16,15 @@ use crate::descendant_graph::{
 };
 use crate::graphql::escape_graphql_string;
 use crate::run_timeline::{
-    build_run_timeline, RunTimeline, RunTimelineRows, TimelineCompactionRow,
+    build_run_timeline, RunActivityRows, RunTimeline, RunTimelineRows, TimelineCompactionRow,
     TimelineConversationRow, TimelineGoalVersionRow, TimelineInferenceCallRow, TimelineMessageRow,
     TimelineProviderContextReductionRow, TimelineRenderedRequestRef, TimelineRenderedRequestRow,
     TimelineRequestRow, TimelineResponseRow, TimelineSessionRow, TimelineToolApprovalRow,
     TimelineToolCallRow,
 };
 use gents_protocol::graphql::graphql_rows_from_response;
+
+const MAX_RUN_ACTIVITY_ROWS: usize = 10_000;
 
 pub async fn load_run_timeline(access: &ConfigAccess, request_id: &str) -> Result<RunTimeline> {
     let mut timeline = build_run_timeline(load_run_timeline_rows(access, request_id).await?);
@@ -54,6 +56,98 @@ pub async fn load_run_timeline(access: &ConfigAccess, request_id: &str) -> Resul
         }
     }
     Ok(timeline)
+}
+
+/// Load the prompt-free subset of ordinary timeline rows needed by live run
+/// observers. One bounded query serves CLI and future bridge projections.
+pub async fn load_run_activity_rows(
+    access: &ConfigAccess,
+    request_ids: &[String],
+    session_ids: &[String],
+) -> Result<RunActivityRows> {
+    let request_ids = request_ids
+        .iter()
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .collect::<BTreeSet<_>>();
+    if request_ids.is_empty() {
+        return Ok(RunActivityRows::default());
+    }
+    let request_list = request_ids
+        .iter()
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let session_ids = session_ids
+        .iter()
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .collect::<BTreeSet<_>>();
+    let session_query = if session_ids.is_empty() {
+        String::new()
+    } else {
+        let session_list = session_ids
+            .iter()
+            .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "AgentSession(filter: {{ session_id: {{ _in: [{session_list}] }} }}) {{ session_id behavior_id started ended status }}"
+        )
+    };
+    let limit = MAX_RUN_ACTIVITY_ROWS + 1;
+    let response = access
+        .execute(&format!(
+            r#"{{
+                {session_query}
+                InferenceCall(
+                    filter: {{
+                        request_id: {{ _in: [{request_list}] }},
+                        call_kind: {{ _eq: "inference" }}
+                    }},
+                    order: {{ started_at: ASC }}, limit: {limit}
+                ) {{
+                    call_id request_id call_seq attempt call_state failure_reason
+                    queued_at started_at ended_at backend_id behavior_id agent_did call_kind
+                    prompt_tokens completion_tokens cached_input_tokens context_accounting_json
+                }}
+                AgentToolCall(
+                    filter: {{ request_id: {{ _in: [{request_list}] }} }},
+                    order: {{ started_at: ASC }}, limit: {limit}
+                ) {{
+                    request_id session_id message_sequence tool_name tool_call_id status
+                    lifecycle_state started_at completed_at tool_failure_class latency_ms
+                }}
+            }}"#
+        ))
+        .await?;
+    let mut sessions = graphql_rows_from_response(&response, "AgentSession")
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<std::result::Result<Vec<TimelineSessionRow>, _>>()
+        .context("decoding live AgentSession activity")?;
+    let mut inference_calls = graphql_rows_from_response(&response, "InferenceCall")
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<std::result::Result<Vec<TimelineInferenceCallRow>, _>>()
+        .context("decoding live InferenceCall activity")?;
+    let mut tool_calls = graphql_rows_from_response(&response, "AgentToolCall")
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<std::result::Result<Vec<TimelineToolCallRow>, _>>()
+        .context("decoding live AgentToolCall activity")?;
+    let truncated = sessions.len() > MAX_RUN_ACTIVITY_ROWS
+        || inference_calls.len() > MAX_RUN_ACTIVITY_ROWS
+        || tool_calls.len() > MAX_RUN_ACTIVITY_ROWS;
+    sessions.truncate(MAX_RUN_ACTIVITY_ROWS);
+    inference_calls.truncate(MAX_RUN_ACTIVITY_ROWS);
+    tool_calls.truncate(MAX_RUN_ACTIVITY_ROWS);
+    Ok(RunActivityRows {
+        sessions,
+        inference_calls,
+        tool_calls,
+        truncated,
+    })
 }
 
 async fn load_timeline_descendant_edges(
@@ -378,6 +472,71 @@ mod tests {
             .and_then(Value::as_str)
             .expect("created _docID")
             .to_string()
+    }
+
+    #[tokio::test]
+    async fn activity_rows_reuse_prompt_free_timeline_vocabulary() {
+        let node = std::sync::Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_schemas(node.as_ref()).await.unwrap();
+        let response = node
+            .execute(
+                r#"mutation {
+                    create_AgentSession(input: {
+                        session_id: "activity-session"
+                        agent_name: "agent"
+                        agent_did: "did:test:agent"
+                        behavior_id: "review"
+                        started: "2026-08-26T00:00:00Z"
+                        status: "active"
+                    }) { _docID }
+                    create_InferenceCall(input: {
+                        call_id: "activity-call"
+                        request_id: "activity-request"
+                        call_seq: 1
+                        attempt: 1
+                        call_kind: "inference"
+                        call_state: "completed"
+                        prompt_tokens: 120
+                        completion_tokens: 30
+                        cached_input_tokens: 64
+                        context_accounting_json: "{\"estimated_input_tokens\":144}"
+                    }) { _docID }
+                    create_AgentToolCall(input: {
+                        tool_call_key: "activity-tool-key"
+                        request_id: "activity-request"
+                        session_id: "activity-session"
+                        agent_did: "did:test:agent"
+                        tool_name: "read_file"
+                        tool_call_id: "activity-tool"
+                        status: "completed"
+                        lifecycle_state: "completed"
+                    }) { _docID }
+                }"#,
+            )
+            .await;
+        assert!(
+            !response.has_errors(),
+            "seed activity rows: {:?}",
+            response.errors
+        );
+
+        let rows = load_run_activity_rows(
+            &ConfigAccess::Local(node.clone()),
+            &["activity-request".to_owned()],
+            &["activity-session".to_owned()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows.sessions[0].status.as_deref(), Some("active"));
+        assert_eq!(rows.inference_calls[0].prompt_tokens, Some(120));
+        assert_eq!(
+            rows.inference_calls[0].context_accounting_json.as_deref(),
+            Some(r#"{"estimated_input_tokens":144}"#)
+        );
+        assert_eq!(rows.tool_calls[0].tool_name, "read_file");
+        assert!(rows.tool_calls[0].args.is_empty());
+        assert!(rows.tool_calls[0].result.is_empty());
+        node.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/gents/src/workspace/documents.rs
+++ b/crates/gents/src/workspace/documents.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::graphql::escape_graphql_string;
 
 use super::action_plan::{CreationPolicy, WorkspaceAdapterKind};
+use super::executor::RepositoryPlacementRef;
 use super::LogicalWorkspaceIdentity;
 
 pub(crate) const ADAPTER_VERSION: &str = "gents-workspace-adapter/1";
@@ -327,6 +328,41 @@ pub fn workspace_placement_upsert_mutation(
         provisioning_state = escape_graphql_string(&doc.provisioning_state),
         observed_tree_hash = escape_graphql_string(&doc.observed_tree_hash),
     )
+}
+
+pub fn repository_placement_upsert_mutation(
+    placement: &RepositoryPlacementRef,
+    updated_at: &str,
+) -> Result<String> {
+    let enabled = if placement.enabled { "true" } else { "false" };
+    let host_path = placement
+        .host_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("repository path is not valid UTF-8"))?;
+    Ok(format!(
+        r#"mutation {{
+            upsert_RepositoryPlacement(
+                filter: {{ repository_id: {{ _eq: "{repository_id}" }} }},
+                add: {{
+                    repository_id: "{repository_id}",
+                    deployment_id: "{deployment_id}",
+                    host_path: "{host_path}",
+                    enabled: {enabled},
+                    updated_at: "{updated_at}"
+                }},
+                update: {{
+                    deployment_id: "{deployment_id}",
+                    host_path: "{host_path}",
+                    enabled: {enabled},
+                    updated_at: "{updated_at}"
+                }}
+            ) {{ _docID }}
+        }}"#,
+        repository_id = escape_graphql_string(&placement.repository_id),
+        deployment_id = escape_graphql_string(&placement.deployment_id),
+        host_path = escape_graphql_string(host_path),
+        updated_at = escape_graphql_string(updated_at),
+    ))
 }
 
 pub fn workspace_binding_upsert_mutation(doc: &WorkspaceBindingDoc) -> String {

--- a/crates/gents/src/workspace/mod.rs
+++ b/crates/gents/src/workspace/mod.rs
@@ -18,6 +18,7 @@ mod executor;
 mod instructions;
 pub(crate) mod journal;
 pub(crate) mod overlay;
+mod quickstart;
 mod runtime;
 
 pub(crate) use action_plan::{
@@ -32,11 +33,11 @@ pub use action_plan::{
     DEFAULT_MAKE_WORKTREE_ARTIFACTS,
 };
 pub use documents::{
-    isolated_workspace_upsert_mutation, workspace_binding_upsert_mutation,
-    workspace_cleanup_docs_mutation, workspace_placement_upsert_mutation,
-    workspace_receipt_create_mutation, IsolatedWorkspaceDoc, MemoryWorkspaceDocuments,
-    ProvisioningObservation, WorkspaceBindingDoc, WorkspaceDocuments, WorkspacePlacementDoc,
-    WorkspaceReceiptDoc,
+    isolated_workspace_upsert_mutation, repository_placement_upsert_mutation,
+    workspace_binding_upsert_mutation, workspace_cleanup_docs_mutation,
+    workspace_placement_upsert_mutation, workspace_receipt_create_mutation, IsolatedWorkspaceDoc,
+    MemoryWorkspaceDocuments, ProvisioningObservation, WorkspaceBindingDoc, WorkspaceDocuments,
+    WorkspacePlacementDoc, WorkspaceReceiptDoc,
 };
 pub use executor::{
     execute_cleanup_workspace_plan, execute_create_workspace_plan,
@@ -50,6 +51,7 @@ pub use instructions::{
     InstructionFile, InstructionManifest, DEFAULT_INSTRUCTION_PATHS,
 };
 pub use journal::{action_journal_prefix_legal, ActionJournalEntry, ActionJournalState};
+pub use quickstart::provision_read_only_workspace;
 pub use runtime::cleanup_workspace;
 pub(crate) use runtime::{
     integrate_on_integrator_success, materialize_workspace_binding, release_writer_binding,

--- a/crates/gents/src/workspace/quickstart.rs
+++ b/crates/gents/src/workspace/quickstart.rs
@@ -1,0 +1,215 @@
+//! Operator-initiated read-only workspace placement for graph entrypoints.
+//!
+//! This composes the existing repository placement, ActionPlan executor, and
+//! workspace document mutations. It does not create a second workspace model.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+
+use super::{
+    emit_create_workspace_plan, execute_create_workspace_plan, isolated_workspace_upsert_mutation,
+    repository_placement_upsert_mutation, workspace_placement_upsert_mutation, ActionJournalEntry,
+    CreateWorkspaceAction, CreateWorkspaceOutcome, CreationPolicy, HostExecutorContext,
+    MemoryWorkspaceDocuments, RepositoryPlacementRef, WorkspaceAdapterKind, CAP_CREATE_WORKSPACE,
+    CAP_OBSERVE_DIRTY_BASE,
+};
+use crate::config_client::ConfigAccess;
+
+fn repository_id(path: &Path, deployment_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(deployment_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(path.as_os_str().as_encoded_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("local-repository-{}", &digest[..24])
+}
+
+async fn require_local_deployment(access: &ConfigAccess, expected: &str) -> Result<()> {
+    let response = access
+        .execute("{ HostDeployment(limit: 2) { deployment_id } }")
+        .await?;
+    let rows = response
+        .get("data")
+        .and_then(|data| data.get("HostDeployment"))
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    if rows.len() != 1 {
+        anyhow::bail!(
+            "local repository placement requires exactly one unambiguous HostDeployment on the connected server"
+        );
+    }
+    let local = rows[0]
+        .get("deployment_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .context("connected server HostDeployment is missing deployment_id")?;
+    if local != expected {
+        anyhow::bail!(
+            "package deployment {expected:?} is not the connected server's local deployment {local:?}; refusing to persist a client-local repository path"
+        );
+    }
+    Ok(())
+}
+
+async fn upsert_repository_placement(
+    access: &ConfigAccess,
+    repository_id: &str,
+    deployment_id: &str,
+    path: &Path,
+) -> Result<()> {
+    let placement = RepositoryPlacementRef {
+        repository_id: repository_id.to_owned(),
+        deployment_id: deployment_id.to_owned(),
+        host_path: path.to_owned(),
+        enabled: true,
+    };
+    let mutation =
+        repository_placement_upsert_mutation(&placement, &chrono::Utc::now().to_rfc3339())?;
+    access.execute_committed(&mutation).await?;
+    Ok(())
+}
+
+async fn flush_workspace_documents(
+    access: &ConfigAccess,
+    documents: &MemoryWorkspaceDocuments,
+) -> Result<()> {
+    if documents.workspaces.is_empty() && documents.placements.is_empty() {
+        return Ok(());
+    }
+    let txn = access.begin_apply_txn().await?;
+    let result = async {
+        for workspace in documents.workspaces.values() {
+            txn.execute(&isolated_workspace_upsert_mutation(workspace))
+                .await?;
+        }
+        let now = chrono::Utc::now().to_rfc3339();
+        for placement in documents.placements.values() {
+            txn.execute(&workspace_placement_upsert_mutation(placement, &now))
+                .await?;
+        }
+        Result::<()>::Ok(())
+    }
+    .await;
+    match result {
+        Ok(()) => txn
+            .commit()
+            .await
+            .context("commit graph workspace placement"),
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+/// Create a Git worktree at an immutable head commit and persist its ordinary
+/// workspace records. The source checkout is only a repository placement; its
+/// path never enters GraphRevision or GraphRun.
+pub async fn provision_read_only_workspace(
+    access: &ConfigAccess,
+    repository_path: &Path,
+    head_sha: &str,
+    deployment_id: &str,
+    principal_did: &str,
+) -> Result<CreateWorkspaceOutcome> {
+    require_local_deployment(access, deployment_id).await?;
+    let repository_path = std::fs::canonicalize(repository_path).with_context(|| {
+        format!(
+            "canonicalizing repository placement {}",
+            repository_path.display()
+        )
+    })?;
+    let repository_id = repository_id(&repository_path, deployment_id);
+    upsert_repository_placement(access, &repository_id, deployment_id, &repository_path).await?;
+
+    let workspace_id = uuid::Uuid::new_v4().to_string();
+    let branch = format!("gents-review-{}", &workspace_id[..12]);
+    let plan = emit_create_workspace_plan(CreateWorkspaceAction {
+        workspace_id: workspace_id.clone(),
+        work_unit_id: workspace_id.clone(),
+        repository_id: repository_id.clone(),
+        base_sha: head_sha.to_owned(),
+        branch,
+        creation_policy: CreationPolicy::GitWorktreeDiff,
+        adapter: WorkspaceAdapterKind::GitWorktree,
+        clone_artifacts: None,
+    });
+    let mut documents = MemoryWorkspaceDocuments::default();
+    let mut journal = Vec::<ActionJournalEntry>::new();
+    let capabilities = [CAP_CREATE_WORKSPACE, CAP_OBSERVE_DIRTY_BASE]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<BTreeSet<_>>();
+    let outcome = {
+        let mut context = HostExecutorContext {
+            deployment_id: deployment_id.to_owned(),
+            repository: RepositoryPlacementRef {
+                repository_id,
+                deployment_id: deployment_id.to_owned(),
+                host_path: repository_path.clone(),
+                enabled: true,
+            },
+            ceiling: Some(&repository_path),
+            capabilities,
+            writer_principal: principal_did.to_owned(),
+            integrator_principal: principal_did.to_owned(),
+            caused_by_invocation_id: format!("graph-workspace-{workspace_id}"),
+            caused_by_correlation: workspace_id,
+            documents: &mut documents,
+        };
+        execute_create_workspace_plan(&plan, &mut journal, &mut context)
+    };
+    flush_workspace_documents(access, &documents).await?;
+    outcome.map_err(|error| anyhow::anyhow!(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use defra_node::EmbeddedNode;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn local_repository_paths_require_the_connected_deployment() {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        let access = ConfigAccess::Local(node.clone());
+        let response = node
+            .execute(
+                r#"mutation { create_HostDeployment(input: {
+                    deployment_id: "local", display_name: "Local"
+                }) { _docID } }"#,
+            )
+            .await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+
+        require_local_deployment(&access, "local").await.unwrap();
+        let mismatch = require_local_deployment(&access, "remote")
+            .await
+            .unwrap_err();
+        assert!(mismatch.to_string().contains("refusing to persist"));
+
+        let response = node
+            .execute(
+                r#"mutation { create_HostDeployment(input: {
+                    deployment_id: "replica", display_name: "Replica"
+                }) { _docID } }"#,
+            )
+            .await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        let ambiguous = require_local_deployment(&access, "local")
+            .await
+            .unwrap_err();
+        assert!(ambiguous.to_string().contains("exactly one unambiguous"));
+
+        drop(access);
+        let node = Arc::try_unwrap(node).unwrap_or_else(|_| panic!("test retained node clone"));
+        node.shutdown().await;
+    }
+}

--- a/crates/gents/src/workspace/tests.rs
+++ b/crates/gents/src/workspace/tests.rs
@@ -249,6 +249,19 @@ fn isolated_workspace_mutation_has_no_host_path() {
         workspace_placement_upsert_mutation(&placement, "2026-08-21T00:00:00Z");
     assert!(placement_mutation.contains("host_path:"));
     assert!(!placement_mutation.contains("[]"));
+    let repository_mutation = repository_placement_upsert_mutation(
+        &RepositoryPlacementRef {
+            repository_id: "repo-1".into(),
+            deployment_id: "deploy-1".into(),
+            host_path: PathBuf::from("/tmp/repo\"quoted"),
+            enabled: true,
+        },
+        "2026-08-21T00:00:00Z",
+    )
+    .unwrap();
+    assert!(repository_mutation.contains("upsert_RepositoryPlacement"));
+    assert!(repository_mutation.contains("/tmp/repo\\\"quoted"));
+    assert!(!repository_mutation.contains("[]"));
     let receipt = WorkspaceReceiptDoc {
         receipt_id: "receipt-writer-ws-1-req-1".into(),
         workspace_id: "ws-1".into(),


### PR DESCRIPTION
## Summary

- add `graph catalog`, `install`, `run`, `watch`, `result`, `disable`, and `enable` CLI flows
- default code review to the current directory, `origin/main`, and `HEAD`
- inherit the initialized default behavior and inference backend
- render durable stage, session, model usage, tool call, failure, and actionable result projections
- expose the same graph/run projection through the desktop bridge

## Review boundary

The CLI is intentionally a code-review adapter over the generic runtime entry contract. A generic variable grammar waits for a second package to prove it.

## Stack

Depends on #1229.

## Verification

- `cargo test -p gents-cli --test cli_graph`
- `cargo check --workspace --all-targets`