### PR TITLE
test: isolate backend auth document runtime fixture

### DIFF
--- a/crates/gents/tests/misc/backend_auth_startup.rs
+++ b/crates/gents/tests/misc/backend_auth_startup.rs
@@ -3,19 +3,14 @@ use std::sync::Arc;
 use anyhow::Result;
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
-use gents::{
-    ensure_runtime_schemas, AgentIdentity, DocumentRuntimeOptions, Gents, ProcessLifecycleState,
-    ToolCeiling,
-};
+use gents::{ensure_runtime_schemas, AgentIdentity, DocumentRuntimeOptions, Gents, ToolCeiling};
 use serde_json::Value;
-use tokio::sync::watch;
 
 use crate::support::fixtures::{bind_default_behavior_backend, test_behavior, test_identity};
 use crate::support::mock_endpoint::MockModelEndpoint;
-use crate::support::waits::RecordingProcessObserver;
 
 #[tokio::test]
-async fn run_agent_uses_backend_specific_api_key_env_var_for_startup_probe() -> Result<()> {
+async fn document_runtime_uses_backend_specific_api_key_env_var() -> Result<()> {
     use std::ffi::OsString;
     use std::sync::LazyLock;
 
@@ -85,34 +80,22 @@ async fn run_agent_uses_backend_specific_api_key_env_var_for_startup_probe() -> 
 
     let mut env = TestEnvGuard::new(&["GENTS_TEST_RUNTIME_BACKEND_KEY"]);
     env.set("GENTS_TEST_RUNTIME_BACKEND_KEY", "backend-key");
-    let observer = Arc::new(RecordingProcessObserver::default());
     let agent = Gents::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
         DocumentRuntimeOptions {
             tool_ceiling: ToolCeiling::meta_only(),
-            process_state_observer: Some(observer.clone()),
             ..Default::default()
         },
     )
     .await?;
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let run_task = tokio::spawn(agent.run(shutdown_rx));
 
-    observer.wait_for(ProcessLifecycleState::Ready).await;
-    let _ = shutdown_tx.send(true);
-    run_task.await??;
-
-    let observed = observer.states();
-    assert_eq!(
-        observed,
-        vec![
-            ProcessLifecycleState::Recovering,
-            ProcessLifecycleState::Ready,
-            ProcessLifecycleState::ShuttingDown,
-            ProcessLifecycleState::Shutdown,
-        ]
-    );
+    let default_behavior = agent
+        .behaviors()
+        .iter()
+        .find(|behavior| behavior.behavior_id == agent.default_behavior_id())
+        .expect("document runtime should load the default behavior");
+    assert_eq!(default_behavior.completion_client_api_key()?, "backend-key");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- keep the backend auth regression at the document-runtime boundary it actually exercises
- resolve the loaded default behavior and assert its completion client reads the backend-specific environment variable
- remove the unrelated full daemon readiness and shutdown lifecycle from this fixture

## Why
Main CI run 33135965925 left this test observing only Recovering before its 5-second readiness watchdog expired. The fixture had already marked its backend healthy, so startup skipped the HTTP probe; waiting for full runtime Ready tested unrelated Defra persistence and reconciliation. This change preserves the server-backed document loading path while asserting the intended credential resolution directly, without increasing a timeout.

## Validation
- exact test: 100/100 repetitions passed in 22s
- full misc integration binary: 10/10 repetitions passed, 270/270 tests in 81s
- cargo test -p gents
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check

No production or Lean changes.

Closes #1270