### PR TITLE
fix(cli): scope Codex skill toggles to bound agent

### DIFF
--- a/crates/gents-cli/src/commands/codex_shim/handlers/basic.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/basic.rs
@@ -16,6 +16,7 @@ use super::super::protocol::{
 use super::super::store::{execute_committed, query_node_json};
 use super::super::{Outbound, ShimState, JSONRPC_INVALID_PARAMS};
 use crate::config_writes::{write_agent_behavior_document, ConfigAccess};
+use crate::extract_mutation_doc_id;
 use gents::graphql::escape_graphql_string;
 
 pub(super) async fn handle_basic_request(
@@ -319,20 +320,39 @@ pub(super) async fn handle_skills_config_write(
             .await;
         }
     };
+    let agent_did = escape_graphql_string(&state.agent_did);
     let mutation = format!(
         r#"mutation {{ update_Skill(
-            filter: {{ skill_id: {{ _eq: "{skill_id}" }} }},
+            filter: {{
+                skill_id: {{ _eq: "{skill_id}" }},
+                agent_did: {{ _eq: "{agent_did}" }}
+            }},
             input: {{ enabled: {enabled} }}
         ) {{ _docID }} }}"#,
         skill_id = escape_graphql_string(&skill_id),
         enabled = params.enabled,
     );
-    if let Err(error) = execute_committed(state.node.as_ref(), &mutation).await {
+    let response = match execute_committed(state.node.as_ref(), &mutation).await {
+        Ok(response) => response,
+        Err(error) => {
+            return send_error(
+                outbound,
+                request_id,
+                JSONRPC_INVALID_PARAMS,
+                format!("failed to update skill {skill_id}: {error}"),
+            )
+            .await;
+        }
+    };
+    if extract_mutation_doc_id(&response, "Skill").is_err() {
         return send_error(
             outbound,
             request_id,
             JSONRPC_INVALID_PARAMS,
-            format!("failed to update skill {skill_id}: {error}"),
+            format!(
+                "no skill {skill_id:?} belongs to bound agent {:?}",
+                state.agent_did
+            ),
         )
         .await;
     }

--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -5446,6 +5446,27 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
         added.get("skill_id").and_then(Value::as_str),
         Some("research")
     );
+    let foreign_agent_did = "did:key:zForeignSkillOwner";
+    run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "skill",
+            "add",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            foreign_agent_did,
+            "--skill-id",
+            "foreign-skill",
+            "--scope",
+            "principal",
+            "--name",
+            "Foreign",
+            "--instructions",
+            "Must remain enabled.",
+        ],
+    )?;
 
     let (mut ws, _) = serve
         .capturing(async {
@@ -5495,6 +5516,44 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
         codex::ClientRequest::SkillsConfigWrite {
             request_id: request_id(3),
             params: codex::SkillsConfigWriteParams {
+                path: Some(std::path::PathBuf::from("/gents/skills/foreign-skill").try_into()?),
+                name: None,
+                enabled: false,
+            },
+        },
+    )
+    .await?;
+    let error = read_error_response(&mut ws, request_id(3)).await?;
+    assert!(
+        error
+            .message
+            .contains("no skill \"foreign-skill\" belongs to bound agent"),
+        "unexpected cross-agent toggle error: {}",
+        error.message
+    );
+    let foreign = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "skill",
+            "show",
+            "--graphql",
+            &graphql,
+            "--skill-id",
+            "foreign-skill",
+        ],
+    )?;
+    assert_eq!(
+        foreign.get("agent_did").and_then(Value::as_str),
+        Some(foreign_agent_did)
+    );
+    assert_eq!(foreign.get("enabled").and_then(Value::as_bool), Some(true));
+
+    send_client_request(
+        &mut ws,
+        codex::ClientRequest::SkillsConfigWrite {
+            request_id: request_id(4),
+            params: codex::SkillsConfigWriteParams {
                 path: None,
                 name: Some("Research".to_string()),
                 enabled: false,
@@ -5503,7 +5562,7 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
     )
     .await?;
     let write: codex::SkillsConfigWriteResponse =
-        read_typed_response(&mut ws, request_id(3)).await?;
+        read_typed_response(&mut ws, request_id(4)).await?;
     assert!(
         !write.effective_enabled,
         "config write should report disabled"
@@ -5512,12 +5571,12 @@ async fn codex_shim_lists_and_toggles_skills() -> Result<()> {
     send_client_request(
         &mut ws,
         codex::ClientRequest::SkillsList {
-            request_id: request_id(4),
+            request_id: request_id(5),
             params: codex::SkillsListParams::default(),
         },
     )
     .await?;
-    let list: codex::SkillsListResponse = read_typed_response(&mut ws, request_id(4)).await?;
+    let list: codex::SkillsListResponse = read_typed_response(&mut ws, request_id(5)).await?;
     let research = list
         .data
         .iter()


### PR DESCRIPTION
## Summary

- require both the requested `skill_id` and the shim-bound `agent_did` in the atomic Skill update
- reject zero-row mutations instead of reporting a false `effective_enabled` result
- add a live WebSocket regression proving a foreign-owned skill remains enabled while an owned skill can still be toggled

## Security boundary

`ShimState.agent_did` is populated from the initialized server identity and remains authoritative for that shim instance. `Skill.agent_did` is the established document owner field. Scoping at the handler is necessary because the embedded transaction is signed by the node identity rather than an individual skill owner.

## Foundation flow

No Lean model change is needed: `Proofs/Skills` already models each Skill with an owner and proves candidate selection respects the principal. This patch enforces that existing ownership invariant at the Codex adapter mutation boundary; the live CLI integration test is the relevant conformance fence.

## Tests

- `cargo test -p gents-cli --test cli_codex_shim codex_shim_lists_and_toggles_skills -- --exact --nocapture`
- `cargo test -p gents-cli`
- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

## Issue scope

Addresses #1152. This fixes only the Codex-shim skill-toggle cross-agent IDOR arm. The webhook signature design remains open and is unchanged by this PR.