### PR TITLE
test: wait on runtime lifecycle boundaries

### DIFF
--- a/crates/gents/src/hook.rs
+++ b/crates/gents/src/hook.rs
@@ -162,7 +162,8 @@ impl BackgroundExecutionRegistry {
         self.remove_now(tool_call_id);
     }
 
-    pub(crate) async fn contains(&self, tool_call_id: &str) -> bool {
+    /// Returns whether this process still owns a live background execution.
+    pub async fn contains(&self, tool_call_id: &str) -> bool {
         self.lock_executions().contains_key(tool_call_id)
     }
 

--- a/crates/gents/tests/e2e_subagent/r6_background_tools.rs
+++ b/crates/gents/tests/e2e_subagent/r6_background_tools.rs
@@ -336,46 +336,23 @@ async fn load_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &st
     first_row(&node.execute(&query).await, "AgentToolCall")
 }
 
-async fn wait_for_tool_terminal_state(
-    node: &EmbeddedNode,
-    session_id: &str,
+async fn wait_for_background_execution_completion(
+    executions: &BackgroundExecutionRegistry,
     tool_call_id: &str,
-) -> ToolCallRow {
-    let mut updates = node.subscribe(&[EventName::Update]);
+) {
     let wait = async {
-        loop {
-            let row = load_tool_call(node, session_id, tool_call_id).await;
-            if row.lifecycle_state.as_deref() != Some("running") {
-                return row;
-            }
-            updates
-                .recv()
-                .await
-                .expect("embedded-node update subscription closed");
+        while executions.contains(tool_call_id).await {
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     };
-    match tokio::time::timeout(std::time::Duration::from_secs(5), wait).await {
-        Ok(row) => row,
-        Err(_) => {
-            let marker = format!(r#"<tool-completion tool_call_id="{tool_call_id}""#);
-            let (last_row, completion) = tokio::join!(
-                bounded_diagnostic(
-                    Duration::from_secs(1),
-                    load_tool_call(node, session_id, tool_call_id),
-                ),
-                bounded_diagnostic(Duration::from_secs(1), async {
-                    fetch_messages(node, session_id)
-                        .await
-                        .into_iter()
-                        .find(|message| message.content.contains(&marker))
-                }),
-            );
+    tokio::time::timeout(Duration::from_secs(5), wait)
+        .await
+        .unwrap_or_else(|error| {
             panic!(
-                "background tool did not terminalize after its durable update; \
-                 last_tool_call={last_row}; completion_marker={completion}"
-            );
-        }
-    }
+                "background execution {tool_call_id} did not leave the live registry after 5s: \
+                 {error}"
+            )
+        });
 }
 
 #[tokio::test]
@@ -813,6 +790,8 @@ async fn panicking_background_tool_terminalizes_and_notifies() {
     )
     .await;
 
+    let executions = BackgroundExecutionRegistry::default();
+    let hook = hook.with_background_execution_registry(executions.clone());
     let receipt = skip_reason_json(
         hook.on_tool_call(
             "spawn_process",
@@ -824,18 +803,24 @@ async fn panicking_background_tool_terminalizes_and_notifies() {
     );
     let tool_call_id = receipt["tool_call_id"].as_str().unwrap().to_string();
 
-    let row = wait_for_tool_terminal_state(db.node.as_ref(), &session_id, &tool_call_id).await;
+    // Registry ownership ends only after terminal persistence and completion
+    // projection finish. Waiting on that in-process boundary avoids competing
+    // Defra reads while the background worker is trying to write under load.
+    wait_for_background_execution_completion(&executions, &tool_call_id).await;
+
+    let row = load_tool_call(db.node.as_ref(), &session_id, &tool_call_id).await;
     assert_eq!(row.lifecycle_state.as_deref(), Some("failed"));
     assert!(row
         .result
         .as_deref()
         .is_some_and(|result| { result.contains("intentional background tool panic") }));
 
-    // The notification append is a separate mutation after the terminal row
-    // write (the row carries `completionPending:tool_panicked` until the side
-    // effects land), so await it rather than reading messages once.
-    let notification =
-        wait_for_tool_completion_message(db.node.as_ref(), &session_id, &tool_call_id).await;
+    let marker = format!(r#"<tool-completion tool_call_id="{tool_call_id}""#);
+    let notification = fetch_messages(db.node.as_ref(), &session_id)
+        .await
+        .into_iter()
+        .find(|message| message.content.contains(&marker))
+        .expect("registry release must follow the completion notification append");
     assert!(notification.content.contains(r#"status="failed""#));
     assert!(notification
         .content

--- a/crates/gents/tests/misc/backend_auth_startup.rs
+++ b/crates/gents/tests/misc/backend_auth_startup.rs
@@ -1,32 +1,18 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::Result;
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
 use gents::{
-    ensure_runtime_schemas, AgentIdentity, DocumentRuntimeOptions, Gents, ProcessLifecycleObserver,
-    ProcessLifecycleState, ToolCeiling,
+    ensure_runtime_schemas, AgentIdentity, DocumentRuntimeOptions, Gents, ProcessLifecycleState,
+    ToolCeiling,
 };
 use serde_json::Value;
 use tokio::sync::watch;
 
 use crate::support::fixtures::{bind_default_behavior_backend, test_behavior, test_identity};
 use crate::support::mock_endpoint::MockModelEndpoint;
-use crate::support::waits::wait_for_runtime_process_state;
-
-#[derive(Default)]
-struct RecordingObserver {
-    states: Mutex<Vec<ProcessLifecycleState>>,
-}
-
-impl ProcessLifecycleObserver for RecordingObserver {
-    fn on_process_state_change(&self, state: ProcessLifecycleState) {
-        self.states
-            .lock()
-            .expect("recording observer mutex poisoned")
-            .push(state);
-    }
-}
+use crate::support::waits::RecordingProcessObserver;
 
 #[tokio::test]
 async fn run_agent_uses_backend_specific_api_key_env_var_for_startup_probe() -> Result<()> {
@@ -99,7 +85,7 @@ async fn run_agent_uses_backend_specific_api_key_env_var_for_startup_probe() -> 
 
     let mut env = TestEnvGuard::new(&["GENTS_TEST_RUNTIME_BACKEND_KEY"]);
     env.set("GENTS_TEST_RUNTIME_BACKEND_KEY", "backend-key");
-    let observer = Arc::new(RecordingObserver::default());
+    let observer = Arc::new(RecordingProcessObserver::default());
     let agent = Gents::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
@@ -113,15 +99,11 @@ async fn run_agent_uses_backend_specific_api_key_env_var_for_startup_probe() -> 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let run_task = tokio::spawn(agent.run(shutdown_rx));
 
-    wait_for_runtime_process_state(node.as_ref(), identity.did(), "ready").await;
+    observer.wait_for(ProcessLifecycleState::Ready).await;
     let _ = shutdown_tx.send(true);
     run_task.await??;
 
-    let observed = observer
-        .states
-        .lock()
-        .expect("recording observer mutex poisoned")
-        .clone();
+    let observed = observer.states();
     assert_eq!(
         observed,
         vec![

--- a/crates/gents/tests/misc/startup_readiness_barrier.rs
+++ b/crates/gents/tests/misc/startup_readiness_barrier.rs
@@ -1,12 +1,12 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use anyhow::Result;
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
 use gents::startup_readiness::StartupReadinessOptions;
 use gents::{
-    ensure_runtime_schemas, AgentIdentity, DocumentRuntimeOptions, Gents, ProcessLifecycleObserver,
-    ProcessLifecycleState, ToolCeiling,
+    ensure_runtime_schemas, AgentIdentity, DocumentRuntimeOptions, Gents, ProcessLifecycleState,
+    ToolCeiling,
 };
 use serde_json::Value;
 use tokio::sync::watch;
@@ -14,21 +14,7 @@ use tokio::sync::watch;
 use crate::support::fixtures::bind_default_behavior_backend;
 use crate::support::fixtures::test_identity;
 use crate::support::mock_endpoint::MockModelEndpoint;
-use crate::support::waits::wait_for_runtime_process_state;
-
-#[derive(Default)]
-struct RecordingObserver {
-    states: Mutex<Vec<ProcessLifecycleState>>,
-}
-
-impl ProcessLifecycleObserver for RecordingObserver {
-    fn on_process_state_change(&self, state: ProcessLifecycleState) {
-        self.states
-            .lock()
-            .expect("recording observer mutex poisoned")
-            .push(state);
-    }
-}
+use crate::support::waits::RecordingProcessObserver;
 
 #[tokio::test]
 async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<()> {
@@ -65,7 +51,7 @@ async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<(
         "the poison env var must not be set for this test to be honest"
     );
 
-    let observer = Arc::new(RecordingObserver::default());
+    let observer = Arc::new(RecordingProcessObserver::default());
     let agent = Gents::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
@@ -88,7 +74,7 @@ async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<(
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let run_task = tokio::spawn(agent.run(shutdown_rx));
 
-    wait_for_runtime_process_state(node.as_ref(), identity.did(), "ready").await;
+    observer.wait_for(ProcessLifecycleState::Ready).await;
 
     let escaped_did = escape_graphql_string(identity.did());
     let query = format!(
@@ -124,11 +110,7 @@ async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<(
     let _ = shutdown_tx.send(true);
     run_task.await??;
 
-    let observed = observer
-        .states
-        .lock()
-        .expect("recording observer mutex poisoned")
-        .clone();
+    let observed = observer.states();
     assert!(
         observed.contains(&ProcessLifecycleState::Ready),
         "process must reach Ready despite the un-buildable behavior; observed {observed:?}"
@@ -191,6 +173,7 @@ async fn transient_build_failure_within_budget_still_reaches_ready_healthy() -> 
     let response = node.execute(&mutation).await;
     assert!(!response.has_errors(), "{:?}", response.errors);
 
+    let observer = Arc::new(RecordingProcessObserver::default());
     let agent = Gents::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
@@ -205,6 +188,7 @@ async fn transient_build_failure_within_budget_still_reaches_ready_healthy() -> 
                 build_failure_budget: 10,
                 ..Default::default()
             },
+            process_state_observer: Some(observer.clone()),
             ..Default::default()
         },
     )
@@ -217,7 +201,7 @@ async fn transient_build_failure_within_budget_still_reaches_ready_healthy() -> 
         std::env::set_var(VAR, "late-key");
     }
 
-    wait_for_runtime_process_state(node.as_ref(), identity.did(), "ready").await;
+    observer.wait_for(ProcessLifecycleState::Ready).await;
 
     let escaped_did = escape_graphql_string(identity.did());
     let query = format!(

--- a/crates/gents/tests/support/waits.rs
+++ b/crates/gents/tests/support/waits.rs
@@ -1,38 +1,64 @@
+use std::sync::Mutex;
 use std::time::Duration;
 
-use gents::defra_node::EmbeddedNode;
-use gents::graphql::escape_graphql_string;
-use serde_json::Value;
+use gents::{ProcessLifecycleObserver, ProcessLifecycleState};
+use tokio::sync::watch;
 
-pub async fn wait_for_runtime_process_state(
-    node: &EmbeddedNode,
-    agent_did: &str,
-    expected_process_state: &str,
-) {
-    let escaped_agent_did = escape_graphql_string(agent_did);
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        let query = format!(
-            r#"{{
-                AgentRuntime(filter: {{ agent_did: {{ _eq: "{escaped_agent_did}" }} }}, limit: 1) {{
-                    process_state
-                }}
-            }}"#
-        );
-        let response = node.execute(&query).await;
-        assert!(!response.has_errors(), "{:?}", response.errors);
-        let process_state = response
-            .data
-            .as_ref()
-            .and_then(|data| data.get("AgentRuntime"))
-            .and_then(Value::as_array)
-            .and_then(|rows| rows.first())
-            .and_then(|row| row.get("process_state"))
-            .and_then(Value::as_str);
-        if process_state == Some(expected_process_state) {
-            return;
+const PROCESS_STATE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct RecordingProcessObserver {
+    states: Mutex<Vec<ProcessLifecycleState>>,
+    process_state_tx: watch::Sender<ProcessLifecycleState>,
+}
+
+impl Default for RecordingProcessObserver {
+    fn default() -> Self {
+        let (process_state_tx, _) = watch::channel(ProcessLifecycleState::Uninitialized);
+        Self {
+            states: Mutex::new(Vec::new()),
+            process_state_tx,
         }
-        assert!(tokio::time::Instant::now() < deadline);
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+impl RecordingProcessObserver {
+    pub fn states(&self) -> Vec<ProcessLifecycleState> {
+        self.states
+            .lock()
+            .expect("recording observer mutex poisoned")
+            .clone()
+    }
+
+    pub async fn wait_for(&self, expected: ProcessLifecycleState) {
+        let mut process_state_rx = self.process_state_tx.subscribe();
+        let wait = async {
+            loop {
+                if *process_state_rx.borrow_and_update() == expected {
+                    return Ok::<(), watch::error::RecvError>(());
+                }
+                process_state_rx.changed().await?;
+            }
+        };
+        match tokio::time::timeout(PROCESS_STATE_WAIT_TIMEOUT, wait).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                panic!("process lifecycle observer closed while waiting for {expected:?}: {error}")
+            }
+            Err(error) => panic!(
+                "timed out after {PROCESS_STATE_WAIT_TIMEOUT:?} waiting for observed process state \
+                 {expected:?}; observed states: {:?}: {error}",
+                self.states()
+            ),
+        }
+    }
+}
+
+impl ProcessLifecycleObserver for RecordingProcessObserver {
+    fn on_process_state_change(&self, state: ProcessLifecycleState) {
+        self.states
+            .lock()
+            .expect("recording observer mutex poisoned")
+            .push(state);
+        self.process_state_tx.send_replace(state);
     }
 }


### PR DESCRIPTION
## Summary

- wait for background panic completion through the live execution registry instead of polling DefraDB while the worker is terminalizing
- replace three startup readiness polling loops with a shared `ProcessLifecycleObserver`-backed watch fixture
- preserve the existing 5-second bounds and perform durable row assertions only after the corresponding in-process lifecycle boundary

The CI failure in run 33126868620 occurred under heavy embedded-node concurrency. The panic test had already spent over 60 seconds in setup and spawn work before its 5-second Defra-backed completion wait failed with the row still `running`; the three misc readiness tests then expired the same Defra polling helper together. Those polling reads competed with the lifecycle writes they were meant to observe. The new waits are driven by runtime ownership/readiness signals and do no Defra reads within their bounded loops.

This is synchronization and observability plumbing only. Runtime transition legality, provider input, and Lean contracts are unchanged.

## Validation

- exact panic regression: 1/1 passed in 1.13s
- exact readiness regressions: 3/3 passed (0.70s startup pair, 0.54s backend auth)
- loaded background-tool stress: 3 x 21 tests, 63/63 passed (17.39s, 13.26s, 11.35s)
- full misc concurrency shape: 27/27 passed in 5.52s
- `cargo test -p gents` (including 107/107 e2e_subagent in 54.96s and 27/27 misc in 4.60s)
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1270