### PR TITLE
test(schedule): retry generation-bump fixture conflicts

### DIFF
--- a/crates/gents/tests/conformance/scheduling.rs
+++ b/crates/gents/tests/conformance/scheduling.rs
@@ -64,7 +64,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use gents::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
+use gents::graphql::{
+    escape_graphql_string, graphql_mutation_with_transaction_retry, single_mutation_document,
+};
 use gents::lifecycle::{ExecutionOrigin, RequestLifecycle, TriggerLineage};
 use gents::{AgentIdentity, DocumentRuntimeOptions, Gents, KeyIdentity, ToolCeiling};
 use serde_json::Value;
@@ -162,15 +164,16 @@ async fn set_schedule_enabled(
     )
     .await
     .expect("update Schedule.enabled");
-    let updated = resp
-        .data
-        .as_ref()
-        .and_then(|data| data.get("update_Schedule"))
-        .and_then(|value| value.as_array())
-        .map_or(0, Vec::len);
-    assert_eq!(
-        updated, 1,
-        "update Schedule.enabled must match exactly one document"
+    let updated = single_mutation_document(&resp, "update_Schedule").unwrap_or_else(|error| {
+        panic!(
+            "decode Schedule.enabled update for {schedule_id}: {error}; response data: {:?}",
+            resp.data
+        )
+    });
+    assert!(
+        updated.is_some(),
+        "update Schedule.enabled must match exactly one document for {schedule_id}; response data: {:?}",
+        resp.data
     );
 }
 

--- a/crates/gents/tests/conformance/scheduling.rs
+++ b/crates/gents/tests/conformance/scheduling.rs
@@ -64,7 +64,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use gents::graphql::escape_graphql_string;
+use gents::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
 use gents::lifecycle::{ExecutionOrigin, RequestLifecycle, TriggerLineage};
 use gents::{AgentIdentity, DocumentRuntimeOptions, Gents, KeyIdentity, ToolCeiling};
 use serde_json::Value;
@@ -155,11 +155,22 @@ async fn set_schedule_enabled(
             ) {{ _docID }}
         }}"#
     );
-    let resp = node.execute(&mutation).await;
-    assert!(
-        !resp.has_errors(),
-        "update Schedule.enabled failed: {:?}",
-        resp.errors
+    let resp = graphql_mutation_with_transaction_retry(
+        node,
+        &mutation,
+        "update Schedule.enabled in generation-bump fixture",
+    )
+    .await
+    .expect("update Schedule.enabled");
+    let updated = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("update_Schedule"))
+        .and_then(|value| value.as_array())
+        .map_or(0, Vec::len);
+    assert_eq!(
+        updated, 1,
+        "update Schedule.enabled must match exactly one document"
     );
 }
 


### PR DESCRIPTION
## Summary

- route the live `Schedule.enabled` fixture mutation through the canonical node-scoped transaction retry boundary
- preserve a strict postcondition that the update matched exactly one schedule document
- leave scheduler runtime behavior and lifecycle semantics unchanged

## Why

The generation-bump conformance test mutates a schedule while the live reconciler can write the same row. A DefraDB `TXN_CONFLICT` is therefore a valid optimistic-concurrency outcome, but the fixture previously executed the mutation only once.

This closes the confirmed `set_schedule_enabled` conflict failure in #1083. The retained attempt-1 log for #802 proves that occurrence is different: it timed out waiting for the first generation bump after the Schedule insert (`snapshot never re-resolved after Schedule insert; stuck at 1`) before execution reached `set_schedule_enabled`. This PR therefore does not close #802.

## Foundation flow

This is test-harness plumbing: it reuses the existing mutation retry/write gate and does not change legal transitions, runtime invariants, or provider input. No Lean model change is required.

## Tests

- `cargo fmt --check`
- exact `scheduling::generation_bump_reconfigures_active_schedules`: 6/6 passing (one cold run plus five warm repeats)
- `cargo test -p gents`
- `cargo check --workspace --all-targets`

Closes #1083
Refs #802