### PR TITLE
test(desktop): qualify mobile session sync end to end

### DIFF
--- a/apps/gents-desktop/src/hooks/desktopShellRuntime.ts
+++ b/apps/gents-desktop/src/hooks/desktopShellRuntime.ts
@@ -72,7 +72,8 @@ export function desktopUpdateRefreshScope(
   responseOnly = false,
 ): DesktopUpdateRefreshScope {
   if (reason === "health") return "snapshot";
-  if (reason === "hydration") return selectedSessionId ? "session" : "snapshot";
+  // Hydration progress also drives global syncHealth on the runtime snapshot.
+  if (reason === "hydration") return selectedSessionId ? "full" : "snapshot";
   if (selectedSessionId && selectedTrackedRequestId) {
     if (reason === "store" && responseOnly) return "sessionDelta";
     return "sessionEvent";

--- a/apps/gents-desktop/tests/desktop-shell-runtime.test.ts
+++ b/apps/gents-desktop/tests/desktop-shell-runtime.test.ts
@@ -34,7 +34,7 @@ describe("desktopUpdateRefreshScope", () => {
     expect(desktopUpdateRefreshScope("store", "session-1", null)).toBe("full");
     expect(desktopUpdateRefreshScope("config", null, null)).toBe("full");
     expect(desktopUpdateRefreshScope("hydration", "session-1", "request-1")).toBe(
-      "session",
+      "full",
     );
     expect(desktopUpdateRefreshScope("hydration", null, null)).toBe("snapshot");
   });

--- a/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
@@ -1,0 +1,109 @@
+import { expect, gotoHarness, openChat, openChatNavigation, test } from "./desktopTest";
+
+test.describe("mobile session sync fixture", () => {
+  test("opens a pre-existing session and hydrates history without blocking local rows", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "session-hydration");
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "syncing",
+    );
+    await openChat(page);
+    await openChatNavigation(page);
+    await page.getByTestId("conversation-session-remote").click();
+    await expect(
+      page.getByTestId("transcript-panel").getByText("hello from desktop"),
+    ).toBeVisible();
+    await expect(page.getByTestId("session-hydration-status")).toHaveAttribute(
+      "data-hydration-phase",
+      "requested",
+    );
+
+    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.progress(2, 4));
+    await expect(page.getByTestId("session-hydration-status")).toHaveText(/2 of 4/);
+    await expect(
+      page
+        .getByTestId("transcript-panel")
+        .getByText("history arrived from the desktop"),
+    ).toBeVisible();
+
+    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.complete());
+    await expect(page.getByTestId("session-hydration-status")).toHaveAttribute(
+      "data-hydration-phase",
+      "complete",
+    );
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "healthy",
+    );
+  });
+
+  test("failed hydration retries through the existing session snapshot path", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "session-hydration");
+    await openChat(page);
+    await openChatNavigation(page);
+    await page.getByTestId("conversation-session-remote").click();
+    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.fail());
+    await expect(page.getByTestId("session-hydration-status")).toHaveAttribute(
+      "data-hydration-phase",
+      "failed",
+    );
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "failed",
+    );
+    await page.getByTestId("session-hydration-retry").click();
+    await expect(page.getByTestId("session-hydration-status")).toHaveAttribute(
+      "data-hydration-phase",
+      "requested",
+    );
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "syncing",
+    );
+  });
+
+  test("global indicator distinguishes offline, stalled, and failed", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "sync-offline");
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "offline",
+    );
+    await expect(page.getByTestId("sync-health-summary")).toContainText(
+      "Offline since",
+    );
+
+    await gotoHarness(page, "sync-stalled");
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "stalled",
+    );
+    await page.getByTestId("sync-health-summary").click();
+    await expect(page.getByTestId("sync-health-details")).toContainText("RpcTimeout");
+
+    await gotoHarness(page, "sync-failed");
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "failed",
+    );
+  });
+
+  test("offline recovers through the existing reconnect control", async ({ page }) => {
+    await gotoHarness(page, "session-hydration");
+    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.goOffline());
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "offline",
+    );
+    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.recover());
+    await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
+      "data-sync-state",
+      "syncing",
+    );
+  });
+});

--- a/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
@@ -33,6 +33,7 @@ test.describe("mobile session sync fixture", () => {
       "data-hydration-phase",
       "complete",
     );
+    await expect(page.getByTestId("session-hydration-status")).toContainText("4 of 4");
     await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
       "data-sync-state",
       "healthy",
@@ -94,16 +95,15 @@ test.describe("mobile session sync fixture", () => {
   });
 
   test("offline recovers through the existing reconnect control", async ({ page }) => {
-    await gotoHarness(page, "session-hydration");
-    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.goOffline());
+    await gotoHarness(page, "sync-offline");
     await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
       "data-sync-state",
       "offline",
     );
-    await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.recover());
+    await page.getByTestId("fleet-repair-p2p").click();
     await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
       "data-sync-state",
-      "syncing",
+      "healthy",
     );
   });
 });

--- a/apps/gents-desktop/tests/playwright/desktopTest.ts
+++ b/apps/gents-desktop/tests/playwright/desktopTest.ts
@@ -10,7 +10,11 @@ export type HarnessScenario =
   | "long-content"
   | "active-turn"
   | "cascade-turn"
-  | "coding";
+  | "coding"
+  | "session-hydration"
+  | "sync-offline"
+  | "sync-stalled"
+  | "sync-failed";
 
 export const PEER_ID = "peer-bombadil-local";
 

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -362,16 +362,18 @@ export function createDesktopUiHarness(
   }
   syncConversations();
 
-  window.addEventListener(
-    "click",
-    (event) => {
-      const target = event.target as HTMLElement | null;
-      if (target?.closest("[data-testid='session-hydration-retry']")) {
-        hydrationRedrive = true;
-      }
-    },
-    true,
-  );
+  if (typeof window !== "undefined") {
+    window.addEventListener(
+      "click",
+      (event) => {
+        const target = event.target as HTMLElement | null;
+        if (target?.closest("[data-testid='session-hydration-retry']")) {
+          hydrationRedrive = true;
+        }
+      },
+      true,
+    );
+  }
 
   function notify(reason: string, responseOnly = false) {
     updateEvents += 1;

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -90,9 +90,6 @@ export type SessionSyncHarnessController = {
   progress(mergedCount: number, servedCount: number): void;
   complete(): void;
   fail(): void;
-  goOffline(): void;
-  recover(): void;
-  stall(): void;
 };
 
 type DesktopUiHarness = {
@@ -854,7 +851,21 @@ export function createDesktopUiHarness(
       };
     },
     async repairP2P() {
-      notify("runtime");
+      p2pStatus = "healthy";
+      const hydrationPhase = syncHealth.hydration?.phase;
+      syncHealth = {
+        ...syncHealth,
+        state:
+          hydrationPhase === "failed"
+            ? "failed"
+            : hydrationPhase === "requested" || hydrationPhase === "serving"
+              ? "syncing"
+              : "healthy",
+        offlineSince: null,
+        stalledSince: null,
+        connectedPeerCount: 1,
+        lastError: null,
+      };
       return snapshot();
     },
     async fetchSessionSnapshot(_sessionId, _agentDid, _requestId, timelinePage) {
@@ -1688,8 +1699,9 @@ export function createDesktopUiHarness(
     complete() {
       const session = sessions.get("session-remote");
       if (!session) return;
-      const mergedCount = Math.max(session.timelineItems.length, 2);
-      const hydration = remoteHydration("complete", mergedCount, mergedCount);
+      const servedCount =
+        session.hydration?.servedCount ?? Math.max(session.timelineItems.length, 2);
+      const hydration = remoteHydration("complete", servedCount, servedCount);
       sessions.set("session-remote", { ...session, hydration });
       syncHealth = { ...syncHealth, state: "healthy", hydration };
       notify("hydration");
@@ -1711,44 +1723,6 @@ export function createDesktopUiHarness(
         hydration,
       };
       notify("hydration");
-    },
-    goOffline() {
-      p2pStatus = "wedged";
-      syncHealth = {
-        ...syncHealth,
-        state: "offline",
-        offlineSince: STARTED_AT,
-        connectedPeerCount: 0,
-      };
-      notify("health");
-    },
-    recover() {
-      p2pStatus = "healthy";
-      const hydrationPhase = syncHealth.hydration?.phase;
-      syncHealth = {
-        ...syncHealth,
-        state:
-          hydrationPhase === "failed"
-            ? "failed"
-            : hydrationPhase === "requested" || hydrationPhase === "serving"
-              ? "syncing"
-              : "healthy",
-        offlineSince: null,
-        stalledSince: null,
-        connectedPeerCount: 1,
-        lastError: null,
-      };
-      notify("health");
-    },
-    stall() {
-      syncHealth = {
-        ...syncHealth,
-        state: "stalled",
-        stalledSince: STARTED_AT,
-        lastErrorClass: "RpcTimeout",
-        pairingRetryCount: 6,
-      };
-      notify("health");
     },
   };
 

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -18,6 +18,7 @@ import type {
   McpServiceProbeResult,
   PeerAddRequest,
   SubagentTreeView,
+  SyncHealthView,
   TaskRunResult,
   ToolServiceTestResult,
 } from "@source-inc/gents-desktop-client";
@@ -43,7 +44,11 @@ export type DesktopUiHarnessScenario =
   | "active-turn"
   | "cascade-turn"
   | "coding"
-  | "mobile-performance";
+  | "mobile-performance"
+  | "session-hydration"
+  | "sync-offline"
+  | "sync-stalled"
+  | "sync-failed";
 
 export type DesktopUiHarnessOptions = {
   scenario?: string | null;
@@ -81,11 +86,21 @@ export type MobilePerformanceHarnessController = {
   setP2PStatus(status: "healthy" | "degraded" | "wedged"): void;
 };
 
+export type SessionSyncHarnessController = {
+  progress(mergedCount: number, servedCount: number): void;
+  complete(): void;
+  fail(): void;
+  goOffline(): void;
+  recover(): void;
+  stall(): void;
+};
+
 type DesktopUiHarness = {
   adapter: DesktopApiAdapter;
   listenerFactory: DesktopClientUpdatedListenerFactory;
   scenario: DesktopUiHarnessScenario;
   performance: MobilePerformanceHarnessController | null;
+  sessionSync: SessionSyncHarnessController;
 };
 
 export const MOBILE_PERFORMANCE_FIXTURE = {
@@ -119,11 +134,14 @@ export function createDesktopUiHarness(
   let rowCount = 42;
   let deployment = createDeployment();
   let removed = false;
-  let p2pStatus: "healthy" | "degraded" | "wedged" = "healthy";
+  let p2pStatus: "healthy" | "degraded" | "wedged" =
+    scenario === "sync-offline" ? "wedged" : "healthy";
+  let syncHealth: SyncHealthView = initialSyncHealth(scenario);
   let updateEvents = 0;
   let storeVersion = 1;
   let reconcileVersion = 1;
   let streamSequence = 0;
+  let hydrationRedrive = false;
   let bridgeCalls: MobilePerformanceBridgeCall[] = [];
   let commits: MobilePerformanceCommit[] = [];
 
@@ -284,6 +302,39 @@ export function createDesktopUiHarness(
         : []),
     ],
   });
+  if (scenario === "session-hydration") {
+    sessions.set("session-remote", {
+      sessionId: "session-remote",
+      agentDid: AGENT_DID,
+      behaviorId: DEFAULT_BEHAVIOR_ID,
+      title: "Desktop-started session",
+      createdAt: THIRTY_DAYS_AGO,
+      updatedAt: TWO_HOURS_AGO,
+      previewText: "hello from desktop",
+      status: "completed",
+      turnState: "completed",
+      latestRequestId: "request-remote",
+      latestResponse: null,
+      pendingTurn: null,
+      activeResponseOverlay: null,
+      timelineItems: [
+        {
+          kind: "userMessage",
+          itemKey: "remote-user",
+          sequence: 1,
+          content: "hello from desktop",
+          timestamp: THIRTY_DAYS_AGO,
+        },
+      ],
+      hydration: {
+        sessionId: "session-remote",
+        agentDid: AGENT_DID,
+        phase: "requested",
+        mergedCount: 1,
+        servedCount: null,
+      },
+    });
+  }
   if (scenario === "mobile-performance") {
     sessions.set("session-large", createLargePerformanceSession());
     for (
@@ -310,6 +361,17 @@ export function createDesktopUiHarness(
       MOBILE_PERFORMANCE_FIXTURE.shortSessionTimelineItems;
   }
   syncConversations();
+
+  window.addEventListener(
+    "click",
+    (event) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.closest("[data-testid='session-hydration-retry']")) {
+        hydrationRedrive = true;
+      }
+    },
+    true,
+  );
 
   function notify(reason: string, responseOnly = false) {
     updateEvents += 1;
@@ -423,6 +485,7 @@ export function createDesktopUiHarness(
         localPeerId: "peer-bombadil-local",
         listenAddresses: ["/ip4/127.0.0.1/tcp/9292"],
         p2pHealth: health,
+        syncHealth,
         bootstrapErrors: [],
         lastMutationError: null,
         focusedRequestId: null,
@@ -798,6 +861,24 @@ export function createDesktopUiHarness(
       if (!session) return null;
       const snapshot = clone(session);
       snapshot.projectionRevision = { storeVersion, reconcileVersion };
+      if (snapshot.hydration?.phase === "failed" && hydrationRedrive) {
+        hydrationRedrive = false;
+        snapshot.hydration = {
+          ...snapshot.hydration,
+          phase: "requested",
+          mergedCount: snapshot.timelineItems.length,
+          servedCount: null,
+        };
+        sessions.set(sessionId, clone(snapshot));
+        syncHealth = {
+          ...syncHealth,
+          state: "syncing",
+          lastErrorClass: null,
+          lastError: null,
+          hydration: snapshot.hydration,
+        };
+        notify("hydration");
+      }
       if (!timelinePage) return snapshot;
 
       const totalItems = snapshot.timelineItems.length;
@@ -1556,7 +1637,126 @@ export function createDesktopUiHarness(
       })
     : adapter;
 
-  return { adapter: measuredAdapter, listenerFactory, scenario, performance };
+  function remoteHydration(
+    phase: NonNullable<DesktopSessionSnapshot["hydration"]>["phase"],
+    mergedCount: number,
+    servedCount: number | null,
+  ) {
+    return {
+      sessionId: "session-remote",
+      agentDid: AGENT_DID,
+      phase,
+      mergedCount,
+      servedCount,
+    };
+  }
+
+  const sessionSync: SessionSyncHarnessController = {
+    progress(mergedCount, servedCount) {
+      const session = sessions.get("session-remote");
+      if (!session) return;
+      const timelineItems = [...session.timelineItems];
+      if (
+        mergedCount >= 2 &&
+        !timelineItems.some((item) => item.itemKey === "remote-assistant")
+      ) {
+        timelineItems.push({
+          kind: "assistantMessage",
+          itemKey: "remote-assistant",
+          sequence: 2,
+          content: "history arrived from the desktop",
+          timestamp: TWO_HOURS_AGO,
+        });
+      }
+      sessions.set("session-remote", {
+        ...session,
+        previewText: timelineItems.at(-1)?.content ?? session.previewText,
+        timelineItems,
+        hydration: remoteHydration("serving", mergedCount, servedCount),
+      });
+      syncHealth = {
+        ...syncHealth,
+        state: "syncing",
+        hydration: remoteHydration("serving", mergedCount, servedCount),
+      };
+      syncConversations();
+      notify("hydration");
+      notify("store");
+    },
+    complete() {
+      const session = sessions.get("session-remote");
+      if (!session) return;
+      const mergedCount = Math.max(session.timelineItems.length, 2);
+      const hydration = remoteHydration("complete", mergedCount, mergedCount);
+      sessions.set("session-remote", { ...session, hydration });
+      syncHealth = { ...syncHealth, state: "healthy", hydration };
+      notify("hydration");
+    },
+    fail() {
+      const session = sessions.get("session-remote");
+      if (!session) return;
+      const hydration = remoteHydration(
+        "failed",
+        session.timelineItems.length,
+        session.hydration?.servedCount ?? null,
+      );
+      sessions.set("session-remote", { ...session, hydration });
+      syncHealth = {
+        ...syncHealth,
+        state: "failed",
+        lastErrorClass: "RemoteUnauthorized",
+        lastError: "hydration rejected",
+        hydration,
+      };
+      notify("hydration");
+    },
+    goOffline() {
+      p2pStatus = "wedged";
+      syncHealth = {
+        ...syncHealth,
+        state: "offline",
+        offlineSince: STARTED_AT,
+        connectedPeerCount: 0,
+      };
+      notify("health");
+    },
+    recover() {
+      p2pStatus = "healthy";
+      const hydrationPhase = syncHealth.hydration?.phase;
+      syncHealth = {
+        ...syncHealth,
+        state:
+          hydrationPhase === "failed"
+            ? "failed"
+            : hydrationPhase === "requested" || hydrationPhase === "serving"
+              ? "syncing"
+              : "healthy",
+        offlineSince: null,
+        stalledSince: null,
+        connectedPeerCount: 1,
+        lastError: null,
+      };
+      notify("health");
+    },
+    stall() {
+      syncHealth = {
+        ...syncHealth,
+        state: "stalled",
+        stalledSince: STARTED_AT,
+        lastErrorClass: "RpcTimeout",
+        pairingRetryCount: 6,
+      };
+      notify("health");
+    },
+  };
+
+  return {
+    adapter: measuredAdapter,
+    listenerFactory,
+    scenario,
+    performance,
+    sessionSync,
+  };
 }
 
 function createLargePerformanceSession(): DesktopSessionSnapshot {
@@ -1919,6 +2119,84 @@ function upsertBy<T extends Record<K, string>, K extends keyof T>(
   return rows.map((row, i) => (i === index ? next : row));
 }
 
+function initialSyncHealth(scenario: DesktopUiHarnessScenario): SyncHealthView {
+  const hydration = {
+    sessionId: scenario === "session-hydration" ? "session-remote" : "",
+    agentDid: AGENT_DID,
+    phase: scenario === "session-hydration" ? "requested" : "idle",
+    mergedCount: scenario === "session-hydration" ? 1 : 0,
+    servedCount: null as number | null,
+  };
+  if (scenario === "sync-offline") {
+    return {
+      state: "offline",
+      since: STARTED_AT,
+      offlineSince: STARTED_AT,
+      stalledSince: null,
+      lastErrorClass: null,
+      lastError: "fixture transport unavailable",
+      pairingRetryCount: 0,
+      routeRetryCount: 0,
+      connectedPeerCount: 0,
+      hydration,
+    };
+  }
+  if (scenario === "sync-stalled") {
+    return {
+      state: "stalled",
+      since: STARTED_AT,
+      offlineSince: null,
+      stalledSince: STARTED_AT,
+      lastErrorClass: "RpcTimeout",
+      lastError: "pairing retry exhausted",
+      pairingRetryCount: 6,
+      routeRetryCount: 6,
+      connectedPeerCount: 1,
+      hydration,
+    };
+  }
+  if (scenario === "sync-failed") {
+    return {
+      state: "failed",
+      since: STARTED_AT,
+      offlineSince: null,
+      stalledSince: null,
+      lastErrorClass: "RemoteUnauthorized",
+      lastError: "permanently rejected",
+      pairingRetryCount: 1,
+      routeRetryCount: 1,
+      connectedPeerCount: 1,
+      hydration,
+    };
+  }
+  if (scenario === "session-hydration") {
+    return {
+      state: "syncing",
+      since: STARTED_AT,
+      offlineSince: null,
+      stalledSince: null,
+      lastErrorClass: null,
+      lastError: null,
+      pairingRetryCount: 0,
+      routeRetryCount: 0,
+      connectedPeerCount: 1,
+      hydration,
+    };
+  }
+  return {
+    state: "healthy",
+    since: STARTED_AT,
+    offlineSince: null,
+    stalledSince: null,
+    lastErrorClass: null,
+    lastError: null,
+    pairingRetryCount: 0,
+    routeRetryCount: 0,
+    connectedPeerCount: 1,
+    hydration,
+  };
+}
+
 function clone<T>(value: T): T {
   return structuredClone(value);
 }
@@ -1935,6 +2213,10 @@ function normalizeScenario(value?: string | null): DesktopUiHarnessScenario {
     case "cascade-turn":
     case "coding":
     case "mobile-performance":
+    case "session-hydration":
+    case "sync-offline":
+    case "sync-stalled":
+    case "sync-failed":
       return value;
     default:
       return "default";

--- a/apps/gents-desktop/tests/ui-harness/harness.tsx
+++ b/apps/gents-desktop/tests/ui-harness/harness.tsx
@@ -11,6 +11,9 @@ declare global {
     __GENTS_MOBILE_PERFORMANCE__?: NonNullable<
       ReturnType<typeof createDesktopUiHarness>["performance"]
     >;
+    __GENTS_SESSION_SYNC__?: NonNullable<
+      ReturnType<typeof createDesktopUiHarness>["sessionSync"]
+    >;
   }
 }
 
@@ -29,6 +32,9 @@ if ("bridgeUrl" in harness && harness.bridgeUrl) {
 }
 if ("performance" in harness && harness.performance) {
   window.__GENTS_MOBILE_PERFORMANCE__ = harness.performance;
+}
+if ("sessionSync" in harness && harness.sessionSync) {
+  window.__GENTS_SESSION_SYNC__ = harness.sessionSync;
 }
 
 setDesktopShellTimingConfigForTests({

--- a/crates/gents-desktop-core/src/client/core/writes.rs
+++ b/crates/gents-desktop-core/src/client/core/writes.rs
@@ -1548,7 +1548,8 @@ impl ClientCore {
         if !response.errors.is_empty() {
             anyhow::bail!("upsert SessionHydrationRequest: {:?}", response.errors);
         }
-        self.hydration.send_replace(
+        publish_hydration_progress(
+            &self.hydration,
             gents::agent::p2p_reconcile::session_hydration::begin_hydration_request(
                 &session_id,
                 &agent_did,
@@ -1572,7 +1573,8 @@ impl ClientCore {
         let (served, failed) =
             load_hydration_server_state(self.node.as_ref(), self.local_peer_id(), session_id)
                 .await?;
-        self.hydration.send_replace(
+        publish_hydration_progress(
+            &self.hydration,
             gents::agent::p2p_reconcile::session_hydration::observe_hydration_progress(
                 &self.hydration_progress(),
                 session_id,
@@ -1606,6 +1608,22 @@ impl ClientCore {
 struct HydrationDocIdRow {
     #[serde(rename = "_docID")]
     doc_id: Option<String>,
+}
+
+fn publish_hydration_progress(
+    sender: &tokio::sync::watch::Sender<
+        gents::agent::p2p_reconcile::session_hydration::ClientHydrationProgress,
+    >,
+    next: gents::agent::p2p_reconcile::session_hydration::ClientHydrationProgress,
+) -> bool {
+    sender.send_if_modified(|current| {
+        if *current == next {
+            false
+        } else {
+            *current = next;
+            true
+        }
+    })
 }
 
 fn should_write_session_hydration_request(
@@ -1849,6 +1867,30 @@ mod delete_source_tests {
         }));
 
         assert_eq!(local_hydration_count_from_response(&response).unwrap(), 6);
+    }
+
+    #[test]
+    fn hydration_watch_notifies_only_when_progress_changes() {
+        use gents::agent::p2p_reconcile::session_hydration::{
+            ClientHydrationPhase, ClientHydrationProgress,
+        };
+
+        let serving = ClientHydrationProgress {
+            session_id: "session-1".into(),
+            agent_did: "did:agent".into(),
+            phase: ClientHydrationPhase::Serving,
+            merged_count: 3,
+            served_count: Some(8),
+        };
+        let (tx, mut rx) = tokio::sync::watch::channel(ClientHydrationProgress::default());
+        let _ = rx.borrow_and_update();
+
+        assert!(publish_hydration_progress(&tx, serving.clone()));
+        assert!(rx.has_changed().expect("hydration watch"));
+        let _ = rx.borrow_and_update();
+
+        assert!(!publish_hydration_progress(&tx, serving));
+        assert!(!rx.has_changed().expect("hydration watch"));
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
+++ b/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
@@ -144,7 +144,7 @@ Client writes it on session open (upsert by `request_key`); it rides the
 admits rows from paired, membership-valid peers whose session ownership checks
 out, enumerates the session's docs across the transcript collections
 (AgentRequest, AgentResponse, AgentMessage, AgentToolCall, AgentToolResult,
-AgentToolApproval, CompactionEntry), pushes them through the **existing
+CompactionEntry), pushes them through the **existing
 doc-pusher under the existing admission bounds and persisted retry ladder** —
 no new delivery machinery — then writes `served` + `served_doc_count`.
 Failures write `rejected` + detail; retry is the client's decision.

--- a/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
+++ b/docs/superpowers/specs/2026-08-17-mobile-session-sync-design.md
@@ -1,7 +1,32 @@
 # Mobile session sync — design
 
 **Milestone:** [Mobile session sync](https://github.com/source-inc/gents/milestones/9) — #1141 → #1142 → #1143 → #1144, with #1145/#1146 independent.
-**Status:** approved in session 2026-08-17; this document is the durable record.
+**Status:** shipped on current `main` plus the `mobile-session-sync/00`–`04` productization stack (2026-08-27). The original 2026-08-17 session approval still holds; the reductions below are the durable record of what actually landed.
+
+## What shipped
+
+Index cards (`AgentConversation` + `AgentSession`) sync eagerly. Transcript history stays lazy: a client writes `SessionHydrationRequest` on session focus, the runtime serves the exact tenant-scoped document set through the existing peer-targeted doc pusher, and the receiver declares completion only after locally merged documents cover `served_doc_count`.
+
+Productization on top of merged PR #1154:
+
+- A pure desktop-core projection derives `healthy | syncing | stalled | offline | failed` from `P2PHealth`, pairing/route retry, and `ClientHydrationProgress`. Terminal/quarantined failure and stalled never collapse into syncing; offline never pretends progress is active.
+- The bridge projects pairing collection status, hydration, and that derived summary on existing snapshots. `desktop://client-updated` gains `reason = "hydration"`. There is no second request lifecycle, polling loop, or `desktop_session_hydrate` / `desktop_sync_status` command. Retry is `desktop_session_snapshot` → `ClientCore::focus_session`. In-flight re-focus refreshes receiver progress instead of resetting the server row to pending.
+- Selected-session UI renders already-local transcript immediately and shows requested / serving N-of-M / complete / failed, with retry on failed. Hydration wakes refresh the selected session and the runtime snapshot (global `syncHealth` lives on the snapshot). Unchanged receiver progress does not re-emit. Delayed snapshots cannot replace another session.
+- A self-contained global indicator on the current fleet and chat surfaces distinguishes the five states and opens pairing/route/error-class/stuck-since/hydration diagnostics. It does not depend on PR #1153 navigation work.
+- CI acceptance uses the existing desktop UI harness (`session-hydration`, `sync-offline`, `sync-stalled`, `sync-failed`). The ignored live two-node test remains the protocol/runtime qualification:
+
+```sh
+GENTS_LIVE_SESSION_HYDRATION=1 cargo test -p gents --features live-e2e \
+  --test e2e_live live_session_hydration_replays_history_to_a_fresh_client \
+  -- --ignored --nocapture
+```
+
+### Reductions from the original issue text
+
+- No `P2PSupervisorCommand::{Foregrounded, NetworkChanged}`. Suspend/resume recovery stays on the existing route repair / `desktop_p2p_repair` path.
+- No dedicated hydration or sync-status Tauri commands. The snapshot and focus path is the single control plane.
+- Per-session replicator filters remain rejected (`session_id` is not `@immutable`).
+- Upstream defradb.rs#1504 FFI `p2p_sync_status` is still not required. Quarantined/permanent rejection is `PairingErrorClass::RemoteUnauthorized` plus hydration `failed`.
 
 ## Problem
 
@@ -143,8 +168,9 @@ Plus CoverageLedger entry, `Executable.lean` contract, Rust conformance file,
 proofs README update. Zero `sorry`s.
 
 Client half (#1143): `ClientCore::request_session_hydration` (the first
-client-authored control-request write path — establishes the pattern). It
-reuses the existing request observation and P2P repair paths rather than
+client-authored control-request write path — establishes the pattern). The
+desktop bridge calls it only from `focus_session` on `desktop_session_snapshot`.
+It reuses the existing request observation and P2P repair paths rather than
 adding focus/network commands or a second progress channel. Progress is
 receiver-side: `served_doc_count` is the denominator, locally merged docIDs
 the numerator. Hydrated sessions persist on-device; no eviction in v1.
@@ -153,13 +179,13 @@ the numerator. Hydrated sessions persist on-device; no eviction in v1.
 
 - `PairingCollectionStatus` (retry counts, error class, `stuck_since`) is
   computed every tick and never exposed — the cheapest win.
-- Bridge: `desktop_session_hydrate`, `desktop_sync_status`,
-  `SessionHydrationView`, `PairingCollectionStatusView`,
-  `ClientUpdateEvent.reason += "hydration"`.
-- UI: global sync pill (healthy / syncing / stalled / offline-since),
-  per-session hydration progress, settings debug panel with raw counters.
-  Stalled (retry class + stuck_since) renders distinctly from syncing;
-  quarantined DAGs are terminal errors, not spinners.
+- Bridge: `SessionHydrationView`, `PairingCollectionStatusView`,
+  `SyncHealthView` on existing snapshots, and
+  `ClientUpdateEvent.reason += "hydration"`. No extra hydrate/status commands.
+- UI: global sync indicator (healthy / syncing / stalled / offline-since /
+  failed) plus a diagnostics panel with raw counters, and per-session
+  hydration progress. Stalled (retry class + stuck_since) renders distinctly
+  from syncing; quarantined/unauthorized work is a terminal error, not a spinner.
 
 ### Independent
 


### PR DESCRIPTION
## Summary

Qualify mobile session sync end to end on the existing desktop UI harness. A session created before the fresh client exists opens with already-local rows, hydrates N-of-M, and reaches an exact complete or failed terminal. Connectivity loss recovers through the existing reconnect control. Global UI distinguishes offline, stalled, and failed.

This PR also closes two product gaps the E2E found:

- Hydration wakes now refresh the runtime snapshot (`full` when a session is selected) so the global indicator can leave `syncing` after complete/failed.
- Unchanged receiver progress uses `send_if_modified`, matching P2P health's material-change gate, so session snapshot re-focus cannot loop hydration events.

Style-token CI failures from earlier stack PRs are fixed on #1250 (`--motion-pulse`) and #1251 (no extra `box-shadow`).

## Invariants / product behavior

- Single hydration control path remains `desktop_session_snapshot` → `ClientCore::focus_session`. Retry is that path.
- No `P2PSupervisorCommand::{Foregrounded, NetworkChanged}`. Recovery uses existing route repair / `desktop_p2p_repair`.
- No dedicated hydrate/status Tauri commands.
- The ignored live two-node test remains the protocol/runtime qualification; CI uses deterministic fixtures (`session-hydration`, `sync-offline`, `sync-stalled`, `sync-failed`).
- Design spec updated to the shipped reductions.

## Review boundary

Acceptance, documentation, and the two product fixes the E2E exposed. No new hydration machinery.

## Stack dependency

Depends on #1251.

## Verification

- `cd apps/gents-desktop && npx playwright test tests/playwright/desktop-session-sync.spec.ts` — 12 passed (4 tests × 3 viewports)
- `cd apps/gents-desktop && npm run format:check` — pass
- `cd apps/gents-desktop && npx vitest run` — 327 passed, 16 skipped
- `cargo test -p gents-desktop-core --lib` — 181 passed
- `cargo test -p gents-desktop-bridge --lib` — 147 passed, 2 ignored
- `cd packages/gents-desktop-client && npm test` — 11 passed
- `cargo test -p gents` — 2466 passed, 3 ignored
- `cargo check --workspace --all-targets` — pass (pre-existing `gents-cli` dead_code warning only)

Live protocol qualification (unchanged, ignored):

```sh
GENTS_LIVE_SESSION_HYDRATION=1 cargo test -p gents --features live-e2e \
  --test e2e_live live_session_hydration_replays_history_to_a_fresh_client \
  -- --ignored --nocapture
```

## Issue closure

Closes #1143
Closes #1144

#1142 is already satisfied by merged #1154 (Lean lifecycle, schema, server sweep, live `served=10 exact_docs=10 collections=6`). It is closed separately with that evidence, not by this PR.

The Mobile session sync milestone should close only after this stack merges onto `main`.