### PR TITLE
docs: point review demo at graph quickstart

### DIFF
--- a/apps/review-demo/src/talk/WhatWeWillSee.tsx
+++ b/apps/review-demo/src/talk/WhatWeWillSee.tsx
@@ -62,9 +62,9 @@ export function WhatWeWillSee() {
     <section className="talk-block">
       <p className="eyebrow">What we’ll see</p>
       <p className="talk-lead">
-        One seed write. Four document edges. No coordinator process. <code>make review</code>{" "}
-        creates a <code>ReviewJob</code>; each create fires a trigger that materializes that
-        stage’s Task on that stage’s Behavior.
+        One seed write. Four document edges. No coordinator process.{" "}
+        <code>gents graph run code-review --watch</code> creates a <code>ReviewJob</code>; each
+        create fires a trigger that materializes that stage’s Task on that stage’s Behavior.
       </p>
       <ol className="edge-list">
         {EDGES.map((edge) => (


### PR DESCRIPTION
## Summary

- replace the deleted `make review` instruction in the live review-demo UI
- point operators at the bundled graph quickstart command

Historical design records remain unchanged.

## Validation

- `npm --prefix apps/review-demo test -- --run`
- `npm --prefix apps/review-demo run build`
- `git diff --check`