### PR TITLE
feat(desktop): surface global sync health and diagnostics

### DIFF
--- a/apps/gents-desktop/src/App.css
+++ b/apps/gents-desktop/src/App.css
@@ -11,6 +11,7 @@
 @import "./styles/primitives/data.css";
 @import "./styles/shell.css";
 @import "./styles/session-hydration.css";
+@import "./styles/sync-health.css";
 @import "./styles/sidebar/base.css";
 @import "./styles/sidebar/connected-peer.css";
 @import "./styles/sidebar/lists.css";

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -201,6 +201,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
           deployments={shell.deployments}
           loading={shell.loading}
           p2pHealth={shell.runtimeHealth}
+          syncHealth={shell.snapshot?.client?.syncHealth ?? null}
           repairingP2P={shell.repairingP2P}
           starting={shell.starting}
           onAddPeer={shell.onAddPeer}
@@ -257,6 +258,7 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
             }}
             onRepairP2P={shell.onRepairP2P}
             repairingP2P={shell.repairingP2P}
+            syncHealth={shell.snapshot?.client?.syncHealth ?? null}
             onStartNewConversation={(behaviorId) => {
               shell.onStartNewConversation(behaviorId);
               setMobileChatPane("conversation");

--- a/apps/gents-desktop/src/components/Sidebar.tsx
+++ b/apps/gents-desktop/src/components/Sidebar.tsx
@@ -4,12 +4,14 @@ import type {
   ConversationSummary,
   DeploymentView,
   MailboxItemView,
+  SyncHealthView,
 } from "@source-inc/gents-desktop-client";
 import {
   BehaviorEnvironmentSection,
   ConnectedPeerSection,
   ConversationListSection,
 } from "./sidebar-widgets";
+import { SyncHealthIndicator } from "./SyncHealthIndicator";
 
 export type SidebarProps = {
   deployments: DeploymentView[];
@@ -29,6 +31,7 @@ export type SidebarProps = {
   onDismissMailboxItem: (itemId: string) => void;
   onRepairP2P?: () => Promise<unknown> | void;
   repairingP2P?: boolean;
+  syncHealth?: SyncHealthView | null;
 };
 
 export function Sidebar({
@@ -49,6 +52,7 @@ export function Sidebar({
   onDismissMailboxItem,
   onRepairP2P,
   repairingP2P,
+  syncHealth = null,
 }: SidebarProps) {
   const [section, setSection] = useState<"sessions" | "mailbox" | "behaviors">(
     "sessions",
@@ -71,6 +75,7 @@ export function Sidebar({
         onRepairP2P={onRepairP2P}
         repairingP2P={repairingP2P}
       />
+      <SyncHealthIndicator deployments={deployments} syncHealth={syncHealth} />
 
       <div aria-label="Agent workspace" className="agent-section-tabs" role="group">
         <button

--- a/apps/gents-desktop/src/components/SyncHealthIndicator.tsx
+++ b/apps/gents-desktop/src/components/SyncHealthIndicator.tsx
@@ -16,6 +16,7 @@ export function SyncHealthIndicator({
   syncHealth = null,
 }: SyncHealthIndicatorProps) {
   const state = syncHealthState(syncHealth);
+  if (!state) return null;
   const label = syncHealthLabel(syncHealth);
   const diagnostics = syncHealthDiagnostics(syncHealth, deployments);
   const hydration = diagnostics.hydration;

--- a/apps/gents-desktop/src/components/SyncHealthIndicator.tsx
+++ b/apps/gents-desktop/src/components/SyncHealthIndicator.tsx
@@ -1,0 +1,122 @@
+import type { DeploymentView, SyncHealthView } from "@source-inc/gents-desktop-client";
+
+import {
+  syncHealthDiagnostics,
+  syncHealthLabel,
+  syncHealthState,
+} from "../lib/syncHealth";
+
+export type SyncHealthIndicatorProps = {
+  deployments?: DeploymentView[];
+  syncHealth?: SyncHealthView | null;
+};
+
+export function SyncHealthIndicator({
+  deployments = [],
+  syncHealth = null,
+}: SyncHealthIndicatorProps) {
+  const state = syncHealthState(syncHealth);
+  const label = syncHealthLabel(syncHealth);
+  const diagnostics = syncHealthDiagnostics(syncHealth, deployments);
+  const hydration = diagnostics.hydration;
+
+  return (
+    <details
+      className={`sync-health-indicator is-${state}`}
+      data-sync-state={state}
+      data-testid="sync-health-indicator"
+    >
+      <summary
+        aria-label={`${label}. Show sync diagnostics.`}
+        data-testid="sync-health-summary"
+      >
+        <span aria-hidden="true" className="sync-health-dot" />
+        <span>{label}</span>
+      </summary>
+      <div
+        className="sync-health-details"
+        data-testid="sync-health-details"
+        role="region"
+        aria-label="Sync diagnostics"
+      >
+        <dl>
+          <div>
+            <dt>State</dt>
+            <dd>{diagnostics.state}</dd>
+          </div>
+          <div>
+            <dt>Since</dt>
+            <dd>{diagnostics.since ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>Offline since</dt>
+            <dd>{diagnostics.offlineSince ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>Stalled since</dt>
+            <dd>{diagnostics.stalledSince ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>Error class</dt>
+            <dd>{diagnostics.lastErrorClass ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>Last error</dt>
+            <dd>{diagnostics.lastError ?? "—"}</dd>
+          </div>
+          <div>
+            <dt>Pairing retries</dt>
+            <dd>{diagnostics.pairingRetryCount}</dd>
+          </div>
+          <div>
+            <dt>Route retries</dt>
+            <dd>{diagnostics.routeRetryCount}</dd>
+          </div>
+          <div>
+            <dt>Connected peers</dt>
+            <dd>{diagnostics.connectedPeerCount}</dd>
+          </div>
+          <div>
+            <dt>Hydration</dt>
+            <dd>
+              {hydration
+                ? `${hydration.phase} · ${hydration.mergedCount}${
+                    hydration.servedCount == null ? "" : ` of ${hydration.servedCount}`
+                  }${hydration.sessionId ? ` · ${hydration.sessionId}` : ""}`
+                : "—"}
+            </dd>
+          </div>
+        </dl>
+        {diagnostics.peers.length > 0 ? (
+          <ul className="sync-health-peers">
+            {diagnostics.peers.map((peer) => (
+              <li key={peer.agentDid}>
+                <strong>{peer.label}</strong>
+                <span>
+                  {peer.dialSucceeded ? "connected" : "not connected"}
+                  {peer.lastError ? ` · ${peer.lastError}` : ""}
+                </span>
+                {peer.pairing.map((pairing) => (
+                  <span key={`${peer.agentDid}:${pairing.collectionId}`}>
+                    {pairing.collectionId}: retries {pairing.pairingRetryCount}
+                    {pairing.lastRetryErrorClass
+                      ? ` · ${pairing.lastRetryErrorClass}`
+                      : ""}
+                    {pairing.stuckSince ? ` · stuck since ${pairing.stuckSince}` : ""}
+                  </span>
+                ))}
+                {peer.routes.map((route) => (
+                  <span key={route.routeId}>
+                    {route.direction}: retries {route.retryCount}
+                    {route.lastRetryErrorClass ? ` · ${route.lastRetryErrorClass}` : ""}
+                    {route.lastError ? ` · ${route.lastError}` : ""}
+                  </span>
+                ))}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </details>
+  );
+}

--- a/apps/gents-desktop/src/components/fleet/FleetHostDashboard.tsx
+++ b/apps/gents-desktop/src/components/fleet/FleetHostDashboard.tsx
@@ -15,9 +15,11 @@ import type {
   GrokLoginResult,
   GrokLoginUrl,
   InferenceProbeResult,
+  SyncHealthView,
 } from "@source-inc/gents-desktop-client";
 
 import { ThemeToggle } from "../ThemeToggle";
+import { SyncHealthIndicator } from "../SyncHealthIndicator";
 import { BrandLockup } from "./BrandLockup";
 
 export type FleetHostDashboardProps = Omit<
@@ -34,6 +36,7 @@ export type FleetHostDashboardProps = Omit<
   onCancelCodexLogin: () => Promise<unknown>;
   onGrokLogin: (agentDid: string) => Promise<GrokLoginResult>;
   onCancelGrokLogin: () => Promise<unknown>;
+  syncHealth?: SyncHealthView | null;
 };
 
 export function FleetHostDashboard({
@@ -47,12 +50,21 @@ export function FleetHostDashboard({
   onCancelCodexLogin,
   onGrokLogin,
   onCancelGrokLogin,
+  syncHealth = null,
   ...fleetProps
 }: FleetHostDashboardProps) {
+  const indicator = (
+    <SyncHealthIndicator deployments={fleetProps.deployments} syncHealth={syncHealth} />
+  );
   return (
     <FleetDashboard
       {...fleetProps}
-      brand={<BrandLockup />}
+      brand={
+        <div className="fleet-brand-row">
+          <BrandLockup />
+          {fleetProps.deployments.length === 0 ? indicator : null}
+        </div>
+      }
       copy={{
         ...fleetProps.copy,
         pairingQrHint: fleetProps.copy?.pairingQrHint ?? (
@@ -62,7 +74,12 @@ export function FleetHostDashboard({
           </>
         ),
       }}
-      headerLeadingActions={<ThemeToggle />}
+      headerLeadingActions={
+        <>
+          {fleetProps.deployments.length > 0 ? indicator : null}
+          <ThemeToggle />
+        </>
+      }
       localRuntimeSetup={
         <LocalRuntimeConnect
           bootstrap={fleetProps.bootstrap}

--- a/apps/gents-desktop/src/lib/syncHealth.ts
+++ b/apps/gents-desktop/src/lib/syncHealth.ts
@@ -1,0 +1,110 @@
+import type { DeploymentView, SyncHealthView } from "@source-inc/gents-desktop-client";
+
+export type SyncHealthStateName =
+  "healthy" | "syncing" | "stalled" | "offline" | "failed";
+
+const STATE_LABEL: Record<SyncHealthStateName, string> = {
+  healthy: "Sync healthy",
+  syncing: "Syncing",
+  stalled: "Sync stalled",
+  offline: "Offline",
+  failed: "Sync failed",
+};
+
+export function syncHealthState(
+  syncHealth: SyncHealthView | null | undefined,
+): SyncHealthStateName {
+  switch (syncHealth?.state) {
+    case "syncing":
+    case "stalled":
+    case "offline":
+    case "failed":
+      return syncHealth.state;
+    default:
+      return "healthy";
+  }
+}
+
+export function syncHealthLabel(
+  syncHealth: SyncHealthView | null | undefined,
+  now = Date.now(),
+): string {
+  const state = syncHealthState(syncHealth);
+  if (state === "offline") {
+    const since = formatElapsedSince(
+      syncHealth?.offlineSince ?? syncHealth?.since,
+      now,
+    );
+    return since ? `Offline since ${since}` : STATE_LABEL.offline;
+  }
+  if (state === "stalled") {
+    const since = formatElapsedSince(
+      syncHealth?.stalledSince ?? syncHealth?.since,
+      now,
+    );
+    return since ? `Sync stalled since ${since}` : STATE_LABEL.stalled;
+  }
+  if (state === "syncing") {
+    const hydration = syncHealth?.hydration;
+    if (
+      hydration &&
+      (hydration.phase === "requested" || hydration.phase === "serving") &&
+      hydration.servedCount != null
+    ) {
+      return `Syncing · ${hydration.mergedCount} of ${hydration.servedCount}`;
+    }
+  }
+  return STATE_LABEL[state];
+}
+
+export function formatElapsedSince(
+  iso: string | null | undefined,
+  now = Date.now(),
+): string | null {
+  if (!iso) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return iso;
+  const elapsedMs = Math.max(0, now - then);
+  const seconds = Math.floor(elapsedMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function syncHealthDiagnostics(
+  syncHealth: SyncHealthView | null | undefined,
+  deployments: DeploymentView[],
+) {
+  const hydration = syncHealth?.hydration;
+  return {
+    state: syncHealthState(syncHealth),
+    since: syncHealth?.since ?? null,
+    offlineSince: syncHealth?.offlineSince ?? null,
+    stalledSince: syncHealth?.stalledSince ?? null,
+    lastErrorClass: syncHealth?.lastErrorClass ?? null,
+    lastError: syncHealth?.lastError ?? null,
+    pairingRetryCount: syncHealth?.pairingRetryCount ?? 0,
+    routeRetryCount: syncHealth?.routeRetryCount ?? 0,
+    connectedPeerCount: syncHealth?.connectedPeerCount ?? 0,
+    hydration: hydration
+      ? {
+          sessionId: hydration.sessionId,
+          phase: hydration.phase,
+          mergedCount: hydration.mergedCount,
+          servedCount: hydration.servedCount,
+        }
+      : null,
+    peers: deployments.map((deployment) => ({
+      label: deployment.label,
+      agentDid: deployment.agentDid,
+      dialSucceeded: deployment.dialSucceeded,
+      lastError: deployment.lastError ?? null,
+      pairing: deployment.pairing ?? [],
+      routes: deployment.routes ?? [],
+    })),
+  };
+}

--- a/apps/gents-desktop/src/lib/syncHealth.ts
+++ b/apps/gents-desktop/src/lib/syncHealth.ts
@@ -13,15 +13,16 @@ const STATE_LABEL: Record<SyncHealthStateName, string> = {
 
 export function syncHealthState(
   syncHealth: SyncHealthView | null | undefined,
-): SyncHealthStateName {
+): SyncHealthStateName | null {
   switch (syncHealth?.state) {
+    case "healthy":
     case "syncing":
     case "stalled":
     case "offline":
     case "failed":
       return syncHealth.state;
     default:
-      return "healthy";
+      return null;
   }
 }
 
@@ -30,6 +31,7 @@ export function syncHealthLabel(
   now = Date.now(),
 ): string {
   const state = syncHealthState(syncHealth);
+  if (!state) return "Sync unavailable";
   if (state === "offline") {
     const since = formatElapsedSince(
       syncHealth?.offlineSince ?? syncHealth?.since,

--- a/apps/gents-desktop/src/styles/sync-health.css
+++ b/apps/gents-desktop/src/styles/sync-health.css
@@ -1,0 +1,127 @@
+@layer components {
+  .fleet-brand-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .sidebar .sync-health-indicator {
+    margin: 0 var(--space-4) var(--space-3);
+  }
+
+  .sync-health-indicator {
+    position: relative;
+    font-size: var(--text-sm);
+    color: var(--color-text-soft);
+  }
+
+  .sync-health-indicator > summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    min-height: 30px;
+    padding: 0 0.65rem;
+    border: 1px solid var(--border-default);
+    background: rgb(var(--color-surface-row-rgb) / 0.88);
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .sync-health-indicator > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .sync-health-indicator > summary:focus-visible {
+    outline: 2px solid rgb(var(--source-green-rgb) / 0.36);
+    outline-offset: 2px;
+  }
+
+  .sync-health-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: var(--color-accent);
+    flex: 0 0 auto;
+  }
+
+  .sync-health-indicator.is-syncing .sync-health-dot {
+    background: var(--color-info);
+  }
+
+  .sync-health-indicator.is-stalled .sync-health-dot {
+    background: var(--color-warning);
+  }
+
+  .sync-health-indicator.is-offline .sync-health-dot,
+  .sync-health-indicator.is-failed .sync-health-dot {
+    background: var(--color-error-strong);
+  }
+
+  .sync-health-indicator.is-failed > summary,
+  .sync-health-indicator.is-stalled > summary,
+  .sync-health-indicator.is-offline > summary {
+    border-color: rgb(var(--color-error-strong-rgb) / 0.35);
+  }
+
+  .sync-health-indicator.is-stalled > summary {
+    border-color: rgb(var(--color-warning-rgb) / 0.4);
+  }
+
+  .sync-health-details {
+    position: absolute;
+    right: 0;
+    z-index: 30;
+    margin-top: 0.35rem;
+    width: min(28rem, calc(100vw - 1.5rem));
+    padding: 0.75rem 0.85rem;
+    border: 1px solid var(--border-strong);
+    background: var(--color-surface-strong);
+    color: var(--color-text);
+    box-shadow: 0 12px 32px rgb(var(--scrim-rgb) / 0.35);
+  }
+
+  .sync-health-details dl {
+    display: grid;
+    gap: 0.35rem 0.75rem;
+    margin: 0;
+    grid-template-columns: max-content 1fr;
+  }
+
+  .sync-health-details dt {
+    color: var(--color-text-muted);
+    font-weight: 600;
+  }
+
+  .sync-health-details dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .sync-health-peers {
+    display: grid;
+    gap: 0.45rem;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .sync-health-peers li {
+    display: grid;
+    gap: 0.15rem;
+  }
+
+  .sync-health-peers span {
+    color: var(--color-text-muted);
+    font-size: var(--text-sm);
+  }
+
+  @media (max-width: 760px) {
+    .sync-health-details {
+      left: auto;
+      right: 0;
+      width: min(100vw - 1rem, 22rem);
+    }
+  }
+}

--- a/apps/gents-desktop/src/styles/sync-health.css
+++ b/apps/gents-desktop/src/styles/sync-health.css
@@ -79,7 +79,6 @@
     border: 1px solid var(--border-strong);
     background: var(--color-surface-strong);
     color: var(--color-text);
-    box-shadow: 0 12px 32px rgb(var(--scrim-rgb) / 0.35);
   }
 
   .sync-health-details dl {

--- a/apps/gents-desktop/tests/playwright/desktop-sidebar.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-sidebar.spec.ts
@@ -13,8 +13,10 @@ test.describe("desktop sidebar workflows", () => {
     page,
   }) => {
     await gotoHarness(page);
+    await expect(page.getByTestId("sync-health-indicator")).toBeVisible();
     await openChat(page);
     await openChatNavigation(page);
+    await expect(page.getByTestId("sync-health-indicator")).toBeVisible();
 
     const connectedPeer = page.locator(".connected-peer-card");
     await expect(connectedPeer).toContainText("Bombadil UI Agent");

--- a/apps/gents-desktop/tests/sync-health-indicator.test.tsx
+++ b/apps/gents-desktop/tests/sync-health-indicator.test.tsx
@@ -27,6 +27,14 @@ function health(overrides: Partial<SyncHealthView> = {}): SyncHealthView {
 }
 
 describe("SyncHealthIndicator", () => {
+  it("does not claim health before a known projection exists", () => {
+    const { rerender } = render(<SyncHealthIndicator syncHealth={null} />);
+    expect(screen.queryByTestId("sync-health-indicator")).not.toBeInTheDocument();
+
+    rerender(<SyncHealthIndicator syncHealth={health({ state: "future-state" })} />);
+    expect(screen.queryByTestId("sync-health-indicator")).not.toBeInTheDocument();
+  });
+
   it("renders each product state and opens diagnostics", () => {
     const { rerender } = render(<SyncHealthIndicator syncHealth={health()} />);
     expect(screen.getByTestId("sync-health-indicator")).toHaveAttribute(

--- a/apps/gents-desktop/tests/sync-health-indicator.test.tsx
+++ b/apps/gents-desktop/tests/sync-health-indicator.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SyncHealthIndicator } from "../src/components/SyncHealthIndicator";
+import type { SyncHealthView } from "@source-inc/gents-desktop-client";
+
+function health(overrides: Partial<SyncHealthView> = {}): SyncHealthView {
+  return {
+    state: "healthy",
+    since: null,
+    offlineSince: null,
+    stalledSince: null,
+    lastErrorClass: null,
+    lastError: null,
+    pairingRetryCount: 0,
+    routeRetryCount: 0,
+    connectedPeerCount: 1,
+    hydration: {
+      sessionId: "session-1",
+      agentDid: "did:test:agent",
+      phase: "idle",
+      mergedCount: 0,
+      servedCount: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("SyncHealthIndicator", () => {
+  it("renders each product state and opens diagnostics", () => {
+    const { rerender } = render(<SyncHealthIndicator syncHealth={health()} />);
+    expect(screen.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "healthy",
+    );
+    expect(screen.getByTestId("sync-health-summary")).toHaveTextContent("Sync healthy");
+
+    rerender(<SyncHealthIndicator syncHealth={health({ state: "syncing" })} />);
+    expect(screen.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "syncing",
+    );
+
+    rerender(<SyncHealthIndicator syncHealth={health({ state: "stalled" })} />);
+    expect(screen.getByTestId("sync-health-summary")).toHaveTextContent("Sync stalled");
+
+    rerender(
+      <SyncHealthIndicator
+        syncHealth={health({
+          state: "offline",
+          offlineSince: "2020-01-01T00:00:00Z",
+        })}
+      />,
+    );
+    expect(screen.getByTestId("sync-health-summary")).toHaveTextContent(
+      "Offline since",
+    );
+
+    rerender(
+      <SyncHealthIndicator
+        deployments={[
+          {
+            label: "Studio",
+            agentDid: "did:test:agent",
+            dialSucceeded: false,
+            lastError: "unauthorized",
+            pairing: [
+              {
+                collectionId: "AgentSession",
+                pairingRetryCount: 1,
+                lastRetryAt: null,
+                lastRetryErrorClass: "RemoteUnauthorized",
+                stuckSince: null,
+              },
+            ],
+            routes: [],
+          } as never,
+        ]}
+        syncHealth={health({
+          state: "failed",
+          lastErrorClass: "RemoteUnauthorized",
+          lastError: "unauthorized",
+        })}
+      />,
+    );
+    expect(screen.getByTestId("sync-health-summary")).toHaveTextContent("Sync failed");
+    fireEvent.click(screen.getByTestId("sync-health-summary"));
+    expect(screen.getByTestId("sync-health-details")).toHaveTextContent(
+      "RemoteUnauthorized",
+    );
+    expect(screen.getByTestId("sync-health-details")).toHaveTextContent("AgentSession");
+    expect(screen.getByTestId("sync-health-details")).toHaveTextContent("unauthorized");
+  });
+});

--- a/apps/gents-desktop/tests/sync-health.test.ts
+++ b/apps/gents-desktop/tests/sync-health.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import type { SyncHealthView } from "@source-inc/gents-desktop-client";
+import {
+  formatElapsedSince,
+  syncHealthDiagnostics,
+  syncHealthLabel,
+  syncHealthState,
+} from "../src/lib/syncHealth";
+
+function health(overrides: Partial<SyncHealthView> = {}): SyncHealthView {
+  return {
+    state: "healthy",
+    since: null,
+    offlineSince: null,
+    stalledSince: null,
+    lastErrorClass: null,
+    lastError: null,
+    pairingRetryCount: 0,
+    routeRetryCount: 0,
+    connectedPeerCount: 1,
+    hydration: {
+      sessionId: "session-1",
+      agentDid: "did:test:agent",
+      phase: "idle",
+      mergedCount: 0,
+      servedCount: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("syncHealthLabel", () => {
+  it("names healthy, syncing, stalled, offline-since, and failed", () => {
+    const now = Date.parse("2026-08-27T12:00:00Z");
+    expect(syncHealthLabel(health(), now)).toBe("Sync healthy");
+    expect(
+      syncHealthLabel(
+        health({
+          state: "syncing",
+          hydration: {
+            sessionId: "session-1",
+            agentDid: "did:test:agent",
+            phase: "serving",
+            mergedCount: 3,
+            servedCount: 9,
+          },
+        }),
+        now,
+      ),
+    ).toBe("Syncing · 3 of 9");
+    expect(
+      syncHealthLabel(
+        health({
+          state: "stalled",
+          stalledSince: "2026-08-27T11:50:00Z",
+        }),
+        now,
+      ),
+    ).toBe("Sync stalled since 10m ago");
+    expect(
+      syncHealthLabel(
+        health({
+          state: "offline",
+          offlineSince: "2026-08-27T10:00:00Z",
+        }),
+        now,
+      ),
+    ).toBe("Offline since 2h ago");
+    expect(syncHealthLabel(health({ state: "failed" }), now)).toBe("Sync failed");
+    expect(syncHealthState(null)).toBe("healthy");
+    expect(formatElapsedSince("2026-08-27T11:59:20Z", now)).toBe("40s ago");
+  });
+});
+
+describe("syncHealthDiagnostics", () => {
+  it("exposes pairing, route, error-class, stuck-since, and hydration counters", () => {
+    const diagnostics = syncHealthDiagnostics(
+      health({
+        state: "stalled",
+        lastErrorClass: "RpcTimeout",
+        lastError: "timeout",
+        pairingRetryCount: 6,
+        stalledSince: "2026-08-27T11:00:00Z",
+      }),
+      [
+        {
+          label: "Studio",
+          agentDid: "did:test:agent",
+          dialSucceeded: true,
+          lastError: null,
+          pairing: [
+            {
+              collectionId: "AgentSession",
+              pairingRetryCount: 6,
+              lastRetryAt: "2026-08-27T11:00:00Z",
+              lastRetryErrorClass: "RpcTimeout",
+              stuckSince: "2026-08-27T11:00:00Z",
+            },
+          ],
+          routes: [
+            {
+              routeId: "r1",
+              direction: "client-to-runtime",
+              directoryId: "peer-1",
+              transportPeerId: null,
+              address: null,
+              template: "machine",
+              desired: true,
+              applied: false,
+              liveMatch: false,
+              filterSummary: "machine",
+              lastError: "timeout",
+              retryCount: 2,
+              lastRetryAt: "2026-08-27T11:00:00Z",
+              lastRetryErrorClass: "RpcTimeout",
+            },
+          ],
+        } as never,
+      ],
+    );
+    expect(diagnostics.state).toBe("stalled");
+    expect(diagnostics.lastErrorClass).toBe("RpcTimeout");
+    expect(diagnostics.pairingRetryCount).toBe(6);
+    expect(diagnostics.peers[0]?.pairing[0]?.stuckSince).toBe("2026-08-27T11:00:00Z");
+    expect(diagnostics.peers[0]?.routes[0]?.retryCount).toBe(2);
+  });
+});

--- a/apps/gents-desktop/tests/sync-health.test.ts
+++ b/apps/gents-desktop/tests/sync-health.test.ts
@@ -68,7 +68,8 @@ describe("syncHealthLabel", () => {
       ),
     ).toBe("Offline since 2h ago");
     expect(syncHealthLabel(health({ state: "failed" }), now)).toBe("Sync failed");
-    expect(syncHealthState(null)).toBe("healthy");
+    expect(syncHealthState(null)).toBeNull();
+    expect(syncHealthState(health({ state: "future-state" }))).toBeNull();
     expect(formatElapsedSince("2026-08-27T11:59:20Z", now)).toBe("40s ago");
   });
 });


### PR DESCRIPTION
## Summary

Add a self-contained global sync indicator based on the derived `SyncHealthView`. It distinguishes healthy, syncing, stalled, offline-since, and terminal failure, and opens a diagnostics panel with pairing retries, route retries, error class, stuck-since, connected peers, and hydration counters.

## Invariants / product behavior

- The indicator is independent of #1153 navigation work. It is wired into the current-main Fleet header and Sidebar with mechanical prop passing only.
- Stalled and failed never render as an endless spinner.
- Compact/mobile layout keeps the summary usable; diagnostics are in a details region with an accessible label.
- No new sync cache. The view is `shell.snapshot?.client?.syncHealth`.

## Review boundary

Global indicator and diagnostics UI only (`SyncHealthIndicator`, `syncHealth.ts`, `styles/sync-health.css`, Fleet/Sidebar wiring, unit tests, sidebar Playwright assertion).

Does not close #1144 by itself. Fixture E2E and issue closeout land in PR 04.

## Stack dependency

Depends on #1250.

## Verification

- `cd apps/gents-desktop && npx vitest run tests/sync-health.test.ts tests/sync-health-indicator.test.tsx`
- Playwright `tests/playwright/desktop-sidebar.spec.ts` asserts the indicator is visible on fleet and chat
- `cd apps/gents-desktop && npm run build`