### PR TITLE
fix(ios): bind bearer readiness to stable endpoint identity

### DIFF
--- a/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
+++ b/crates/gents-desktop-core/src/client/core/bearer_pairing.rs
@@ -378,14 +378,14 @@ async fn verify_bearer_pairing_ready_row(
         .into_vec()
         .context("decoding the bearer readiness signature")?,
     };
+    // Iroh tickets include a mutable route set; node_id is the stable endpoint identity.
     if record.issuer_did != issuer_did
         || record.claimant_did != claimant_did
         || record.peer_id != local_endpoint.node_id
-        || record.address != local_endpoint.address
         || record.template != expected_template
     {
         bail!(
-            "bearer readiness acknowledgement does not match issuer, claimant, or the current signed endpoint; pairing rejected"
+            "bearer readiness acknowledgement does not match issuer, claimant, or endpoint identity; pairing rejected"
         );
     }
     match identity
@@ -1123,7 +1123,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn readiness_acknowledgement_is_bound_to_current_endpoint() {
+    async fn readiness_acknowledgement_is_bound_to_stable_endpoint_identity() {
         let now = Utc::now();
         let (_temp, identity, _encoded) = signed_token(now).await;
         let endpoint = EndpointRecord {
@@ -1187,9 +1187,9 @@ mod tests {
         .await
         .expect("valid machine readiness acknowledgement");
 
-        let mut rotated_endpoint = endpoint;
+        let mut rotated_endpoint = endpoint.clone();
         rotated_endpoint.address = "rotated-ticket".into();
-        let error = verify_bearer_pairing_ready_row(
+        verify_bearer_pairing_ready_row(
             &identity,
             identity.did(),
             &rotated_endpoint.did,
@@ -1198,8 +1198,21 @@ mod tests {
             &row,
         )
         .await
-        .expect_err("stale endpoint acknowledgement");
-        assert!(error.to_string().contains("current signed endpoint"));
+        .expect("route-set rotation preserves the signed Iroh endpoint identity");
+
+        let mut different_endpoint = endpoint;
+        different_endpoint.node_id = "different-phone-node".into();
+        let error = verify_bearer_pairing_ready_row(
+            &identity,
+            identity.did(),
+            &different_endpoint.did,
+            "conversation",
+            &different_endpoint,
+            &row,
+        )
+        .await
+        .expect_err("readiness for another Iroh endpoint identity");
+        assert!(error.to_string().contains("endpoint identity"));
     }
 
     #[test]

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -1701,7 +1701,10 @@ pub fn merge_layered_desired(
         (Some(desired), None) | (None, Some(desired)) => Some(desired),
         (Some(mut left), Some(right)) => {
             left.collections.extend(right.collections);
-            left.replicator_addresses.extend(right.replicator_addresses);
+            // The data-plane layer comes from the verified current PeerEndpoint.
+            if !right.replicator_addresses.is_empty() {
+                left.replicator_addresses = right.replicator_addresses;
+            }
             left.replicator_collections
                 .extend(right.replicator_collections);
             left.replicator_filter.extend(right.replicator_filter);

--- a/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine/tests.rs
@@ -221,6 +221,20 @@ fn merge_desired_unions_control_and_data_plane_state() {
 }
 
 #[test]
+fn signed_data_plane_route_supersedes_the_bearer_bootstrap_route() {
+    let control = bearer_desired(
+        "network-control",
+        "did:key:claimant",
+        "peer-a@127.0.0.1:4100",
+    );
+    let data = bearer_desired("conversation", "did:key:claimant", "peer-a@127.0.0.1:4200");
+
+    let merged = merge_desired(Some(control), Some(data)).expect("merged desired");
+
+    assert_eq!(merged.replicator_addresses, set(&["peer-a@127.0.0.1:4200"]));
+}
+
+#[test]
 fn data_plane_only_desired_is_replicator_only() {
     let data = PairingDesired {
         collections: set(&["AgentRequest"]),

--- a/crates/gents/tests/conformance/pairing_reconcile.rs
+++ b/crates/gents/tests/conformance/pairing_reconcile.rs
@@ -138,17 +138,18 @@ fn operator_delete_owns_endpoint_despite_observed_configuration_drift() {
 
 #[test]
 fn layered_desired_merge_keeps_data_plane_replicator_only() {
-    let address = "/ip4/127.0.0.1/tcp/4103/p2p/peer-a";
+    let bootstrap_address = "/ip4/127.0.0.1/tcp/4103/p2p/peer-a";
+    let signed_address = "/ip4/127.0.0.1/tcp/5103/p2p/peer-a";
     let control = PairingDesired {
         collections: set(&["AgentNetwork", "NetworkMembership", "PeerEndpoint"]),
-        replicator_addresses: set(&[address]),
+        replicator_addresses: set(&[bootstrap_address]),
         replicator_collections: set(&["AgentNetwork", "NetworkMembership", "PeerEndpoint"]),
         replicator_filter: PairingFilters::new(),
         template_ids: BTreeSet::new(),
     };
     let data_plane = PairingDesired {
         collections: set(&["AgentRequest", "AgentResponse"]),
-        replicator_addresses: set(&[address]),
+        replicator_addresses: set(&[signed_address]),
         replicator_collections: set(&["AgentRequest", "AgentResponse"]),
         replicator_filter: one_filter("AgentRequest", "requester_did", "did:key:a")
             .into_iter()
@@ -174,7 +175,7 @@ fn layered_desired_merge_keeps_data_plane_replicator_only() {
             "AgentResponse",
         ])
     );
-    assert_eq!(merged.replicator_addresses, set(&[address]));
+    assert_eq!(merged.replicator_addresses, set(&[signed_address]));
     assert_eq!(
         merged
             .replicator_filter


### PR DESCRIPTION
## Summary\n\n- treat the signed Iroh node ID as endpoint identity while retaining the issuer-signed route ticket as evidence\n- allow the ticket route set to evolve without invalidating readiness for the same DID, node, and template\n- make the verified data-plane PeerEndpoint route supersede the bearer bootstrap route when layered desired state is merged\n\n## Invariant\n\nA readiness row still must match issuer DID, claimant DID, claimant Iroh node ID, and template, and its complete payload, including the acknowledged route, is issuer-signed. A different node ID remains rejected. Only exact equality of the mutable route set is removed.\n\n## Verification\n\n- desktop readiness and signed route precedence unit coverage: pass\n- pairing conformance coverage: pass\n- cargo test -p gents: pass\n- cargo check --workspace --all-targets: pass\n- fresh iPhone 17 Pro simulator on iOS 26.5, debug native-e2e build, local inference: cold and warm runs passed\n- both runs remained alive for 30 seconds after terminal response\n- issuer database retained exactly one physical AgentNetwork root\n- git diff --check\n\nStack: #1235 → #1236 → this PR.