### PR TITLE
test(runtime): synchronize observability startup

### DIFF
--- a/crates/gents/tests/e2e_runtime/runtime_observability.rs
+++ b/crates/gents/tests/e2e_runtime/runtime_observability.rs
@@ -3,9 +3,12 @@ use std::time::Duration;
 
 use gents::{
     ensure_agent_principal, load_agent_behavior, upsert_agent_behavior, AgentIdentity,
-    DocumentRuntimeOptions, Gents, KeyIdentity, ToolCeiling,
+    DocumentRuntimeOptions, Gents, KeyIdentity, ProcessLifecycleObserver, ProcessLifecycleState,
+    RuntimeSnapshotObserver, ToolCeiling,
 };
+use tokio::sync::watch;
 
+use crate::support::interrupt::TEST_RUNTIME_READY_TIMEOUT;
 use crate::support::snapshots::{fetch_runtime_snapshot, RuntimeSnapshot};
 use crate::support::test_db;
 
@@ -14,6 +17,51 @@ const UNUSED_BACKEND_ENDPOINT: &str = "http://127.0.0.1:9/v1";
 fn test_identity(name: &str) -> KeyIdentity {
     let path = std::env::temp_dir().join(format!("{name}-{}.key", uuid::Uuid::new_v4()));
     KeyIdentity::load_or_create(path, None).unwrap()
+}
+
+struct RuntimeEventObserver {
+    process_state_tx: watch::Sender<ProcessLifecycleState>,
+    generation_tx: watch::Sender<u64>,
+}
+
+impl ProcessLifecycleObserver for RuntimeEventObserver {
+    fn on_process_state_change(&self, state: ProcessLifecycleState) {
+        self.process_state_tx.send_replace(state);
+    }
+}
+
+impl RuntimeSnapshotObserver for RuntimeEventObserver {
+    fn on_generation_published(&self, generation: u64, _runnable_behavior_ids: &[String]) {
+        self.generation_tx.send_replace(generation);
+    }
+}
+
+async fn wait_for_observed<T>(
+    receiver: &mut watch::Receiver<T>,
+    description: &str,
+    predicate: impl Fn(&T) -> bool,
+) where
+    T: Clone + std::fmt::Debug,
+{
+    let wait = async {
+        loop {
+            if predicate(&receiver.borrow_and_update()) {
+                return Ok::<(), watch::error::RecvError>(());
+            }
+            receiver.changed().await?;
+        }
+    };
+    match tokio::time::timeout(TEST_RUNTIME_READY_TIMEOUT, wait).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            panic!("runtime observer closed while waiting for {description}: {error}")
+        }
+        Err(error) => panic!(
+            "timed out after {TEST_RUNTIME_READY_TIMEOUT:?} waiting for {description}; \
+             last observed value: {:?}: {error}",
+            receiver.borrow().clone()
+        ),
+    }
 }
 
 async fn bind_default_behavior_backend(
@@ -73,16 +121,18 @@ async fn wait_for_runtime_snapshot<F>(
 where
     F: Fn(&RuntimeSnapshot) -> bool,
 {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    let deadline = tokio::time::Instant::now() + TEST_RUNTIME_READY_TIMEOUT;
     loop {
-        if let Some(snapshot) = fetch_runtime_snapshot(node, agent_did).await {
+        let last_snapshot = fetch_runtime_snapshot(node, agent_did).await;
+        if let Some(snapshot) = last_snapshot.as_ref() {
             if predicate(&snapshot) {
-                return snapshot;
+                return snapshot.clone();
             }
         }
         assert!(
             tokio::time::Instant::now() < deadline,
-            "timed out waiting for runtime snapshot for {agent_did}"
+            "timed out after {TEST_RUNTIME_READY_TIMEOUT:?} waiting for runtime snapshot for \
+             {agent_did}; last observed snapshot: {last_snapshot:?}"
         );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -99,11 +149,20 @@ async fn runtime_status_surfaces_startup_reconcile_and_shutdown() {
         UNUSED_BACKEND_ENDPOINT,
     )
     .await;
+    let (process_state_tx, mut process_state_rx) =
+        watch::channel(ProcessLifecycleState::Uninitialized);
+    let (generation_tx, mut generation_rx) = watch::channel(0);
+    let observer = Arc::new(RuntimeEventObserver {
+        process_state_tx,
+        generation_tx,
+    });
     let agent = Gents::from_default_behavior_documents(
         db.node.clone(),
         identity,
         DocumentRuntimeOptions {
             tool_ceiling: ToolCeiling::meta_only(),
+            process_state_observer: Some(observer.clone()),
+            runtime_snapshot_observer: Some(observer),
             ..Default::default()
         },
     )
@@ -115,6 +174,12 @@ async fn runtime_status_surfaces_startup_reconcile_and_shutdown() {
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let handle = tokio::spawn(agent.run(shutdown_rx));
 
+    wait_for_observed(
+        &mut process_state_rx,
+        "runtime process state Ready",
+        |state| *state == ProcessLifecycleState::Ready,
+    )
+    .await;
     let startup = wait_for_runtime_snapshot(db.node.as_ref(), &agent_did, |snapshot| {
         snapshot.process_state == "ready"
             && snapshot.reconcile_phase == "idle"
@@ -135,6 +200,10 @@ async fn runtime_status_surfaces_startup_reconcile_and_shutdown() {
         .await
         .unwrap();
 
+    wait_for_observed(&mut generation_rx, "runtime generation 2", |generation| {
+        *generation >= 2
+    })
+    .await;
     let reconciled = wait_for_runtime_snapshot(db.node.as_ref(), &agent_did, |snapshot| {
         snapshot.process_state == "ready"
             && snapshot.reconcile_phase == "idle"
@@ -149,10 +218,10 @@ async fn runtime_status_surfaces_startup_reconcile_and_shutdown() {
     let _ = shutdown_tx.send(true);
     handle.await.unwrap().unwrap();
 
-    let shutdown = wait_for_runtime_snapshot(db.node.as_ref(), &agent_did, |snapshot| {
-        snapshot.process_state == "shutdown"
-    })
-    .await;
+    let shutdown = fetch_runtime_snapshot(db.node.as_ref(), &agent_did)
+        .await
+        .expect("shutdown runtime snapshot");
+    assert_eq!(shutdown.process_state, "shutdown");
     assert_eq!(shutdown.reconcile_phase, "idle");
     assert_eq!(shutdown.router_generation, 2);
 }


### PR DESCRIPTION
## Summary

- synchronize the runtime observability test with the existing process Ready observer before asserting the durable startup snapshot
- wait for the published reconcile generation before checking the durable generation-2 projection
- reuse the suite-safe readiness bound and include the last observer value or persisted snapshot in timeout diagnostics
- read the shutdown projection after the runtime handle completes, which already follows the durable shutdown write

## Why

The current test still used the original blind 20-second startup poll from #800. A later shared 120-second readiness bound and last-snapshot diagnostics existed, but this test never adopted them. Passing runs on current main therefore did not satisfy the issue criteria or remove the under-load synchronization race.

This is test-harness synchronization only. It uses existing runtime lifecycle and snapshot observer seams and does not change runtime transitions, schemas, or Lean-modeled behavior.

## Validation

- exact runtime observability test: 6/6 passes
- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #800