### PR TITLE
test(ios): harden native readiness acceptance

### DIFF
--- a/apps/gents-desktop/src/lib/nativeSimulatorE2e.test.ts
+++ b/apps/gents-desktop/src/lib/nativeSimulatorE2e.test.ts
@@ -1,10 +1,107 @@
-import { describe, expect, it } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   conversationRowCount,
+  findAgentChatButton,
+  findAgentDeploymentControl,
   findAssistantResponseMarker,
+  findNewChatButton,
+  findPairingReadyStatus,
   isConversationTurnSettled,
+  startNativeSimulatorE2e,
 } from "./nativeSimulatorE2e";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+});
+
+describe("startNativeSimulatorE2e", () => {
+  it("does not probe test-only bridge commands in an ordinary Tauri build", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: { invoke: vi.fn() },
+    });
+
+    await startNativeSimulatorE2e(false);
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});
+
+describe("findAgentDeploymentControl", () => {
+  it("finds the current fleet detail control after pairing materializes a deployment", () => {
+    document.body.innerHTML = `
+      <button data-testid="fleet-detail-name-peer-a">iPhone E2E</button>
+    `;
+
+    expect(findAgentDeploymentControl("iPhone E2E")).not.toBeNull();
+  });
+
+  it("uses an exact label instead of colliding with a similarly named deployment", () => {
+    document.body.innerHTML = `
+      <button data-testid="fleet-detail-name-peer-a">iPhone E2E staging</button>
+      <button data-testid="fleet-detail-name-peer-b">iPhone E2E</button>
+    `;
+
+    expect(findAgentDeploymentControl("iPhone E2E")?.dataset.testid).toBe(
+      "fleet-detail-name-peer-b",
+    );
+  });
+});
+
+describe("findAgentChatButton", () => {
+  it("waits for the matching deployment's signed-ready chat control", () => {
+    document.body.innerHTML = `
+      <button aria-label="Open iPhone E2E staging chat" data-testid="fleet-chat-peer-a"></button>
+      <button aria-label="Open iPhone E2E chat" data-testid="fleet-chat-peer-b" disabled></button>
+    `;
+
+    expect(findAgentDeploymentControl("iPhone E2E")).not.toBeNull();
+    expect(findAgentChatButton("iPhone E2E")).toBeNull();
+
+    document
+      .querySelector<HTMLButtonElement>('[data-testid="fleet-chat-peer-b"]')
+      ?.removeAttribute("disabled");
+
+    expect(findAgentChatButton("iPhone E2E")?.dataset.testid).toBe("fleet-chat-peer-b");
+  });
+});
+
+describe("findNewChatButton", () => {
+  it("finds the enabled environment action in the current sessions flow", () => {
+    document.body.innerHTML = `
+      <button data-testid="sidebar-new-chat-disabled" disabled>New session</button>
+      <button data-testid="sidebar-new-chat-default">New session</button>
+    `;
+
+    expect(findNewChatButton("iPhone E2E")?.disabled).toBe(false);
+  });
+
+  it("does not silently choose between multiple enabled environments", () => {
+    document.body.innerHTML = `
+      <button data-testid="sidebar-new-chat-default">New session</button>
+      <button data-testid="sidebar-new-chat-review">New session</button>
+    `;
+
+    expect(findNewChatButton("iPhone E2E")).toBeNull();
+  });
+});
+
+describe("findPairingReadyStatus", () => {
+  it("waits for the requested deployment's truthful signed readiness", () => {
+    document.body.innerHTML = `
+      <p data-testid="fleet-pair-status">
+        iPhone E2E is ready. Signed membership and bidirectional replication were observed.
+      </p>
+    `;
+
+    expect(findPairingReadyStatus("iPhone E2E")).not.toBeNull();
+    expect(findPairingReadyStatus("iPhone E2E staging")).toBeNull();
+  });
+});
 
 describe("findAssistantResponseMarker", () => {
   it("does not mistake the user prompt for an assistant response", () => {

--- a/apps/gents-desktop/src/lib/nativeSimulatorE2e.ts
+++ b/apps/gents-desktop/src/lib/nativeSimulatorE2e.ts
@@ -1,6 +1,26 @@
 import { invoke } from "@tauri-apps/api/core";
 import { bridgeCommand } from "@source-inc/gents-desktop-client";
 
+import {
+  conversationRowCount,
+  findAgentChatButton,
+  findAgentDeploymentControl,
+  findAssistantResponseMarker,
+  findNewChatButton,
+  findPairingReadyStatus,
+  isConversationTurnSettled,
+} from "./nativeSimulatorE2eDom";
+
+export {
+  conversationRowCount,
+  findAgentChatButton,
+  findAgentDeploymentControl,
+  findAssistantResponseMarker,
+  findNewChatButton,
+  findPairingReadyStatus,
+  isConversationTurnSettled,
+} from "./nativeSimulatorE2eDom";
+
 type NativeE2eConfig = {
   agentLabel: string;
   pairToken: string;
@@ -37,7 +57,12 @@ type TauriBridgeWindow = Window & {
 let activeRun: Promise<void> | null = null;
 let activeConfig: NativeE2eConfig | null = null;
 
-export function startNativeSimulatorE2e(): Promise<void> {
+export function startNativeSimulatorE2e(
+  enabled = import.meta.env.VITE_GENTS_NATIVE_E2E === "1",
+): Promise<void> {
+  if (!enabled) {
+    return Promise.resolve();
+  }
   if (activeRun) {
     return activeRun;
   }
@@ -70,36 +95,44 @@ async function runNativeSimulatorE2e() {
     await waitForText("Fleet Dashboard", 30_000);
     await reportStatus({ stage: "shell-interactive" });
 
-    let chatButton = await waitForOptional(
-      () => findAgentChatButton(config.agentLabel),
+    let pairedThisRun = false;
+    const deploymentControl = await waitForOptional(
+      () => findAgentDeploymentControl(config.agentLabel),
       15_000,
     );
-    if (!chatButton) {
+    if (!deploymentControl) {
       await reportStatus({ stage: "pairing" });
       await pairAgent(config);
-      chatButton = await waitFor(
-        () => findAgentChatButton(config.agentLabel),
+      pairedThisRun = true;
+      await waitFor(
+        () => findAgentDeploymentControl(config.agentLabel),
         300_000,
         `${config.agentLabel} deployment`,
       );
     }
+    if (pairedThisRun) {
+      await waitFor(
+        () => findPairingReadyStatus(config.agentLabel),
+        300_000,
+        `${config.agentLabel} signed pairing readiness`,
+      );
+    }
 
     await reportStatus({ stage: "waiting-ready" });
-    chatButton.click();
+    const currentChatButton = await waitFor(
+      () => findAgentChatButton(config.agentLabel),
+      300_000,
+      `${config.agentLabel} enabled chat control after signed pairing readiness`,
+    );
+    currentChatButton.click();
     await waitFor(
-      () => document.querySelector<HTMLElement>(".conversation-list"),
+      () => document.querySelector<HTMLButtonElement>('[data-testid="session-new"]'),
       30_000,
       "visible session index",
     );
     await reportStatus({ stage: "session-index-visible" });
 
-    const newChatButton = await waitFor(
-      () => findNewChatButton(config.agentLabel),
-      300_000,
-      `${config.agentLabel} default behavior readiness`,
-    );
     if (config.expectEmptyConversationSlice) {
-      await delay(3_000);
       const conversationCount = conversationRowCount(document);
       if (conversationCount > 0) {
         throw new Error(
@@ -107,6 +140,25 @@ async function runNativeSimulatorE2e() {
         );
       }
     }
+
+    const environmentReadinessDeadline = window.performance.now() + 300_000;
+    const chooseEnvironmentButton = await waitFor(
+      () => {
+        const button = document.querySelector<HTMLButtonElement>(
+          '[data-testid="session-new"]',
+        );
+        return button && !button.disabled ? button : null;
+      },
+      remainingMs(environmentReadinessDeadline),
+      `${config.agentLabel} session creation readiness`,
+    );
+    chooseEnvironmentButton.click();
+
+    const newChatButton = await waitFor(
+      () => findNewChatButton(config.agentLabel),
+      remainingMs(environmentReadinessDeadline),
+      `${config.agentLabel} unique enabled behavior readiness`,
+    );
     newChatButton.click();
 
     const composer = await waitFor(
@@ -194,61 +246,6 @@ async function pairAgent(config: NativeE2eConfig) {
   submit.click();
 }
 
-function findAgentChatButton(label: string): HTMLButtonElement | null {
-  const expected = normalized(label);
-  return (
-    Array.from(
-      document.querySelectorAll<HTMLButtonElement>(
-        '[data-testid^="fleet-chat-name-"], [aria-label^="Open "][aria-label$=" chat"]',
-      ),
-    ).find((button) => normalized(button.textContent ?? "").includes(expected)) ?? null
-  );
-}
-
-function findNewChatButton(label: string): HTMLButtonElement | null {
-  const expected = normalized(`Start new chat with ${label}`);
-  return (
-    Array.from(
-      document.querySelectorAll<HTMLButtonElement>(
-        '[aria-label^="Start new chat with "]',
-      ),
-    ).find(
-      (button) => normalized(button.getAttribute("aria-label") ?? "") === expected,
-    ) ?? null
-  );
-}
-
-export function findAssistantResponseMarker(
-  root: ParentNode,
-  expectedResponse: string,
-): HTMLElement | null {
-  return (
-    Array.from(
-      root.querySelectorAll<HTMLElement>('[data-testid="assistant-message"]'),
-    ).find((message) =>
-      message
-        .querySelector<HTMLElement>(".message-content")
-        ?.textContent?.includes(expectedResponse),
-    ) ?? null
-  );
-}
-
-export function conversationRowCount(root: ParentNode): number {
-  return root.querySelectorAll(
-    '.conversation-list .conversation-row > button[data-testid^="conversation-"]',
-  ).length;
-}
-
-export function isConversationTurnSettled(
-  root: ParentNode,
-  expectedResponse: string,
-): boolean {
-  return (
-    findAssistantResponseMarker(root, expectedResponse) !== null &&
-    root.querySelector('[data-testid="cancel-button"]') === null
-  );
-}
-
 function setControlledValue(
   element: HTMLInputElement | HTMLTextAreaElement,
   value: string,
@@ -279,8 +276,8 @@ async function waitFor<T>(
   timeoutMs: number,
   description: string,
 ): Promise<T> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  const deadline = window.performance.now() + timeoutMs;
+  while (window.performance.now() < deadline) {
     const value = sample();
     if (value) {
       return value;
@@ -306,8 +303,8 @@ async function waitForOptional<T>(
   sample: () => T | null | undefined,
   timeoutMs: number,
 ): Promise<T | null> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  const deadline = window.performance.now() + timeoutMs;
+  while (window.performance.now() < deadline) {
     const value = sample();
     if (value) {
       return value;
@@ -375,10 +372,10 @@ function renderStatus(status: NativeE2eStatus) {
   banner.textContent = `Native E2E: ${status.stage}${detail}`;
 }
 
-function normalized(value: string) {
-  return value.trim().toLocaleLowerCase();
-}
-
 function delay(milliseconds: number) {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+function remainingMs(deadline: number) {
+  return Math.max(0, deadline - window.performance.now());
 }

--- a/apps/gents-desktop/src/lib/nativeSimulatorE2eDom.ts
+++ b/apps/gents-desktop/src/lib/nativeSimulatorE2eDom.ts
@@ -1,0 +1,108 @@
+export function findAgentDeploymentControl(label: string): HTMLButtonElement | null {
+  const expected = normalized(label);
+  const expectedChatLabel = normalized(`Open ${label} chat`);
+  const expectedDetailsTitle = normalized(`Open ${label} details`);
+  const selectors = [
+    '[data-testid^="fleet-chat-"], [aria-label^="Open "][aria-label$=" chat"]',
+    '[data-testid^="fleet-detail-name-"]',
+  ];
+  for (const selector of selectors) {
+    const match = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(selector),
+    ).find(
+      (button) =>
+        normalized(button.textContent ?? "") === expected ||
+        normalized(button.getAttribute("aria-label") ?? "") === expectedChatLabel ||
+        normalized(button.getAttribute("title") ?? "") === expectedDetailsTitle,
+    );
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+export function findAgentChatButton(label: string): HTMLButtonElement | null {
+  const expected = normalized(`Open ${label} chat`);
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        '[data-testid^="fleet-chat-"], [aria-label^="Open "][aria-label$=" chat"]',
+      ),
+    ).find(
+      (button) =>
+        !button.disabled &&
+        normalized(button.getAttribute("aria-label") ?? "") === expected,
+    ) ?? null
+  );
+}
+
+export function findNewChatButton(label: string): HTMLButtonElement | null {
+  const enabledCurrent = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-testid^="sidebar-new-chat-"]'),
+  ).filter((button) => !button.disabled);
+  if (enabledCurrent.length === 1) {
+    return enabledCurrent[0];
+  }
+  if (enabledCurrent.length > 1) {
+    return null;
+  }
+
+  const expected = normalized(`Start new chat with ${label}`);
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        '[aria-label^="Start new chat with "]',
+      ),
+    ).find(
+      (button) =>
+        !button.disabled &&
+        normalized(button.getAttribute("aria-label") ?? "") === expected,
+    ) ?? null
+  );
+}
+
+export function findPairingReadyStatus(label: string): HTMLElement | null {
+  const status = document.querySelector<HTMLElement>(
+    '[data-testid="fleet-pair-status"]',
+  );
+  return status &&
+    normalized(status.textContent ?? "").includes(normalized(`${label} is ready`))
+    ? status
+    : null;
+}
+
+export function findAssistantResponseMarker(
+  root: ParentNode,
+  expectedResponse: string,
+): HTMLElement | null {
+  return (
+    Array.from(
+      root.querySelectorAll<HTMLElement>('[data-testid="assistant-message"]'),
+    ).find((message) =>
+      message
+        .querySelector<HTMLElement>(".message-content")
+        ?.textContent?.includes(expectedResponse),
+    ) ?? null
+  );
+}
+
+export function conversationRowCount(root: ParentNode): number {
+  return root.querySelectorAll(
+    '.conversation-list .conversation-row > button[data-testid^="conversation-"]',
+  ).length;
+}
+
+export function isConversationTurnSettled(
+  root: ParentNode,
+  expectedResponse: string,
+): boolean {
+  return (
+    findAssistantResponseMarker(root, expectedResponse) !== null &&
+    root.querySelector('[data-testid="cancel-button"]') === null
+  );
+}
+
+function normalized(value: string) {
+  return value.trim().toLocaleLowerCase();
+}

--- a/apps/gents-desktop/tests/run-ios-simulator-e2e.mjs
+++ b/apps/gents-desktop/tests/run-ios-simulator-e2e.mjs
@@ -20,6 +20,10 @@ const STATUS_FILENAME = "native-e2e-status.json";
 const EVENTS_FILENAME = "native-e2e-events.jsonl";
 const DEFAULT_TIMEOUT_MS = 10 * 60_000;
 const DEFAULT_POST_PASS_STABILITY_MS = 30_000;
+const nativeE2eBuildEnv = {
+  ...process.env,
+  VITE_GENTS_NATIVE_E2E: "1",
+};
 
 const args = new Set(process.argv.slice(2));
 const skipBuild = args.has("--skip-build");
@@ -365,7 +369,7 @@ const appBundle =
   join(APPLE_ROOT, "build", "arm64-sim", "Gents.app");
 
 if (!skipBuild) {
-  run("npm", ["run", "build"]);
+  run("npm", ["run", "build"], { env: nativeE2eBuildEnv });
   const priorTauriBuild = join(APPLE_ROOT, "build");
   if (existsSync(priorTauriBuild)) {
     renameSync(priorTauriBuild, join(artifactRoot, "prior-tauri-build"));
@@ -388,7 +392,7 @@ if (!skipBuild) {
       "--features",
       "native-e2e",
     ],
-    { cwd: APP_ROOT },
+    { cwd: APP_ROOT, env: nativeE2eBuildEnv },
   );
 }
 

--- a/docs/reusable-desktop-packages.md
+++ b/docs/reusable-desktop-packages.md
@@ -638,10 +638,12 @@ config}`. The coarse ping-then-refetch model is the contract; fine-grained
   bridge crate (module `e2e`) behind a **`native-e2e` cargo feature**. Cargo features
   are additive and cannot be tied to build profiles, so the gating is explicit, not
   automatic: the feature is never in `default`; the app crate forwards it
-  (`native-e2e = ["gents-desktop-bridge/native-e2e"]`); the E2E launchers
-  (`run-ios-simulator-e2e.mjs`, the live harness) pass `--features native-e2e` to
-  their build steps; release packaging builds without it, and a release gate asserts
-  the commands are absent. Compilation alone is not activation: the webview must
+  (`native-e2e = ["gents-desktop-bridge/native-e2e"]`); the iOS E2E launcher
+  (`run-ios-simulator-e2e.mjs`) passes `--features native-e2e` to its build step;
+  release packaging builds without it, and a release gate asserts the commands are
+  absent. The launcher also sets `VITE_GENTS_NATIVE_E2E=1` while
+  building the webview; ordinary builds never probe the test-only commands.
+  Compilation alone is not activation: the webview must
   also be _granted_ the plugin's `native-e2e` permission. That grant lives in an
   E2E-only capability file (`capabilities/native-e2e.json`) — and a pitfall makes
   explicit enumeration mandatory: when `app.security.capabilities` is omitted or


### PR DESCRIPTION
## Summary\n\n- compile the native E2E webview driver only when the launcher explicitly enables it\n- wait on exact deployment, signed-readiness, enabled-chat, session-index, empty-conversation, and turn-terminal states\n- use monotonic browser deadlines and remove the fixed empty-session sleep\n- isolate DOM selectors in a focused sub-400-line module with deterministic tests\n\n## Scope\n\nThis is the acceptance and diagnostic base for the iOS readiness fixes. It does not change pairing, replication, provider, or runtime semantics.\n\n## Verification\n\n- npm --prefix apps/gents-desktop test -- --run src/lib/nativeSimulatorE2e.test.ts (12/12)\n- npm --prefix apps/gents-desktop run build\n- fresh-issuer native iOS simulator acceptance at the full stack tip: cold and warm runs passed\n- git diff --check