### PR TITLE
feat: surface graph package external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,14 @@ Firecrawl smoke checks before returning:
 ```bash
 git clone https://github.com/source-inc/web-research-mcp.git
 cd web-research-mcp
-./scripts/stack up
+./scripts/stack install-mcp
 ```
 
-Register the resulting `http://127.0.0.1:9213/mcp` endpoint once against the
-running local Gents node (the upsert is safe to repeat):
-
-```bash
-gents mcp register web-research-mcp \
-  --endpoint http://127.0.0.1:9213/mcp \
-  --display-name "Web Research MCP" \
-  --description "Local bounded web evidence gateway" \
-  --version 0.1.6 \
-  --send-agent-did
-gents mcp probe web-research-mcp --timeout 30s
-```
+`install-mcp` starts the released real stack, waits for both backend smoke
+checks, registers `http://127.0.0.1:9213/mcp` against the running local Gents
+node, and probes readiness. The graph package installs Gents documents and
+declares this external dependency; it deliberately does not silently allocate
+the roughly 12 GB Docker stack during `graph install`.
 
 Then install the graph and run it with live fan-out progress:
 

--- a/crates/gents-cli/src/commands/graph.rs
+++ b/crates/gents-cli/src/commands/graph.rs
@@ -53,7 +53,7 @@ fn catalog(args: GraphCatalogArgs) -> Result<()> {
 }
 
 async fn install(args: GraphInstallArgs) -> Result<()> {
-    load_bundled_graph_package(&args.package)?;
+    let package = load_bundled_graph_package(&args.package)?;
     let (access, owner_did) = access_and_actor(&args.scope).await?;
     let bindings = if let Some(path) = args.bindings.as_deref() {
         let bindings: GraphPackageInstallBindings = serde_json::from_slice(
@@ -93,6 +93,7 @@ async fn install(args: GraphInstallArgs) -> Result<()> {
             "install": receipt,
             "activation": activation,
             "bindings": bindings,
+            "external_dependencies": package.manifest.external_dependencies,
         })),
         OutputFormat::Text => {
             let mut out = io::stdout().lock();
@@ -102,6 +103,12 @@ async fn install(args: GraphInstallArgs) -> Result<()> {
                 receipt.package_name, receipt.package_version
             )?;
             writeln!(out, "Backend: inherited from your default behavior")?;
+            for dependency in &package.manifest.external_dependencies {
+                writeln!(out, "Requires: {}", dependency.service_id)?;
+                writeln!(out, "  {}", dependency.description)?;
+                writeln!(out, "  Repository: {}", dependency.repository_url)?;
+                writeln!(out, "  After cloning: {}", dependency.install_command)?;
+            }
             writeln!(out, "Run: gents graph run {}", receipt.package_name)?;
             Ok(())
         }

--- a/crates/gents-cli/tests/cli_graph.rs
+++ b/crates/gents-cli/tests/cli_graph.rs
@@ -66,6 +66,20 @@ fn web_deep_research_is_in_the_bundled_catalog() -> Result<()> {
                 .any(|entry| { entry.get("name").and_then(Value::as_str) == Some("research") })),
         "catalog package did not expose the research entry: {catalog}"
     );
+    let dependencies = packages[0]
+        .get("external_dependencies")
+        .and_then(Value::as_array)
+        .context("catalog package did not expose external dependencies")?;
+    anyhow::ensure!(
+        dependencies.len() == 1
+            && dependencies[0].get("service_id").and_then(Value::as_str)
+                == Some("web-research-mcp")
+            && dependencies[0]
+                .get("install_command")
+                .and_then(Value::as_str)
+                == Some("./scripts/stack install-mcp"),
+        "catalog package exposed the wrong external dependency: {catalog}"
+    );
     Ok(())
 }
 

--- a/crates/gents/assets/graph_packages/web-deep-research/manifest.json
+++ b/crates/gents/assets/graph_packages/web-deep-research/manifest.json
@@ -4,6 +4,14 @@
   "version": "1.0.0",
   "description": "Bounded four-stage web research: plan, parallel investigation, evidence adjudication, and cited report.",
   "compiler_version": "graph-intent-v3",
+  "external_dependencies": [
+    {
+      "service_id": "web-research-mcp",
+      "description": "Real self-hosted SearXNG search, Firecrawl extraction, and durable evidence gateway.",
+      "repository_url": "https://github.com/source-inc/web-research-mcp",
+      "install_command": "./scripts/stack install-mcp"
+    }
+  ],
   "roles": [
     {"name": "coordinator", "description": "Plans the research, adjudicates evidence, and writes the report."},
     {"name": "researcher", "description": "Searches and extracts web evidence for one bounded research lens."}

--- a/crates/gents/src/graph_package/catalog.rs
+++ b/crates/gents/src/graph_package/catalog.rs
@@ -26,12 +26,23 @@ pub struct PackageRoleDeclaration {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct PackageExternalDependency {
+    pub service_id: String,
+    pub description: String,
+    pub repository_url: String,
+    pub install_command: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GraphPackageManifest {
     pub manifest_version: u32,
     pub name: String,
     pub version: String,
     pub description: String,
     pub compiler_version: String,
+    #[serde(default)]
+    pub external_dependencies: Vec<PackageExternalDependency>,
     pub roles: Vec<PackageRoleDeclaration>,
     pub schemas: Vec<String>,
     pub intent: String,
@@ -63,6 +74,7 @@ pub struct GraphPackageCatalogEntry {
     pub description: String,
     pub package_digest: String,
     pub compiler_version: String,
+    pub external_dependencies: Vec<PackageExternalDependency>,
     pub roles: Vec<PackageRoleDeclaration>,
     pub entries: Vec<EntryBinding>,
     pub results: Vec<ResultContract>,
@@ -102,6 +114,7 @@ impl BundledGraphPackage {
             description: self.manifest.description.clone(),
             package_digest: self.package_digest.clone(),
             compiler_version: self.manifest.compiler_version.clone(),
+            external_dependencies: self.manifest.external_dependencies.clone(),
             roles: self.manifest.roles.clone(),
             entries: self.intent.entries.clone(),
             results: self.intent.results.clone(),
@@ -267,6 +280,10 @@ mod tests {
     fn web_deep_research_package_is_complete_and_compiler_valid() {
         let package = load_bundled_graph_package("web-deep-research").unwrap();
         assert!(package.package_digest.starts_with("sha256:"));
+        assert_eq!(package.manifest.external_dependencies.len(), 1);
+        let dependency = &package.manifest.external_dependencies[0];
+        assert_eq!(dependency.service_id, "web-research-mcp");
+        assert_eq!(dependency.install_command, "./scripts/stack install-mcp");
         for path in &package.asset_paths {
             assert!(!package.asset(path).unwrap().is_empty(), "{path}");
         }

--- a/crates/gents/src/graph_package/mod.rs
+++ b/crates/gents/src/graph_package/mod.rs
@@ -4,7 +4,7 @@ mod install;
 pub use catalog::{
     graph_package_catalog, load_bundled_graph_package, BundledGraphPackage,
     GraphPackageCatalogEntry, GraphPackageManifest, PackageCapabilityTemplate,
-    PackageRoleDeclaration,
+    PackageExternalDependency, PackageRoleDeclaration,
 };
 pub use install::{
     bundled_graph_id, default_bundled_graph_package_install_bindings,


### PR DESCRIPTION
Makes external service setup discoverable from graph package metadata and install output. web-deep-research now advertises the public web-research-mcp repository and ./scripts/stack install-mcp helper; README uses the same paved path.\n\nValidated with focused gents catalog and CLI integration tests plus cargo check -p gents-cli and formatting checks.