### PR TITLE
test: await owned background completion boundary

### DIFF
--- a/crates/gents/src/hook.rs
+++ b/crates/gents/src/hook.rs
@@ -7,7 +7,7 @@ use crate::llm::tool::ToolDyn;
 use crate::llm::{HookAction, ToolCallHookAction};
 use chrono::{DateTime, Utc};
 use defra_node::EmbeddedNode;
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
 use tokio_util::sync::CancellationToken;
 
 use crate::background_tools::LiveToolOutputRegistry;
@@ -87,6 +87,7 @@ impl BackgroundToolRegistry {
 #[derive(Clone)]
 struct BackgroundExecution {
     cancellation_token: CancellationToken,
+    completion_tx: watch::Sender<bool>,
 }
 
 #[derive(Clone, Default)]
@@ -147,9 +148,13 @@ impl BackgroundExecutionRegistry {
         tool_call_id: String,
         cancellation_token: CancellationToken,
     ) -> BackgroundExecutionReservation {
+        let (completion_tx, _) = watch::channel(false);
         self.lock_executions().insert(
             tool_call_id.clone(),
-            BackgroundExecution { cancellation_token },
+            BackgroundExecution {
+                cancellation_token,
+                completion_tx,
+            },
         );
         BackgroundExecutionReservation {
             registry: self.clone(),
@@ -158,17 +163,45 @@ impl BackgroundExecutionRegistry {
         }
     }
 
+    #[cfg(test)]
     pub(crate) async fn remove(&self, tool_call_id: &str) {
         self.remove_now(tool_call_id);
     }
 
     /// Returns whether this process still owns a live background execution.
-    pub async fn contains(&self, tool_call_id: &str) -> bool {
+    pub(crate) async fn contains(&self, tool_call_id: &str) -> bool {
         self.lock_executions().contains_key(tool_call_id)
     }
 
+    /// Waits until this process releases ownership of a background execution.
+    ///
+    /// Normal worker completion releases ownership after durable terminal
+    /// persistence, completion projection, and live-output cleanup. An
+    /// unexpected task panic or abort drops the same ownership guard earlier,
+    /// allowing recovery to observe the abandoned durable execution.
+    ///
+    /// Subscribing while holding the registry lock makes the boundary
+    /// missed-event-safe: an execution removed before this call returns
+    /// immediately, while an execution removed afterward signals this waiter.
+    pub async fn wait_for_completion(&self, tool_call_id: &str) {
+        let mut completion_rx = {
+            let executions = self.lock_executions();
+            let Some(execution) = executions.get(tool_call_id) else {
+                return;
+            };
+            execution.completion_tx.subscribe()
+        };
+        while !*completion_rx.borrow_and_update() {
+            if completion_rx.changed().await.is_err() {
+                break;
+            }
+        }
+    }
+
     fn remove_now(&self, tool_call_id: &str) {
-        self.lock_executions().remove(tool_call_id);
+        if let Some(execution) = self.lock_executions().remove(tool_call_id) {
+            execution.completion_tx.send_replace(true);
+        }
     }
 
     fn lock_executions(&self) -> std::sync::MutexGuard<'_, HashMap<String, BackgroundExecution>> {
@@ -188,6 +221,7 @@ pub(crate) struct BackgroundExecutionReservation {
 }
 
 impl BackgroundExecutionReservation {
+    #[cfg(test)]
     pub(crate) fn disarm(mut self) {
         self.armed = false;
     }

--- a/crates/gents/src/hook/persistence/background_tools.rs
+++ b/crates/gents/src/hook/persistence/background_tools.rs
@@ -145,7 +145,6 @@ impl DefraSessionHook {
         lifecycle.start_running().await?;
 
         let node = self.node.clone();
-        let executions = self.background_executions.clone();
         let live_outputs = self.background_live_outputs.clone();
         let execution_call_id = background_tool_call_id.clone();
         let execution_session_id = session_id.clone();
@@ -402,10 +401,12 @@ impl DefraSessionHook {
                 }
             }
 
-            executions.remove(&execution_call_id).await;
             live_outputs.remove(&execution_call_id).await;
+            // Keep volatile ownership attached to the spawned task itself.
+            // Dropping this guard after cleanup signals ordinary completion;
+            // task panic or abort also releases ownership for recovery.
+            drop(execution_reservation);
         });
-        execution_reservation.disarm();
 
         Ok(self.skip_tool_result(
             SPAWN_PROCESS_TOOL_NAME,

--- a/crates/gents/src/hook/tests.rs
+++ b/crates/gents/src/hook/tests.rs
@@ -2810,6 +2810,54 @@ async fn background_execution_reservation_drop_releases_ownership() {
 }
 
 #[tokio::test]
+async fn background_execution_completion_wait_is_missed_event_safe() {
+    let registry = BackgroundExecutionRegistry::default();
+    let reservation = registry.reserve("tool-waited".to_string(), CancellationToken::new());
+    reservation.disarm();
+
+    let waiter_registry = registry.clone();
+    let waiter = tokio::spawn(async move {
+        waiter_registry.wait_for_completion("tool-waited").await;
+    });
+    tokio::task::yield_now().await;
+    assert!(!waiter.is_finished());
+
+    registry.remove("tool-waited").await;
+    tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+        .await
+        .expect("completion waiter should observe registry removal")
+        .expect("completion waiter task should not panic");
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        registry.wait_for_completion("tool-waited"),
+    )
+    .await
+    .expect("waiting after registry removal should return immediately");
+}
+
+#[tokio::test]
+async fn background_execution_completion_wait_observes_task_abort_guard_drop() {
+    let registry = BackgroundExecutionRegistry::default();
+    let reservation = registry.reserve("tool-aborted".to_string(), CancellationToken::new());
+    let task = tokio::spawn(async move {
+        let _reservation = reservation;
+        std::future::pending::<()>().await;
+    });
+    tokio::task::yield_now().await;
+
+    task.abort();
+    let error = task.await.expect_err("aborted task should not complete");
+    assert!(error.is_cancelled());
+    tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        registry.wait_for_completion("tool-aborted"),
+    )
+    .await
+    .expect("task-owned reservation should release on abort");
+}
+
+#[tokio::test]
 async fn flushed_sequence_commit_cannot_resurrect_removed_live_output() {
     let state = BackgroundLiveOutputState::default();
     state.record_flushed_seq_if_live("removed-tool", 7).await;

--- a/crates/gents/tests/e2e_subagent/r6_background_tools.rs
+++ b/crates/gents/tests/e2e_subagent/r6_background_tools.rs
@@ -336,25 +336,6 @@ async fn load_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &st
     first_row(&node.execute(&query).await, "AgentToolCall")
 }
 
-async fn wait_for_background_execution_completion(
-    executions: &BackgroundExecutionRegistry,
-    tool_call_id: &str,
-) {
-    let wait = async {
-        while executions.contains(tool_call_id).await {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(5), wait)
-        .await
-        .unwrap_or_else(|error| {
-            panic!(
-                "background execution {tool_call_id} did not leave the live registry after 5s: \
-                 {error}"
-            )
-        });
-}
-
 #[tokio::test]
 async fn background_diagnostic_snapshot_is_bounded_and_explicit() {
     let ready = bounded_diagnostic(Duration::from_secs(1), async { "ready" }).await;
@@ -804,9 +785,9 @@ async fn panicking_background_tool_terminalizes_and_notifies() {
     let tool_call_id = receipt["tool_call_id"].as_str().unwrap().to_string();
 
     // Registry ownership ends only after terminal persistence and completion
-    // projection finish. Waiting on that in-process boundary avoids competing
-    // Defra reads while the background worker is trying to write under load.
-    wait_for_background_execution_completion(&executions, &tool_call_id).await;
+    // projection finish. Await that owned task boundary directly instead of
+    // imposing a wall-clock deadline on Defra writes under suite load.
+    executions.wait_for_completion(&tool_call_id).await;
 
     let row = load_tool_call(db.node.as_ref(), &session_id, &tool_call_id).await;
     assert_eq!(row.lifecycle_state.as_deref(), Some("failed"));


### PR DESCRIPTION
## Summary
- attach a missed-event-safe completion signal to each live background execution reservation
- keep the armed reservation owned by the spawned worker so normal completion, panic, and abort all release volatile ownership truthfully
- await that owned boundary in the panic integration fixture instead of polling registry state behind an arbitrary 5-second wall clock

## Why
Post-merge main CI run 33143298744 took 239 seconds for the `e2e_subagent` binary and reached the panic fixture while its worker was still completing terminal persistence and notification projection. Registry removal is correctly ordered after those side effects, so the fixture five-second watchdog failed under shared Defra load even though the task was not leaked.

Normal completion now signals only after durable terminal persistence, completion projection, and live-output cleanup. Unexpected task panic or abort drops the same guard earlier so recovery can observe abandoned work. This is volatile task-ownership plumbing; it does not change legal lifecycle transitions, provider input, or Lean contracts.

## Validation
- completion boundary unit tests: 2/2 passed, including task-abort guard cleanup
- exact panic integration selector: 100/100 passed in 68s
- full e2e_subagent binary: 10/10 runs passed, 1,070/1,070 tests in 691s
- cargo test -p gents
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check

Closes #1270