### PR TITLE
feat(desktop): render per-session hydration progress

### DIFF
--- a/apps/gents-desktop/src/App.css
+++ b/apps/gents-desktop/src/App.css
@@ -10,6 +10,7 @@
 @import "./styles/primitives/forms.css";
 @import "./styles/primitives/data.css";
 @import "./styles/shell.css";
+@import "./styles/session-hydration.css";
 @import "./styles/sidebar/base.css";
 @import "./styles/sidebar/connected-peer.css";
 @import "./styles/sidebar/lists.css";

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -312,6 +312,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
               onRenameConversationTitle={shell.onRenameConversationTitle}
               onSend={shell.onSendMessage}
               onRetryMessage={shell.onRetryMessage}
+              onRetryHydration={() => shell.refreshSession(shell.selectedSessionId)}
               onLoadOlderTimeline={shell.loadOlderSessionTimeline}
               rowCount={shell.snapshot?.client?.rowCount ?? 0}
               runtimeHealth={shell.runtimeHealth}

--- a/apps/gents-desktop/src/components/ChatWorkspace.tsx
+++ b/apps/gents-desktop/src/components/ChatWorkspace.tsx
@@ -20,6 +20,7 @@ import {
 } from "@source-inc/gents-desktop-chat";
 import { effectiveBehaviorSkills } from "@source-inc/gents-desktop-chat";
 import { HoldsPanel } from "@source-inc/gents-desktop-operations";
+import { SessionHydrationStatus } from "./SessionHydrationStatus";
 
 export type ChatWorkspaceProps = {
   api?: DesktopApiAdapter;
@@ -46,6 +47,7 @@ export type ChatWorkspaceProps = {
   onSend: (event: FormEvent) => void;
   onRetryMessage?: (requestId: string) => void | Promise<void>;
   onLoadOlderTimeline?: () => Promise<boolean>;
+  onRetryHydration?: () => void | Promise<unknown>;
   onOpenMobileNavigation?: () => void;
   onInterruptAccepted?: () => void | Promise<void>;
 };
@@ -98,6 +100,7 @@ export function ActiveChatWorkspace({
   onSend,
   onRetryMessage,
   onLoadOlderTimeline,
+  onRetryHydration,
   onOpenMobileNavigation,
   onInterruptAccepted,
 }: ActiveChatWorkspaceProps) {
@@ -187,6 +190,12 @@ export function ActiveChatWorkspace({
 
       <section className="chat-workspace">
         <div className="chat-main">
+          <SessionHydrationStatus
+            agentDid={session?.agentDid ?? selectedDeployment.agentDid}
+            hydration={session?.hydration}
+            onRetry={onRetryHydration}
+            sessionId={selectedSessionId}
+          />
           <ChatTranscriptPanel
             selectedSessionId={selectedSessionId}
             session={session}

--- a/apps/gents-desktop/src/components/SessionHydrationStatus.tsx
+++ b/apps/gents-desktop/src/components/SessionHydrationStatus.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+
+import type { SessionHydrationView } from "@source-inc/gents-desktop-client";
+
+import {
+  sessionHydrationLabel,
+  sessionHydrationNeedsRetry,
+  visibleSessionHydration,
+} from "../lib/sessionHydration";
+
+export type SessionHydrationStatusProps = {
+  hydration?: SessionHydrationView | null;
+  sessionId: string | null;
+  agentDid?: string | null;
+  onRetry?: () => void | Promise<unknown>;
+};
+
+export function SessionHydrationStatus({
+  hydration,
+  sessionId,
+  agentDid,
+  onRetry,
+}: SessionHydrationStatusProps) {
+  const visible = visibleSessionHydration(hydration, sessionId, agentDid);
+  const [retrying, setRetrying] = useState(false);
+  if (!visible) return null;
+
+  const label = sessionHydrationLabel(visible);
+  const failed = sessionHydrationNeedsRetry(visible);
+  const inFlight = visible.phase === "requested" || visible.phase === "serving";
+
+  async function retry() {
+    if (!onRetry || retrying) return;
+    setRetrying(true);
+    try {
+      await onRetry();
+    } finally {
+      setRetrying(false);
+    }
+  }
+
+  return (
+    <div
+      aria-live={failed ? "assertive" : "polite"}
+      className={`session-hydration-status is-${visible.phase}`}
+      data-hydration-phase={visible.phase}
+      data-testid="session-hydration-status"
+      role={failed ? "alert" : "status"}
+    >
+      <span className="session-hydration-copy">
+        {inFlight ? (
+          <span aria-hidden="true" className="session-hydration-pulse" />
+        ) : null}
+        {label}
+      </span>
+      {failed && onRetry ? (
+        <button
+          className="chip-button"
+          data-testid="session-hydration-retry"
+          disabled={retrying}
+          onClick={() => void retry()}
+          type="button"
+        >
+          {retrying ? "Retrying…" : "Retry"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/gents-desktop/src/hooks/desktopShellRuntime.ts
+++ b/apps/gents-desktop/src/hooks/desktopShellRuntime.ts
@@ -72,6 +72,7 @@ export function desktopUpdateRefreshScope(
   responseOnly = false,
 ): DesktopUpdateRefreshScope {
   if (reason === "health") return "snapshot";
+  if (reason === "hydration") return selectedSessionId ? "session" : "snapshot";
   if (selectedSessionId && selectedTrackedRequestId) {
     if (reason === "store" && responseOnly) return "sessionDelta";
     return "sessionEvent";

--- a/apps/gents-desktop/src/hooks/useDesktopSessionProjection.ts
+++ b/apps/gents-desktop/src/hooks/useDesktopSessionProjection.ts
@@ -67,9 +67,12 @@ export function useDesktopSessionProjection({
         selectedTrackedRequestIdRef.current,
         { limit: SESSION_TIMELINE_PAGE_SIZE },
       );
-      if (refreshSeq.current === currentRefresh) {
-        setSession((current) => (next ? mergeSessionTipSnapshot(current, next) : null));
-      }
+      const stillCurrent =
+        refreshSeq.current === currentRefresh &&
+        selectedSessionIdRef.current === nextSessionId &&
+        (!next || next.sessionId === nextSessionId);
+      if (!stillCurrent) return null;
+      setSession((current) => (next ? mergeSessionTipSnapshot(current, next) : null));
       return next;
     } catch (error) {
       if (refreshSeq.current === currentRefresh) setError(String(error));

--- a/apps/gents-desktop/src/lib/sessionHydration.ts
+++ b/apps/gents-desktop/src/lib/sessionHydration.ts
@@ -1,0 +1,62 @@
+import type { SessionHydrationView } from "@source-inc/gents-desktop-client";
+
+export type VisibleHydrationPhase = "requested" | "serving" | "complete" | "failed";
+
+export type VisibleSessionHydration = SessionHydrationView & {
+  phase: VisibleHydrationPhase;
+};
+
+export function visibleSessionHydration(
+  hydration: SessionHydrationView | null | undefined,
+  sessionId: string | null,
+  agentDid?: string | null,
+): VisibleSessionHydration | null {
+  if (!hydration || !sessionId || hydration.sessionId !== sessionId) {
+    return null;
+  }
+  if (agentDid && hydration.agentDid && hydration.agentDid !== agentDid) {
+    return null;
+  }
+  if (
+    hydration.phase !== "requested" &&
+    hydration.phase !== "serving" &&
+    hydration.phase !== "complete" &&
+    hydration.phase !== "failed"
+  ) {
+    return null;
+  }
+  if (
+    hydration.phase === "complete" &&
+    (hydration.servedCount ?? hydration.mergedCount) === 0
+  ) {
+    return null;
+  }
+  return hydration as VisibleSessionHydration;
+}
+
+export function sessionHydrationLabel(hydration: VisibleSessionHydration): string {
+  const served = hydration.servedCount;
+  const merged = hydration.mergedCount;
+  switch (hydration.phase) {
+    case "requested":
+      return "Fetching session history";
+    case "serving":
+      return served == null
+        ? merged > 0
+          ? `Fetching session history · ${merged} documents so far`
+          : "Fetching session history"
+        : `Fetching session history · ${merged} of ${served}`;
+    case "complete":
+      return served == null
+        ? "Session history loaded"
+        : `Session history loaded · ${merged} of ${served}`;
+    case "failed":
+      return "Couldn't fetch the rest of this session";
+  }
+}
+
+export function sessionHydrationNeedsRetry(
+  hydration: VisibleSessionHydration,
+): boolean {
+  return hydration.phase === "failed";
+}

--- a/apps/gents-desktop/src/styles/session-hydration.css
+++ b/apps/gents-desktop/src/styles/session-hydration.css
@@ -1,0 +1,71 @@
+@layer chat {
+  .session-hydration-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    margin: 0 var(--space-4);
+    padding: 0.45rem 0.7rem;
+    border: 1px solid var(--border-default);
+    border-left-width: 3px;
+    background: rgb(var(--color-surface-row-rgb) / 0.72);
+    color: var(--color-text-soft);
+    font-size: var(--text-sm);
+    letter-spacing: 0.01em;
+  }
+
+  .session-hydration-status.is-requested,
+  .session-hydration-status.is-serving {
+    border-left-color: var(--color-info);
+  }
+
+  .session-hydration-status.is-complete {
+    border-left-color: var(--color-accent);
+    color: var(--color-text-warm);
+  }
+
+  .session-hydration-status.is-failed {
+    border-left-color: var(--color-error-strong);
+    background: rgb(var(--color-error-deep-rgb) / 0.55);
+    color: var(--color-error-soft);
+  }
+
+  .session-hydration-copy {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-width: 0;
+  }
+
+  .session-hydration-pulse {
+    width: 0.55rem;
+    height: 0.55rem;
+    flex: 0 0 auto;
+    border-radius: 999px;
+    background: var(--color-info);
+    box-shadow: 0 0 0 0 rgb(var(--color-info-rgb) / 0.45);
+    animation: session-hydration-pulse 1.4s ease-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .session-hydration-pulse {
+      animation: none;
+    }
+  }
+
+  @keyframes session-hydration-pulse {
+    0% {
+      box-shadow: 0 0 0 0 rgb(var(--color-info-rgb) / 0.4);
+    }
+    100% {
+      box-shadow: 0 0 0 0.55rem rgb(var(--color-info-rgb) / 0);
+    }
+  }
+
+  @media (max-width: 760px) {
+    .session-hydration-status {
+      margin: 0 var(--space-3);
+      padding: 0.4rem 0.55rem;
+    }
+  }
+}

--- a/apps/gents-desktop/src/styles/session-hydration.css
+++ b/apps/gents-desktop/src/styles/session-hydration.css
@@ -43,8 +43,7 @@
     flex: 0 0 auto;
     border-radius: 999px;
     background: var(--color-info);
-    box-shadow: 0 0 0 0 rgb(var(--color-info-rgb) / 0.45);
-    animation: session-hydration-pulse 1.4s ease-out infinite;
+    animation: session-hydration-pulse var(--motion-pulse) ease-out infinite;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -54,11 +53,8 @@
   }
 
   @keyframes session-hydration-pulse {
-    0% {
-      box-shadow: 0 0 0 0 rgb(var(--color-info-rgb) / 0.4);
-    }
-    100% {
-      box-shadow: 0 0 0 0.55rem rgb(var(--color-info-rgb) / 0);
+    50% {
+      opacity: 0.2;
     }
   }
 

--- a/apps/gents-desktop/tests/desktop-session-projection.test.tsx
+++ b/apps/gents-desktop/tests/desktop-session-projection.test.tsx
@@ -51,12 +51,15 @@ function session(
   };
 }
 
-function renderProjection(api: DesktopApiAdapter) {
+function renderProjection(
+  api: DesktopApiAdapter,
+  selectedSessionIdRef: { current: string | null } = { current: "session-1" },
+) {
   return renderHook(() =>
     useDesktopSessionProjection({
       api,
       selectedAgentDidRef: { current: "did:key:test" },
-      selectedSessionIdRef: { current: "session-1" },
+      selectedSessionIdRef,
       selectedTrackedRequestIdRef: { current: "request-1" },
       setError: vi.fn(),
     }),
@@ -218,5 +221,60 @@ describe("useDesktopSessionProjection", () => {
     expect(result.current.session?.timelineItems.at(-1)).toMatchObject({
       content: "hello world",
     });
+  });
+
+  it("drops a delayed snapshot after the selected session changes", async () => {
+    let release!: (value: DesktopSessionSnapshot) => void;
+    const delayed = new Promise<DesktopSessionSnapshot>((resolve) => {
+      release = resolve;
+    });
+    const other = session(["other"], {
+      totalItems: 1,
+      totalItemsExact: true,
+      pageItems: 1,
+      hasOlder: false,
+      hasNewer: false,
+      oldestItemKey: "other",
+      newestItemKey: "other",
+    });
+    other.sessionId = "session-2";
+    const fetchSessionSnapshot = vi.fn().mockImplementation((sessionId: string) => {
+      if (sessionId === "session-1") return delayed;
+      return Promise.resolve(other);
+    });
+    const selectedSessionIdRef = { current: "session-1" };
+    const { result } = renderProjection(
+      { fetchSessionSnapshot } as unknown as DesktopApiAdapter,
+      selectedSessionIdRef,
+    );
+
+    let first: Promise<DesktopSessionSnapshot | null>;
+    await act(async () => {
+      first = result.current.refreshSession("session-1");
+    });
+    selectedSessionIdRef.current = "session-2";
+    await act(async () => {
+      await result.current.refreshSession("session-2");
+    });
+    expect(result.current.session?.sessionId).toBe("session-2");
+    expect(result.current.session?.timelineItems[0]?.itemKey).toBe("other");
+
+    const stale = session(["stale"], {
+      totalItems: 1,
+      totalItemsExact: true,
+      pageItems: 1,
+      hasOlder: false,
+      hasNewer: false,
+      oldestItemKey: "stale",
+      newestItemKey: "stale",
+    });
+    await act(async () => {
+      release(stale);
+      await first!;
+    });
+    expect(result.current.session?.sessionId).toBe("session-2");
+    expect(result.current.session?.timelineItems.map((item) => item.itemKey)).toEqual([
+      "other",
+    ]);
   });
 });

--- a/apps/gents-desktop/tests/desktop-shell-runtime.test.ts
+++ b/apps/gents-desktop/tests/desktop-shell-runtime.test.ts
@@ -33,6 +33,10 @@ describe("desktopUpdateRefreshScope", () => {
     );
     expect(desktopUpdateRefreshScope("store", "session-1", null)).toBe("full");
     expect(desktopUpdateRefreshScope("config", null, null)).toBe("full");
+    expect(desktopUpdateRefreshScope("hydration", "session-1", "request-1")).toBe(
+      "session",
+    );
+    expect(desktopUpdateRefreshScope("hydration", null, null)).toBe("snapshot");
   });
 });
 

--- a/apps/gents-desktop/tests/session-hydration-status.test.tsx
+++ b/apps/gents-desktop/tests/session-hydration-status.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SessionHydrationStatus } from "../src/components/SessionHydrationStatus";
+import { ActiveChatWorkspace } from "../src/components/ChatWorkspace";
+import type {
+  DeploymentView,
+  DesktopSessionSnapshot,
+  SessionHydrationView,
+} from "@source-inc/gents-desktop-client";
+
+function hydration(
+  overrides: Partial<SessionHydrationView> = {},
+): SessionHydrationView {
+  return {
+    sessionId: "session-1",
+    agentDid: "did:test:agent",
+    phase: "serving",
+    mergedCount: 2,
+    servedCount: 6,
+    ...overrides,
+  };
+}
+
+describe("SessionHydrationStatus", () => {
+  it("renders requested, serving counts, complete, and failed retry", async () => {
+    const { rerender } = render(
+      <SessionHydrationStatus
+        hydration={hydration({ phase: "requested", mergedCount: 0, servedCount: null })}
+        sessionId="session-1"
+      />,
+    );
+    expect(screen.getByTestId("session-hydration-status")).toHaveAttribute(
+      "data-hydration-phase",
+      "requested",
+    );
+    expect(screen.getByTestId("session-hydration-status")).toHaveTextContent(
+      "Fetching session history",
+    );
+
+    rerender(<SessionHydrationStatus hydration={hydration()} sessionId="session-1" />);
+    expect(screen.getByTestId("session-hydration-status")).toHaveTextContent(
+      "Fetching session history · 2 of 6",
+    );
+
+    rerender(
+      <SessionHydrationStatus
+        hydration={hydration({ phase: "complete", mergedCount: 6 })}
+        sessionId="session-1"
+      />,
+    );
+    expect(screen.getByTestId("session-hydration-status")).toHaveTextContent(
+      "Session history loaded · 6 of 6",
+    );
+    expect(screen.queryByTestId("session-hydration-retry")).not.toBeInTheDocument();
+
+    const onRetry = vi.fn(async () => {});
+    rerender(
+      <SessionHydrationStatus
+        hydration={hydration({ phase: "failed" })}
+        onRetry={onRetry}
+        sessionId="session-1"
+      />,
+    );
+    expect(screen.getByTestId("session-hydration-status")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    fireEvent.click(screen.getByTestId("session-hydration-retry"));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("does not render another session's hydration onto the selected session", () => {
+    render(
+      <SessionHydrationStatus
+        hydration={hydration({ sessionId: "session-2" })}
+        sessionId="session-1"
+      />,
+    );
+    expect(screen.queryByTestId("session-hydration-status")).not.toBeInTheDocument();
+  });
+});
+
+describe("ChatWorkspace hydration", () => {
+  const deployment = {
+    peerId: "peer-1",
+    label: "Local",
+    agentDid: "did:test:agent",
+    addr: "local",
+    source: "local",
+    graphql: null,
+    dialSucceeded: true,
+    pairingReady: true,
+    pairing: [],
+    chatSafe: true,
+    routes: [],
+    lastError: null,
+    defaultBehaviorId: "default",
+    agentPrincipal: { agentDid: "did:test:agent", displayName: "Local" },
+    runtime: null,
+    behaviors: [
+      { behaviorId: "default", displayName: "Default", enabled: true, isDefault: true },
+    ],
+    behaviorEnvironments: [],
+    inferenceBackends: [],
+    inferenceProfiles: [],
+    toolSelections: [],
+    toolServiceRegistries: [],
+    skills: [],
+    tasks: [],
+    schedules: [],
+    eventTriggers: [],
+    conversations: [],
+    mailboxItems: [],
+  } as unknown as DeploymentView;
+
+  it("keeps already-local transcript visible while history hydrates", () => {
+    const session = {
+      sessionId: "session-1",
+      agentDid: "did:test:agent",
+      timelineItems: [
+        {
+          kind: "userMessage",
+          itemKey: "u1",
+          requestId: "req-1",
+          content: "hello from the other device",
+        },
+      ],
+      hydration: hydration(),
+    } as unknown as DesktopSessionSnapshot;
+
+    render(
+      <ActiveChatWorkspace
+        activeRequestId={null}
+        approxSerializedBytes={0}
+        canSend
+        configuredPeerCount={1}
+        dialedPeerCount={1}
+        draft=""
+        interruptVisible={false}
+        onDraftChange={vi.fn()}
+        onRenameConversationTitle={vi.fn()}
+        onSend={vi.fn()}
+        rowCount={1}
+        runtimeHealth={null}
+        selectedBehaviorId="default"
+        selectedConversationTitle="Other device"
+        selectedDeployment={deployment}
+        selectedSessionId="session-1"
+        sending={false}
+        sendHint={null}
+        session={session}
+        turnState={null}
+      />,
+    );
+
+    expect(screen.getByTestId("session-hydration-status")).toHaveTextContent(
+      "Fetching session history · 2 of 6",
+    );
+    expect(screen.getByText("hello from the other device")).toBeInTheDocument();
+  });
+});

--- a/apps/gents-desktop/tests/session-hydration.test.ts
+++ b/apps/gents-desktop/tests/session-hydration.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionHydrationView } from "@source-inc/gents-desktop-client";
+import {
+  sessionHydrationLabel,
+  sessionHydrationNeedsRetry,
+  visibleSessionHydration,
+} from "../src/lib/sessionHydration";
+
+function hydration(
+  overrides: Partial<SessionHydrationView> = {},
+): SessionHydrationView {
+  return {
+    sessionId: "session-1",
+    agentDid: "did:test:agent",
+    phase: "serving",
+    mergedCount: 4,
+    servedCount: 11,
+    ...overrides,
+  };
+}
+
+describe("visibleSessionHydration", () => {
+  it("keeps requested, serving, complete, and failed for the selected session", () => {
+    expect(
+      visibleSessionHydration(hydration({ phase: "requested" }), "session-1")?.phase,
+    ).toBe("requested");
+    expect(visibleSessionHydration(hydration(), "session-1")?.phase).toBe("serving");
+    expect(
+      visibleSessionHydration(hydration({ phase: "complete" }), "session-1")?.phase,
+    ).toBe("complete");
+    expect(
+      visibleSessionHydration(hydration({ phase: "failed" }), "session-1")?.phase,
+    ).toBe("failed");
+  });
+
+  it("suppresses idle, empty complete, and other-session updates", () => {
+    expect(
+      visibleSessionHydration(hydration({ phase: "idle" }), "session-1"),
+    ).toBeNull();
+    expect(
+      visibleSessionHydration(
+        hydration({ phase: "complete", mergedCount: 0, servedCount: 0 }),
+        "session-1",
+      ),
+    ).toBeNull();
+    expect(visibleSessionHydration(hydration(), "session-2")).toBeNull();
+    expect(visibleSessionHydration(hydration(), "session-1", "did:other")).toBeNull();
+  });
+});
+
+describe("sessionHydrationLabel", () => {
+  it("names requested, N of M, complete, and failed states", () => {
+    expect(
+      sessionHydrationLabel(
+        hydration({ phase: "requested", mergedCount: 0, servedCount: null }),
+      ),
+    ).toBe("Fetching session history");
+    expect(sessionHydrationLabel(hydration())).toBe(
+      "Fetching session history · 4 of 11",
+    );
+    expect(
+      sessionHydrationLabel(hydration({ servedCount: null, mergedCount: 3 })),
+    ).toBe("Fetching session history · 3 documents so far");
+    expect(
+      sessionHydrationLabel(hydration({ phase: "complete", mergedCount: 11 })),
+    ).toBe("Session history loaded · 11 of 11");
+    expect(sessionHydrationLabel(hydration({ phase: "failed" }))).toBe(
+      "Couldn't fetch the rest of this session",
+    );
+    expect(sessionHydrationNeedsRetry(hydration({ phase: "failed" }))).toBe(true);
+    expect(sessionHydrationNeedsRetry(hydration())).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Wire hydration state into the selected-session shell and render already-local transcript immediately while missing history hydrates. Show requested / serving N-of-M / complete / failed without blocking unrelated chat state. Retry re-enters through the existing session snapshot path.

## Invariants / product behavior

- Local transcript rows render while hydration is still requested or serving.
- Hydration for session A cannot mutate session B's view (stale snapshot suppression + session-id/agent-did filter).
- Retry is `shell.refreshSession` → `desktop_session_snapshot` → `ClientCore::focus_session`. No second command.
- Hydration wakes originally mapped to a selected-session refresh to avoid request storms. PR 04 corrects that mapping so global `syncHealth` (on the runtime snapshot) also updates; this PR still owns the selected-session banner and identity preservation.

## Review boundary

Selected-session UX only: `SessionHydrationStatus`, `sessionHydration.ts`, ChatWorkspace banner, App retry wiring, and unit tests.

Does not close #1143 by itself. Remaining product proof (global indicator, fixture E2E, documented reductions) lands in later stack PRs.

## Stack dependency

Depends on #1249.

## Verification

- `cd apps/gents-desktop && npx vitest run tests/session-hydration.test.ts tests/session-hydration-status.test.tsx tests/desktop-shell-runtime.test.ts tests/desktop-session-projection.test.tsx`
- `cd apps/gents-desktop && npm run build`