### PR TITLE
test(desktop): clean up failed bridge startup

### DIFF
--- a/apps/gents-desktop/tests/live-bridge-runner.test.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner.test.ts
@@ -8,6 +8,7 @@ import {
   type RequestDiagnosticsBundle,
 } from "./live-bridge-runner";
 import {
+  disposeRunnerProcess,
   terminateRunnerProcess,
   waitForReadyMessage,
 } from "./live-bridge-runner/process";
@@ -71,6 +72,59 @@ describe("live bridge runner process lifecycle", () => {
     expect(child.exitCode).toBeNull();
     expect(child.signalCode).toBeNull();
     await terminateRunnerProcess(child);
+  });
+
+  it("preserves graceful stdin disposal before terminating a stalled group", async () => {
+    const gracefulChild = spawnRunnerFixture(`
+      process.stdin.resume();
+      process.stdin.on("end", () => process.exit(0));
+      process.stdout.write(${JSON.stringify(
+        `${JSON.stringify({
+          kind: "ready",
+          baseUrl: "http://127.0.0.1:1234",
+          deploymentLabel: "graceful-fixture",
+          agentDid: "did:key:graceful-fixture",
+          toolRoot: "/tmp/graceful-fixture",
+        })}\n`,
+      )});
+    `);
+    await waitForReadyMessage(gracefulChild, 2_000);
+
+    await disposeRunnerProcess(gracefulChild, 500);
+
+    expect(gracefulChild.exitCode).toBe(0);
+    expect(gracefulChild.signalCode).toBeNull();
+
+    const stalledChild = spawnRunnerFixture(`
+      const { spawn } = require("node:child_process");
+      if (${process.platform !== "win32"}) {
+        spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+          stdio: "ignore",
+        });
+      }
+      process.stdin.resume();
+      process.stdout.write(${JSON.stringify(
+        `${JSON.stringify({
+          kind: "ready",
+          baseUrl: "http://127.0.0.1:1234",
+          deploymentLabel: "stalled-fixture",
+          agentDid: "did:key:stalled-fixture",
+          toolRoot: "/tmp/stalled-fixture",
+        })}\n`,
+      )});
+      setInterval(() => {}, 1_000);
+    `);
+    const stalledGroupId = stalledChild.pid;
+    await waitForReadyMessage(stalledChild, 2_000);
+
+    await disposeRunnerProcess(stalledChild, 50);
+
+    expect(stalledChild.exitCode !== null || stalledChild.signalCode !== null).toBe(
+      true,
+    );
+    if (process.platform !== "win32" && stalledGroupId !== undefined) {
+      expect(() => process.kill(-stalledGroupId, 0)).toThrow();
+    }
   });
 });
 

--- a/apps/gents-desktop/tests/live-bridge-runner.test.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner.test.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -5,6 +7,72 @@ import {
   observeRemoteTerminalDesktopStall,
   type RequestDiagnosticsBundle,
 } from "./live-bridge-runner";
+import {
+  terminateRunnerProcess,
+  waitForReadyMessage,
+} from "./live-bridge-runner/process";
+
+function spawnRunnerFixture(script: string) {
+  return spawn(process.execPath, ["-e", script], {
+    detached: process.platform !== "win32",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+describe("live bridge runner process lifecycle", () => {
+  it("kills and awaits a runner process group when readiness times out", async () => {
+    const child = spawnRunnerFixture(`
+      const { spawn } = require("node:child_process");
+      if (${process.platform !== "win32"}) {
+        spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+          stdio: "ignore",
+        });
+      }
+      process.stdout.write("cargo still compiling");
+      process.stderr.write("compiler diagnostic");
+      setInterval(() => {}, 1_000);
+    `);
+    const processGroupId = child.pid;
+
+    let startupError: Error | null = null;
+    try {
+      await waitForReadyMessage(child, 500);
+    } catch (error) {
+      startupError = error as Error;
+    }
+
+    expect(startupError?.message).toContain(
+      "bridge runner did not become ready within 500ms",
+    );
+    expect(startupError?.message).toContain("cargo still compiling");
+    expect(startupError?.message).toContain("compiler diagnostic");
+    expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+    if (process.platform !== "win32" && processGroupId !== undefined) {
+      expect(() => process.kill(-processGroupId, 0)).toThrow();
+    }
+  });
+
+  it("leaves a ready runner alive for normal construction", async () => {
+    const readyMessage = {
+      kind: "ready",
+      baseUrl: "http://127.0.0.1:1234",
+      deploymentLabel: "fixture",
+      agentDid: "did:key:fixture",
+      toolRoot: "/tmp/fixture",
+    };
+    const child = spawnRunnerFixture(`
+      process.stdout.write(${JSON.stringify(`${JSON.stringify(readyMessage)}\n`)});
+      setInterval(() => {}, 1_000);
+    `);
+
+    const ready = await waitForReadyMessage(child, 2_000);
+
+    expect(ready.message).toEqual(readyMessage);
+    expect(child.exitCode).toBeNull();
+    expect(child.signalCode).toBeNull();
+    await terminateRunnerProcess(child);
+  });
+});
 
 function requestDiagnosticsBundle({
   desktopTurnState = "streaming",

--- a/apps/gents-desktop/tests/live-bridge-runner.test.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner.test.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
 
 import { describe, expect, it } from "vitest";
 
@@ -8,6 +9,7 @@ import {
   type RequestDiagnosticsBundle,
 } from "./live-bridge-runner";
 import {
+  assertLiveBridgeRunnerPlatform,
   disposeRunnerProcess,
   terminateRunnerProcess,
   waitForReadyMessage,
@@ -15,67 +17,116 @@ import {
 
 function spawnRunnerFixture(script: string) {
   return spawn(process.execPath, ["-e", script], {
-    detached: process.platform !== "win32",
+    detached: true,
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
 
-describe("live bridge runner process lifecycle", () => {
-  it("kills and awaits a runner process group when readiness times out", async () => {
-    const child = spawnRunnerFixture(`
-      const { spawn } = require("node:child_process");
-      if (${process.platform !== "win32"}) {
-        spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
-          stdio: "ignore",
-        });
+async function forceCleanupRunnerFixture(child: ChildProcessWithoutNullStreams) {
+  if (!child.stdin.destroyed && !child.stdin.writableEnded) {
+    child.stdin.destroy();
+  }
+  child.stdout.resume();
+  child.stderr.resume();
+
+  if (Number.isInteger(child.pid) && child.pid! > 0) {
+    try {
+      process.kill(-child.pid!, "SIGKILL");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        throw error;
       }
+    }
+  }
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await Promise.race([
+      once(child, "exit"),
+      new Promise((resolve) => setTimeout(resolve, 2_000)),
+    ]);
+  }
+}
+
+function permissionDenied() {
+  const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+  error.code = "EPERM";
+  return error;
+}
+
+describe("live bridge runner platform contract", () => {
+  it("fails early on Windows rather than claiming process-tree cleanup", () => {
+    expect(() => assertLiveBridgeRunnerPlatform("win32")).toThrow(
+      "requires POSIX process-group cleanup",
+    );
+    expect(() => assertLiveBridgeRunnerPlatform("darwin")).not.toThrow();
+    expect(() => assertLiveBridgeRunnerPlatform("linux")).not.toThrow();
+  });
+});
+
+describe.skipIf(process.platform === "win32")(
+  "live bridge runner process lifecycle",
+  () => {
+    it("kills and awaits a runner process group when readiness times out", async () => {
+      const child = spawnRunnerFixture(`
+      const { spawn } = require("node:child_process");
+      spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+        stdio: "ignore",
+      });
       process.stdout.write("cargo still compiling");
       process.stderr.write("compiler diagnostic");
       setInterval(() => {}, 1_000);
     `);
-    const processGroupId = child.pid;
+      const processGroupId = child.pid;
 
-    let startupError: Error | null = null;
-    try {
-      await waitForReadyMessage(child, 500);
-    } catch (error) {
-      startupError = error as Error;
-    }
+      try {
+        let startupError: Error | null = null;
+        try {
+          await waitForReadyMessage(child, 500);
+        } catch (error) {
+          startupError = error as Error;
+        }
 
-    expect(startupError?.message).toContain(
-      "bridge runner did not become ready within 500ms",
-    );
-    expect(startupError?.message).toContain("cargo still compiling");
-    expect(startupError?.message).toContain("compiler diagnostic");
-    expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
-    if (process.platform !== "win32" && processGroupId !== undefined) {
-      expect(() => process.kill(-processGroupId, 0)).toThrow();
-    }
-  });
+        expect(startupError?.message).toContain(
+          "bridge runner did not become ready within 500ms",
+        );
+        expect(startupError?.message).toContain("cargo still compiling");
+        expect(startupError?.message).toContain("compiler diagnostic");
+        expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+        if (processGroupId !== undefined) {
+          expect(() => process.kill(-processGroupId, 0)).toThrow();
+        }
+      } finally {
+        await forceCleanupRunnerFixture(child);
+      }
+    });
 
-  it("leaves a ready runner alive for normal construction", async () => {
-    const readyMessage = {
-      kind: "ready",
-      baseUrl: "http://127.0.0.1:1234",
-      deploymentLabel: "fixture",
-      agentDid: "did:key:fixture",
-      toolRoot: "/tmp/fixture",
-    };
-    const child = spawnRunnerFixture(`
+    it("leaves a ready runner alive for normal construction", async () => {
+      const readyMessage = {
+        kind: "ready",
+        baseUrl: "http://127.0.0.1:1234",
+        deploymentLabel: "fixture",
+        agentDid: "did:key:fixture",
+        toolRoot: "/tmp/fixture",
+      };
+      const child = spawnRunnerFixture(`
       process.stdout.write(${JSON.stringify(`${JSON.stringify(readyMessage)}\n`)});
       setInterval(() => {}, 1_000);
     `);
 
-    const ready = await waitForReadyMessage(child, 2_000);
+      try {
+        const ready = await waitForReadyMessage(child, 2_000);
 
-    expect(ready.message).toEqual(readyMessage);
-    expect(child.exitCode).toBeNull();
-    expect(child.signalCode).toBeNull();
-    await terminateRunnerProcess(child);
-  });
+        expect(ready.message).toEqual(readyMessage);
+        expect(child.exitCode).toBeNull();
+        expect(child.signalCode).toBeNull();
+        await terminateRunnerProcess(child);
+      } finally {
+        await forceCleanupRunnerFixture(child);
+      }
+    });
 
-  it("preserves graceful stdin disposal before terminating a stalled group", async () => {
-    const gracefulChild = spawnRunnerFixture(`
+    it("preserves graceful stdin disposal", async () => {
+      const gracefulChild = spawnRunnerFixture(`
       process.stdin.resume();
       process.stdin.on("end", () => process.exit(0));
       process.stdout.write(${JSON.stringify(
@@ -88,20 +139,23 @@ describe("live bridge runner process lifecycle", () => {
         })}\n`,
       )});
     `);
-    await waitForReadyMessage(gracefulChild, 2_000);
+      try {
+        await waitForReadyMessage(gracefulChild, 2_000);
+        await disposeRunnerProcess(gracefulChild, 500);
 
-    await disposeRunnerProcess(gracefulChild, 500);
-
-    expect(gracefulChild.exitCode).toBe(0);
-    expect(gracefulChild.signalCode).toBeNull();
-
-    const stalledChild = spawnRunnerFixture(`
-      const { spawn } = require("node:child_process");
-      if (${process.platform !== "win32"}) {
-        spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
-          stdio: "ignore",
-        });
+        expect(gracefulChild.exitCode).toBe(0);
+        expect(gracefulChild.signalCode).toBeNull();
+      } finally {
+        await forceCleanupRunnerFixture(gracefulChild);
       }
+    });
+
+    it("terminates a stalled ready runner and its descendant during disposal", async () => {
+      const stalledChild = spawnRunnerFixture(`
+      const { spawn } = require("node:child_process");
+      spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+        stdio: "ignore",
+      });
       process.stdin.resume();
       process.stdout.write(${JSON.stringify(
         `${JSON.stringify({
@@ -114,19 +168,118 @@ describe("live bridge runner process lifecycle", () => {
       )});
       setInterval(() => {}, 1_000);
     `);
-    const stalledGroupId = stalledChild.pid;
-    await waitForReadyMessage(stalledChild, 2_000);
+      const stalledGroupId = stalledChild.pid;
+      try {
+        await waitForReadyMessage(stalledChild, 2_000);
+        await disposeRunnerProcess(stalledChild, 50);
 
-    await disposeRunnerProcess(stalledChild, 50);
+        expect(stalledChild.exitCode !== null || stalledChild.signalCode !== null).toBe(
+          true,
+        );
+        if (stalledGroupId !== undefined) {
+          expect(() => process.kill(-stalledGroupId, 0)).toThrow();
+        }
+      } finally {
+        await forceCleanupRunnerFixture(stalledChild);
+      }
+    });
 
-    expect(stalledChild.exitCode !== null || stalledChild.signalCode !== null).toBe(
-      true,
-    );
-    if (process.platform !== "win32" && stalledGroupId !== undefined) {
-      expect(() => process.kill(-stalledGroupId, 0)).toThrow();
-    }
-  });
-});
+    it("captures process errors and cleans up before rejecting", async () => {
+      const child = spawnRunnerFixture(`
+      process.stdout.write("startup stdout");
+      process.stderr.write("startup stderr");
+      setInterval(() => {}, 1_000);
+    `);
+      try {
+        const stdoutSeen = once(child.stdout, "data");
+        const stderrSeen = once(child.stderr, "data");
+        const ready = waitForReadyMessage(child, 2_000);
+        await Promise.all([stdoutSeen, stderrSeen]);
+        const processError = new Error("synthetic EACCES") as NodeJS.ErrnoException;
+        processError.code = "EACCES";
+        child.emit("error", processError);
+
+        await expect(ready).rejects.toThrow("synthetic EACCES");
+        await expect(ready).rejects.toThrow("startup stdout");
+        await expect(ready).rejects.toThrow("startup stderr");
+        expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+      } finally {
+        await forceCleanupRunnerFixture(child);
+      }
+    });
+
+    it("handles a spawn ENOENT without waiting for the readiness timeout", async () => {
+      const child = spawn("gents-live-bridge-command-that-does-not-exist", [], {
+        detached: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      await expect(waitForReadyMessage(child, 2_000)).rejects.toThrow("ENOENT");
+    });
+
+    it("ignores process-group EPERM only after the leader exits", async () => {
+      const exitedChild = spawnRunnerFixture("process.exit(0)");
+      const exitedPid = exitedChild.pid;
+      try {
+        await once(exitedChild, "exit");
+        const exitedSignals: Array<[number, string | number]> = [];
+
+        await terminateRunnerProcess(exitedChild, {
+          killByPid: (pid, signal) => {
+            exitedSignals.push([pid, signal]);
+            throw permissionDenied();
+          },
+        });
+
+        expect(exitedSignals).toEqual([[-exitedPid!, "SIGTERM"]]);
+
+        const probeSignals: Array<[number, string | number]> = [];
+        await terminateRunnerProcess(exitedChild, {
+          graceMs: 1,
+          killByPid: (pid, signal) => {
+            probeSignals.push([pid, signal]);
+            if (signal === "SIGTERM") {
+              return true;
+            }
+            throw permissionDenied();
+          },
+        });
+        expect(probeSignals[0]).toEqual([-exitedPid!, "SIGTERM"]);
+        expect(probeSignals).toContainEqual([-exitedPid!, 0]);
+        expect(probeSignals[probeSignals.length - 1]).toEqual([-exitedPid!, "SIGKILL"]);
+      } finally {
+        await forceCleanupRunnerFixture(exitedChild);
+      }
+
+      const liveChild = spawnRunnerFixture(`
+      process.stdout.write(${JSON.stringify(
+        `${JSON.stringify({
+          kind: "ready",
+          baseUrl: "http://127.0.0.1:1234",
+          deploymentLabel: "eperm-fixture",
+          agentDid: "did:key:eperm-fixture",
+          toolRoot: "/tmp/eperm-fixture",
+        })}\n`,
+      )});
+      setInterval(() => {}, 1_000);
+    `);
+      try {
+        await waitForReadyMessage(liveChild, 2_000);
+        await expect(
+          terminateRunnerProcess(liveChild, {
+            killByPid: () => {
+              throw permissionDenied();
+            },
+          }),
+        ).rejects.toMatchObject({ code: "EPERM" });
+        expect(liveChild.exitCode).toBeNull();
+        expect(liveChild.signalCode).toBeNull();
+      } finally {
+        await forceCleanupRunnerFixture(liveChild);
+      }
+    });
+  },
+);
 
 function requestDiagnosticsBundle({
   desktopTurnState = "streaming",

--- a/apps/gents-desktop/tests/live-bridge-runner.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner.ts
@@ -16,7 +16,11 @@ import {
   VERSION_POLL_MS,
 } from "./live-bridge-runner/listener";
 import { RunnerLogs, type RunnerExitStatus } from "./live-bridge-runner/logs";
-import { appendRunnerArg, waitForReadyMessage } from "./live-bridge-runner/process";
+import {
+  appendRunnerArg,
+  disposeRunnerProcess,
+  waitForReadyMessage,
+} from "./live-bridge-runner/process";
 import {
   waitForRequestCompletion,
   type RequestCompletionTarget,
@@ -158,20 +162,7 @@ export class LiveBridgeRunner implements TauriDriverBridge {
   }
 
   async dispose() {
-    this.process.stdin.end();
-    const exited = await new Promise<boolean>((resolve) => {
-      const timeout = setTimeout(() => {
-        this.process.kill("SIGKILL");
-        resolve(false);
-      }, 10_000);
-      this.process.once("exit", () => {
-        clearTimeout(timeout);
-        resolve(true);
-      });
-    });
-    if (!exited) {
-      await new Promise((resolve) => this.process.once("exit", resolve));
-    }
+    await disposeRunnerProcess(this.process);
   }
 
   async getJson<T>(path: string) {

--- a/apps/gents-desktop/tests/live-bridge-runner.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner.ts
@@ -113,6 +113,7 @@ export class LiveBridgeRunner implements TauriDriverBridge {
     );
     const child = spawn("cargo", runnerArgs, {
       cwd: REPO_ROOT,
+      detached: process.platform !== "win32",
       env: {
         ...process.env,
         CARGO_NET_GIT_FETCH_WITH_CLI:

--- a/apps/gents-desktop/tests/live-bridge-runner.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner.ts
@@ -18,6 +18,7 @@ import {
 import { RunnerLogs, type RunnerExitStatus } from "./live-bridge-runner/logs";
 import {
   appendRunnerArg,
+  assertLiveBridgeRunnerPlatform,
   disposeRunnerProcess,
   waitForReadyMessage,
 } from "./live-bridge-runner/process";
@@ -88,6 +89,7 @@ export class LiveBridgeRunner implements TauriDriverBridge {
   }
 
   static async start(options: LiveBridgeRunnerOptions = {}) {
+    assertLiveBridgeRunnerPlatform();
     const runnerArgs = [
       "run",
       "-p",
@@ -117,7 +119,10 @@ export class LiveBridgeRunner implements TauriDriverBridge {
     );
     const child = spawn("cargo", runnerArgs, {
       cwd: REPO_ROOT,
-      detached: process.platform !== "win32",
+      // Detachment makes bounded process-group cleanup possible. An abrupt
+      // SIGKILL of this Node harness can still strand the group; the enclosing
+      // test job remains the final reaping boundary for that case.
+      detached: true,
       env: {
         ...process.env,
         CARGO_NET_GIT_FETCH_WITH_CLI:

--- a/apps/gents-desktop/tests/live-bridge-runner/process.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner/process.ts
@@ -6,6 +6,18 @@ const RUNNER_STOP_GRACE_MS = 2_000;
 const RUNNER_KILL_DRAIN_MS = 2_000;
 const RUNNER_DISPOSE_GRACE_MS = 10_000;
 
+type KillByPid = (pid: number, signal: NodeJS.Signals | 0) => boolean;
+
+const killByPid: KillByPid = (pid, signal) => process.kill(pid, signal);
+
+export function assertLiveBridgeRunnerPlatform(platform = process.platform) {
+  if (platform === "win32") {
+    throw new Error(
+      "the live bridge runner requires POSIX process-group cleanup and is not supported on Windows",
+    );
+  }
+}
+
 export async function waitForReadyMessage(
   child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
@@ -94,16 +106,28 @@ async function readReadyMessage(
       );
     };
 
+    const onError = (error: Error) => {
+      cleanup();
+      reject(
+        new Error(
+          `bridge runner process error before ready: ${error.message}\nstdout:\n${stdout}${stdoutBuffer}\nstderr:\n${stderr}`,
+          { cause: error },
+        ),
+      );
+    };
+
     const cleanup = () => {
       clearTimeout(timeout);
       child.stdout.off("data", onStdout);
       child.stderr.off("data", onStderr);
       child.off("exit", onExit);
+      child.off("error", onError);
     };
 
     child.stdout.on("data", onStdout);
     child.stderr.on("data", onStderr);
     child.on("exit", onExit);
+    child.on("error", onError);
   });
 }
 
@@ -112,20 +136,41 @@ export async function terminateRunnerProcess(
   {
     graceMs = RUNNER_STOP_GRACE_MS,
     killDrainMs = RUNNER_KILL_DRAIN_MS,
-  }: { graceMs?: number; killDrainMs?: number } = {},
+    killByPid: signalByPid = killByPid,
+  }: { graceMs?: number; killDrainMs?: number; killByPid?: KillByPid } = {},
 ) {
   endRunnerStdin(child);
   child.stdout.resume();
   child.stderr.resume();
 
-  const processGroupId = runnerProcessGroupId(child);
-  signalRunnerProcess(child, "SIGTERM", processGroupId);
-  if (await waitForRunnerDrain(child, processGroupId, graceMs)) {
+  if (!Number.isInteger(child.pid) || child.pid! <= 0) {
     return;
   }
 
-  signalRunnerProcess(child, "SIGKILL", processGroupId);
-  if (!(await waitForRunnerDrain(child, processGroupId, killDrainMs))) {
+  const processGroupId = runnerProcessGroupId(child);
+  const termSignalSent = signalRunnerProcess(
+    child,
+    "SIGTERM",
+    processGroupId,
+    signalByPid,
+  );
+  if (!termSignalSent) {
+    return;
+  }
+  if (await waitForRunnerDrain(child, processGroupId, graceMs, signalByPid)) {
+    return;
+  }
+
+  const killSignalSent = signalRunnerProcess(
+    child,
+    "SIGKILL",
+    processGroupId,
+    signalByPid,
+  );
+  if (!killSignalSent) {
+    return;
+  }
+  if (!(await waitForRunnerDrain(child, processGroupId, killDrainMs, signalByPid))) {
     throw new Error(
       `bridge runner process${processGroupId === null ? "" : ` group ${processGroupId}`} did not exit after SIGKILL`,
     );
@@ -137,7 +182,14 @@ export async function disposeRunnerProcess(
   gracefulExitMs = RUNNER_DISPOSE_GRACE_MS,
 ) {
   endRunnerStdin(child);
-  if (await waitForRunnerDrain(child, runnerProcessGroupId(child), gracefulExitMs)) {
+  if (
+    await waitForRunnerDrain(
+      child,
+      runnerProcessGroupId(child),
+      gracefulExitMs,
+      killByPid,
+    )
+  ) {
     return;
   }
   await terminateRunnerProcess(child);
@@ -159,13 +211,20 @@ function signalRunnerProcess(
   child: ChildProcessWithoutNullStreams,
   signal: NodeJS.Signals,
   processGroupId: number | null,
+  signalByPid: KillByPid,
 ) {
   if (processGroupId !== null) {
     try {
-      process.kill(-processGroupId, signal);
-      return;
+      signalByPid(-processGroupId, signal);
+      return true;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EPERM" && childHasExited(child)) {
+        // macOS can retain an unsignalable process-group identifier after the
+        // leader has exited. Its successful exit remains authoritative.
+        return false;
+      }
+      if (code !== "ESRCH") {
         throw error;
       }
     }
@@ -174,18 +233,20 @@ function signalRunnerProcess(
   if (child.exitCode === null && child.signalCode === null) {
     child.kill(signal);
   }
+  return true;
 }
 
 async function waitForRunnerDrain(
   child: ChildProcessWithoutNullStreams,
   processGroupId: number | null,
   timeoutMs: number,
+  signalByPid: KillByPid,
 ) {
   const [childExited, processGroupExited] = await Promise.all([
     waitForChildExit(child, timeoutMs),
     processGroupId === null
       ? Promise.resolve(true)
-      : waitForProcessGroupExit(processGroupId, timeoutMs),
+      : waitForProcessGroupExit(processGroupId, timeoutMs, signalByPid),
   ]);
   return childExited && processGroupExited;
 }
@@ -207,9 +268,13 @@ function waitForChildExit(child: ChildProcessWithoutNullStreams, timeoutMs: numb
   });
 }
 
-async function waitForProcessGroupExit(processGroupId: number, timeoutMs: number) {
+async function waitForProcessGroupExit(
+  processGroupId: number,
+  timeoutMs: number,
+  signalByPid: KillByPid,
+) {
   const deadline = Date.now() + timeoutMs;
-  while (processGroupExists(processGroupId)) {
+  while (processGroupExists(processGroupId, signalByPid)) {
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
       return false;
@@ -219,9 +284,9 @@ async function waitForProcessGroupExit(processGroupId: number, timeoutMs: number
   return true;
 }
 
-function processGroupExists(processGroupId: number) {
+function processGroupExists(processGroupId: number, signalByPid: KillByPid) {
   try {
-    process.kill(-processGroupId, 0);
+    signalByPid(-processGroupId, 0);
     return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ESRCH") {
@@ -232,6 +297,10 @@ function processGroupExists(processGroupId: number) {
     }
     throw error;
   }
+}
+
+function childHasExited(child: ChildProcessWithoutNullStreams) {
+  return child.exitCode !== null || child.signalCode !== null;
 }
 
 export function appendRunnerArg(args: string[], flag: string, value?: string | null) {

--- a/apps/gents-desktop/tests/live-bridge-runner/process.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner/process.ts
@@ -4,6 +4,7 @@ import type { RunnerReadyMessage } from "./types";
 
 const RUNNER_STOP_GRACE_MS = 2_000;
 const RUNNER_KILL_DRAIN_MS = 2_000;
+const RUNNER_DISPOSE_GRACE_MS = 10_000;
 
 export async function waitForReadyMessage(
   child: ChildProcessWithoutNullStreams,
@@ -113,16 +114,11 @@ export async function terminateRunnerProcess(
     killDrainMs = RUNNER_KILL_DRAIN_MS,
   }: { graceMs?: number; killDrainMs?: number } = {},
 ) {
-  if (!child.stdin.destroyed && !child.stdin.writableEnded) {
-    child.stdin.end();
-  }
+  endRunnerStdin(child);
   child.stdout.resume();
   child.stderr.resume();
 
-  const processGroupId =
-    process.platform !== "win32" && Number.isInteger(child.pid) && child.pid! > 0
-      ? child.pid!
-      : null;
+  const processGroupId = runnerProcessGroupId(child);
   signalRunnerProcess(child, "SIGTERM", processGroupId);
   if (await waitForRunnerDrain(child, processGroupId, graceMs)) {
     return;
@@ -134,6 +130,29 @@ export async function terminateRunnerProcess(
       `bridge runner process${processGroupId === null ? "" : ` group ${processGroupId}`} did not exit after SIGKILL`,
     );
   }
+}
+
+export async function disposeRunnerProcess(
+  child: ChildProcessWithoutNullStreams,
+  gracefulExitMs = RUNNER_DISPOSE_GRACE_MS,
+) {
+  endRunnerStdin(child);
+  if (await waitForRunnerDrain(child, runnerProcessGroupId(child), gracefulExitMs)) {
+    return;
+  }
+  await terminateRunnerProcess(child);
+}
+
+function endRunnerStdin(child: ChildProcessWithoutNullStreams) {
+  if (!child.stdin.destroyed && !child.stdin.writableEnded) {
+    child.stdin.end();
+  }
+}
+
+function runnerProcessGroupId(child: ChildProcessWithoutNullStreams) {
+  return process.platform !== "win32" && Number.isInteger(child.pid) && child.pid! > 0
+    ? child.pid!
+    : null;
 }
 
 function signalRunnerProcess(

--- a/apps/gents-desktop/tests/live-bridge-runner/process.ts
+++ b/apps/gents-desktop/tests/live-bridge-runner/process.ts
@@ -2,8 +2,34 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
 import type { RunnerReadyMessage } from "./types";
 
+const RUNNER_STOP_GRACE_MS = 2_000;
+const RUNNER_KILL_DRAIN_MS = 2_000;
+
 export async function waitForReadyMessage(
-  process: ChildProcessWithoutNullStreams,
+  child: ChildProcessWithoutNullStreams,
+  timeoutMs: number,
+) {
+  try {
+    return await readReadyMessage(child, timeoutMs);
+  } catch (startupError) {
+    try {
+      await terminateRunnerProcess(child);
+    } catch (cleanupError) {
+      const startupMessage =
+        startupError instanceof Error ? startupError.message : String(startupError);
+      const cleanupMessage =
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      throw new Error(
+        `${startupMessage}\nfailed to clean up bridge runner: ${cleanupMessage}`,
+        { cause: cleanupError },
+      );
+    }
+    throw startupError;
+  }
+}
+
+async function readReadyMessage(
+  child: ChildProcessWithoutNullStreams,
   timeoutMs: number,
 ) {
   let stdoutBuffer = "";
@@ -19,7 +45,7 @@ export async function waitForReadyMessage(
       cleanup();
       reject(
         new Error(
-          `bridge runner did not become ready within ${timeoutMs}ms\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          `bridge runner did not become ready within ${timeoutMs}ms\nstdout:\n${stdout}${stdoutBuffer}\nstderr:\n${stderr}`,
         ),
       );
     }, timeoutMs);
@@ -58,26 +84,135 @@ export async function waitForReadyMessage(
       stderr += chunk.toString();
     };
 
-    const onExit = (code: number | null) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       cleanup();
       reject(
         new Error(
-          `bridge runner exited before ready (code=${code ?? "null"})\nstdout:\n${stdout}${stdoutBuffer}\nstderr:\n${stderr}`,
+          `bridge runner exited before ready (code=${code ?? "null"}, signal=${signal ?? "null"})\nstdout:\n${stdout}${stdoutBuffer}\nstderr:\n${stderr}`,
         ),
       );
     };
 
     const cleanup = () => {
       clearTimeout(timeout);
-      process.stdout.off("data", onStdout);
-      process.stderr.off("data", onStderr);
-      process.off("exit", onExit);
+      child.stdout.off("data", onStdout);
+      child.stderr.off("data", onStderr);
+      child.off("exit", onExit);
     };
 
-    process.stdout.on("data", onStdout);
-    process.stderr.on("data", onStderr);
-    process.on("exit", onExit);
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
+    child.on("exit", onExit);
   });
+}
+
+export async function terminateRunnerProcess(
+  child: ChildProcessWithoutNullStreams,
+  {
+    graceMs = RUNNER_STOP_GRACE_MS,
+    killDrainMs = RUNNER_KILL_DRAIN_MS,
+  }: { graceMs?: number; killDrainMs?: number } = {},
+) {
+  if (!child.stdin.destroyed && !child.stdin.writableEnded) {
+    child.stdin.end();
+  }
+  child.stdout.resume();
+  child.stderr.resume();
+
+  const processGroupId =
+    process.platform !== "win32" && Number.isInteger(child.pid) && child.pid! > 0
+      ? child.pid!
+      : null;
+  signalRunnerProcess(child, "SIGTERM", processGroupId);
+  if (await waitForRunnerDrain(child, processGroupId, graceMs)) {
+    return;
+  }
+
+  signalRunnerProcess(child, "SIGKILL", processGroupId);
+  if (!(await waitForRunnerDrain(child, processGroupId, killDrainMs))) {
+    throw new Error(
+      `bridge runner process${processGroupId === null ? "" : ` group ${processGroupId}`} did not exit after SIGKILL`,
+    );
+  }
+}
+
+function signalRunnerProcess(
+  child: ChildProcessWithoutNullStreams,
+  signal: NodeJS.Signals,
+  processGroupId: number | null,
+) {
+  if (processGroupId !== null) {
+    try {
+      process.kill(-processGroupId, signal);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        throw error;
+      }
+    }
+  }
+
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill(signal);
+  }
+}
+
+async function waitForRunnerDrain(
+  child: ChildProcessWithoutNullStreams,
+  processGroupId: number | null,
+  timeoutMs: number,
+) {
+  const [childExited, processGroupExited] = await Promise.all([
+    waitForChildExit(child, timeoutMs),
+    processGroupId === null
+      ? Promise.resolve(true)
+      : waitForProcessGroupExit(processGroupId, timeoutMs),
+  ]);
+  return childExited && processGroupExited;
+}
+
+function waitForChildExit(child: ChildProcessWithoutNullStreams, timeoutMs: number) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise<boolean>((resolve) => {
+    const timeout = setTimeout(() => {
+      child.off("exit", onExit);
+      resolve(false);
+    }, timeoutMs);
+    const onExit = () => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    child.once("exit", onExit);
+  });
+}
+
+async function waitForProcessGroupExit(processGroupId: number, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs;
+  while (processGroupExists(processGroupId)) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(25, remainingMs)));
+  }
+  return true;
+}
+
+function processGroupExists(processGroupId: number) {
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+      return false;
+    }
+    if ((error as NodeJS.ErrnoException).code === "EPERM") {
+      return true;
+    }
+    throw error;
+  }
 }
 
 export function appendRunnerArg(args: string[], flag: string, value?: string | null) {


### PR DESCRIPTION
## Summary

- launch the live Cargo bridge in its own POSIX process group
- reject readiness on child-process errors such as ENOENT/EACCES, preserve captured startup logs, and route all failures through bounded cleanup
- terminate and await the runner tree with bounded SIGTERM/SIGKILL cleanup after readiness rejection
- preserve the existing 10-second stdin grace during normal disposal, then clean up the full group if it stalls
- tolerate macOS EPERM process-group signaling only after the group leader has exited; live-leader EPERM remains an error
- make fixture cleanup assertion-safe and explicitly fail before spawning on Windows, where the harness cannot guarantee descendant-tree cleanup

## Scope

Live desktop test-harness process management only. No runtime lifecycle, schema, provider-input, Rust, or Lean behavior changes. Independent of the current graph stack and #1241.

The launcher is intentionally POSIX-only: adding and validating a separate Windows taskkill tree-management path would substantially widen this small harness fix. An abrupt SIGKILL of the Node test harness can still strand its detached group; the enclosing test job remains the final reaping boundary for that residual case.

## Validation

- `npm ci`
- `npm run build:packages`
- `npm --prefix apps/gents-desktop run build`
- `npm --prefix apps/gents-desktop run test:ui:unit` (325 passed, 16 skipped)
- `npm --prefix apps/gents-desktop run test:ui:unit -- --run tests/live-bridge-runner.test.ts` (16 passed)
- `npm --prefix apps/gents-desktop run format:check`
- `git diff --check`

Closes #1244