### PR TITLE
test(p2p): retry event trigger fixture mutations

### DIFF
--- a/crates/gents/tests/e2e_triggers/event_trigger_p2p_e2e.rs
+++ b/crates/gents/tests/e2e_triggers/event_trigger_p2p_e2e.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gents::defra_node::EmbeddedNode;
-use gents::graphql::escape_graphql_string;
+use gents::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
 use gents::{AgentIdentity, DocumentRuntimeOptions, Gents, ToolCeiling};
 use serde::Deserialize;
 use serde_json::Value;
@@ -77,12 +77,9 @@ async fn create_task(node: &EmbeddedNode, task_id: &str, behavior_id: &str, prom
             }}) {{ _docID }}
         }}"#
     );
-    let response = node.execute(&mutation).await;
-    assert!(
-        !response.has_errors(),
-        "create Task failed: {:?}",
-        response.errors
-    );
+    graphql_mutation_with_transaction_retry(node, &mutation, "create P2P trigger Task fixture")
+        .await
+        .expect("create Task");
 }
 
 async fn create_event_trigger_with_filter(
@@ -112,12 +109,9 @@ async fn create_event_trigger_with_filter(
             }}) {{ _docID }}
         }}"#
     );
-    let response = node.execute(&mutation).await;
-    assert!(
-        !response.has_errors(),
-        "create EventTrigger failed: {:?}",
-        response.errors
-    );
+    graphql_mutation_with_transaction_retry(node, &mutation, "create P2P EventTrigger fixture")
+        .await
+        .expect("create EventTrigger");
 }
 
 async fn wait_for_runtime_snapshot<F>(
@@ -257,12 +251,10 @@ async fn write_replicated_event(node: &EmbeddedNode, external_id: &str, kind: &s
             }}) {{ _docID }}
         }}"#
     );
-    let response = node.execute(&mutation).await;
-    assert!(
-        !response.has_errors(),
-        "add_ReplicatedEvent failed: {:?}",
-        response.errors
-    );
+    let response =
+        graphql_mutation_with_transaction_retry(node, &mutation, "add P2P ReplicatedEvent fixture")
+            .await
+            .expect("add ReplicatedEvent");
     let data = response
         .data
         .as_ref()


### PR DESCRIPTION
## Summary

- route P2P event-trigger Task and EventTrigger setup writes through the canonical node-scoped mutation retry boundary
- route the replicated source-document write through the same bounded conflict retry while preserving its document-ID response parsing
- remove the remaining bare fixture mutation paths identified in #1023; no ad-hoc retry loop

## Foundation boundary

Test-harness plumbing only. This reuses the existing transaction-conflict policy and does not change runtime lifecycle transitions, provider input, schemas, or Lean contracts.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- exact regression: `RUSTC_WRAPPER= CARGO_BUILD_JOBS=1 cargo test -p gents --test e2e_triggers event_trigger_p2p_e2e::p2p_replicated_doc_fires_event_trigger -- --exact --nocapture` — passed
- five additional warm exact repetitions — 5/5 passed (6/6 total)

The worktree clone contained incompatible Cargo metadata. A worktree-local `cargo clean` removed 224 GiB of recoverable artifacts; parallel cold rebuilds then hit fresh dependency-metadata E0463 failures. Removing the compiler wrapper and using one Cargo job produced a clean build and the passing targeted results above. Full `cargo test -p gents` and `cargo check --workspace --all-targets` remain deferred to CI because the clean targeted rebuild alone took 28 minutes.

Closes #1023