### PR TITLE
test(cli): await serving state before home chat

### DIFF
--- a/crates/gents-cli/tests/cli_server.rs
+++ b/crates/gents-cli/tests/cli_server.rs
@@ -1233,14 +1233,17 @@ async fn init_and_server_use_backend_specific_api_key_env_var() -> Result<()> {
     let backend_id = generated_backend_id_for_agent(&agent_did);
     let tool_selection_id = generated_tool_selection_id_for_agent(&agent_did);
 
-    let mut serve = spawn_server_with_env(
+    let (_serve, readiness) = spawn_server_with_ready_json(
         &home_dir,
         port,
         &[],
         &[("GENTS_TEST_CLI_BACKEND_KEY", "backend-key")],
     )?;
-    wait_for_port(port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    assert_eq!(
+        readiness.get("graphql").and_then(Value::as_str),
+        Some(graphql.as_str()),
+        "serving payload must identify the allocated GraphQL endpoint"
+    );
 
     assert_runtime_init_state(
         &graphql,


### PR DESCRIPTION
## Summary

- wait for the server serving payload before launching a home-scoped `gents chat` child
- assert that the serving payload advertises the test's allocated GraphQL endpoint
- remove the weaker `AgentRuntime=ready` barrier, which can precede `runtime.json` publication

## Foundation flow

Test-fixture synchronization only; no runtime lifecycle semantics or Lean changes.

## Testing

- focused auth test: 6/6 passes (including a clean build)
- `cargo test -p gents-cli --test cli_server`
- `cargo test -p gents-cli`
- `cargo check --workspace --all-targets`
- `cargo fmt --check`
- `git diff --check`

Closes #1256