### PR TITLE
fix(desktop): repair v0.14 mobile first-run UX

### DIFF
--- a/apps/gents-desktop/index.html
+++ b/apps/gents-desktop/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>Gents</title>
   </head>
 

--- a/apps/gents-desktop/src/App.css
+++ b/apps/gents-desktop/src/App.css
@@ -22,6 +22,7 @@
 @import "@source-inc/gents-desktop-chat/styles.css";
 @import "@source-inc/gents-desktop-fleet/styles.css";
 @import "@source-inc/gents-desktop-fleet/local-runtime.css";
+@import "@source-inc/gents-desktop-operations/styles.css";
 @import "./styles/config/workspace.css";
 @import "./styles/config/agent-behavior.css";
 @import "./styles/config/documents.css";

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -321,6 +321,12 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
               sendHint={
                 shell.sendStatus.kind === "disabled" ? shell.sendStatus.hint : null
               }
+              retryUnavailableHint={
+                shell.sendStatus.kind === "disabled" &&
+                shell.sendStatus.reason === "behaviorUnavailable"
+                  ? shell.sendStatus.hint
+                  : null
+              }
               selectedBehaviorId={shell.selectedBehaviorId}
               selectedConversationTitle={
                 shell.session

--- a/apps/gents-desktop/src/components/ChatWorkspace.tsx
+++ b/apps/gents-desktop/src/components/ChatWorkspace.tsx
@@ -38,6 +38,7 @@ export type ChatWorkspaceProps = {
   configuredPeerCount: number;
   canSend: boolean;
   sendHint: string | null;
+  retryUnavailableHint?: string | null;
   draft: string;
   interruptVisible: boolean;
   sending: boolean;
@@ -91,6 +92,7 @@ export function ActiveChatWorkspace({
   configuredPeerCount,
   canSend,
   sendHint,
+  retryUnavailableHint,
   draft,
   interruptVisible,
   sending,
@@ -201,6 +203,7 @@ export function ActiveChatWorkspace({
             session={session}
             optimisticPendingTurn={optimisticPendingTurn}
             onRetryMessage={onRetryMessage}
+            retryUnavailableHint={retryUnavailableHint}
             onLoadOlder={onLoadOlderTimeline}
           />
 

--- a/apps/gents-desktop/src/hooks/desktopShellChatActions.ts
+++ b/apps/gents-desktop/src/hooks/desktopShellChatActions.ts
@@ -122,6 +122,10 @@ export function createDesktopShellChatActions({
     if (!selectedDeployment) {
       return;
     }
+    if (shellProjection.nonEmptyContentSendStatus.kind !== "ready") {
+      setError(shellProjection.nonEmptyContentSendStatus.hint);
+      return;
+    }
     setLocalWorkflow({
       kind: "submittingRequest",
       agentDid: selectedDeployment.agentDid,

--- a/apps/gents-desktop/src/hooks/useDesktopChatProjectionState.ts
+++ b/apps/gents-desktop/src/hooks/useDesktopChatProjectionState.ts
@@ -12,6 +12,7 @@ import type {
   DeploymentView,
   DesktopSessionSnapshot,
 } from "@source-inc/gents-desktop-client";
+import { selectedBehaviorUnavailableHint } from "../lib/behaviorAvailability";
 import { trackedRequestIdForSession } from "./desktopShellRuntime";
 
 type ChatProjectionStateOptions = {
@@ -68,29 +69,34 @@ export function useDesktopChatProjectionState({
     },
     [draftContextKey],
   );
-  const shellProjection = useMemo(
-    () =>
-      projectChatShell({
-        clientAvailable,
-        selectedAgentDid,
-        selectedSessionId,
-        draft,
-        sending,
-        session,
-        selectedConversation,
-        localWorkflow,
-      }),
-    [
+  const shellProjection = useMemo(() => {
+    const behaviorUnavailableHint = selectedBehaviorUnavailableHint(
+      selectedDeployment,
+      selectedBehaviorId,
+    );
+    return projectChatShell({
       clientAvailable,
-      draft,
-      localWorkflow,
       selectedAgentDid,
-      selectedConversation,
       selectedSessionId,
+      draft,
       sending,
       session,
-    ],
-  );
+      selectedConversation,
+      localWorkflow,
+      behaviorUnavailableHint,
+    });
+  }, [
+    clientAvailable,
+    draft,
+    localWorkflow,
+    selectedAgentDid,
+    selectedBehaviorId,
+    selectedConversation,
+    selectedDeployment,
+    selectedSessionId,
+    sending,
+    session,
+  ]);
 
   useEffect(() => {
     setLocalWorkflow((current) =>

--- a/apps/gents-desktop/src/hooks/useMobileVisualViewport.ts
+++ b/apps/gents-desktop/src/hooks/useMobileVisualViewport.ts
@@ -5,6 +5,32 @@ const WIDTH = "--mobile-visual-viewport-width";
 const TOP = "--mobile-visual-viewport-top";
 const LEFT = "--mobile-visual-viewport-left";
 const MIN_USEFUL_DIMENSION = 64;
+const FOCUSED_CONTROL_SELECTOR =
+  'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled]), [contenteditable="true"]';
+const FOCUSED_CONTROL_MARGIN = 16;
+const KEYBOARD_SETTLE_DELAY_MS = 350;
+
+function revealFocusedControl(viewport: VisualViewport) {
+  if (
+    viewport.width > 760 ||
+    viewport.width < MIN_USEFUL_DIMENSION ||
+    viewport.height < MIN_USEFUL_DIMENSION
+  ) {
+    return;
+  }
+  const control = document.activeElement;
+  if (!(control instanceof HTMLElement) || !control.matches(FOCUSED_CONTROL_SELECTOR)) {
+    return;
+  }
+
+  const rect = control.getBoundingClientRect();
+  const visibleTop = Math.max(0, viewport.offsetTop) + FOCUSED_CONTROL_MARGIN;
+  const visibleBottom =
+    Math.max(0, viewport.offsetTop) + viewport.height - FOCUSED_CONTROL_MARGIN;
+  if (rect.top >= visibleTop && rect.bottom <= visibleBottom) return;
+
+  control.scrollIntoView({ behavior: "auto", block: "center", inline: "nearest" });
+}
 
 /**
  * Keep the mobile shell pinned to WebKit's visible viewport while the software
@@ -19,6 +45,21 @@ export function useMobileVisualViewport() {
 
     const root = document.documentElement;
     let frame: number | null = null;
+    let revealFrame: number | null = null;
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleReveal = () => {
+      if (revealFrame == null) {
+        revealFrame = requestAnimationFrame(() => {
+          revealFrame = null;
+          revealFocusedControl(viewport);
+        });
+      }
+      if (settleTimer != null) clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        settleTimer = null;
+        revealFocusedControl(viewport);
+      }, KEYBOARD_SETTLE_DELAY_MS);
+    };
     const apply = () => {
       frame = null;
       if (
@@ -37,6 +78,7 @@ export function useMobileVisualViewport() {
       root.style.setProperty(WIDTH, `${viewport.width}px`);
       root.style.setProperty(TOP, `${Math.max(0, viewport.offsetTop)}px`);
       root.style.setProperty(LEFT, `${Math.max(0, viewport.offsetLeft)}px`);
+      scheduleReveal();
     };
     const schedule = () => {
       if (frame == null) frame = requestAnimationFrame(apply);
@@ -49,13 +91,17 @@ export function useMobileVisualViewport() {
     window.addEventListener("resize", schedule);
     window.addEventListener("pageshow", schedule);
     window.addEventListener("orientationchange", schedule);
+    document.addEventListener("focusin", scheduleReveal);
     return () => {
       if (frame != null) cancelAnimationFrame(frame);
+      if (revealFrame != null) cancelAnimationFrame(revealFrame);
+      if (settleTimer != null) clearTimeout(settleTimer);
       viewport.removeEventListener("resize", schedule);
       viewport.removeEventListener("scroll", schedule);
       window.removeEventListener("resize", schedule);
       window.removeEventListener("pageshow", schedule);
       window.removeEventListener("orientationchange", schedule);
+      document.removeEventListener("focusin", scheduleReveal);
       root.style.removeProperty(HEIGHT);
       root.style.removeProperty(WIDTH);
       root.style.removeProperty(TOP);

--- a/apps/gents-desktop/src/lib/behaviorAvailability.ts
+++ b/apps/gents-desktop/src/lib/behaviorAvailability.ts
@@ -31,9 +31,10 @@ export function selectedBehaviorUnavailableHint(
 
   const displayName = backendName(backend.name, backend.backendId);
   if (backend.enabled !== true) return `Backend “${displayName}” is disabled`;
-  if (backend.probeStatus === "healthy") return null;
-  if (!backend.probeStatus || backend.probeStatus === "unknown") {
-    return `Backend “${displayName}” is still checking readiness`;
-  }
-  return `Backend “${displayName}” is unavailable (${backend.probeStatus.replace(/_/g, " ")})`;
+
+  // Persisted probe status is diagnostic history, not the runtime admission
+  // decision. It can remain unknown after the runtime has measured a backend
+  // healthy (and for provider kinds the prober intentionally skips), so using
+  // it as a client-side gate can disagree with the authoritative runtime.
+  return null;
 }

--- a/apps/gents-desktop/src/lib/behaviorAvailability.ts
+++ b/apps/gents-desktop/src/lib/behaviorAvailability.ts
@@ -19,18 +19,20 @@ export function selectedBehaviorUnavailableHint(
   const behavior = deployment.behaviors.find(
     (candidate) => candidate.behaviorId === behaviorId,
   );
-  if (!behavior) return "The selected behavior is unavailable";
-  if (!behavior.enabled) return `Behavior “${behavior.displayName}” is disabled`;
+  if (!behavior) return null;
+  if (behavior.enabled === false) {
+    return `Behavior “${behavior.displayName}” is disabled`;
+  }
 
   const backendId = behavior.backendId?.trim();
-  if (!backendId) return `Behavior “${behavior.displayName}” has no backend`;
+  if (!backendId) return null;
   const backend = deployment.inferenceBackends.find(
     (candidate) => candidate.backendId === backendId,
   );
-  if (!backend) return `Backend “${backendId}” is unavailable`;
+  if (!backend) return null;
 
   const displayName = backendName(backend.name, backend.backendId);
-  if (backend.enabled !== true) return `Backend “${displayName}” is disabled`;
+  if (backend.enabled === false) return `Backend “${displayName}” is disabled`;
 
   // Persisted probe status is diagnostic history, not the runtime admission
   // decision. It can remain unknown after the runtime has measured a backend

--- a/apps/gents-desktop/src/lib/behaviorAvailability.ts
+++ b/apps/gents-desktop/src/lib/behaviorAvailability.ts
@@ -1,0 +1,39 @@
+import type { DeploymentView } from "@source-inc/gents-desktop-client";
+
+function backendName(name: string | null, backendId: string): string {
+  return name?.trim() || backendId;
+}
+
+/** Explain why the selected behavior cannot currently accept a request. */
+export function selectedBehaviorUnavailableHint(
+  deployment: DeploymentView | null,
+  selectedBehaviorId: string | null,
+): string | null {
+  if (!deployment) return null;
+
+  const behaviorId =
+    selectedBehaviorId ??
+    deployment.defaultBehaviorId ??
+    deployment.behaviors.find((behavior) => behavior.isDefault)?.behaviorId ??
+    null;
+  const behavior = deployment.behaviors.find(
+    (candidate) => candidate.behaviorId === behaviorId,
+  );
+  if (!behavior) return "The selected behavior is unavailable";
+  if (!behavior.enabled) return `Behavior “${behavior.displayName}” is disabled`;
+
+  const backendId = behavior.backendId?.trim();
+  if (!backendId) return `Behavior “${behavior.displayName}” has no backend`;
+  const backend = deployment.inferenceBackends.find(
+    (candidate) => candidate.backendId === backendId,
+  );
+  if (!backend) return `Backend “${backendId}” is unavailable`;
+
+  const displayName = backendName(backend.name, backend.backendId);
+  if (backend.enabled !== true) return `Backend “${displayName}” is disabled`;
+  if (backend.probeStatus === "healthy") return null;
+  if (!backend.probeStatus || backend.probeStatus === "unknown") {
+    return `Backend “${displayName}” is still checking readiness`;
+  }
+  return `Backend “${displayName}” is unavailable (${backend.probeStatus.replace(/_/g, " ")})`;
+}

--- a/apps/gents-desktop/src/styles/sidebar/base.css
+++ b/apps/gents-desktop/src/styles/sidebar/base.css
@@ -1,7 +1,7 @@
 @layer sidebar {
   .sidebar {
     display: grid;
-    grid-template-rows: auto auto minmax(0, 1fr);
+    grid-template-rows: auto auto auto minmax(0, 1fr);
     gap: var(--space-4);
     min-height: 0;
     min-width: 0;
@@ -25,7 +25,7 @@
 
   .agent-section-tabs {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     min-height: 42px;
     border: 1px solid var(--border-default);
     background: var(--color-surface-muted);

--- a/apps/gents-desktop/src/styles/sidebar/lists.css
+++ b/apps/gents-desktop/src/styles/sidebar/lists.css
@@ -1,11 +1,19 @@
 @layer sidebar {
   .mailbox-item {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 0.4rem;
+    min-width: 0;
   }
 
   .mailbox-item p {
     margin: 0;
+  }
+
+  .mailbox-item .list-item-title,
+  .mailbox-item .list-item-meta,
+  .mailbox-payload {
+    overflow-wrap: anywhere;
   }
 
   .mailbox-actions {

--- a/apps/gents-desktop/src/styles/sync-health.css
+++ b/apps/gents-desktop/src/styles/sync-health.css
@@ -119,11 +119,25 @@
   @media (max-width: 760px) {
     .sync-health-details {
       position: fixed;
-      top: calc(env(safe-area-inset-top, 0px) + 4rem);
-      right: 0.5rem;
-      left: 0.5rem;
-      width: auto;
-      max-height: calc(100dvh - 5rem);
+      top: calc(
+        var(--mobile-visual-viewport-top, 0px) +
+          var(--mobile-safe-area-top, env(safe-area-inset-top, 0px)) + 4rem
+      );
+      right: auto;
+      left: calc(
+        var(--mobile-visual-viewport-left, 0px) +
+          var(--mobile-safe-area-left, env(safe-area-inset-left, 0px)) + 0.5rem
+      );
+      width: calc(
+        var(--mobile-visual-viewport-width, 100dvw) -
+          var(--mobile-safe-area-left, env(safe-area-inset-left, 0px)) -
+          var(--mobile-safe-area-right, env(safe-area-inset-right, 0px)) - 1rem
+      );
+      max-height: calc(
+        var(--mobile-visual-viewport-height, 100dvh) -
+          var(--mobile-safe-area-top, env(safe-area-inset-top, 0px)) -
+          var(--mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) - 5rem
+      );
       overflow: auto;
     }
   }

--- a/apps/gents-desktop/src/styles/sync-health.css
+++ b/apps/gents-desktop/src/styles/sync-health.css
@@ -118,9 +118,13 @@
 
   @media (max-width: 760px) {
     .sync-health-details {
-      left: auto;
-      right: 0;
-      width: min(100vw - 1rem, 22rem);
+      position: fixed;
+      top: calc(env(safe-area-inset-top, 0px) + 4rem);
+      right: 0.5rem;
+      left: 0.5rem;
+      width: auto;
+      max-height: calc(100dvh - 5rem);
+      overflow: auto;
     }
   }
 }

--- a/apps/gents-desktop/tests/add-peer-form.test.tsx
+++ b/apps/gents-desktop/tests/add-peer-form.test.tsx
@@ -103,6 +103,17 @@ describe("AddPeerForm", () => {
     expect(props.onProbePeerAddress).not.toHaveBeenCalled();
   });
 
+  it("contains a rejected manual peer submission after the shell records it", async () => {
+    const onSubmit = vi.fn(async () => {
+      throw new Error("peer rejected");
+    });
+    renderForm({ onSubmit });
+    fireEvent.click(screen.getByText("Enter connection details manually"));
+    fireEvent.click(screen.getByTestId("fleet-add-submit"));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+
   it("fetches /status and submits the discovered peer in one action", async () => {
     const discovered = {
       agent_name: "discovered-worker",

--- a/apps/gents-desktop/tests/add-peer-form.test.tsx
+++ b/apps/gents-desktop/tests/add-peer-form.test.tsx
@@ -48,8 +48,29 @@ function renderForm(overrides: Partial<AddPeerFormProps> = {}) {
 }
 
 describe("AddPeerForm", () => {
+  it("shows server status connection before collapsed alternatives", () => {
+    renderForm();
+
+    const statusForm = screen.getByTestId("fleet-status-form");
+    const manual = screen
+      .getByText("Enter connection details manually")
+      .closest("details");
+    const signed = screen.getByText("Use a signed pairing invite").closest("details");
+
+    expect(statusForm).toHaveTextContent("Recommended");
+    expect(manual).not.toHaveAttribute("open");
+    expect(signed).not.toHaveAttribute("open");
+    expect(
+      statusForm.compareDocumentPosition(manual!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      statusForm.compareDocumentPosition(signed!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("pairs from a signed bearer invite", async () => {
     const props = renderForm();
+    fireEvent.click(screen.getByText("Use a signed pairing invite"));
     fireEvent.change(screen.getByTestId("fleet-pair-label"), {
       target: { value: "Amy" },
     });
@@ -69,6 +90,7 @@ describe("AddPeerForm", () => {
 
   it("submits a complete manual peer via onSubmit without fetching /status", async () => {
     const props = renderForm();
+    fireEvent.click(screen.getByText("Enter connection details manually"));
     fireEvent.click(screen.getByTestId("fleet-add-submit"));
     await waitFor(() => {
       expect(props.onSubmit).toHaveBeenCalledWith({
@@ -81,7 +103,7 @@ describe("AddPeerForm", () => {
     expect(props.onProbePeerAddress).not.toHaveBeenCalled();
   });
 
-  it("fetches /status then submits the discovered peer when the manual triple is incomplete", async () => {
+  it("fetches /status and submits the discovered peer in one action", async () => {
     const discovered = {
       agent_name: "discovered-worker",
       agent_did: "did:key:z6MkDiscovered",
@@ -94,7 +116,7 @@ describe("AddPeerForm", () => {
     fireEvent.change(screen.getByTestId("fleet-add-server-address"), {
       target: { value: "http://127.0.0.1:9181" },
     });
-    fireEvent.click(screen.getByTestId("fleet-add-submit"));
+    fireEvent.click(screen.getByTestId("fleet-fetch-status"));
 
     await waitFor(() => {
       expect(props.onProbePeerAddress).toHaveBeenCalledWith("http://127.0.0.1:9181");

--- a/apps/gents-desktop/tests/app-shell-sad-path.test.tsx
+++ b/apps/gents-desktop/tests/app-shell-sad-path.test.tsx
@@ -11,7 +11,7 @@ import type {
 import { bootstrap, deployment } from "./config-panel-wiring/fixtures";
 import { renderTauriAppDriverWithBridge, type TauriDriverBridge } from "./tauri-driver";
 
-function desktopSnapshot(): DesktopClientSnapshot {
+function desktopSnapshot(selectedDeployment = deployment): DesktopClientSnapshot {
   return {
     bootstrap,
     client: {
@@ -29,13 +29,16 @@ function desktopSnapshot(): DesktopClientSnapshot {
       peerIssueCount: 0,
       rowCount: 42,
       approxSerializedBytes: 2048,
-      deployments: [deployment],
+      deployments: [selectedDeployment],
     },
   };
 }
 
-function makeBridge(overrides: Partial<DesktopApiAdapter>): TauriDriverBridge {
-  const snapshot = desktopSnapshot();
+function makeBridge(
+  overrides: Partial<DesktopApiAdapter>,
+  selectedDeployment = deployment,
+): TauriDriverBridge {
+  const snapshot = desktopSnapshot(selectedDeployment);
   const listenerFactory: DesktopClientUpdatedListenerFactory = async () => () => {};
   const defaults: Partial<DesktopApiAdapter> = {
     fetchDesktopSnapshot: vi.fn(async () => snapshot),
@@ -73,6 +76,43 @@ function makeBridge(overrides: Partial<DesktopApiAdapter>): TauriDriverBridge {
 }
 
 describe("App shell command sad paths", () => {
+  it("keeps the real composer usable when client-route backend data is absent", async () => {
+    const remoteDeployment = {
+      ...deployment,
+      source: "bearer",
+      inferenceBackends: [],
+    };
+    const sendChatMessage = vi.fn(async () => ({
+      agentDid: remoteDeployment.agentDid,
+      sessionId: "remote-session",
+      requestId: "remote-request",
+    }));
+    const driver = renderTauriAppDriverWithBridge(
+      makeBridge({ sendChatMessage }, remoteDeployment),
+      remoteDeployment.peerId,
+    );
+
+    try {
+      await driver.ready();
+      await driver.openChat();
+      await driver.typeComposer("check the fleet");
+
+      expect(driver.sendButton()).toBeEnabled();
+      await driver.clickSend();
+      await waitFor(() => {
+        expect(sendChatMessage).toHaveBeenCalledWith({
+          agentDid: remoteDeployment.agentDid,
+          behaviorId: remoteDeployment.defaultBehaviorId,
+          sessionId: null,
+          content: "check the fleet",
+          causedBySourceDocId: null,
+        });
+      });
+    } finally {
+      await driver.dispose();
+    }
+  });
+
   it("opens the agent navigation pane when Fleet selects a deployment", async () => {
     const driver = renderTauriAppDriverWithBridge(makeBridge({}), deployment.peerId);
 

--- a/apps/gents-desktop/tests/behavior-availability.test.ts
+++ b/apps/gents-desktop/tests/behavior-availability.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import type { DeploymentView } from "@source-inc/gents-desktop-client";
+import { selectedBehaviorUnavailableHint } from "../src/lib/behaviorAvailability";
+
+function deployment(probeStatus: string | null): DeploymentView {
+  return {
+    defaultBehaviorId: "default",
+    behaviors: [
+      {
+        behaviorId: "default",
+        displayName: "Default",
+        backendId: "workstation-2",
+        enabled: true,
+        isDefault: true,
+      },
+    ],
+    inferenceBackends: [
+      {
+        backendId: "workstation-2",
+        name: "Workstation 2",
+        enabled: true,
+        probeStatus,
+      },
+    ],
+  } as DeploymentView;
+}
+
+describe("selectedBehaviorUnavailableHint", () => {
+  it("admits only a healthy selected behavior backend", () => {
+    expect(selectedBehaviorUnavailableHint(deployment("healthy"), null)).toBeNull();
+    expect(selectedBehaviorUnavailableHint(deployment("unknown"), null)).toBe(
+      "Backend “Workstation 2” is still checking readiness",
+    );
+    expect(selectedBehaviorUnavailableHint(deployment("unhealthy"), null)).toBe(
+      "Backend “Workstation 2” is unavailable (unhealthy)",
+    );
+  });
+});

--- a/apps/gents-desktop/tests/behavior-availability.test.ts
+++ b/apps/gents-desktop/tests/behavior-availability.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { DeploymentView } from "@source-inc/gents-desktop-client";
 import { selectedBehaviorUnavailableHint } from "../src/lib/behaviorAvailability";
 
-function deployment(probeStatus: string | null): DeploymentView {
+function deployment(probeStatus: string | null, enabled = true): DeploymentView {
   return {
     defaultBehaviorId: "default",
     behaviors: [
@@ -19,7 +19,7 @@ function deployment(probeStatus: string | null): DeploymentView {
       {
         backendId: "workstation-2",
         name: "Workstation 2",
-        enabled: true,
+        enabled,
         probeStatus,
       },
     ],
@@ -27,13 +27,12 @@ function deployment(probeStatus: string | null): DeploymentView {
 }
 
 describe("selectedBehaviorUnavailableHint", () => {
-  it("admits only a healthy selected behavior backend", () => {
+  it("treats persisted probe status as advisory and blocks disabled config", () => {
     expect(selectedBehaviorUnavailableHint(deployment("healthy"), null)).toBeNull();
-    expect(selectedBehaviorUnavailableHint(deployment("unknown"), null)).toBe(
-      "Backend “Workstation 2” is still checking readiness",
-    );
-    expect(selectedBehaviorUnavailableHint(deployment("unhealthy"), null)).toBe(
-      "Backend “Workstation 2” is unavailable (unhealthy)",
+    expect(selectedBehaviorUnavailableHint(deployment("unknown"), null)).toBeNull();
+    expect(selectedBehaviorUnavailableHint(deployment("unhealthy"), null)).toBeNull();
+    expect(selectedBehaviorUnavailableHint(deployment("unknown", false), null)).toBe(
+      "Backend “Workstation 2” is disabled",
     );
   });
 });

--- a/apps/gents-desktop/tests/behavior-availability.test.ts
+++ b/apps/gents-desktop/tests/behavior-availability.test.ts
@@ -35,4 +35,33 @@ describe("selectedBehaviorUnavailableHint", () => {
       "Backend “Workstation 2” is disabled",
     );
   });
+
+  it("treats absent or redacted backend data as unknown", () => {
+    const clientRouteDeployment = {
+      ...deployment("unknown"),
+      inferenceBackends: [],
+    };
+    expect(selectedBehaviorUnavailableHint(clientRouteDeployment, null)).toBeNull();
+
+    const redactedDeployment = {
+      ...clientRouteDeployment,
+      behaviors: clientRouteDeployment.behaviors.map((behavior) => ({
+        ...behavior,
+        backendId: null,
+      })),
+    };
+    expect(selectedBehaviorUnavailableHint(redactedDeployment, null)).toBeNull();
+  });
+
+  it("blocks only explicit disabled evidence", () => {
+    const disabledBehavior = deployment("healthy");
+    disabledBehavior.behaviors[0].enabled = false;
+    expect(selectedBehaviorUnavailableHint(disabledBehavior, null)).toBe(
+      "Behavior “Default” is disabled",
+    );
+
+    expect(
+      selectedBehaviorUnavailableHint(deployment("healthy"), "missing"),
+    ).toBeNull();
+  });
 });

--- a/apps/gents-desktop/tests/chat-copy-retry.test.tsx
+++ b/apps/gents-desktop/tests/chat-copy-retry.test.tsx
@@ -138,6 +138,43 @@ describe("error card retry", () => {
     expect(onRetryMessage).toHaveBeenCalledWith("req-failed");
   });
 
+  it("surfaces an actionable backend-readiness failure", () => {
+    render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={{
+          ...session,
+          latestResponse: {
+            status: "failed",
+            errorMessage:
+              "behavior default backend workstation-2 is unavailable (enabled=true probe_status=unknown)",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("response-error-card")).toHaveTextContent(
+      "Backend “workstation-2” is not ready yet",
+    );
+  });
+
+  it("disables retry while the selected behavior backend is unavailable", () => {
+    render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={session}
+        onRetryMessage={vi.fn()}
+        retryUnavailableHint="Backend “Workstation 2” is still checking readiness"
+      />,
+    );
+
+    expect(screen.getByTestId("retry-turn")).toBeDisabled();
+    expect(screen.getByTestId("retry-turn")).toHaveAttribute(
+      "title",
+      "Backend “Workstation 2” is still checking readiness",
+    );
+  });
+
   it("omits Retry when no handler is wired", () => {
     render(<ChatTranscriptPanel selectedSessionId="s1" session={session} />);
     expect(screen.queryByTestId("retry-turn")).not.toBeInTheDocument();

--- a/apps/gents-desktop/tests/fleet-dashboard.test.tsx
+++ b/apps/gents-desktop/tests/fleet-dashboard.test.tsx
@@ -113,7 +113,7 @@ describe("FleetHostDashboard add connection flow", () => {
     fireEvent.change(screen.getByTestId("fleet-add-server-address"), {
       target: { value: "http://127.0.0.1:9181" },
     });
-    fireEvent.click(screen.getByTestId("fleet-add-submit"));
+    fireEvent.click(screen.getByTestId("fleet-fetch-status"));
 
     await waitFor(() => {
       expect(onProbePeerAddress).toHaveBeenCalledWith("http://127.0.0.1:9181");
@@ -126,7 +126,7 @@ describe("FleetHostDashboard add connection flow", () => {
     });
   });
 
-  it("lets users preview discovered /status details before adding", async () => {
+  it("keeps discovered details available when adding the connection fails", async () => {
     const onProbePeerAddress = vi.fn(async () => ({
       agent_name: "api-gateway",
       agent_did: "did:key:z6MkGateway",
@@ -142,7 +142,9 @@ describe("FleetHostDashboard add connection flow", () => {
         p2pHealth={null}
         repairingP2P={false}
         starting={false}
-        onAddPeer={vi.fn()}
+        onAddPeer={vi.fn(async () => {
+          throw new Error("connection rejected");
+        })}
         onPairBearer={vi.fn()}
         onProbePeerAddress={onProbePeerAddress}
         onInitLocalRuntime={vi.fn()}
@@ -170,6 +172,7 @@ describe("FleetHostDashboard add connection flow", () => {
       expect(
         (screen.getByTestId("fleet-add-connection-json") as HTMLTextAreaElement).value,
       ).toContain('"agent_name": "api-gateway"');
+      expect(screen.getByText("connection rejected")).toBeInTheDocument();
     });
   });
 
@@ -247,6 +250,7 @@ describe("FleetHostDashboard add connection flow", () => {
     fireEvent.change(screen.getByTestId("fleet-add-server-address"), {
       target: { value: "http://100.73.235.38:9181/api/v0/graphql" },
     });
+    fireEvent.click(screen.getByText("Enter connection details manually"));
     fireEvent.change(screen.getByTestId("fleet-add-label"), {
       target: { value: "studio-1-steward" },
     });
@@ -312,6 +316,7 @@ describe("FleetHostDashboard add connection flow", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Add Agent" }));
+    fireEvent.click(screen.getByText("Use a signed pairing invite"));
     fireEvent.change(screen.getByTestId("fleet-pair-label"), {
       target: { value: "amygdalabook-steward" },
     });

--- a/apps/gents-desktop/tests/playwright/desktop-fleet-actions.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-fleet-actions.spec.ts
@@ -1,16 +1,17 @@
 import { expect, gotoHarness, PEER_ID, test } from "./desktopTest";
 
 test.describe("fleet deployment navigation", () => {
-  test("signed bearer invite is the primary remote pairing flow", async ({ page }) => {
+  test("server status is the primary remote pairing flow", async ({ page }) => {
     await gotoHarness(page, "default");
     await page.getByRole("button", { name: "Add Agent", exact: true }).click();
 
-    await page.getByTestId("fleet-pair-label").fill("Amy");
-    await page.getByTestId("fleet-pair-token").fill("dabear1-harness-signed-token");
-    await page.getByTestId("fleet-pair-submit").click();
+    await page.getByTestId("fleet-add-server-address").fill("http://amy:9191");
+    await page.getByTestId("fleet-fetch-status").click();
 
-    await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toContainText("Amy");
-    await expect(page.getByTestId("fleet-pair-token")).toHaveCount(0);
+    await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toContainText(
+      "Bombadil UI Agent",
+    );
+    await expect(page.getByTestId("fleet-add-server-address")).toHaveCount(0);
   });
 
   test("deployment row opens the chat workspace", async ({ page }) => {

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -223,6 +223,81 @@ test.describe("desktop responsive layout guardrails", () => {
     await expectNoPageHorizontalOverflow(page);
   });
 
+  test("keyboard viewport resize reveals the focused pairing address", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) > 760,
+      "mobile viewport guardrail",
+    );
+    await page.addInitScript(() => {
+      const viewport = new EventTarget() as EventTarget & {
+        height: number;
+        width: number;
+        offsetTop: number;
+        offsetLeft: number;
+      };
+      Object.assign(viewport, {
+        height: window.innerHeight,
+        width: window.innerWidth,
+        offsetTop: 0,
+        offsetLeft: 0,
+      });
+      const originalScrollIntoView = Element.prototype.scrollIntoView;
+      Object.defineProperty(window, "visualViewport", {
+        configurable: true,
+        value: viewport,
+      });
+      Object.assign(window, {
+        __focusedControlRevealCount: 0,
+        __setTestVisualViewport(height: number) {
+          viewport.height = height;
+          viewport.dispatchEvent(new Event("resize"));
+        },
+      });
+      Element.prototype.scrollIntoView = function (options) {
+        if (this === document.activeElement) {
+          (
+            window as typeof window & { __focusedControlRevealCount: number }
+          ).__focusedControlRevealCount += 1;
+        }
+        return originalScrollIntoView.call(this, options);
+      };
+    });
+
+    await gotoHarness(page, "empty-fleet");
+    await page
+      .getByTestId("fleet-remote-disclosure")
+      .locator(":scope > summary")
+      .click();
+    const address = page.getByTestId("fleet-add-server-address");
+    await address.focus();
+    await page.evaluate(() => {
+      (
+        window as typeof window & {
+          __setTestVisualViewport: (height: number) => void;
+        }
+      ).__setTestVisualViewport(360);
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as typeof window & { __focusedControlRevealCount: number })
+              .__focusedControlRevealCount,
+        ),
+      )
+      .toBeGreaterThan(0);
+    await expect(page.locator(".app-shell")).toHaveCSS("height", "360px");
+    const addressRect = await address.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { bottom: rect.bottom, top: rect.top };
+    });
+    expect(addressRect.top).toBeGreaterThanOrEqual(0);
+    expect(addressRect.bottom).toBeLessThanOrEqual(360);
+  });
+
   test("populated-fleet status discovery stays reachable on mobile", async ({
     page,
   }) => {

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -84,6 +84,38 @@ test.describe("desktop responsive layout guardrails", () => {
     await expectNoPageHorizontalOverflow(page);
   });
 
+  test("multiple approval holds preserve the composer and final actions", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) > 760,
+      "mobile viewport guardrail",
+    );
+    await gotoHarness(page, "tool-hold");
+    await openChat(page);
+    const finalAction = page.getByTestId("hold-approve-hold-mobile-6");
+    await finalAction.scrollIntoViewIfNeeded();
+    await expect(finalAction).toBeVisible();
+    const contained = await page.evaluate(() => {
+      const chat = document.querySelector<HTMLElement>(".chat-main");
+      const composer = document.querySelector<HTMLElement>(".composer-panel");
+      const finalAction = document.querySelector<HTMLElement>(
+        '[data-testid="hold-approve-hold-mobile-6"]',
+      );
+      if (!chat || !composer || !finalAction) throw new Error("holds geometry missing");
+      const chatRect = chat.getBoundingClientRect();
+      const composerRect = composer.getBoundingClientRect();
+      const actionRect = finalAction.getBoundingClientRect();
+      return {
+        composer:
+          composerRect.top >= chatRect.top && composerRect.bottom <= chatRect.bottom,
+        finalAction:
+          actionRect.top >= chatRect.top && actionRect.bottom <= chatRect.bottom,
+      };
+    });
+    expect(contained).toEqual({ composer: true, finalAction: true });
+  });
+
   test("phone chat uses one full-screen pane at a time", async ({ page }) => {
     test.skip(
       (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) > 760,

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -10,15 +10,39 @@ import {
   test,
 } from "./desktopTest";
 
-const scenarios = ["default", "empty-fleet", "loading", "long-content"] as const;
+const chatScenarios = [
+  "default",
+  "long-content",
+  "active-turn",
+  "cascade-turn",
+  "coding",
+  "session-hydration",
+  "backend-unavailable",
+] as const;
+
+const shellScenarios = [
+  "empty-fleet",
+  "loading",
+  "bridge-unavailable",
+  "save-error",
+  "backend-health-error",
+  "sync-offline",
+  "sync-stalled",
+  "sync-failed",
+] as const;
 
 test.describe("desktop responsive layout guardrails", () => {
-  for (const scenario of scenarios) {
+  for (const scenario of chatScenarios) {
     test(`${scenario} has no page-level horizontal overflow`, async ({ page }) => {
       await gotoHarness(page, scenario);
-      if (scenario !== "empty-fleet" && scenario !== "loading") {
-        await openChat(page);
-      }
+      await openChat(page);
+      await expectNoPageHorizontalOverflow(page);
+    });
+  }
+
+  for (const scenario of shellScenarios) {
+    test(`${scenario} has no page-level horizontal overflow`, async ({ page }) => {
+      await gotoHarness(page, scenario);
       await expectNoPageHorizontalOverflow(page);
     });
   }
@@ -59,6 +83,26 @@ test.describe("desktop responsive layout guardrails", () => {
     await expect(page.locator(".sidebar")).toBeVisible();
     await expect(page.locator(".chat-column")).toBeHidden();
 
+    for (const tab of ["sessions", "mailbox", "behaviors"]) {
+      await page.getByTestId(`agent-tab-${tab}`).click();
+      const geometry = await page.evaluate(() => {
+        const sidebar = document.querySelector<HTMLElement>(".sidebar");
+        const tabs = document.querySelector<HTMLElement>(".agent-section-tabs");
+        const section = sidebar?.lastElementChild as HTMLElement | null;
+        if (!sidebar || !tabs || !section) throw new Error("sidebar geometry missing");
+        return {
+          sidebar: sidebar.getBoundingClientRect().toJSON(),
+          tabs: tabs.getBoundingClientRect().toJSON(),
+          section: section.getBoundingClientRect().toJSON(),
+        };
+      });
+      expect(geometry.tabs.height).toBeLessThanOrEqual(56);
+      expect(geometry.section.top).toBeGreaterThanOrEqual(geometry.tabs.bottom);
+      expect(geometry.section.bottom).toBeLessThanOrEqual(geometry.sidebar.bottom);
+      await expectNoPageHorizontalOverflow(page);
+    }
+
+    await page.getByTestId("agent-tab-sessions").click();
     await page.getByTestId("conversation-session-intro").click();
     await expect(page.locator(".chat-column")).toBeVisible();
     await expect(page.locator(".sidebar")).toBeHidden();

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -18,6 +18,7 @@ const chatScenarios = [
   "coding",
   "session-hydration",
   "backend-unavailable",
+  "tool-hold",
 ] as const;
 
 const shellScenarios = [
@@ -66,6 +67,21 @@ test.describe("desktop responsive layout guardrails", () => {
       await expect(page.locator(".config-editor").first()).toBeVisible();
       await expectNoPageHorizontalOverflow(page);
     }
+  });
+
+  test("adversarial mailbox content stays inside the phone sidebar", async ({
+    page,
+  }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) > 760,
+      "mobile viewport guardrail",
+    );
+    await gotoHarness(page, "mailbox-overflow");
+    await openChat(page);
+    await openChatNavigation(page);
+    await page.getByTestId("agent-tab-mailbox").click();
+    await expect(page.locator(".mailbox-item")).toBeVisible();
+    await expectNoPageHorizontalOverflow(page);
   });
 
   test("phone chat uses one full-screen pane at a time", async ({ page }) => {

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -186,19 +186,40 @@ test.describe("desktop responsive layout guardrails", () => {
       .getByTestId("fleet-remote-disclosure")
       .locator(":scope > summary")
       .click();
-    await page.getByText("Advanced manual discovery", { exact: true }).click();
+
+    const statusForm = page.getByTestId("fleet-status-form");
+    const manualAlternative = page.locator(".fleet-manual-disclosure");
+    const signedAlternative = page.locator(".fleet-alternative-disclosure");
+    await expect(statusForm).toBeVisible();
+    await expect(manualAlternative).not.toHaveAttribute("open", "");
+    await expect(signedAlternative).not.toHaveAttribute("open", "");
+
+    const pairingOrder = await Promise.all(
+      [statusForm, manualAlternative, signedAlternative].map((locator) =>
+        locator.evaluate((element) => element.getBoundingClientRect().top),
+      ),
+    );
+    expect(pairingOrder[0]).toBeLessThan(pairingOrder[1]);
+    expect(pairingOrder[1]).toBeLessThan(pairingOrder[2]);
+
     await page.getByTestId("fleet-add-server-address").fill("http://studio-1:9191");
 
-    const submit = page.getByTestId("fleet-add-submit");
+    const submit = page.getByTestId("fleet-fetch-status");
     await expect(submit).toBeAttached();
     await submit.scrollIntoViewIfNeeded();
     await expect(submit).toBeVisible();
     await submit.click({ trial: true });
 
-    const shellScrollTop = await page
-      .locator(".app-shell")
-      .evaluate((element) => element.scrollTop);
-    expect(shellScrollTop).toBeGreaterThan(0);
+    const submitRect = await submit.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top };
+    });
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(submitRect.top).toBeGreaterThanOrEqual(0);
+    expect(submitRect.left).toBeGreaterThanOrEqual(0);
+    expect(submitRect.right).toBeLessThanOrEqual(viewport!.width);
+    expect(submitRect.bottom).toBeLessThanOrEqual(viewport!.height);
     await expectNoPageHorizontalOverflow(page);
   });
 
@@ -212,7 +233,6 @@ test.describe("desktop responsive layout guardrails", () => {
 
     await gotoHarness(page);
     await page.getByRole("button", { name: "Add Agent", exact: true }).click();
-    await page.getByText("Advanced manual discovery", { exact: true }).click();
 
     const address = page.getByTestId("fleet-add-server-address");
     const fetchStatus = page.getByTestId("fleet-fetch-status");
@@ -224,17 +244,16 @@ test.describe("desktop responsive layout guardrails", () => {
     await expect(fetchStatus).toBeVisible();
     await fetchStatus.click({ trial: true });
 
-    const dashboardScroll = await page
-      .getByTestId("fleet-dashboard")
-      .evaluate((element) => ({
-        clientHeight: element.clientHeight,
-        overflowY: getComputedStyle(element).overflowY,
-        scrollHeight: element.scrollHeight,
-        scrollTop: element.scrollTop,
-      }));
-    expect(dashboardScroll.overflowY).toBe("auto");
-    expect(dashboardScroll.scrollHeight).toBeGreaterThan(dashboardScroll.clientHeight);
-    expect(dashboardScroll.scrollTop).toBeGreaterThan(0);
+    const fetchStatusRect = await fetchStatus.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top };
+    });
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    expect(fetchStatusRect.top).toBeGreaterThanOrEqual(0);
+    expect(fetchStatusRect.left).toBeGreaterThanOrEqual(0);
+    expect(fetchStatusRect.right).toBeLessThanOrEqual(viewport!.width);
+    expect(fetchStatusRect.bottom).toBeLessThanOrEqual(viewport!.height);
     await expectNoPageHorizontalOverflow(page);
   });
 });

--- a/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
@@ -124,12 +124,37 @@ test.describe("mobile session sync fixture", () => {
     );
 
     await gotoHarness(page, "sync-stalled");
+    await page.evaluate(() => {
+      const root = document.documentElement;
+      root.style.setProperty("--mobile-safe-area-top", "47px");
+      root.style.setProperty("--mobile-safe-area-right", "13px");
+      root.style.setProperty("--mobile-safe-area-bottom", "34px");
+      root.style.setProperty("--mobile-safe-area-left", "11px");
+    });
     await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(
       "data-sync-state",
       "stalled",
     );
     await page.getByTestId("sync-health-summary").click();
-    await expect(page.getByTestId("sync-health-details")).toContainText("RpcTimeout");
+    const details = page.getByTestId("sync-health-details");
+    await expect(details).toContainText("RpcTimeout");
+    const bounds = await details.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+        left: rect.left,
+        viewportHeight: window.innerHeight,
+        viewportWidth: window.innerWidth,
+      };
+    });
+    if (bounds.viewportWidth <= 760) {
+      expect(bounds.top).toBeGreaterThanOrEqual(47 + 64);
+      expect(bounds.left).toBeGreaterThanOrEqual(11 + 8);
+      expect(bounds.right).toBeLessThanOrEqual(bounds.viewportWidth - 13 - 8);
+      expect(bounds.bottom).toBeLessThanOrEqual(bounds.viewportHeight - 34);
+    }
     await expectNoPageHorizontalOverflow(page);
 
     await gotoHarness(page, "sync-failed");

--- a/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
@@ -1,4 +1,11 @@
-import { expect, gotoHarness, openChat, openChatNavigation, test } from "./desktopTest";
+import {
+  expect,
+  expectNoPageHorizontalOverflow,
+  gotoHarness,
+  openChat,
+  openChatNavigation,
+  test,
+} from "./desktopTest";
 
 test.describe("mobile session sync fixture", () => {
   test("opens a pre-existing session and hydrates history without blocking local rows", async ({
@@ -27,6 +34,43 @@ test.describe("mobile session sync fixture", () => {
         .getByTestId("transcript-panel")
         .getByText("history arrived from the desktop"),
     ).toBeVisible();
+
+    if ((page.viewportSize()?.width ?? 761) <= 760) {
+      const geometry = await page.evaluate(() => {
+        const shell = document.querySelector<HTMLElement>(".app-shell");
+        const header = document.querySelector<HTMLElement>(".chat-header");
+        const hydration = document.querySelector<HTMLElement>(
+          "[data-testid=session-hydration-status]",
+        );
+        const transcript = document.querySelector<HTMLElement>(
+          "[data-testid=transcript-panel]",
+        );
+        const composer = document.querySelector<HTMLElement>(".composer-panel");
+        if (!shell || !header || !hydration || !transcript || !composer) {
+          throw new Error("mobile hydration geometry missing");
+        }
+        return {
+          shell: shell.getBoundingClientRect().toJSON(),
+          header: header.getBoundingClientRect().toJSON(),
+          hydration: hydration.getBoundingClientRect().toJSON(),
+          transcript: transcript.getBoundingClientRect().toJSON(),
+          composer: composer.getBoundingClientRect().toJSON(),
+          headerScrollWidth: header.scrollWidth,
+          headerClientWidth: header.clientWidth,
+        };
+      });
+
+      expect(geometry.headerScrollWidth).toBeLessThanOrEqual(
+        geometry.headerClientWidth,
+      );
+      expect(geometry.header.left).toBeGreaterThanOrEqual(geometry.shell.left);
+      expect(geometry.header.right).toBeLessThanOrEqual(geometry.shell.right);
+      expect(geometry.hydration.height).toBeLessThanOrEqual(56);
+      expect(geometry.transcript.height).toBeGreaterThan(geometry.hydration.height * 2);
+      expect(geometry.transcript.top).toBeGreaterThanOrEqual(geometry.hydration.bottom);
+      expect(geometry.transcript.bottom).toBeLessThanOrEqual(geometry.composer.top);
+      expect(geometry.composer.bottom).toBeLessThanOrEqual(geometry.shell.bottom);
+    }
 
     await page.evaluate(() => window.__GENTS_SESSION_SYNC__?.complete());
     await expect(page.getByTestId("session-hydration-status")).toHaveAttribute(
@@ -86,6 +130,7 @@ test.describe("mobile session sync fixture", () => {
     );
     await page.getByTestId("sync-health-summary").click();
     await expect(page.getByTestId("sync-health-details")).toContainText("RpcTimeout");
+    await expectNoPageHorizontalOverflow(page);
 
     await gotoHarness(page, "sync-failed");
     await expect(page.getByTestId("sync-health-indicator")).toHaveAttribute(

--- a/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-session-sync.spec.ts
@@ -147,9 +147,14 @@ test.describe("mobile session sync fixture", () => {
         left: rect.left,
         viewportHeight: window.innerHeight,
         viewportWidth: window.innerWidth,
+        computedMaxHeight: Number.parseFloat(getComputedStyle(element).maxHeight),
       };
     });
     if (bounds.viewportWidth <= 760) {
+      expect(bounds.computedMaxHeight).toBeCloseTo(
+        bounds.viewportHeight - 47 - 34 - 80,
+        0,
+      );
       expect(bounds.top).toBeGreaterThanOrEqual(47 + 64);
       expect(bounds.left).toBeGreaterThanOrEqual(11 + 8);
       expect(bounds.right).toBeLessThanOrEqual(bounds.viewportWidth - 13 - 8);

--- a/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
@@ -2,6 +2,7 @@ import {
   adjacentDuplicateTranscriptRows,
   captureStableScreenshot,
   expect,
+  expectNoPageHorizontalOverflow,
   gotoHarness,
   openChat,
   openChatNavigation,
@@ -290,6 +291,7 @@ test.describe("desktop UI harness", () => {
       page.getByRole("dialog", { name: /interrupt parent request/i }),
     ).toBeVisible();
     await expect(page.getByText("Will be interrupted")).toBeVisible();
+    await expectNoPageHorizontalOverflow(page);
     await page.getByTestId("cascade-interrupt-confirm").click();
     await expect(page.getByTestId("chat-toast")).toContainText("Interrupt requested");
   });

--- a/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
@@ -14,14 +14,14 @@ import {
 } from "./desktopTest";
 
 test.describe("desktop UI harness", () => {
-  test("chat blocks requests until the selected behavior backend is ready", async ({
+  test("chat blocks requests when the selected behavior backend is disabled", async ({
     page,
   }) => {
     await gotoHarness(page, "backend-unavailable");
     await openChat(page);
 
     await expect(page.getByTestId("composer-status")).toHaveText(
-      "Backend “OpenAI Harness” is still checking readiness",
+      "Backend “OpenAI Harness” is disabled",
     );
     await expect(page.getByTestId("composer-input")).toBeEditable();
     await expect(page.getByRole("button", { name: "Send" })).toBeDisabled();

--- a/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-ui.spec.ts
@@ -13,6 +13,19 @@ import {
 } from "./desktopTest";
 
 test.describe("desktop UI harness", () => {
+  test("chat blocks requests until the selected behavior backend is ready", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "backend-unavailable");
+    await openChat(page);
+
+    await expect(page.getByTestId("composer-status")).toHaveText(
+      "Backend “OpenAI Harness” is still checking readiness",
+    );
+    await expect(page.getByTestId("composer-input")).toBeEditable();
+    await expect(page.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
   test("mobile conversation pins the title and composer to the viewport", async ({
     page,
   }) => {

--- a/apps/gents-desktop/tests/playwright/desktopTest.ts
+++ b/apps/gents-desktop/tests/playwright/desktopTest.ts
@@ -7,6 +7,7 @@ export type HarnessScenario =
   | "bridge-unavailable"
   | "save-error"
   | "backend-health-error"
+  | "backend-unavailable"
   | "long-content"
   | "active-turn"
   | "cascade-turn"
@@ -206,9 +207,24 @@ export async function expectNoPageHorizontalOverflow(page: Page) {
             ".fleet-dashboard",
             ".fleet-empty",
             ".operations-rail",
+            ".chat-header",
+            ".chat-title-block",
+            ".chat-status",
+            ".session-hydration-status",
+            ".composer-panel",
+            ".fleet-header",
+            ".fleet-add-form",
+            ".config-header",
+            ".config-editor",
+            ".config-actions",
+            ".confirm-dialog",
+            ".fleet-qr-dialog",
+            ".context-meter-popover",
+            ".sync-health-details",
           ].join(", "),
         ),
       )
+        .filter((element) => !element.closest("details:not([open])"))
         .map((element) => {
           const htmlElement = element as HTMLElement;
           const style = window.getComputedStyle(htmlElement);
@@ -220,11 +236,15 @@ export async function expectNoPageHorizontalOverflow(page: Page) {
             clientWidth: htmlElement.clientWidth,
             scrollWidth: htmlElement.scrollWidth,
             overflowX: style.overflowX,
+            bounds: htmlElement.getBoundingClientRect().toJSON(),
           };
         })
         .filter((entry) => {
           const scrollDelta = entry.scrollWidth - entry.clientWidth;
-          return scrollDelta > 2 && entry.overflowX === "visible";
+          const escapesViewport =
+            entry.bounds.width > 0 &&
+            (entry.bounds.left < -2 || entry.bounds.right > window.innerWidth + 2);
+          return escapesViewport || (scrollDelta > 2 && entry.overflowX === "visible");
         }),
     };
   });

--- a/apps/gents-desktop/tests/playwright/desktopTest.ts
+++ b/apps/gents-desktop/tests/playwright/desktopTest.ts
@@ -8,6 +8,8 @@ export type HarnessScenario =
   | "save-error"
   | "backend-health-error"
   | "backend-unavailable"
+  | "tool-hold"
+  | "mailbox-overflow"
   | "long-content"
   | "active-turn"
   | "cascade-turn"
@@ -218,9 +220,13 @@ export async function expectNoPageHorizontalOverflow(page: Page) {
             ".config-editor",
             ".config-actions",
             ".confirm-dialog",
+            ".dialog",
             ".fleet-qr-dialog",
             ".context-meter-popover",
             ".sync-health-details",
+            ".holds-panel",
+            ".holds-panel-row",
+            ".mailbox-item",
           ].join(", "),
         ),
       )

--- a/apps/gents-desktop/tests/tauri-driver.live.fleet.test.tsx
+++ b/apps/gents-desktop/tests/tauri-driver.live.fleet.test.tsx
@@ -5,7 +5,7 @@ import { withLiveDesktop } from "./tauri-driver-live/harness";
 import { describeLive, logTurn } from "./tauri-driver-live/helpers";
 
 describeLive("Tauri app live fleet add flow", () => {
-  it("previews a live runner /status payload before adding the connection", async () => {
+  it("adds a live runner directly from its /status address", async () => {
     await withLiveDesktop(async ({ runner, driver, deployment: firstDeployment }) => {
       await driver.ready();
       logTurn(`fleet driver ready statusUrl=${runner.baseUrl}/status`);
@@ -13,18 +13,6 @@ describeLive("Tauri app live fleet add flow", () => {
       await driver.user.click(screen.getByRole("button", { name: "Add Agent" }));
       await driver.replaceInput("fleet-add-server-address", runner.baseUrl);
       await driver.user.click(screen.getByTestId("fleet-fetch-status"));
-
-      await waitFor(
-        () => {
-          expect(driver.input("fleet-add-label")).toHaveValue(firstDeployment.label);
-          expect(driver.input("fleet-add-agent-did")).toHaveValue(runner.agentDid);
-          expect(driver.input("fleet-add-addr")).toHaveValue(firstDeployment.addr);
-          expect(screen.getByText("Fetched /status")).toBeInTheDocument();
-        },
-        { timeout: 30_000 },
-      );
-
-      await driver.user.click(screen.getByTestId("fleet-add-submit"));
 
       await waitFor(
         async () => {
@@ -68,8 +56,9 @@ describeLive("Tauri app live fleet add flow", () => {
         { timeout: 30_000 },
       );
       expect(driver.input("fleet-add-server-address")).toBeEnabled();
-      expect(screen.getByTestId("fleet-add-submit")).toBeEnabled();
+      expect(screen.getByTestId("fleet-fetch-status")).toBeEnabled();
 
+      await driver.user.click(screen.getByText("Enter connection details manually"));
       await driver.replaceInput("fleet-add-label", "Invalid Peer");
       await driver.replaceInput("fleet-add-agent-did", "   ");
       await driver.replaceInput("fleet-add-addr", "iroh://invalid-peer");

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -162,7 +162,7 @@ export function createDesktopUiHarness(
         : null,
       inferenceBackends: deployment.inferenceBackends.map((backend) => ({
         ...backend,
-        probeStatus: "unknown",
+        enabled: false,
       })),
     };
   }

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -40,6 +40,7 @@ export type DesktopUiHarnessScenario =
   | "bridge-unavailable"
   | "save-error"
   | "backend-health-error"
+  | "backend-unavailable"
   | "long-content"
   | "active-turn"
   | "cascade-turn"
@@ -130,6 +131,22 @@ export function createDesktopUiHarness(
   let sessionSeq = 1;
   let rowCount = 42;
   let deployment = createDeployment();
+  if (scenario === "backend-unavailable") {
+    deployment = {
+      ...deployment,
+      runtime: deployment.runtime
+        ? {
+            ...deployment.runtime,
+            runnableBehaviorCount: 0,
+            unavailableBehaviorCount: deployment.behaviors.length,
+          }
+        : null,
+      inferenceBackends: deployment.inferenceBackends.map((backend) => ({
+        ...backend,
+        probeStatus: "unknown",
+      })),
+    };
+  }
   let removed = false;
   let p2pStatus: "healthy" | "degraded" | "wedged" =
     scenario === "sync-offline" ? "wedged" : "healthy";
@@ -2184,6 +2201,7 @@ function normalizeScenario(value?: string | null): DesktopUiHarnessScenario {
     case "bridge-unavailable":
     case "save-error":
     case "backend-health-error":
+    case "backend-unavailable":
     case "long-content":
     case "active-turn":
     case "cascade-turn":

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -41,6 +41,8 @@ export type DesktopUiHarnessScenario =
   | "save-error"
   | "backend-health-error"
   | "backend-unavailable"
+  | "tool-hold"
+  | "mailbox-overflow"
   | "long-content"
   | "active-turn"
   | "cascade-turn"
@@ -115,7 +117,25 @@ export function createDesktopUiHarness(
   options: DesktopUiHarnessOptions = {},
 ): DesktopUiHarness {
   const scenario = normalizeScenario(options.scenario);
-  let heldToolCalls: HeldToolCallView[] = [];
+  let heldToolCalls: HeldToolCallView[] =
+    scenario === "tool-hold"
+      ? [
+          {
+            toolCallDocId: "hold-doc-mobile",
+            toolCallId: "hold-mobile",
+            requestId: "request_01JZ6Q0Y5Q7V0MOBILE_APPROVAL_BOUNDARY_WITHOUT_BREAKS",
+            sessionId: "session-intro",
+            agentDid: AGENT_DID,
+            toolName:
+              "mcp__workstation_diagnostics__inspect_namespaced_service_without_breaks",
+            args: JSON.stringify({
+              target:
+                "https://workstation.example/internal/service/with/a/very/long/unbroken/path",
+            }),
+            deadlineAt: "2099-08-28T23:59:59Z",
+          },
+        ]
+      : [];
   const listeners = new Set<DesktopClientUpdatedHandler>();
   const sessions = new Map<string, DesktopSessionSnapshot>();
   const sessionLineage = new Map<
@@ -145,6 +165,39 @@ export function createDesktopUiHarness(
         ...backend,
         probeStatus: "unknown",
       })),
+    };
+  }
+  if (scenario === "mailbox-overflow") {
+    deployment = {
+      ...deployment,
+      mailboxItems: [
+        {
+          itemId: "mailbox-mobile",
+          itemKey: "mailbox-mobile-key",
+          requesterDid: "did:key:z6MkRequesterWithAnUnbrokenIdentifierForMobile",
+          agentDid: AGENT_DID,
+          status: "pending",
+          kind: "notification",
+          action: "ack",
+          title:
+            "LongUnbrokenMailboxTitleThatMustWrapInsideTheMobileSidebarInsteadOfClippingActions",
+          summary: "A mailbox item with adversarial mobile-width content.",
+          payload:
+            "https://example.invalid/a/very/long/unbroken/payload/path/that/must/stay/inside/the/sidebar",
+          sourceKind: "AgentRequest",
+          sourceId: "request_01JZ6Q0Y5Q7V0MOBILE_SOURCE_IDENTIFIER_WITHOUT_BREAKS",
+          sessionId: "session-intro",
+          requestId: "request-intro",
+          graphRunId: null,
+          causeDocId: null,
+          targetAgentDid: AGENT_DID,
+          targetBehaviorId: DEFAULT_BEHAVIOR_ID,
+          expectedCollection: "AgentResponse",
+          parentItemId: null,
+          deadlineAt: null,
+          createdAt: STARTED_AT,
+        },
+      ],
     };
   }
   let removed = false;
@@ -1512,13 +1565,15 @@ export function createDesktopUiHarness(
         scenario === "cascade-turn"
           ? [
               {
-                requestId: "request-child-1",
-                sessionId: "session-child-1",
+                requestId: "request_01JZ6Q0Y5Q7V0MOBILE_CASCADE_CHILD_WITHOUT_BREAKS",
+                sessionId: "session_01JZ6Q0Y5Q7V0MOBILE_CASCADE_CHILD_WITHOUT_BREAKS",
                 behaviorId: "ops",
                 lifecycleState: "processing",
                 parentRequestId: request.requestId,
-                parentToolCallId: "tool-call-child-1",
-                toolName: "delegate",
+                parentToolCallId:
+                  "tool_call_01JZ6Q0Y5Q7V0MOBILE_CASCADE_PARENT_WITHOUT_BREAKS",
+                toolName:
+                  "mcp__subagent_coordinator__delegate_to_remote_behavior_without_breaks",
                 awaitMode: "foreground",
                 cancelPolicy: "cascade",
               },
@@ -2202,6 +2257,8 @@ function normalizeScenario(value?: string | null): DesktopUiHarnessScenario {
     case "save-error":
     case "backend-health-error":
     case "backend-unavailable":
+    case "tool-hold":
+    case "mailbox-overflow":
     case "long-content":
     case "active-turn":
     case "cascade-turn":

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -119,22 +119,21 @@ export function createDesktopUiHarness(
   const scenario = normalizeScenario(options.scenario);
   let heldToolCalls: HeldToolCallView[] =
     scenario === "tool-hold"
-      ? [
-          {
-            toolCallDocId: "hold-doc-mobile",
-            toolCallId: "hold-mobile",
-            requestId: "request_01JZ6Q0Y5Q7V0MOBILE_APPROVAL_BOUNDARY_WITHOUT_BREAKS",
+      ? Array.from({ length: 6 }, (_, index) => {
+          const ordinal = index + 1;
+          return {
+            toolCallDocId: `hold-doc-mobile-${ordinal}`,
+            toolCallId: `hold-mobile-${ordinal}`,
+            requestId: `request_01JZ6Q0Y5Q7V0MOBILE_APPROVAL_BOUNDARY_WITHOUT_BREAKS_${ordinal}`,
             sessionId: "session-intro",
             agentDid: AGENT_DID,
-            toolName:
-              "mcp__workstation_diagnostics__inspect_namespaced_service_without_breaks",
+            toolName: `mcp__workstation_diagnostics__inspect_namespaced_service_without_breaks_${ordinal}`,
             args: JSON.stringify({
-              target:
-                "https://workstation.example/internal/service/with/a/very/long/unbroken/path",
+              target: `https://workstation.example/internal/service/with/a/very/long/unbroken/path/${ordinal}`,
             }),
             deadlineAt: "2099-08-28T23:59:59Z",
-          },
-        ]
+          };
+        })
       : [];
   const listeners = new Set<DesktopClientUpdatedHandler>();
   const sessions = new Map<string, DesktopSessionSnapshot>();

--- a/packages/gents-desktop-chat/src/chat-shell.test.ts
+++ b/packages/gents-desktop-chat/src/chat-shell.test.ts
@@ -326,6 +326,28 @@ function compactWorkflow(workflow: ChatWorkflowState) {
 }
 
 describe("projectChatShell", () => {
+  it("blocks empty-draft and retry sends when the behavior backend is unavailable", () => {
+    const projection = projectChatShell({
+      clientAvailable: true,
+      selectedAgentDid: "did:key:agent",
+      selectedSessionId: null,
+      draft: "",
+      sending: false,
+      session: null,
+      selectedConversation: null,
+      localWorkflow: { kind: "ready" },
+      behaviorUnavailableHint:
+        "Backend “Workstation 2” is still checking readiness",
+    });
+
+    expect(projection.sendStatus).toEqual({
+      kind: "disabled",
+      reason: "behaviorUnavailable",
+      hint: "Backend “Workstation 2” is still checking readiness",
+    });
+    expect(projection.nonEmptyContentSendStatus).toEqual(projection.sendStatus);
+  });
+
   test(
     "matches generated Lean ClientShell projection contracts",
     () => {

--- a/packages/gents-desktop-chat/src/chat-shell.ts
+++ b/packages/gents-desktop-chat/src/chat-shell.ts
@@ -49,6 +49,7 @@ export type TurnState =
 export type ChatBlockedReason =
   | "clientOffline"
   | "agentNotSelected"
+  | "behaviorUnavailable"
   | "composerEmpty"
   | "submittingRequest"
   | "waitingForRequestObservation"
@@ -91,6 +92,7 @@ type ProjectionInput = {
   session: DesktopSessionSnapshot | null;
   selectedConversation: ConversationSummary | null;
   localWorkflow: ChatWorkflowState;
+  behaviorUnavailableHint?: string | null;
 };
 
 export type ChatShellProjection = {
@@ -181,6 +183,8 @@ function hintFor(reason: ChatBlockedReason, turnState?: TurnState | null) {
       return "Client offline";
     case "agentNotSelected":
       return "Select an agent before sending";
+    case "behaviorUnavailable":
+      return "The selected behavior is unavailable";
     case "composerEmpty":
       return "Type a message to send";
     case "submittingRequest":
@@ -324,6 +328,13 @@ export function projectChatShell(input: ProjectionInput): ChatShellProjection {
         kind: "disabled",
         reason: "agentNotSelected",
         hint: hintFor("agentNotSelected"),
+      };
+    }
+    if (input.behaviorUnavailableHint) {
+      return {
+        kind: "disabled",
+        reason: "behaviorUnavailable",
+        hint: input.behaviorUnavailableHint,
       };
     }
     if (composerEmpty) {

--- a/packages/gents-desktop-chat/src/components/chat/ChatTranscriptPanel.tsx
+++ b/packages/gents-desktop-chat/src/components/chat/ChatTranscriptPanel.tsx
@@ -15,11 +15,23 @@ export type ChatTranscriptPanelProps = {
   session: DesktopSessionSnapshot | null;
   optimisticPendingTurn?: OptimisticPendingTurn | null;
   onRetryMessage?: (requestId: string) => void | Promise<void>;
+  retryUnavailableHint?: string | null;
   onLoadOlder?: () => Promise<boolean>;
 };
 
 export const TRANSCRIPT_PAGE_SIZE = 40;
 const TRANSCRIPT_RETAINED_ITEMS = TRANSCRIPT_PAGE_SIZE * 2;
+
+export function responseErrorSummary(error: string): string {
+  const unavailable = error.match(
+    /^behavior\s+\S+\s+backend\s+(.+?)\s+is unavailable\s+\(enabled=(?:true|false)\s+probe_status=([^\s)]+)\)$/i,
+  );
+  if (!unavailable) return "The assistant couldn't complete this turn.";
+  const [, backendId, probeStatus] = unavailable;
+  return probeStatus === "unknown"
+    ? `Backend “${backendId}” is not ready yet. Check its connection or choose another behavior.`
+    : `Backend “${backendId}” is unavailable (${probeStatus.replace(/_/g, " ")}).`;
+}
 
 function timelineChangeSignal(items: RenderedTimelineItem[]) {
   return JSON.stringify(
@@ -73,6 +85,7 @@ export function ChatTranscriptPanel({
   session,
   optimisticPendingTurn,
   onRetryMessage,
+  retryUnavailableHint,
   onLoadOlder,
 }: ChatTranscriptPanelProps) {
   const transcriptPanelRef = useRef<HTMLElement | null>(null);
@@ -414,7 +427,7 @@ export function ChatTranscriptPanel({
               >
                 <div className="message-role">assistant error</div>
                 <div className="message-content">
-                  The assistant couldn&apos;t complete this turn.
+                  {responseErrorSummary(responseError)}
                 </div>
                 <details className="response-error-details">
                   <summary>Error details</summary>
@@ -426,7 +439,11 @@ export function ChatTranscriptPanel({
                       className="ghost-button"
                       data-testid="retry-turn"
                       type="button"
-                      disabled={retryingRequestId === retryRequestId}
+                      disabled={
+                        retryingRequestId === retryRequestId ||
+                        Boolean(retryUnavailableHint)
+                      }
+                      title={retryUnavailableHint ?? undefined}
                       onClick={() => void handleRetry(retryRequestId)}
                     >
                       {retryingRequestId === retryRequestId

--- a/packages/gents-desktop-chat/styles/cancel-ux.css
+++ b/packages/gents-desktop-chat/styles/cancel-ux.css
@@ -95,6 +95,8 @@
   }
 
   .dialog header .sub code {
+    min-width: 0;
+    overflow-wrap: anywhere;
     font-family: var(--font-mono);
     background: var(--color-surface-strong);
     padding: 1px var(--space-2);
@@ -177,18 +179,24 @@
   }
 
   .group ul li .reqid {
+    min-width: 0;
     font-family: var(--font-mono);
     color: var(--color-text);
+    overflow-wrap: anywhere;
   }
 
   .group ul li .desc {
+    min-width: 0;
     color: var(--color-text-soft);
+    overflow-wrap: anywhere;
   }
 
   .group ul li .meta {
+    min-width: 0;
     font-family: var(--font-mono);
     color: var(--color-text-muted);
     font-size: var(--text-xs);
+    overflow-wrap: anywhere;
   }
 
   .group.unknown-policy ul {
@@ -246,5 +254,28 @@
 
   .notice strong {
     font-weight: 600;
+  }
+
+  @media (max-width: 760px) {
+    .dialog header,
+    .dialog .body,
+    .dialog footer {
+      padding-right: var(--space-5);
+      padding-left: var(--space-5);
+    }
+
+    .group ul li {
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--space-2);
+    }
+
+    .dialog footer {
+      flex-wrap: wrap;
+    }
+
+    .dialog footer .btn-danger {
+      flex: 1 1 100%;
+      order: -1;
+    }
   }
 }

--- a/packages/gents-desktop-chat/styles/chat.css
+++ b/packages/gents-desktop-chat/styles/chat.css
@@ -9,8 +9,8 @@
   }
 
   .chat-main {
-    display: grid;
-    grid-template-rows: minmax(0, 1fr) auto;
+    display: flex;
+    flex-direction: column;
     gap: var(--space-5);
     min-width: 0;
     min-height: 0;
@@ -169,8 +169,9 @@
   }
 
   .transcript-panel {
+    flex: 1 1 0;
     max-width: 100%;
-    height: 100%;
+    height: auto;
     overflow: auto;
     display: grid;
     align-content: start;
@@ -350,6 +351,10 @@
     min-height: 180px;
   }
 
+  .empty-transcript.compact-empty {
+    min-height: 180px;
+  }
+
   .empty-transcript {
     min-height: 260px;
     display: grid;
@@ -360,7 +365,9 @@
 
   @media (max-width: 760px) {
     .chat-header {
-      align-items: center;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      align-items: stretch;
       gap: var(--space-3);
       padding: 0;
     }
@@ -371,8 +378,8 @@
     }
 
     .chat-status {
-      flex: 0 0 auto;
-      justify-content: flex-end;
+      min-width: 0;
+      justify-content: flex-start;
       gap: var(--space-2);
     }
 
@@ -390,7 +397,7 @@
 
     .chat-title-block {
       display: flex;
-      flex: 1 1 auto;
+      width: 100%;
       align-items: center;
       gap: var(--space-3);
     }
@@ -425,6 +432,10 @@
     .composer-input {
       max-height: 160px;
       padding: var(--space-4);
+    }
+
+    .empty-transcript.compact-empty {
+      min-height: 120px;
     }
   }
 }

--- a/packages/gents-desktop-fleet/src/components/AddPeerForm.tsx
+++ b/packages/gents-desktop-fleet/src/components/AddPeerForm.tsx
@@ -44,12 +44,6 @@ export function AddPeerForm({
 
   return (
     <div className="fleet-pairing">
-      <BearerPairingForm
-        addingPeer={addingPeer}
-        busy={busy}
-        onPairBearer={onPairBearer}
-        pairingQrHint={pairingQrHint}
-      />
       <ManualPeerDiscoveryForm
         addingPeer={addingPeer}
         busy={busy}
@@ -59,6 +53,15 @@ export function AddPeerForm({
         peerForm={peerForm}
         onPeerFormChange={onPeerFormChange}
       />
+      <details className="fleet-alternative-disclosure">
+        <summary>Use a signed pairing invite</summary>
+        <BearerPairingForm
+          addingPeer={addingPeer}
+          busy={busy}
+          onPairBearer={onPairBearer}
+          pairingQrHint={pairingQrHint}
+        />
+      </details>
     </div>
   );
 }

--- a/packages/gents-desktop-fleet/src/components/addPeer/BearerPairingForm.tsx
+++ b/packages/gents-desktop-fleet/src/components/addPeer/BearerPairingForm.tsx
@@ -70,7 +70,6 @@ export function BearerPairingForm({
         onSubmit={(event) => void handleSubmit(event)}
       >
         <div className="fleet-pairing-copy">
-          <p className="eyebrow">Recommended</p>
           <h3>Pair with a signed invite</h3>
           <p className="muted">
             Scan the QR code on your agent or paste its one-time invite. The app

--- a/packages/gents-desktop-fleet/src/components/addPeer/ManualPeerDiscoveryForm.tsx
+++ b/packages/gents-desktop-fleet/src/components/addPeer/ManualPeerDiscoveryForm.tsx
@@ -21,22 +21,26 @@ export function ManualPeerDiscoveryForm({
   onPeerFormChange,
 }: ManualPeerDiscoveryFormProps) {
   return (
-    <details className="fleet-manual-disclosure">
-      <summary>Advanced manual discovery</summary>
-      <p className="muted">
-        Diagnostic fallback only. Manual <code>/status</code> imports do not
-        exchange signed membership claims.
-      </p>
+    <>
       <form
-        className="fleet-add-form"
+        className="fleet-status-form"
+        data-testid="fleet-status-form"
         onSubmit={(event) => {
           event.preventDefault();
-          void discovery.submit();
+          void discovery.connectFromStatus();
         }}
       >
+        <div className="fleet-pairing-copy">
+          <p className="eyebrow">Recommended</p>
+          <h3>Connect by server address</h3>
+          <p className="muted">
+            Enter an agent&apos;s IP address, hostname, or URL. Gents reads its
+            <code> /status</code> endpoint and adds the connection.
+          </p>
+        </div>
         <div className="fleet-discovery-row">
           <label className="field">
-            <span>Server address</span>
+            <span>Agent server</span>
             <input
               className="mono"
               data-testid="fleet-add-server-address"
@@ -44,18 +48,23 @@ export function ManualPeerDiscoveryForm({
               onChange={(event) =>
                 discovery.updateServerAddress(event.currentTarget.value)
               }
-              placeholder="http://127.0.0.1:9181/api/v0/graphql"
+              placeholder="100.69.4.79:9191"
               value={discovery.serverAddress}
             />
           </label>
           <button
-            className="ghost-button"
+            className="primary-button"
             data-testid="fleet-fetch-status"
             disabled={busy || !discovery.serverAddressReady}
-            onClick={() => void discovery.fetchStatus()}
-            type="button"
+            type="submit"
           >
-            {discovery.fetchingStatus ? "Fetching..." : "Fetch /status"}
+            {discovery.fetchingStatus
+              ? "Connecting..."
+              : addingPeer
+                ? "Adding..."
+                : disabled
+                  ? "Preparing..."
+                  : "Connect from /status"}
           </button>
         </div>
         {discovery.importStatus ? (
@@ -67,78 +76,92 @@ export function ManualPeerDiscoveryForm({
             {discovery.importStatus}
           </p>
         ) : null}
-        <label className="field fleet-import-field">
-          <span>Connection JSON</span>
-          <textarea
-            className="mono"
-            data-testid="fleet-add-connection-json"
-            disabled={busy}
-            onChange={(event) =>
-              discovery.updateConnectionJson(event.currentTarget.value)
-            }
-            placeholder='{"label":"api-gateway","agentDid":"did:key:z6Mk...","addr":"/ip4/100.73.235.38/tcp/9161/p2p/12D3Koo..."}'
-            value={discovery.connectionJson}
-          />
-        </label>
-        <PeerField
-          label="Agent label"
-          testId="fleet-add-label"
-          value={peerForm.label}
-          placeholder="api-gateway"
-          disabled={busy}
-          onChange={(label) => onPeerFormChange({ ...peerForm, label })}
-        />
-        <PeerField
-          mono
-          label="Agent DID"
-          testId="fleet-add-agent-did"
-          value={peerForm.agentDid}
-          placeholder="did:key:z6Mk..."
-          disabled={busy}
-          onChange={(agentDid) => onPeerFormChange({ ...peerForm, agentDid })}
-        />
-        <PeerField
-          mono
-          label="P2P address"
-          testId="fleet-add-addr"
-          value={peerForm.addr}
-          placeholder="/ip4/100.73.235.38/tcp/9161/p2p/12D3Koo..."
-          disabled={busy}
-          onChange={(addr) => onPeerFormChange({ ...peerForm, addr })}
-        />
-        <PeerField
-          mono
-          label="GraphQL endpoint"
-          testId="fleet-add-graphql"
-          value={peerForm.graphql ?? ""}
-          placeholder="http://127.0.0.1:9181/api/v0/graphql"
-          disabled={busy}
-          onChange={(graphql) => onPeerFormChange({ ...peerForm, graphql })}
-        />
         {localError ? <p className="fleet-inline-error">{localError}</p> : null}
-        <div className="fleet-add-actions">
-          <button
-            className="primary-button"
-            data-testid="fleet-add-submit"
-            disabled={
-              disabled ||
-              addingPeer ||
-              discovery.fetchingStatus ||
-              (!discovery.manualPeerReady && !discovery.serverAddressReady)
-            }
-            type="submit"
-          >
-            {discovery.fetchingStatus
-              ? "Fetching..."
-              : addingPeer
+      </form>
+
+      <details className="fleet-manual-disclosure">
+        <summary>Enter connection details manually</summary>
+        <p className="muted">
+          Diagnostic fallback for importing connection JSON or entering peer
+          identity and transport fields directly.
+        </p>
+        <form
+          className="fleet-add-form"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void discovery.submitManual();
+          }}
+        >
+          <label className="field fleet-import-field">
+            <span>Connection JSON</span>
+            <textarea
+              className="mono"
+              data-testid="fleet-add-connection-json"
+              disabled={busy}
+              onChange={(event) =>
+                discovery.updateConnectionJson(event.currentTarget.value)
+              }
+              placeholder='{"label":"api-gateway","agentDid":"did:key:z6Mk...","addr":"/ip4/100.73.235.38/tcp/9161/p2p/12D3Koo..."}'
+              value={discovery.connectionJson}
+            />
+          </label>
+          <PeerField
+            label="Agent label"
+            testId="fleet-add-label"
+            value={peerForm.label}
+            placeholder="api-gateway"
+            disabled={busy}
+            onChange={(label) => onPeerFormChange({ ...peerForm, label })}
+          />
+          <PeerField
+            mono
+            label="Agent DID"
+            testId="fleet-add-agent-did"
+            value={peerForm.agentDid}
+            placeholder="did:key:z6Mk..."
+            disabled={busy}
+            onChange={(agentDid) => onPeerFormChange({ ...peerForm, agentDid })}
+          />
+          <PeerField
+            mono
+            label="P2P address"
+            testId="fleet-add-addr"
+            value={peerForm.addr}
+            placeholder="/ip4/100.73.235.38/tcp/9161/p2p/12D3Koo..."
+            disabled={busy}
+            onChange={(addr) => onPeerFormChange({ ...peerForm, addr })}
+          />
+          <PeerField
+            mono
+            label="GraphQL endpoint"
+            testId="fleet-add-graphql"
+            value={peerForm.graphql ?? ""}
+            placeholder="http://127.0.0.1:9181/api/v0/graphql"
+            disabled={busy}
+            onChange={(graphql) => onPeerFormChange({ ...peerForm, graphql })}
+          />
+          <div className="fleet-add-actions">
+            <button
+              className="primary-button"
+              data-testid="fleet-add-submit"
+              disabled={
+                disabled ||
+                addingPeer ||
+                discovery.fetchingStatus ||
+                !discovery.manualPeerReady
+              }
+              type="submit"
+            >
+              {addingPeer
                 ? "Adding..."
                 : disabled
                   ? "Preparing..."
-                  : "Add Agent Connection"}
-          </button>
-        </div>
-      </form>
-    </details>
+                  : "Add Manual Connection"}
+            </button>
+          </div>
+        </form>
+      </details>
+    </>
   );
 }
 

--- a/packages/gents-desktop-fleet/src/components/addPeer/useManualPeerDiscovery.ts
+++ b/packages/gents-desktop-fleet/src/components/addPeer/useManualPeerDiscovery.ts
@@ -87,7 +87,12 @@ export function useManualPeerDiscovery({
 
   async function submitManual() {
     if (!manualPeerReady) return;
-    await onSubmit(withGraphqlFallback(peerForm, serverAddress));
+    try {
+      await onSubmit(withGraphqlFallback(peerForm, serverAddress));
+    } catch {
+      // The desktop shell owns and renders mutation errors; contain its rejection
+      // because this submit is launched from a React event handler.
+    }
   }
 
   return {

--- a/packages/gents-desktop-fleet/src/components/addPeer/useManualPeerDiscovery.ts
+++ b/packages/gents-desktop-fleet/src/components/addPeer/useManualPeerDiscovery.ts
@@ -78,21 +78,16 @@ export function useManualPeerDiscovery({
     }
   }
 
-  async function submit() {
+  async function connectFromStatus() {
     try {
-      const request = manualPeerReady
-        ? withGraphqlFallback(peerForm, serverAddress)
-        : await fetchServerStatus();
+      const request = await fetchServerStatus();
       await onSubmit(request);
-    } catch {
-    }
+    } catch {}
   }
 
-  async function fetchStatus() {
-    try {
-      await fetchServerStatus();
-    } catch {
-    }
+  async function submitManual() {
+    if (!manualPeerReady) return;
+    await onSubmit(withGraphqlFallback(peerForm, serverAddress));
   }
 
   return {
@@ -103,8 +98,8 @@ export function useManualPeerDiscovery({
     manualPeerReady,
     serverAddress,
     serverAddressReady,
-    fetchStatus,
-    submit,
+    connectFromStatus,
+    submitManual,
     updateConnectionJson,
     updateServerAddress,
   };

--- a/packages/gents-desktop-fleet/styles/layout/pairing.css
+++ b/packages/gents-desktop-fleet/styles/layout/pairing.css
@@ -15,6 +15,15 @@
     background: rgb(var(--color-accent-rgb) / 0.06);
   }
 
+  .fleet-status-form {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-5);
+    border: 1px solid rgb(var(--color-accent-rgb) / 0.3);
+    border-radius: var(--radius-lg);
+    background: rgb(var(--color-accent-rgb) / 0.06);
+  }
+
   .fleet-pairing-copy {
     grid-column: 1 / -1;
     display: grid;
@@ -49,18 +58,21 @@
     font-size: var(--text-sm);
   }
 
-  .fleet-manual-disclosure {
+  .fleet-manual-disclosure,
+  .fleet-alternative-disclosure {
     border-top: 1px solid var(--border-subtle);
     padding-top: var(--space-4);
   }
 
-  .fleet-manual-disclosure > summary {
+  .fleet-manual-disclosure > summary,
+  .fleet-alternative-disclosure > summary {
     width: fit-content;
     cursor: pointer;
     color: var(--color-text-muted);
   }
 
-  .fleet-manual-disclosure > p {
+  .fleet-manual-disclosure > p,
+  .fleet-alternative-disclosure > .fleet-bearer-form {
     margin: var(--space-3) 0 var(--space-5);
   }
 

--- a/packages/gents-desktop-fleet/styles/layout/responsive.css
+++ b/packages/gents-desktop-fleet/styles/layout/responsive.css
@@ -17,6 +17,7 @@
     }
 
     .fleet-local-runtime,
+    .fleet-status-form,
     .fleet-bearer-form,
     .fleet-discovery-row,
     .fleet-add-form,
@@ -57,6 +58,5 @@
       display: grid;
       grid-template-columns: 1fr 1fr;
     }
-
   }
 }

--- a/packages/gents-desktop-operations/styles/holds.css
+++ b/packages/gents-desktop-operations/styles/holds.css
@@ -56,8 +56,12 @@
   }
 
   .holds-panel-tool {
+    min-width: 0;
+    overflow: hidden;
     font-weight: 600;
     color: var(--color-text);
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .holds-panel-args {
@@ -79,6 +83,7 @@
   .holds-panel-row-meta {
     font-size: var(--text-xs);
     color: var(--color-text-muted);
+    overflow-wrap: anywhere;
   }
 
   .holds-panel-args-details {

--- a/packages/gents-desktop-operations/styles/holds.css
+++ b/packages/gents-desktop-operations/styles/holds.css
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
+    min-height: 0;
     padding: var(--space-5);
   }
 
@@ -30,12 +31,15 @@
   }
 
   .holds-panel-list {
+    flex: 1 1 auto;
+    min-height: 0;
     list-style: none;
     margin: 0;
     padding: 0;
     display: flex;
     flex-direction: column;
     gap: var(--space-3);
+    overflow-y: auto;
   }
 
   .holds-panel-row {
@@ -127,5 +131,13 @@
     border-radius: var(--radius-md);
     background: var(--color-surface);
     color: var(--color-text);
+  }
+
+  @media (max-width: 760px) {
+    .holds-panel {
+      flex: 0 1 min(40dvh, 20rem);
+      max-height: min(40dvh, 20rem);
+      overflow: hidden;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- repair the conditional-row chat layout that let hydration consume the transcript viewport
- make the phone header, sidebar, sync overlay, approval holds, mailbox, and cascade dialog viewport-safe
- make server-address status pairing the visible first path and combine discovery plus add into one action
- collapse manual fields and signed invites as explicit alternatives
- treat absent or redacted backend data as unknown and block send/retry only on authoritative explicit disabled state
- catch failed manual peer submission after surfacing the inline error, avoiding unhandled promise rejections
- surface the actual terminal backend failure without escaping server-controlled details into markup
- add adversarial 390×844 geometry coverage for long tokens, overlays, sidebar tabs, multiple holds, pairing order, remote client-route readiness, and containment

## Root cause
Session hydration was added as another child of a two-row chat grid. It took the flexible row, pushed the transcript/composer into implicit rows, and produced the oversized screen seen on the v0.14 phone. Several existing tests only checked page scrollWidth, which missed children clipped inside overflow-hidden surfaces.

The initial fix also treated persisted probe status and absent backend documents as admission results. Live validation showed probe status is diagnostic history, while the client replication route intentionally excludes InferenceBackend because it contains secrets and BehaviorView may redact backend identity. The UI now defers runtime admission to the server, treats absent/redacted backend data as unknown, and blocks only explicit disabled configuration.

The peer form also led with two workflows that are not the normal phone setup. The common flow is now: enter an IP, hostname, or URL, then press Connect from /status. The status payload is discovered and added in the same operation. Failed submission remains an inline UI error without producing an unhandled rejected promise.

## Validation
- npm run build:packages
- desktop production build
- desktop unit: 340 passed, 15 skipped
- full Playwright from the viewport repair: 165 passed, 12 skipped
- updated narrow viewport layout suite: 23 passed
- focused status pairing and fleet dashboard coverage
- client-route-shaped composer readiness regression with no replicated backend documents
- rejected manual-submit regression
- fleet package tests and build
- cargo check --workspace --all-targets
- format and diff checks
- independent exact-head review clean at 18181882a472ff39627be98998e4afb76d2b96fa

Stack 1/2. PR #1283 carries the foundation-first hydration request-order correction.