### PR TITLE
fix(desktop): request session hydration before observing progress

### DIFF
--- a/crates/gents-desktop-core/tests/client_core.rs
+++ b/crates/gents-desktop-core/tests/client_core.rs
@@ -53,6 +53,87 @@ async fn client_core_starts_and_registers_schemas() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn focus_session_requests_hydration_when_local_transcript_rows_already_exist() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let paths = DesktopPaths::from_root(tempdir.path());
+    let core =
+        ClientCore::start_with_paths_and_options(paths, ClientCoreOptions::local_only()).await?;
+    let requester_did = gents::graphql::escape_graphql_string(core.principal().did());
+    let agent_did = "did:test:amy";
+    let session_id = "session-with-local-failed-turn";
+    let response = core
+        .node()
+        .execute(&format!(
+            r#"mutation {{
+                request: create_AgentRequest(input: {{
+                    request_id: "local-request"
+                    requester_did: "{requester_did}"
+                    agent_did: "{agent_did}"
+                    behavior_id: "default"
+                    session_id: "{session_id}"
+                    content: "hello"
+                    status: "error"
+                    lifecycle_state: "failed"
+                }}) {{ _docID }}
+                response: create_AgentResponse(input: {{
+                    response_key: "local-request:response"
+                    request_id: "local-request"
+                    requester_did: "{requester_did}"
+                    agent_did: "{agent_did}"
+                    behavior_id: "default"
+                    session_id: "{session_id}"
+                    status: "error"
+                    error_message: "backend unavailable"
+                }}) {{ _docID }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !response.has_errors(),
+        "seed local transcript rows: {:?}",
+        response.errors
+    );
+
+    core.focus_session(session_id, agent_did).await?;
+
+    let progress = core.hydration_progress();
+    assert_eq!(progress.phase.as_str(), "serving");
+    assert_eq!(progress.merged_count, 2);
+    assert_eq!(progress.served_count, None);
+    let request_key =
+        gents::graphql::escape_graphql_string(&format!("{}:{session_id}", core.local_peer_id()));
+    let response = core
+        .node()
+        .execute(&format!(
+            r#"{{
+                SessionHydrationRequest(filter: {{ request_key: {{ _eq: "{request_key}" }} }}) {{
+                    request_key status served_doc_count
+                }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !response.has_errors(),
+        "query hydration request: {:?}",
+        response.errors
+    );
+    let rows = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("SessionHydrationRequest"))
+        .and_then(serde_json::Value::as_array)
+        .context("SessionHydrationRequest rows")?;
+    assert_eq!(rows.len(), 1, "focus must persist exactly one request");
+    assert_eq!(
+        rows[0].get("status").and_then(serde_json::Value::as_str),
+        Some("pending")
+    );
+
+    core.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_client_cores_connect_over_iroh() -> Result<()> {
     let tempdir_a = tempfile::tempdir()?;
     let tempdir_b = tempfile::tempdir()?;

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/SessionHydration.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/SessionHydration.lean
@@ -129,7 +129,12 @@ def sessionHydrationProgressCases : List SessionHydrationProgressCase :=
     , prevSession := "session-1", prevAgent := "agent-1"
     , session := "session-1", agent := "agent-1"
     , prevPhase := "idle", prevMerged := 0, prevServed := none
-    , merged := 0, served := none, failed := false, beginRequest := false }
+    , merged := 0, served := none, failed := false, beginRequest := true }
+  , { name := "local_documents_do_not_imply_request"
+    , prevSession := "session-1", prevAgent := "agent-1"
+    , session := "session-1", agent := "agent-1"
+    , prevPhase := "idle", prevMerged := 0, prevServed := none
+    , merged := 2, served := none, failed := false, beginRequest := false }
   , { name := "serving_partial"
     , prevSession := "session-1", prevAgent := "agent-1"
     , session := "session-1", agent := "agent-1"

--- a/crates/gents/proofs/Proofs/SessionHydration/Receiver.lean
+++ b/crates/gents/proofs/Proofs/SessionHydration/Receiver.lean
@@ -52,10 +52,13 @@ def observeCore (prev : ClientProgress) (merged : Nat) (served : Option Nat)
     { phase := .failed, mergedCount := merged, servedCount := served }
   else if canComplete merged served then
     { phase := .complete, mergedCount := merged, servedCount := served }
-  else if served.isSome || decide (merged > 0) || decide (prev.phase = .serving) then
+  else if served.isSome || decide (prev.phase = .serving) ||
+      (decide (prev.phase = .requested) && decide (merged > 0)) then
     { phase := .serving, mergedCount := merged, servedCount := served }
-  else
+  else if decide (prev.phase = .requested) then
     { phase := .requested, mergedCount := merged, servedCount := served }
+  else
+    { phase := .idle, mergedCount := merged, servedCount := served }
 
 def observe (prev : ClientProgress) (mergedCount : Nat) (servedCount : Option Nat)
     (failed : Bool) (session agent : String) : ClientProgress :=
@@ -108,6 +111,17 @@ theorem observe_cannot_complete_without_server (prev : ClientProgress)
     (observe_complete_iff prev mergedCount none session agent hprev).mp hcomplete
   unfold canComplete at hiff
   simp [hserved] at hiff
+
+/-- Locally present transcript rows are not evidence that a hydration request
+was started. Only `beginRequest` may move an idle receiver into an in-flight
+phase when the server has not supplied a denominator. -/
+theorem observe_idle_without_server_stays_idle (prev : ClientProgress)
+    (mergedCount : Nat) (session agent : String)
+    (hidle : (progressFor prev session agent).phase = .idle)
+    (hserved : (progressFor prev session agent).servedCount = none) :
+    (observe prev mergedCount none false session agent).phase = .idle := by
+  unfold observe observeCore
+  simp [hidle, hserved, mergeServed, canComplete]
 
 /-- Focusing a different session/agent starts from an idle, zero-count receiver state. -/
 theorem progressFor_other_target_resets (prev : ClientProgress) (session agent : String)

--- a/crates/gents/src/agent/p2p_reconcile/session_hydration.rs
+++ b/crates/gents/src/agent/p2p_reconcile/session_hydration.rs
@@ -254,7 +254,10 @@ pub fn observe_hydration_progress(
             served_count: served,
         };
     }
-    if served.is_some() || merged > 0 || base.phase == ClientHydrationPhase::Serving {
+    if served.is_some()
+        || base.phase == ClientHydrationPhase::Serving
+        || (base.phase == ClientHydrationPhase::Requested && merged > 0)
+    {
         return ClientHydrationProgress {
             session_id: session_id.to_string(),
             agent_did: agent_did.to_string(),
@@ -266,7 +269,11 @@ pub fn observe_hydration_progress(
     ClientHydrationProgress {
         session_id: session_id.to_string(),
         agent_did: agent_did.to_string(),
-        phase: ClientHydrationPhase::Requested,
+        phase: if base.phase == ClientHydrationPhase::Requested {
+            ClientHydrationPhase::Requested
+        } else {
+            ClientHydrationPhase::Idle
+        },
         merged_count: merged,
         served_count: served,
     }


### PR DESCRIPTION
## Summary
- preserve Receiver idle state until an explicit hydration request begins
- update the Lean Receiver model and JSON contract before the Rust observer
- add real ClientCore coverage for sessions that already contain local request/response rows

## Root cause
The phone refreshed hydration before writing its request. The observer incorrectly promoted idle to serving merely because two local transcript documents existed, and the serving state then suppressed the request write. No SessionHydrationRequest was ever created, leaving the UI spinning indefinitely.

## Validation
- focused Receiver Lean proof
- JSON contract Lean proof and full Contracts runner
- exact generated hydration conformance
- exact real ClientCore regression
- cargo test -p gents
- cargo test -p gents-desktop-core
- cargo check --workspace --all-targets
- cargo fmt and diff checks

Stack 2/2, based on #1282. This corrects request ordering; legacy server-status pairing still lacks the membership evidence required by hydration admission and is intentionally not weakened here.