### PR TITLE
test: await startup build readiness boundaries

### DIFF
--- a/crates/gents/src/agent.rs
+++ b/crates/gents/src/agent.rs
@@ -93,6 +93,9 @@ pub struct DocumentRuntimeOptions {
     pub backend_health: Option<BackendHealthMap>,
     pub process_state_observer: Option<Arc<dyn ProcessLifecycleObserver>>,
     pub runtime_snapshot_observer: Option<Arc<dyn RuntimeSnapshotObserver>>,
+    #[doc(hidden)]
+    pub startup_build_failure_observer:
+        Option<Arc<dyn crate::startup_readiness::StartupBuildFailureObserver>>,
     pub startup_readiness: crate::startup_readiness::StartupReadinessOptions,
 }
 
@@ -121,6 +124,8 @@ pub struct Gents {
     backend_health: BackendHealthMap,
     process_state_observer: Option<Arc<dyn ProcessLifecycleObserver>>,
     runtime_snapshot_observer: Option<Arc<dyn RuntimeSnapshotObserver>>,
+    startup_build_failure_observer:
+        Option<Arc<dyn crate::startup_readiness::StartupBuildFailureObserver>>,
     startup_readiness: crate::startup_readiness::StartupReadinessOptions,
     rendered_request_capture_factory:
         Option<crate::rendered_request::RenderedRequestCaptureFactory>,
@@ -209,6 +214,7 @@ impl Gents {
             backend_health,
             process_state_observer: options.process_state_observer,
             runtime_snapshot_observer: options.runtime_snapshot_observer,
+            startup_build_failure_observer: options.startup_build_failure_observer,
             startup_readiness: options.startup_readiness,
             // Capture is mandatory (#840): a provider call with no durable
             // rendered input is a log entry, not a fact record. The public

--- a/crates/gents/src/agent/builder.rs
+++ b/crates/gents/src/agent/builder.rs
@@ -239,6 +239,7 @@ impl GentsBuilder {
             backend_health: crate::backend_health::BackendHealthMap::new(),
             process_state_observer: self.process_state_observer,
             runtime_snapshot_observer: None,
+            startup_build_failure_observer: None,
             startup_readiness: Default::default(),
             // Same default as `Gents::from_default_behavior_documents`: every
             // provider request must pass through the durable DefraDB sink.

--- a/crates/gents/src/agent/reconcile/slot.rs
+++ b/crates/gents/src/agent/reconcile/slot.rs
@@ -50,6 +50,7 @@ impl BehaviorSlot {
 #[async_trait::async_trait]
 pub(crate) trait SlotFailurePolicy: Send + Sync {
     fn build_failure_budget(&self) -> u32;
+    fn on_build_failure(&self, _behavior_id: &str, _failure_number: u32, _error: &str) {}
     async fn try_demote(&self, behavior_id: &str, error: &str) -> bool;
     async fn on_slot_retired(&self, behavior_id: &str, recreated: bool);
 }
@@ -71,26 +72,31 @@ async fn handle_slot_failure(
         Transitioned,
         StillPending,
     }
-    let verdict = match standing.lock() {
-        Err(_) => Verdict::Restart,
+    let (verdict, failure_number) = match standing.lock() {
+        Err(_) => (Verdict::Restart, None),
         Ok(mut standing) => {
             if standing.released() {
                 if *standing == BuildStanding::Demoted {
-                    Verdict::AlreadyDemoted
+                    (Verdict::AlreadyDemoted, None)
                 } else {
-                    Verdict::Restart
+                    (Verdict::Restart, None)
                 }
             } else {
                 let next = standing.step(policy.build_failure_budget(), BuildOutcome::Failed);
                 *standing = next;
                 if next == BuildStanding::Demoted {
-                    Verdict::Transitioned
+                    (Verdict::Transitioned, Some(policy.build_failure_budget()))
+                } else if let BuildStanding::Pending { failures } = next {
+                    (Verdict::StillPending, Some(failures))
                 } else {
-                    Verdict::StillPending
+                    (Verdict::Restart, None)
                 }
             }
         }
     };
+    if let Some(failure_number) = failure_number {
+        policy.on_build_failure(behavior_id, failure_number, error);
+    }
     match verdict {
         Verdict::Restart | Verdict::StillPending => return false,
         Verdict::AlreadyDemoted => {

--- a/crates/gents/src/agent/runtime/startup.rs
+++ b/crates/gents/src/agent/runtime/startup.rs
@@ -44,6 +44,7 @@ struct StartupSlotFailurePolicy {
     barrier: Arc<StartupBarrier>,
     demotions: Arc<crate::startup_readiness::StartupDemotions>,
     runtime_status: RuntimeStatusHandle,
+    observer: Option<Arc<dyn crate::startup_readiness::StartupBuildFailureObserver>>,
     budget: u32,
 }
 
@@ -51,6 +52,17 @@ struct StartupSlotFailurePolicy {
 impl crate::agent::reconcile::SlotFailurePolicy for StartupSlotFailurePolicy {
     fn build_failure_budget(&self) -> u32 {
         self.budget.max(1)
+    }
+
+    fn on_build_failure(&self, behavior_id: &str, failure_number: u32, error: &str) {
+        if let Some(observer) = &self.observer {
+            observer.on_build_failure(
+                behavior_id,
+                failure_number,
+                self.build_failure_budget(),
+                error,
+            );
+        }
     }
 
     async fn try_demote(&self, behavior_id: &str, error: &str) -> bool {
@@ -183,6 +195,7 @@ pub(in crate::agent) async fn run_agent(
             barrier: startup_barrier.clone(),
             demotions: startup_demotions.clone(),
             runtime_status: runtime_status.clone(),
+            observer: agent.startup_build_failure_observer.clone(),
             budget: agent.startup_readiness.build_failure_budget,
         });
     let generation_supervisor = GenerationSupervisor::bootstrap(

--- a/crates/gents/src/startup_readiness.rs
+++ b/crates/gents/src/startup_readiness.rs
@@ -21,6 +21,15 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Duration;
 
+/// Observes failed startup behavior-build attempts.
+///
+/// This is diagnostic plumbing for embedders and deterministic test fixtures;
+/// it does not participate in the build-failure verdict.
+#[doc(hidden)]
+pub trait StartupBuildFailureObserver: Send + Sync {
+    fn on_build_failure(&self, behavior_id: &str, failure_number: u32, budget: u32, error: &str);
+}
+
 #[derive(Debug, Clone)]
 pub struct StartupReadinessOptions {
     pub build_failure_budget: u32,

--- a/crates/gents/tests/misc/startup_readiness_barrier.rs
+++ b/crates/gents/tests/misc/startup_readiness_barrier.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use events::EventName;
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
 use gents::startup_readiness::StartupReadinessOptions;
@@ -15,6 +16,118 @@ use crate::support::fixtures::bind_default_behavior_backend;
 use crate::support::fixtures::test_identity;
 use crate::support::mock_endpoint::MockModelEndpoint;
 use crate::support::waits::RecordingProcessObserver;
+
+#[derive(Clone, Debug)]
+struct BuildFailure {
+    behavior_id: String,
+    failure_number: u32,
+    budget: u32,
+    error: String,
+}
+
+struct RecordingBuildFailureObserver {
+    failures: Mutex<Vec<BuildFailure>>,
+    failure_count_tx: watch::Sender<usize>,
+}
+
+impl Default for RecordingBuildFailureObserver {
+    fn default() -> Self {
+        let (failure_count_tx, _) = watch::channel(0);
+        Self {
+            failures: Mutex::new(Vec::new()),
+            failure_count_tx,
+        }
+    }
+}
+
+impl RecordingBuildFailureObserver {
+    fn failures(&self) -> Vec<BuildFailure> {
+        self.failures
+            .lock()
+            .expect("build failure observer mutex poisoned")
+            .clone()
+    }
+
+    async fn wait_for_failure_count(&self, expected: usize) {
+        let mut failure_count_rx = self.failure_count_tx.subscribe();
+        loop {
+            if self
+                .failures
+                .lock()
+                .expect("build failure observer mutex poisoned")
+                .len()
+                >= expected
+            {
+                return;
+            }
+            failure_count_rx
+                .changed()
+                .await
+                .expect("build failure observer closed");
+        }
+    }
+}
+
+impl gents::startup_readiness::StartupBuildFailureObserver for RecordingBuildFailureObserver {
+    fn on_build_failure(&self, behavior_id: &str, failure_number: u32, budget: u32, error: &str) {
+        let count = {
+            let mut failures = self
+                .failures
+                .lock()
+                .expect("build failure observer mutex poisoned");
+            failures.push(BuildFailure {
+                behavior_id: behavior_id.to_string(),
+                failure_number,
+                budget,
+                error: error.to_string(),
+            });
+            failures.len()
+        };
+        self.failure_count_tx.send_replace(count);
+    }
+}
+
+async fn wait_for_runtime_counts(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    runnable: i64,
+    unavailable: i64,
+) -> Value {
+    let escaped_did = escape_graphql_string(agent_did);
+    let query = format!(
+        r#"{{
+            AgentRuntime(filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }}, limit: 1) {{
+                runnable_behavior_count
+                unavailable_behavior_count
+            }}
+        }}"#
+    );
+    let mut updates = node.subscribe(&[EventName::Update]);
+    loop {
+        let response = node.execute(&query).await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        if let Some(row) = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("AgentRuntime"))
+            .and_then(Value::as_array)
+            .and_then(|rows| rows.first())
+            .cloned()
+        {
+            let observed_runnable = row.get("runnable_behavior_count").and_then(Value::as_i64);
+            let observed_unavailable = row
+                .get("unavailable_behavior_count")
+                .and_then(Value::as_i64);
+            if observed_runnable == Some(runnable) && observed_unavailable == Some(unavailable) {
+                return row;
+            }
+        }
+        updates
+            .recv()
+            .await
+            .expect("runtime status update subscription closed");
+    }
+}
 
 #[tokio::test]
 async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<()> {
@@ -52,12 +165,14 @@ async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<(
     );
 
     let observer = Arc::new(RecordingProcessObserver::default());
+    let build_failure_observer = Arc::new(RecordingBuildFailureObserver::default());
     let agent = Gents::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
         DocumentRuntimeOptions {
             tool_ceiling: ToolCeiling::meta_only(),
             process_state_observer: Some(observer.clone()),
+            startup_build_failure_observer: Some(build_failure_observer.clone()),
             retry_policy: gents::retry::RetryPolicy {
                 max_retries: 3,
                 base_delay_ms: 1,
@@ -71,30 +186,25 @@ async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<(
         },
     )
     .await?;
+    let default_behavior_id = agent.default_behavior_id().to_string();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let run_task = tokio::spawn(agent.run(shutdown_rx));
 
     observer.wait_for(ProcessLifecycleState::Ready).await;
 
-    let escaped_did = escape_graphql_string(identity.did());
-    let query = format!(
-        r#"{{
-            AgentRuntime(filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }}, limit: 1) {{
-                runnable_behavior_count
-                unavailable_behavior_count
-            }}
-        }}"#
-    );
-    let response = node.execute(&query).await;
-    assert!(!response.has_errors(), "{:?}", response.errors);
-    let row = response
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentRuntime"))
-        .and_then(Value::as_array)
-        .and_then(|rows| rows.first())
-        .cloned()
-        .expect("AgentRuntime row");
+    let failures = build_failure_observer.failures();
+    assert_eq!(failures.len(), 2, "the configured budget must be exhausted");
+    assert_eq!(failures[0].failure_number, 1);
+    assert_eq!(failures[1].failure_number, 2);
+    assert!(failures
+        .iter()
+        .all(|failure| failure.behavior_id == default_behavior_id));
+    assert!(failures.iter().all(|failure| failure.budget == 2));
+    assert!(failures
+        .iter()
+        .all(|failure| failure.error.contains("GENTS_TEST_559_UNSET_KEY")));
+
+    let row = wait_for_runtime_counts(node.as_ref(), identity.did(), 0, 1).await;
     assert_eq!(
         row.get("runnable_behavior_count").and_then(Value::as_i64),
         Some(0),
@@ -174,6 +284,7 @@ async fn transient_build_failure_within_budget_still_reaches_ready_healthy() -> 
     assert!(!response.has_errors(), "{:?}", response.errors);
 
     let observer = Arc::new(RecordingProcessObserver::default());
+    let build_failure_observer = Arc::new(RecordingBuildFailureObserver::default());
     let agent = Gents::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
@@ -189,39 +300,34 @@ async fn transient_build_failure_within_budget_still_reaches_ready_healthy() -> 
                 ..Default::default()
             },
             process_state_observer: Some(observer.clone()),
+            startup_build_failure_observer: Some(build_failure_observer.clone()),
             ..Default::default()
         },
     )
     .await?;
+    let default_behavior_id = agent.default_behavior_id().to_string();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let run_task = tokio::spawn(agent.run(shutdown_rx));
 
-    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    build_failure_observer.wait_for_failure_count(1).await;
     unsafe {
         std::env::set_var(VAR, "late-key");
     }
 
     observer.wait_for(ProcessLifecycleState::Ready).await;
 
-    let escaped_did = escape_graphql_string(identity.did());
-    let query = format!(
-        r#"{{
-            AgentRuntime(filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }}, limit: 1) {{
-                runnable_behavior_count
-                unavailable_behavior_count
-            }}
-        }}"#
+    let failures = build_failure_observer.failures();
+    assert!(
+        !failures.is_empty(),
+        "the key must be installed only after an observed failed build"
     );
-    let response = node.execute(&query).await;
-    assert!(!response.has_errors(), "{:?}", response.errors);
-    let row = response
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentRuntime"))
-        .and_then(Value::as_array)
-        .and_then(|rows| rows.first())
-        .cloned()
-        .expect("AgentRuntime row");
+    assert!(failures.iter().all(|failure| failure.budget == 10));
+    assert!(failures
+        .iter()
+        .all(|failure| failure.behavior_id == default_behavior_id));
+    assert!(failures.iter().all(|failure| failure.error.contains(VAR)));
+
+    let row = wait_for_runtime_counts(node.as_ref(), identity.did(), 1, 0).await;
     assert_eq!(
         row.get("runnable_behavior_count").and_then(Value::as_i64),
         Some(1),

--- a/crates/gents/tests/support/waits.rs
+++ b/crates/gents/tests/support/waits.rs
@@ -1,10 +1,6 @@
-use std::sync::Mutex;
-use std::time::Duration;
-
 use gents::{ProcessLifecycleObserver, ProcessLifecycleState};
+use std::sync::Mutex;
 use tokio::sync::watch;
-
-const PROCESS_STATE_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct RecordingProcessObserver {
     states: Mutex<Vec<ProcessLifecycleState>>,
@@ -31,24 +27,17 @@ impl RecordingProcessObserver {
 
     pub async fn wait_for(&self, expected: ProcessLifecycleState) {
         let mut process_state_rx = self.process_state_tx.subscribe();
-        let wait = async {
-            loop {
-                if *process_state_rx.borrow_and_update() == expected {
-                    return Ok::<(), watch::error::RecvError>(());
-                }
-                process_state_rx.changed().await?;
+        loop {
+            if self.states().contains(&expected) {
+                return;
             }
-        };
-        match tokio::time::timeout(PROCESS_STATE_WAIT_TIMEOUT, wait).await {
-            Ok(Ok(())) => {}
-            Ok(Err(error)) => {
-                panic!("process lifecycle observer closed while waiting for {expected:?}: {error}")
-            }
-            Err(error) => panic!(
-                "timed out after {PROCESS_STATE_WAIT_TIMEOUT:?} waiting for observed process state \
-                 {expected:?}; observed states: {:?}: {error}",
-                self.states()
-            ),
+            process_state_rx.changed().await.unwrap_or_else(|error| {
+                panic!(
+                    "process lifecycle observer closed while waiting for {expected:?}; \
+                     observed states: {:?}: {error}",
+                    self.states()
+                )
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace the loaded-suite 5-second process observer deadline with a latched lifecycle boundary that is safe when Ready has already been observed
- add diagnostic-only startup build-failure observation after the existing BuildStanding transition, so the transient fixture installs its late key only after a real failed build
- await subscription-backed durable AgentRuntime counts before asserting the demoted and healthy projections

The failing main run timed out with no observed process states because run_agent performs runtime migrations before publishing Recovering. The old transient fixture also used a blind 75ms sleep, which could install the key before the first build under load and therefore fail to exercise recovery. This patch changes observability and test synchronization only; it does not change lifecycle transitions, provider input, or the Lean model.

## Verification

- focused startup readiness pair: 2/2
- persistent exact selector: 100/100
- transient exact selector: 100/100 (run concurrently with persistent stress)
- full misc binary under five-way process concurrency: 10/10 runs, 270/270 tests
- cargo test -p gents
- cargo check --workspace --all-targets (green; existing Matcher.description dead-code warning only)
- cargo fmt --all -- --check
- git diff --check

Closes #1270