### PR TITLE
fix(cli): hydrate materialized response show output

### DIFF
--- a/crates/gents-cli/src/commands/chat/streaming.rs
+++ b/crates/gents-cli/src/commands/chat/streaming.rs
@@ -7,8 +7,9 @@ use gents::graphql::escape_graphql_string;
 use serde_json::Value;
 
 use crate::{
-    hydrate_materialized_response_content, is_terminal_lifecycle_state, post_graphql,
-    request_diagnostic_hint,
+    hydrate_materialized_response_content, is_terminal_lifecycle_state,
+    materialized_response_diagnostic, post_graphql, request_diagnostic_hint,
+    MaterializedResponsePresentation,
 };
 
 use super::SubmittedRequest;
@@ -227,7 +228,10 @@ pub(super) async fn stream_turn_progress(
             .map(|progress| progress.status.as_str())
             .unwrap_or("");
         let terminal_by_request = is_terminal_lifecycle_state(lifecycle_state);
-        let terminal_by_response = matches!(response_status, "complete" | "completed" | "error");
+        let terminal_by_response = matches!(
+            response_status,
+            "complete" | "completed" | "error" | "failed" | "interrupted"
+        );
 
         if terminal_by_request || terminal_by_response {
             let had_response_row = response_row.is_some();
@@ -240,33 +244,31 @@ pub(super) async fn stream_turn_progress(
                     "error_message": failure_reason,
                 })
             });
-            let should_wait_for_materialized_content =
-                matches!(response_status, "complete" | "completed")
-                    && terminal_response
-                        .get("content")
-                        .and_then(Value::as_str)
-                        .map(str::trim)
-                        .unwrap_or_default()
-                        .is_empty()
-                    && terminal_response
-                        .get("materialized_message_sequence")
-                        .is_some_and(|value| !value.is_null());
-            let hydrated = if had_response_row {
+            let presentation = if had_response_row {
                 hydrate_materialized_response_content(graphql, &mut terminal_response).await?
             } else {
-                true
+                MaterializedResponsePresentation::Presentable
             };
-            if should_wait_for_materialized_content && !hydrated {
-                if last_progress_at.elapsed() >= idle_timeout {
-                    anyhow::bail!(
-                        "timed out waiting for materialized AgentMessage {} after {}s of inactivity\n{}",
-                        submitted.request_id,
-                        timeout_secs,
-                        request_diagnostic_hint(&submitted.request_id)
-                    );
+            match presentation {
+                MaterializedResponsePresentation::Presentable => {}
+                MaterializedResponsePresentation::Pending => {
+                    if last_progress_at.elapsed() >= idle_timeout {
+                        anyhow::bail!(
+                            "timed out waiting for materialized AgentMessage {} after {}s of inactivity\n{}",
+                            submitted.request_id,
+                            timeout_secs,
+                            request_diagnostic_hint(&submitted.request_id)
+                        );
+                    }
+                    tokio::time::sleep(Duration::from_secs(poll_secs)).await;
+                    continue;
                 }
-                tokio::time::sleep(Duration::from_secs(poll_secs)).await;
-                continue;
+                MaterializedResponsePresentation::Invalid => {
+                    anyhow::bail!(materialized_response_diagnostic(
+                        &submitted.request_id,
+                        &terminal_response
+                    ));
+                }
             }
 
             let terminal_content = terminal_response

--- a/crates/gents-cli/src/commands/response.rs
+++ b/crates/gents-cli/src/commands/response.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use crate::cli::args::{ResponseCommand, ResponseShowArgs, ResponseWaitArgs};
 use crate::{
     hydrate_materialized_response_content, post_graphql, print_json, resolve_graphql_endpoint,
-    resolve_request_id, response_query, wait_for_terminal_response,
+    resolve_request_id, response_field_is_blank, response_query, wait_for_terminal_response,
 };
 
 pub(crate) async fn dispatch(command: ResponseCommand) -> Result<()> {
@@ -20,23 +20,29 @@ pub(crate) async fn response_show(args: ResponseShowArgs) -> Result<()> {
     let query = response_query(&request_id);
     let mut response = post_graphql(&graphql, &query).await?;
     if let Some(response_row) = response.pointer_mut("/data/AgentResponse/0") {
-        let materialized_sequence = response_row
-            .get("materialized_message_sequence")
-            .and_then(serde_json::Value::as_i64);
-        let session_id = response_row
-            .get("session_id")
+        hydrate_materialized_response_content(&graphql, response_row).await?;
+        let completed = response_row
+            .get("status")
             .and_then(serde_json::Value::as_str)
-            .map(ToOwned::to_owned);
-        let hydrated = hydrate_materialized_response_content(&graphql, response_row).await?;
-        if !hydrated {
-            if let Some(sequence) = materialized_sequence {
-                let session_id = session_id.as_deref().unwrap_or("<missing>");
-                anyhow::bail!(
-                    "could not hydrate materialized AgentMessage for request {request_id} \
-                     (session_id={session_id}, sequence={sequence}); the referenced message is \
-                     missing or invalid"
-                );
-            }
+            .is_some_and(|status| matches!(status, "complete" | "completed"));
+        if completed
+            && response_field_is_blank(response_row, "content")
+            && response_field_is_blank(response_row, "reasoning")
+        {
+            let sequence = response_row
+                .get("materialized_message_sequence")
+                .and_then(serde_json::Value::as_i64)
+                .map(|sequence| sequence.to_string())
+                .unwrap_or_else(|| "<missing>".to_string());
+            let session_id = response_row
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<missing>");
+            anyhow::bail!(
+                "could not hydrate materialized AgentMessage for request {request_id} \
+                 (session_id={session_id}, sequence={sequence}); the referenced message is \
+                 missing or invalid"
+            );
         }
     }
     print_json(&response)?;

--- a/crates/gents-cli/src/commands/response.rs
+++ b/crates/gents-cli/src/commands/response.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 
 use crate::cli::args::{ResponseCommand, ResponseShowArgs, ResponseWaitArgs};
 use crate::{
-    hydrate_materialized_response_content, post_graphql, print_json, resolve_graphql_endpoint,
-    resolve_request_id, response_field_is_blank, response_query, wait_for_terminal_response,
+    hydrate_materialized_response_content, materialized_response_diagnostic, post_graphql,
+    print_json, resolve_graphql_endpoint, resolve_request_id, response_query,
+    wait_for_terminal_response, MaterializedResponsePresentation,
 };
 
 pub(crate) async fn dispatch(command: ResponseCommand) -> Result<()> {
@@ -20,29 +21,12 @@ pub(crate) async fn response_show(args: ResponseShowArgs) -> Result<()> {
     let query = response_query(&request_id);
     let mut response = post_graphql(&graphql, &query).await?;
     if let Some(response_row) = response.pointer_mut("/data/AgentResponse/0") {
-        hydrate_materialized_response_content(&graphql, response_row).await?;
-        let completed = response_row
-            .get("status")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|status| matches!(status, "complete" | "completed"));
-        if completed
-            && response_field_is_blank(response_row, "content")
-            && response_field_is_blank(response_row, "reasoning")
-        {
-            let sequence = response_row
-                .get("materialized_message_sequence")
-                .and_then(serde_json::Value::as_i64)
-                .map(|sequence| sequence.to_string())
-                .unwrap_or_else(|| "<missing>".to_string());
-            let session_id = response_row
-                .get("session_id")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("<missing>");
-            anyhow::bail!(
-                "could not hydrate materialized AgentMessage for request {request_id} \
-                 (session_id={session_id}, sequence={sequence}); the referenced message is \
-                 missing or invalid"
-            );
+        let presentation = hydrate_materialized_response_content(&graphql, response_row).await?;
+        if matches!(
+            presentation,
+            MaterializedResponsePresentation::Pending | MaterializedResponsePresentation::Invalid
+        ) {
+            anyhow::bail!(materialized_response_diagnostic(&request_id, response_row));
         }
     }
     print_json(&response)?;

--- a/crates/gents-cli/src/commands/response.rs
+++ b/crates/gents-cli/src/commands/response.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 
 use crate::cli::args::{ResponseCommand, ResponseShowArgs, ResponseWaitArgs};
 use crate::{
-    post_graphql, print_json, resolve_graphql_endpoint, resolve_request_id, response_query,
-    wait_for_terminal_response,
+    hydrate_materialized_response_content, post_graphql, print_json, resolve_graphql_endpoint,
+    resolve_request_id, response_query, wait_for_terminal_response,
 };
 
 pub(crate) async fn dispatch(command: ResponseCommand) -> Result<()> {
@@ -18,7 +18,27 @@ pub(crate) async fn response_show(args: ResponseShowArgs) -> Result<()> {
     let request_id =
         resolve_request_id(args.request_id.as_deref(), args.request_id_flag.as_deref())?;
     let query = response_query(&request_id);
-    let response = post_graphql(&graphql, &query).await?;
+    let mut response = post_graphql(&graphql, &query).await?;
+    if let Some(response_row) = response.pointer_mut("/data/AgentResponse/0") {
+        let materialized_sequence = response_row
+            .get("materialized_message_sequence")
+            .and_then(serde_json::Value::as_i64);
+        let session_id = response_row
+            .get("session_id")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned);
+        let hydrated = hydrate_materialized_response_content(&graphql, response_row).await?;
+        if !hydrated {
+            if let Some(sequence) = materialized_sequence {
+                let session_id = session_id.as_deref().unwrap_or("<missing>");
+                anyhow::bail!(
+                    "could not hydrate materialized AgentMessage for request {request_id} \
+                     (session_id={session_id}, sequence={sequence}); the referenced message is \
+                     missing or invalid"
+                );
+            }
+        }
+    }
     print_json(&response)?;
     Ok(())
 }

--- a/crates/gents-cli/src/request_helpers.rs
+++ b/crates/gents-cli/src/request_helpers.rs
@@ -145,7 +145,7 @@ pub(crate) fn is_terminal_lifecycle_state(state: &str) -> bool {
     )
 }
 
-fn response_field_is_blank(response: &Value, field: &str) -> bool {
+pub(crate) fn response_field_is_blank(response: &Value, field: &str) -> bool {
     response
         .get(field)
         .and_then(Value::as_str)
@@ -193,6 +193,9 @@ pub(crate) async fn hydrate_materialized_response_content(
     let Some(role) = message.get("role").and_then(Value::as_str) else {
         return Ok(false);
     };
+    if role != "assistant" {
+        return Ok(false);
+    }
     let Some(content) = message.get("content").and_then(Value::as_str) else {
         return Ok(false);
     };

--- a/crates/gents-cli/src/request_helpers.rs
+++ b/crates/gents-cli/src/request_helpers.rs
@@ -145,13 +145,24 @@ pub(crate) fn is_terminal_lifecycle_state(state: &str) -> bool {
     )
 }
 
-pub(crate) fn response_field_is_blank(response: &Value, field: &str) -> bool {
+fn response_field_is_blank(response: &Value, field: &str) -> bool {
     response
         .get(field)
         .and_then(Value::as_str)
         .map(str::trim)
         .unwrap_or_default()
         .is_empty()
+}
+
+fn response_is_completed(response: &Value) -> bool {
+    response
+        .get("status")
+        .and_then(Value::as_str)
+        .is_some_and(|status| matches!(status, "complete" | "completed"))
+}
+
+fn response_has_presentation(response: &Value) -> bool {
+    !response_field_is_blank(response, "content") || !response_field_is_blank(response, "reasoning")
 }
 
 fn response_materialized_sequence(response: &Value) -> Option<i64> {
@@ -164,21 +175,60 @@ fn response_materialized_sequence(response: &Value) -> Option<i64> {
         })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MaterializedResponsePresentation {
+    Presentable,
+    Pending,
+    Invalid,
+}
+
+fn classify_materialized_response(
+    response: &Value,
+    blank_completed: MaterializedResponsePresentation,
+) -> MaterializedResponsePresentation {
+    if response_has_presentation(response) || !response_is_completed(response) {
+        MaterializedResponsePresentation::Presentable
+    } else {
+        blank_completed
+    }
+}
+
+pub(crate) fn materialized_response_diagnostic(request_id: &str, response: &Value) -> String {
+    let session_id = response
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or("<missing>");
+    let sequence = response_materialized_sequence(response)
+        .map(|sequence| sequence.to_string())
+        .unwrap_or_else(|| "<missing>".to_string());
+    format!(
+        "could not hydrate materialized AgentMessage for request {request_id} \
+         (session_id={session_id}, sequence={sequence}); the referenced message is missing or \
+         invalid"
+    )
+}
+
 pub(crate) async fn hydrate_materialized_response_content(
     graphql: &str,
     response: &mut Value,
-) -> Result<bool> {
+) -> Result<MaterializedResponsePresentation> {
     let content_blank = response_field_is_blank(response, "content");
     let reasoning_blank = response_field_is_blank(response, "reasoning");
     if !content_blank && !reasoning_blank {
-        return Ok(true);
+        return Ok(MaterializedResponsePresentation::Presentable);
     }
 
     let Some(sequence) = response_materialized_sequence(response) else {
-        return Ok(!content_blank || !reasoning_blank);
+        return Ok(classify_materialized_response(
+            response,
+            MaterializedResponsePresentation::Invalid,
+        ));
     };
     let Some(session_id) = response.get("session_id").and_then(Value::as_str) else {
-        return Ok(!content_blank || !reasoning_blank);
+        return Ok(classify_materialized_response(
+            response,
+            MaterializedResponsePresentation::Invalid,
+        ));
     };
 
     let query = materialized_message_query(session_id, sequence);
@@ -188,21 +238,33 @@ pub(crate) async fn hydrate_materialized_response_content(
         .and_then(Value::as_array)
         .and_then(|rows| rows.first())
     else {
-        return Ok(false);
+        return Ok(classify_materialized_response(
+            response,
+            MaterializedResponsePresentation::Pending,
+        ));
     };
     let Some(role) = message.get("role").and_then(Value::as_str) else {
-        return Ok(false);
+        return Ok(classify_materialized_response(
+            response,
+            MaterializedResponsePresentation::Invalid,
+        ));
     };
     if role != "assistant" {
-        return Ok(false);
+        return Ok(classify_materialized_response(
+            response,
+            MaterializedResponsePresentation::Invalid,
+        ));
     }
     let Some(content) = message.get("content").and_then(Value::as_str) else {
-        return Ok(false);
+        return Ok(classify_materialized_response(
+            response,
+            MaterializedResponsePresentation::Invalid,
+        ));
     };
 
     let presentation = present_persisted_message(role, content);
     let Some(object) = response.as_object_mut() else {
-        return Ok(false);
+        return Ok(MaterializedResponsePresentation::Invalid);
     };
 
     if content_blank && !presentation.body_markdown.trim().is_empty() {
@@ -224,7 +286,10 @@ pub(crate) async fn hydrate_materialized_response_content(
         }
     }
 
-    Ok(true)
+    Ok(classify_materialized_response(
+        response,
+        MaterializedResponsePresentation::Invalid,
+    ))
 }
 
 pub(crate) async fn create_agent_request(
@@ -527,15 +592,11 @@ pub(crate) async fn wait_for_terminal_response(
             .and_then(|row| row.get("status"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        let should_wait_for_materialized_content =
-            matches!(response_status, "complete" | "completed")
-                && response_row.as_ref().is_some_and(|row| {
-                    response_field_is_blank(row, "content")
-                        && response_materialized_sequence(row).is_some()
-                });
-
         let terminal_by_request = is_terminal_lifecycle_state(lifecycle_state);
-        let terminal_by_response = matches!(response_status, "complete" | "completed" | "error");
+        let terminal_by_response = matches!(
+            response_status,
+            "complete" | "completed" | "error" | "failed" | "interrupted"
+        );
         if terminal_by_request || terminal_by_response {
             let response_row = if response_row.is_some() {
                 let response = post_graphql(graphql, &response_query(request_id)).await?;
@@ -554,16 +615,21 @@ pub(crate) async fn wait_for_terminal_response(
                     "content": null,
                 })
             });
-            let hydrated = hydrate_materialized_response_content(graphql, &mut envelope).await?;
-            if should_wait_for_materialized_content && !hydrated {
-                if last_progress_at.elapsed() >= idle_timeout {
-                    anyhow::bail!(
-                        "timed out waiting for materialized AgentMessage {request_id} after {timeout_secs}s of inactivity\n{}",
-                        request_diagnostic_hint(request_id)
-                    );
+            match hydrate_materialized_response_content(graphql, &mut envelope).await? {
+                MaterializedResponsePresentation::Presentable => {}
+                MaterializedResponsePresentation::Pending => {
+                    if last_progress_at.elapsed() >= idle_timeout {
+                        anyhow::bail!(
+                            "timed out waiting for materialized AgentMessage {request_id} after {timeout_secs}s of inactivity\n{}",
+                            request_diagnostic_hint(request_id)
+                        );
+                    }
+                    tokio::time::sleep(Duration::from_secs(poll_secs)).await;
+                    continue;
                 }
-                tokio::time::sleep(Duration::from_secs(poll_secs)).await;
-                continue;
+                MaterializedResponsePresentation::Invalid => {
+                    anyhow::bail!(materialized_response_diagnostic(request_id, &envelope));
+                }
             }
             if let Some(object) = envelope.as_object_mut() {
                 object.insert(

--- a/crates/gents-cli/tests/cli_runtime.rs
+++ b/crates/gents-cli/tests/cli_runtime.rs
@@ -17,6 +17,8 @@ mod cli_mailbox;
 mod cli_reconciliation;
 #[path = "suites/cli_request.rs"]
 mod cli_request;
+#[path = "suites/cli_response.rs"]
+mod cli_response;
 #[path = "suites/cli_session.rs"]
 mod cli_session;
 #[path = "suites/cli_status.rs"]

--- a/crates/gents-cli/tests/suites/cli_response.rs
+++ b/crates/gents-cli/tests/suites/cli_response.rs
@@ -1,0 +1,303 @@
+use crate::support::*;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use uuid::Uuid;
+
+struct ResponseTestRuntime {
+    _tempdir: tempfile::TempDir,
+    home_dir: PathBuf,
+    _mock_endpoint: MockModelEndpoint,
+    _serve: ServeProcess,
+    graphql: String,
+    agent_did: String,
+}
+
+async fn start_response_runtime(label: &str) -> Result<ResponseTestRuntime> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-response-{label}-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let agent_name = format!("cli-response-{label}-{}", Uuid::new_v4().simple());
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    Ok(ResponseTestRuntime {
+        _tempdir: tempdir,
+        home_dir,
+        _mock_endpoint: mock_endpoint,
+        _serve: serve,
+        graphql,
+        agent_did,
+    })
+}
+
+struct MaterializedResponse<'a> {
+    request_id: &'a str,
+    session_id: &'a str,
+    response_content: &'a str,
+    response_reasoning: &'a str,
+    message_content: Option<&'a str>,
+    message_reasoning: &'a str,
+    sequence: i64,
+}
+
+async fn insert_materialized_response(
+    runtime: &ResponseTestRuntime,
+    fixture: MaterializedResponse<'_>,
+) -> Result<()> {
+    let MaterializedResponse {
+        request_id,
+        session_id,
+        response_content,
+        response_reasoning,
+        message_content,
+        message_reasoning,
+        sequence,
+    } = fixture;
+    let now = chrono::Utc::now().to_rfc3339();
+    let response_key = format!("response-{request_id}");
+    let message_mutation = message_content.map_or_else(String::new, |content| {
+        let message_key = format!("{session_id}:{sequence}");
+        format!(
+            r#"create_AgentMessage(input: {{
+                message_key: "{message_key}",
+                session_id: "{session_id}",
+                agent_did: "{agent_did}",
+                request_id: "{request_id}",
+                sequence: {sequence},
+                role: "assistant",
+                content: "{content}",
+                reasoning: "{message_reasoning}",
+                timestamp: "{now}"
+            }}) {{ _docID }}"#,
+            message_key = escape_graphql_string(&message_key),
+            session_id = escape_graphql_string(session_id),
+            agent_did = escape_graphql_string(&runtime.agent_did),
+            request_id = escape_graphql_string(request_id),
+            content = escape_graphql_string(content),
+            message_reasoning = escape_graphql_string(message_reasoning),
+            now = escape_graphql_string(&now),
+        )
+    });
+    let mutation = format!(
+        r#"mutation {{
+            {message_mutation}
+            create_AgentResponse(input: {{
+                response_key: "{response_key}",
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "response-test",
+                session_id: "{session_id}",
+                content: "{response_content}",
+                reasoning: "{response_reasoning}",
+                status: "complete",
+                error_message: "",
+                token_count: 1241,
+                progress_seq: 31,
+                reasoning_progress_seq: 17,
+                materialized_message_sequence: {sequence},
+                materialized_at: "{now}",
+                created_at: "{now}",
+                completed_at: "{now}"
+            }}) {{ _docID }}
+        }}"#,
+        response_key = escape_graphql_string(&response_key),
+        request_id = escape_graphql_string(request_id),
+        agent_did = escape_graphql_string(&runtime.agent_did),
+        session_id = escape_graphql_string(session_id),
+        response_content = escape_graphql_string(response_content),
+        response_reasoning = escape_graphql_string(response_reasoning),
+        now = escape_graphql_string(&now),
+    );
+    graphql_query(&runtime.graphql, &mutation).await?;
+    Ok(())
+}
+
+fn response_show(runtime: &ResponseTestRuntime, request_id: &str) -> Result<Value> {
+    run_cli_json(
+        &runtime.home_dir,
+        &[
+            "response",
+            "show",
+            "--graphql",
+            &runtime.graphql,
+            request_id,
+        ],
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn response_show_hydrates_materialized_content_like_response_wait() -> Result<()> {
+    let runtime = start_response_runtime("hydrate").await?;
+    let request_id = format!("response-hydrate-{}", Uuid::new_v4().simple());
+    let session_id = format!("session-hydrate-{}", Uuid::new_v4().simple());
+    let durable_content = format!("durable answer {}", Uuid::new_v4().simple());
+    let durable_reasoning = format!("durable reasoning {}", Uuid::new_v4().simple());
+    let persisted_message = serde_json::json!({
+        "role": "assistant",
+        "id": null,
+        "content": [{ "text": durable_content }]
+    })
+    .to_string();
+
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &request_id,
+            session_id: &session_id,
+            response_content: "",
+            response_reasoning: "",
+            message_content: Some(&persisted_message),
+            message_reasoning: &durable_reasoning,
+            sequence: 409,
+        },
+    )
+    .await?;
+
+    let shown = response_show(&runtime, &request_id)?;
+    let waited = run_cli_json(
+        &runtime.home_dir,
+        &[
+            "response",
+            "wait",
+            "--graphql",
+            &runtime.graphql,
+            "--timeout-secs",
+            "5",
+            "--poll-secs",
+            "1",
+            &request_id,
+        ],
+    )?;
+    let shown_row = shown
+        .pointer("/data/AgentResponse/0")
+        .context("response show output missing GraphQL envelope row")?;
+
+    assert_eq!(shown_row.get("content"), waited.get("content"));
+    assert_eq!(shown_row.get("reasoning"), waited.get("reasoning"));
+    assert_eq!(
+        shown_row.get("content").and_then(Value::as_str),
+        Some(durable_content.as_str())
+    );
+    assert_eq!(
+        shown_row.get("reasoning").and_then(Value::as_str),
+        Some(durable_reasoning.as_str())
+    );
+    assert_eq!(
+        shown_row.get("status").and_then(Value::as_str),
+        Some("complete")
+    );
+    assert_eq!(
+        shown_row.get("token_count").and_then(Value::as_i64),
+        Some(1241)
+    );
+    assert_eq!(
+        shown_row.get("progress_seq").and_then(Value::as_i64),
+        Some(31)
+    );
+    assert_eq!(
+        shown_row
+            .get("reasoning_progress_seq")
+            .and_then(Value::as_i64),
+        Some(17)
+    );
+    assert_eq!(
+        shown_row
+            .get("materialized_message_sequence")
+            .and_then(Value::as_i64),
+        Some(409)
+    );
+    assert!(shown_row
+        .get("materialized_at")
+        .is_some_and(Value::is_string));
+    assert!(shown_row.get("completed_at").is_some_and(Value::is_string));
+
+    let preserved_request_id = format!("response-preserved-{}", Uuid::new_v4().simple());
+    let preserved_session_id = format!("session-preserved-{}", Uuid::new_v4().simple());
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &preserved_request_id,
+            session_id: &preserved_session_id,
+            response_content: "already present",
+            response_reasoning: "already reasoned",
+            message_content: Some("durable replacement that must not win"),
+            message_reasoning: "replacement reasoning that must not win",
+            sequence: 7,
+        },
+    )
+    .await?;
+    let preserved = response_show(&runtime, &preserved_request_id)?;
+    let preserved_row = preserved
+        .pointer("/data/AgentResponse/0")
+        .context("preserved response show output missing GraphQL envelope row")?;
+    assert_eq!(
+        preserved_row.get("content").and_then(Value::as_str),
+        Some("already present")
+    );
+    assert_eq!(
+        preserved_row.get("reasoning").and_then(Value::as_str),
+        Some("already reasoned")
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
+    let runtime = start_response_runtime("missing").await?;
+    let request_id = format!("response-missing-{}", Uuid::new_v4().simple());
+    let session_id = format!("session-missing-{}", Uuid::new_v4().simple());
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &request_id,
+            session_id: &session_id,
+            response_content: "",
+            response_reasoning: "",
+            message_content: None,
+            message_reasoning: "",
+            sequence: 73,
+        },
+    )
+    .await?;
+
+    let stderr = run_cli_failure_stderr(
+        &runtime.home_dir,
+        &[
+            "response",
+            "show",
+            "--graphql",
+            &runtime.graphql,
+            &request_id,
+        ],
+    )?;
+    assert!(stderr.contains("could not hydrate materialized AgentMessage"));
+    assert!(stderr.contains(&format!("request {request_id}")));
+    assert!(stderr.contains(&format!("session_id={session_id}")));
+    assert!(stderr.contains("sequence=73"));
+    assert!(stderr.contains("missing or invalid"));
+
+    Ok(())
+}

--- a/crates/gents-cli/tests/suites/cli_response.rs
+++ b/crates/gents-cli/tests/suites/cli_response.rs
@@ -153,6 +153,44 @@ fn response_show(runtime: &ResponseTestRuntime, request_id: &str) -> Result<Valu
     )
 }
 
+fn response_wait(runtime: &ResponseTestRuntime, request_id: &str) -> Result<Value> {
+    run_cli_json(
+        &runtime.home_dir,
+        &[
+            "response",
+            "wait",
+            "--graphql",
+            &runtime.graphql,
+            "--timeout-secs",
+            "5",
+            "--poll-secs",
+            "1",
+            request_id,
+        ],
+    )
+}
+
+fn response_wait_failure(
+    runtime: &ResponseTestRuntime,
+    request_id: &str,
+    timeout_secs: &str,
+) -> Result<String> {
+    run_cli_failure_stderr(
+        &runtime.home_dir,
+        &[
+            "response",
+            "wait",
+            "--graphql",
+            &runtime.graphql,
+            "--timeout-secs",
+            timeout_secs,
+            "--poll-secs",
+            "1",
+            request_id,
+        ],
+    )
+}
+
 fn assert_materialization_failure(
     runtime: &ResponseTestRuntime,
     request_id: &str,
@@ -320,6 +358,9 @@ async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
     .await?;
 
     assert_materialization_failure(&runtime, &request_id, &session_id, 73)?;
+    let missing_wait_error = response_wait_failure(&runtime, &request_id, "1")?;
+    assert!(missing_wait_error.contains("timed out waiting for materialized AgentMessage"));
+    assert!(missing_wait_error.contains(&request_id));
 
     let partial_request_id = format!("response-partial-{}", Uuid::new_v4().simple());
     let partial_session_id = format!("session-partial-{}", Uuid::new_v4().simple());
@@ -351,6 +392,33 @@ async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
         Some("")
     );
 
+    let reasoning_request_id = format!("response-reasoning-{}", Uuid::new_v4().simple());
+    let reasoning_session_id = format!("session-reasoning-{}", Uuid::new_v4().simple());
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &reasoning_request_id,
+            session_id: &reasoning_session_id,
+            response_content: "",
+            response_reasoning: "preserve this reasoning-only output",
+            message_content: None,
+            message_role: "assistant",
+            message_reasoning: "",
+            response_status: "complete",
+            sequence: 741,
+        },
+    )
+    .await?;
+    let reasoning_wait = response_wait(&runtime, &reasoning_request_id)?;
+    assert_eq!(
+        reasoning_wait.get("content").and_then(Value::as_str),
+        Some("")
+    );
+    assert_eq!(
+        reasoning_wait.get("reasoning").and_then(Value::as_str),
+        Some("preserve this reasoning-only output")
+    );
+
     let wrong_role_request_id = format!("response-wrong-role-{}", Uuid::new_v4().simple());
     let wrong_role_session_id = format!("session-wrong-role-{}", Uuid::new_v4().simple());
     let assistant_text = serde_json::json!({
@@ -375,6 +443,12 @@ async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
     )
     .await?;
     assert_materialization_failure(&runtime, &wrong_role_request_id, &wrong_role_session_id, 75)?;
+    let wrong_role_wait_error = response_wait_failure(&runtime, &wrong_role_request_id, "5")?;
+    assert!(wrong_role_wait_error.contains("could not hydrate materialized AgentMessage"));
+    assert!(wrong_role_wait_error.contains(&format!("request {wrong_role_request_id}")));
+    assert!(wrong_role_wait_error.contains(&format!("session_id={wrong_role_session_id}")));
+    assert!(wrong_role_wait_error.contains("sequence=75"));
+    assert!(!wrong_role_wait_error.contains("timed out"));
 
     let tool_only = serde_json::json!({
         "role": "assistant",
@@ -406,6 +480,12 @@ async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
     )
     .await?;
     assert_materialization_failure(&runtime, &tool_only_request_id, &tool_only_session_id, 76)?;
+    let tool_only_wait_error = response_wait_failure(&runtime, &tool_only_request_id, "5")?;
+    assert!(tool_only_wait_error.contains("could not hydrate materialized AgentMessage"));
+    assert!(tool_only_wait_error.contains(&format!("request {tool_only_request_id}")));
+    assert!(tool_only_wait_error.contains(&format!("session_id={tool_only_session_id}")));
+    assert!(tool_only_wait_error.contains("sequence=76"));
+    assert!(!tool_only_wait_error.contains("timed out"));
 
     let interrupted_request_id = format!("response-interrupted-{}", Uuid::new_v4().simple());
     let interrupted_session_id = format!("session-interrupted-{}", Uuid::new_v4().simple());
@@ -437,6 +517,19 @@ async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
         .and_then(Value::as_str)
         .is_some_and(str::is_empty));
     assert!(interrupted_row
+        .get("reasoning")
+        .and_then(Value::as_str)
+        .is_some_and(str::is_empty));
+    let interrupted_wait = response_wait(&runtime, &interrupted_request_id)?;
+    assert_eq!(
+        interrupted_wait.get("status").and_then(Value::as_str),
+        Some("interrupted")
+    );
+    assert!(interrupted_wait
+        .get("content")
+        .and_then(Value::as_str)
+        .is_some_and(str::is_empty));
+    assert!(interrupted_wait
         .get("reasoning")
         .and_then(Value::as_str)
         .is_some_and(str::is_empty));

--- a/crates/gents-cli/tests/suites/cli_response.rs
+++ b/crates/gents-cli/tests/suites/cli_response.rs
@@ -58,7 +58,9 @@ struct MaterializedResponse<'a> {
     response_content: &'a str,
     response_reasoning: &'a str,
     message_content: Option<&'a str>,
+    message_role: &'a str,
     message_reasoning: &'a str,
+    response_status: &'a str,
     sequence: i64,
 }
 
@@ -72,7 +74,9 @@ async fn insert_materialized_response(
         response_content,
         response_reasoning,
         message_content,
+        message_role,
         message_reasoning,
+        response_status,
         sequence,
     } = fixture;
     let now = chrono::Utc::now().to_rfc3339();
@@ -86,7 +90,7 @@ async fn insert_materialized_response(
                 agent_did: "{agent_did}",
                 request_id: "{request_id}",
                 sequence: {sequence},
-                role: "assistant",
+                role: "{message_role}",
                 content: "{content}",
                 reasoning: "{message_reasoning}",
                 timestamp: "{now}"
@@ -96,6 +100,7 @@ async fn insert_materialized_response(
             agent_did = escape_graphql_string(&runtime.agent_did),
             request_id = escape_graphql_string(request_id),
             content = escape_graphql_string(content),
+            message_role = escape_graphql_string(message_role),
             message_reasoning = escape_graphql_string(message_reasoning),
             now = escape_graphql_string(&now),
         )
@@ -111,7 +116,7 @@ async fn insert_materialized_response(
                 session_id: "{session_id}",
                 content: "{response_content}",
                 reasoning: "{response_reasoning}",
-                status: "complete",
+                status: "{response_status}",
                 error_message: "",
                 token_count: 1241,
                 progress_seq: 31,
@@ -128,6 +133,7 @@ async fn insert_materialized_response(
         session_id = escape_graphql_string(session_id),
         response_content = escape_graphql_string(response_content),
         response_reasoning = escape_graphql_string(response_reasoning),
+        response_status = escape_graphql_string(response_status),
         now = escape_graphql_string(&now),
     );
     graphql_query(&runtime.graphql, &mutation).await?;
@@ -145,6 +151,30 @@ fn response_show(runtime: &ResponseTestRuntime, request_id: &str) -> Result<Valu
             request_id,
         ],
     )
+}
+
+fn assert_materialization_failure(
+    runtime: &ResponseTestRuntime,
+    request_id: &str,
+    session_id: &str,
+    sequence: i64,
+) -> Result<()> {
+    let stderr = run_cli_failure_stderr(
+        &runtime.home_dir,
+        &[
+            "response",
+            "show",
+            "--graphql",
+            &runtime.graphql,
+            request_id,
+        ],
+    )?;
+    assert!(stderr.contains("could not hydrate materialized AgentMessage"));
+    assert!(stderr.contains(&format!("request {request_id}")));
+    assert!(stderr.contains(&format!("session_id={session_id}")));
+    assert!(stderr.contains(&format!("sequence={sequence}")));
+    assert!(stderr.contains("missing or invalid"));
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -169,7 +199,9 @@ async fn response_show_hydrates_materialized_content_like_response_wait() -> Res
             response_content: "",
             response_reasoning: "",
             message_content: Some(&persisted_message),
+            message_role: "assistant",
             message_reasoning: &durable_reasoning,
+            response_status: "complete",
             sequence: 409,
         },
     )
@@ -243,7 +275,9 @@ async fn response_show_hydrates_materialized_content_like_response_wait() -> Res
             response_content: "already present",
             response_reasoning: "already reasoned",
             message_content: Some("durable replacement that must not win"),
+            message_role: "assistant",
             message_reasoning: "replacement reasoning that must not win",
+            response_status: "complete",
             sequence: 7,
         },
     )
@@ -277,27 +311,135 @@ async fn response_show_diagnoses_missing_materialized_message() -> Result<()> {
             response_content: "",
             response_reasoning: "",
             message_content: None,
+            message_role: "assistant",
             message_reasoning: "",
+            response_status: "complete",
             sequence: 73,
         },
     )
     .await?;
 
-    let stderr = run_cli_failure_stderr(
-        &runtime.home_dir,
-        &[
-            "response",
-            "show",
-            "--graphql",
-            &runtime.graphql,
-            &request_id,
-        ],
-    )?;
-    assert!(stderr.contains("could not hydrate materialized AgentMessage"));
-    assert!(stderr.contains(&format!("request {request_id}")));
-    assert!(stderr.contains(&format!("session_id={session_id}")));
-    assert!(stderr.contains("sequence=73"));
-    assert!(stderr.contains("missing or invalid"));
+    assert_materialization_failure(&runtime, &request_id, &session_id, 73)?;
+
+    let partial_request_id = format!("response-partial-{}", Uuid::new_v4().simple());
+    let partial_session_id = format!("session-partial-{}", Uuid::new_v4().simple());
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &partial_request_id,
+            session_id: &partial_session_id,
+            response_content: "preserve this partial output",
+            response_reasoning: "",
+            message_content: None,
+            message_role: "assistant",
+            message_reasoning: "",
+            response_status: "complete",
+            sequence: 74,
+        },
+    )
+    .await?;
+    let partial = response_show(&runtime, &partial_request_id)?;
+    let partial_row = partial
+        .pointer("/data/AgentResponse/0")
+        .context("partial response show output missing GraphQL envelope row")?;
+    assert_eq!(
+        partial_row.get("content").and_then(Value::as_str),
+        Some("preserve this partial output")
+    );
+    assert_eq!(
+        partial_row.get("reasoning").and_then(Value::as_str),
+        Some("")
+    );
+
+    let wrong_role_request_id = format!("response-wrong-role-{}", Uuid::new_v4().simple());
+    let wrong_role_session_id = format!("session-wrong-role-{}", Uuid::new_v4().simple());
+    let assistant_text = serde_json::json!({
+        "role": "assistant",
+        "id": null,
+        "content": [{ "text": "must not hydrate from a user row" }]
+    })
+    .to_string();
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &wrong_role_request_id,
+            session_id: &wrong_role_session_id,
+            response_content: "",
+            response_reasoning: "",
+            message_content: Some(&assistant_text),
+            message_role: "user",
+            message_reasoning: "",
+            response_status: "complete",
+            sequence: 75,
+        },
+    )
+    .await?;
+    assert_materialization_failure(&runtime, &wrong_role_request_id, &wrong_role_session_id, 75)?;
+
+    let tool_only = serde_json::json!({
+        "role": "assistant",
+        "id": null,
+        "content": [{
+            "id": "call-1",
+            "call_id": "call-1",
+            "function": { "name": "echo", "arguments": {} },
+            "signature": null,
+            "additional_params": null
+        }]
+    })
+    .to_string();
+    let tool_only_request_id = format!("response-tool-only-{}", Uuid::new_v4().simple());
+    let tool_only_session_id = format!("session-tool-only-{}", Uuid::new_v4().simple());
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &tool_only_request_id,
+            session_id: &tool_only_session_id,
+            response_content: "",
+            response_reasoning: "",
+            message_content: Some(&tool_only),
+            message_role: "assistant",
+            message_reasoning: "",
+            response_status: "complete",
+            sequence: 76,
+        },
+    )
+    .await?;
+    assert_materialization_failure(&runtime, &tool_only_request_id, &tool_only_session_id, 76)?;
+
+    let interrupted_request_id = format!("response-interrupted-{}", Uuid::new_v4().simple());
+    let interrupted_session_id = format!("session-interrupted-{}", Uuid::new_v4().simple());
+    insert_materialized_response(
+        &runtime,
+        MaterializedResponse {
+            request_id: &interrupted_request_id,
+            session_id: &interrupted_session_id,
+            response_content: "",
+            response_reasoning: "",
+            message_content: Some(&tool_only),
+            message_role: "assistant",
+            message_reasoning: "",
+            response_status: "interrupted",
+            sequence: 77,
+        },
+    )
+    .await?;
+    let interrupted = response_show(&runtime, &interrupted_request_id)?;
+    let interrupted_row = interrupted
+        .pointer("/data/AgentResponse/0")
+        .context("interrupted response show output missing GraphQL envelope row")?;
+    assert_eq!(
+        interrupted_row.get("status").and_then(Value::as_str),
+        Some("interrupted")
+    );
+    assert!(interrupted_row
+        .get("content")
+        .and_then(Value::as_str)
+        .is_some_and(str::is_empty));
+    assert!(interrupted_row
+        .get("reasoning")
+        .and_then(Value::as_str)
+        .is_some_and(str::is_empty));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- hydrate blank response content and reasoning from the referenced durable AgentMessage through one shared show/wait presentation contract
- classify materialization as presentable, pending, or invalid so missing rows remain retryable while stable invalid rows fail immediately
- preserve the GraphQL envelope, terminal metadata, and any nonblank content or reasoning when optional hydration is unavailable
- reject non-assistant and blank completed materializations with request, session, and sequence diagnostics
- keep blank tool-call-only failed or interrupted responses inspectable through both response show and response wait

## Testing

- PASS: cargo test -p gents-cli --test cli_runtime cli_response:: -- --nocapture (2 passed; server-backed show/wait coverage includes missing, wrong-role, completed tool-only, reasoning-only, and interrupted cases)
- PASS: cargo check --workspace --all-targets
- PASS: cargo fmt --all -- --check
- PARTIAL: cargo test -p gents-cli (638 passed, 1 unrelated existing failure)
  - commands::demo::pack::tests::defending_code_pack_is_typed_static_and_closes_both_fan_outs
  - reproduced repeatedly: expected expected_total but fixture value was empty
  - this PR does not modify the demo pack or its test

Closes #849