### PR TITLE
ci: make elan setup idempotent

### DIFF
--- a/.github/scripts/setup-elan.sh
+++ b/.github/scripts/setup-elan.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+elan_home="${ELAN_HOME:-$HOME/.elan}"
+export ELAN_HOME="$elan_home"
+mkdir -p "$elan_home"
+
+# Multiple self-hosted runner processes share the same account and can enter
+# the installer together. Re-enter under a host lock so proxy creation is
+# atomic, then skip the network installer when a usable elan already exists.
+if [[ "${GENTS_ELAN_INSTALL_LOCKED:-0}" != "1" ]] && command -v lockf >/dev/null 2>&1; then
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  exec lockf -k "$elan_home/.gents-install.lock" \
+    env GENTS_ELAN_INSTALL_LOCKED=1 ELAN_HOME="$elan_home" \
+    "$script_dir/$(basename "$0")" "$@"
+fi
+
+if [[ ! -x "$elan_home/bin/elan" ]]; then
+  curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf \
+    | sh -s -- -y
+fi
+
+echo "$elan_home/bin" >> "$GITHUB_PATH"
+"$elan_home/bin/elan" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,10 @@ jobs:
         # boundary and identity_decide fences.
         if: matrix.suite == 'runtime' || matrix.suite == 'desktop' || (matrix.suite == 'cli' && github.event_name != 'pull_request')
         run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          .github/scripts/setup-elan.sh
           cargo_dir="$(dirname "$(rustup which cargo)")"
           echo "${cargo_dir}" >> "$GITHUB_PATH"
           "${cargo_dir}/cargo" --version
-          "$HOME/.elan/bin/elan" --version
 
       - name: Install protobuf compiler
         run: .github/scripts/setup-protoc.sh
@@ -349,10 +347,7 @@ jobs:
           persist-credentials: false
 
       - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" --version
+        run: .github/scripts/setup-elan.sh
 
       - name: Prepare persistent Lean build cache
         run: .github/scripts/setup-lean-build-cache.sh

--- a/.github/workflows/desktop-ui-qa.yml
+++ b/.github/workflows/desktop-ui-qa.yml
@@ -32,10 +32,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" --version
+        run: .github/scripts/setup-elan.sh
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release-desktop-packages.yml
+++ b/.github/workflows/release-desktop-packages.yml
@@ -34,10 +34,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install elan
-        run: |
-          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" --version
+        run: .github/scripts/setup-elan.sh
 
       - name: Install workspace dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- serialize Elan installation on shared self-hosted runners when `lockf` is available
- reuse an already-installed Elan binary
- centralize the setup across CI, desktop QA, and release workflows

## Scope

This is an independent CI reliability fix extracted from #1216. It has no runtime or iOS pairing behavior changes.