### PR TITLE
refactor(desktop): establish mobile viewport ownership

### DIFF
--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -196,9 +196,11 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
       </section>
 
       <section
-        className={`app-route-slot ${
-          routeOwnsPageScroll ? "app-route-slot-scroll" : "app-route-slot-locked"
-        }`}
+        className={
+          routeOwnsPageScroll
+            ? "app-route-slot app-route-slot-scroll"
+            : "app-route-slot"
+        }
         data-scroll-owner={routeOwnsPageScroll ? "route" : undefined}
         data-testid="app-route-slot"
       >

--- a/apps/gents-desktop/src/App.tsx
+++ b/apps/gents-desktop/src/App.tsx
@@ -169,12 +169,14 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
     setWorkspaceView("config");
   }
 
+  const routeOwnsPageScroll =
+    shell.startupPhase !== "ready" ||
+    workspaceView === "fleet" ||
+    workspaceView === "config";
+
   return (
     <main className={`app-shell app-view-${workspaceView}`}>
       <div aria-hidden="true" className="titlebar-drag-region" data-tauri-drag-region />
-      {shell.error && shell.startupPhase === "ready" ? (
-        <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
-      ) : null}
       <ShortcutsHelp open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
       <ConfirmDialog
         cancelLabel="Keep editing"
@@ -187,203 +189,221 @@ function AppShell({ bridge: explicitBridge }: { bridge?: DesktopShellBridge }) {
         title="Discard unsaved changes?"
       />
 
-      {shell.startupPhase !== "ready" ? (
-        <StartupScreen
-          error={shell.error}
-          onRetry={shell.onRetryStartup}
-          phase={shell.startupPhase}
-        />
-      ) : workspaceView === "fleet" ? (
-        <FleetHostDashboard
-          api={bridge.api}
-          addingPeer={shell.addingPeer}
-          bootstrap={shell.snapshot?.bootstrap ?? null}
-          deployments={shell.deployments}
-          loading={shell.loading}
-          p2pHealth={shell.runtimeHealth}
-          syncHealth={shell.snapshot?.client?.syncHealth ?? null}
-          repairingP2P={shell.repairingP2P}
-          starting={shell.starting}
-          onAddPeer={shell.onAddPeer}
-          onPairBearer={shell.onPairBearer}
-          onProbePeerAddress={shell.onProbePeerAddress}
-          onInitLocalRuntime={shell.onInitLocalRuntime}
-          onStartManagedServer={
-            bridge.api.startManagedServer
-              ? (agentName) => bridge.api.startManagedServer!(agentName)
-              : undefined
-          }
-          onCommitManagedServerAutoStart={
-            bridge.api.commitManagedServerAutoStart
-              ? (agentName) => bridge.api.commitManagedServerAutoStart!(agentName)
-              : undefined
-          }
-          onOpenChat={openChat}
-          onOpenConfig={openConfig}
-          onRemovePeer={shell.onRemovePeer}
-          onRenamePeer={shell.onRenamePeer}
-          onRepairP2P={shell.onRepairP2P}
-          onSaveBackendConfig={shell.onSaveBackendConfig}
-          onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
-          onProbeInferenceEndpoint={shell.onProbeInferenceEndpoint}
-          onCodexLogin={shell.onCodexLogin}
-          onCancelCodexLogin={shell.onCancelCodexLogin}
-          onGrokLogin={shell.onGrokLogin}
-          onCancelGrokLogin={shell.onCancelGrokLogin}
-        />
-      ) : workspaceView === "chat" ? (
-        <section
-          className={`workspace mobile-chat-pane-${mobileChatPane}`}
-          data-mobile-chat-pane={mobileChatPane}
-        >
-          <Sidebar
-            conversations={shell.selectedDeployment?.conversations ?? []}
-            mailboxItems={shell.selectedDeployment?.mailboxItems ?? []}
-            deployments={shell.deployments}
-            onConfigureDeployment={(agentDid) => openConfig(agentDid)}
-            onOpenFleet={() => {
-              shell.clearPendingMailboxCause();
-              setWorkspaceView("fleet");
-            }}
-            onSelectBehavior={shell.setSelectedBehaviorId}
-            onSelectAgent={(agentDid) => {
-              shell.clearPendingMailboxCause();
-              shell.setSelectedAgentDid(agentDid);
-              shell.setSelectedSessionId(null);
-            }}
-            onSelectSession={shell.onSelectSession}
-            onOpenSession={(sessionId) => {
-              shell.onSelectSession(sessionId);
-              setMobileChatPane("conversation");
-            }}
-            onRepairP2P={shell.onRepairP2P}
-            repairingP2P={shell.repairingP2P}
-            syncHealth={shell.snapshot?.client?.syncHealth ?? null}
-            onStartNewConversation={(behaviorId) => {
-              shell.onStartNewConversation(behaviorId);
-              setMobileChatPane("conversation");
-            }}
-            onOpenMailboxItem={(itemId) => {
-              void shell
-                .onOpenMailboxItem(itemId)
-                .then(() => {
-                  setWorkspaceView("chat");
-                  setMobileChatPane("conversation");
-                  requestAnimationFrame(() => {
-                    document
-                      .querySelector<HTMLTextAreaElement>(
-                        '[data-testid="composer-input"]',
-                      )
-                      ?.focus();
-                  });
-                })
-                .catch(() => {});
-            }}
-            onDismissMailboxItem={(itemId) => {
-              void shell.onDismissMailboxItem(itemId).catch(() => {});
-            }}
-            selectedAgentDid={shell.selectedAgentDid}
-            selectedBehaviorId={shell.selectedBehaviorId}
-            selectedSessionId={shell.selectedSessionId}
-          />
+      <section className="app-notice-slot" data-testid="app-notice-slot">
+        {shell.error && shell.startupPhase === "ready" ? (
+          <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
+        ) : null}
+      </section>
 
-          <section className="chat-column">
-            {shell.pendingMailboxCauseId ? (
-              <div
-                className="mailbox-compose-banner"
-                data-testid="mailbox-compose-banner"
-              >
-                This reply is linked to a mailbox item.
-                <button onClick={shell.clearPendingMailboxCause} type="button">
-                  Cancel link
-                </button>
-              </div>
-            ) : null}
-            <ChatWorkspace
-              api={bridge.api}
-              activeRequestId={
-                shell.activeRequestId ?? shell.session?.latestRequestId ?? null
-              }
-              approxSerializedBytes={shell.snapshot?.client?.approxSerializedBytes ?? 0}
-              canSend={shell.canSendMessage}
-              configuredPeerCount={shell.snapshot?.client?.configuredPeerCount ?? 0}
-              dialedPeerCount={shell.snapshot?.client?.dialedPeerCount ?? 0}
-              draft={shell.draft}
-              interruptVisible={shell.interruptVisible}
-              onDraftChange={shell.setDraft}
-              onRenameConversationTitle={shell.onRenameConversationTitle}
-              onSend={shell.onSendMessage}
-              onRetryMessage={shell.onRetryMessage}
-              onRetryHydration={() => shell.refreshSession(shell.selectedSessionId)}
-              onLoadOlderTimeline={shell.loadOlderSessionTimeline}
-              rowCount={shell.snapshot?.client?.rowCount ?? 0}
-              runtimeHealth={shell.runtimeHealth}
-              sendHint={
-                shell.sendStatus.kind === "disabled" ? shell.sendStatus.hint : null
-              }
-              retryUnavailableHint={
-                shell.sendStatus.kind === "disabled" &&
-                shell.sendStatus.reason === "behaviorUnavailable"
-                  ? shell.sendStatus.hint
-                  : null
-              }
-              selectedBehaviorId={shell.selectedBehaviorId}
-              selectedConversationTitle={
-                shell.session
-                  ? (shell.session.title ?? null)
-                  : (shell.selectedConversation?.title ?? null)
-              }
-              selectedDeployment={shell.selectedDeployment}
-              selectedSessionId={shell.selectedSessionId}
-              sending={shell.sending}
-              session={shell.session}
-              optimisticPendingTurn={shell.optimisticPendingTurn}
-              turnState={shell.turnState ?? shell.session?.turnState ?? null}
-              onOpenMobileNavigation={() => setMobileChatPane("navigation")}
-              onInterruptAccepted={async () => {
-                await shell.refreshSession(shell.selectedSessionId);
-              }}
-            />
-          </section>
-        </section>
-      ) : (
-        <section className="config-page">
-          <ConfigWorkspace
+      <section
+        className={`app-route-slot ${
+          routeOwnsPageScroll ? "app-route-slot-scroll" : "app-route-slot-locked"
+        }`}
+        data-scroll-owner={routeOwnsPageScroll ? "route" : undefined}
+        data-testid="app-route-slot"
+      >
+        {shell.startupPhase !== "ready" ? (
+          <StartupScreen
+            error={shell.error}
+            onRetry={shell.onRetryStartup}
+            phase={shell.startupPhase}
+          />
+        ) : workspaceView === "fleet" ? (
+          <FleetHostDashboard
             api={bridge.api}
-            backLabel={configReturnView === "fleet" ? "Back to Fleet" : "Back to Chat"}
+            addingPeer={shell.addingPeer}
             bootstrap={shell.snapshot?.bootstrap ?? null}
-            onBack={navigateBack}
-            onDirtyChange={configNavigation.reportDirty}
-            onDeleteSkillConfig={shell.onDeleteSkillConfig}
-            onDeleteTaskConfig={shell.onDeleteTaskConfig}
-            onDeleteScheduleConfig={shell.onDeleteScheduleConfig}
-            onDeleteEventTriggerConfig={shell.onDeleteEventTriggerConfig}
-            onDeleteBackendConfig={shell.onDeleteBackendConfig}
-            onDeleteInferenceProfileConfig={shell.onDeleteInferenceProfileConfig}
-            onDeleteToolSelectionConfig={shell.onDeleteToolSelectionConfig}
-            onDeleteToolServiceConfig={shell.onDeleteToolServiceConfig}
-            onDeleteBehaviorConfig={shell.onDeleteBehaviorConfig}
-            onSaveAgentConfig={shell.onSaveAgentConfig}
-            onRunTask={shell.onRunTask}
+            deployments={shell.deployments}
+            loading={shell.loading}
+            p2pHealth={shell.runtimeHealth}
+            syncHealth={shell.snapshot?.client?.syncHealth ?? null}
+            repairingP2P={shell.repairingP2P}
+            starting={shell.starting}
+            onAddPeer={shell.onAddPeer}
+            onPairBearer={shell.onPairBearer}
+            onProbePeerAddress={shell.onProbePeerAddress}
+            onInitLocalRuntime={shell.onInitLocalRuntime}
+            onStartManagedServer={
+              bridge.api.startManagedServer
+                ? (agentName) => bridge.api.startManagedServer!(agentName)
+                : undefined
+            }
+            onCommitManagedServerAutoStart={
+              bridge.api.commitManagedServerAutoStart
+                ? (agentName) => bridge.api.commitManagedServerAutoStart!(agentName)
+                : undefined
+            }
+            onOpenChat={openChat}
+            onOpenConfig={openConfig}
+            onRemovePeer={shell.onRemovePeer}
+            onRenamePeer={shell.onRenamePeer}
+            onRepairP2P={shell.onRepairP2P}
             onSaveBackendConfig={shell.onSaveBackendConfig}
             onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
-            onSaveEventTriggerConfig={shell.onSaveEventTriggerConfig}
-            onSaveInferenceProfileConfig={shell.onSaveInferenceProfileConfig}
-            onSaveScheduleConfig={shell.onSaveScheduleConfig}
-            onSaveSkillConfig={shell.onSaveSkillConfig}
-            onSaveTaskConfig={shell.onSaveTaskConfig}
-            onSaveToolSelectionConfig={shell.onSaveToolSelectionConfig}
-            onSaveToolServiceConfig={shell.onSaveToolServiceConfig}
-            onTestToolService={shell.onTestToolService}
-            requestNavigation={requestConfigNavigation}
-            onRunSchedule={shell.onRunSchedule}
-            runningTask={shell.runningTask}
-            saving={shell.savingConfig}
-            selectedBehaviorId={shell.selectedBehaviorId}
-            selectedDeployment={shell.selectedDeployment}
+            onProbeInferenceEndpoint={shell.onProbeInferenceEndpoint}
+            onCodexLogin={shell.onCodexLogin}
+            onCancelCodexLogin={shell.onCancelCodexLogin}
+            onGrokLogin={shell.onGrokLogin}
+            onCancelGrokLogin={shell.onCancelGrokLogin}
           />
-        </section>
-      )}
+        ) : workspaceView === "chat" ? (
+          <section
+            className={`workspace mobile-chat-pane-${mobileChatPane}`}
+            data-mobile-chat-pane={mobileChatPane}
+          >
+            <Sidebar
+              conversations={shell.selectedDeployment?.conversations ?? []}
+              mailboxItems={shell.selectedDeployment?.mailboxItems ?? []}
+              deployments={shell.deployments}
+              onConfigureDeployment={(agentDid) => openConfig(agentDid)}
+              onOpenFleet={() => {
+                shell.clearPendingMailboxCause();
+                setWorkspaceView("fleet");
+              }}
+              onSelectBehavior={shell.setSelectedBehaviorId}
+              onSelectAgent={(agentDid) => {
+                shell.clearPendingMailboxCause();
+                shell.setSelectedAgentDid(agentDid);
+                shell.setSelectedSessionId(null);
+              }}
+              onSelectSession={shell.onSelectSession}
+              onOpenSession={(sessionId) => {
+                shell.onSelectSession(sessionId);
+                setMobileChatPane("conversation");
+              }}
+              onRepairP2P={shell.onRepairP2P}
+              repairingP2P={shell.repairingP2P}
+              syncHealth={shell.snapshot?.client?.syncHealth ?? null}
+              onStartNewConversation={(behaviorId) => {
+                shell.onStartNewConversation(behaviorId);
+                setMobileChatPane("conversation");
+              }}
+              onOpenMailboxItem={(itemId) => {
+                void shell
+                  .onOpenMailboxItem(itemId)
+                  .then(() => {
+                    setWorkspaceView("chat");
+                    setMobileChatPane("conversation");
+                    requestAnimationFrame(() => {
+                      document
+                        .querySelector<HTMLTextAreaElement>(
+                          '[data-testid="composer-input"]',
+                        )
+                        ?.focus();
+                    });
+                  })
+                  .catch(() => {});
+              }}
+              onDismissMailboxItem={(itemId) => {
+                void shell.onDismissMailboxItem(itemId).catch(() => {});
+              }}
+              selectedAgentDid={shell.selectedAgentDid}
+              selectedBehaviorId={shell.selectedBehaviorId}
+              selectedSessionId={shell.selectedSessionId}
+            />
+
+            <section className="chat-column">
+              {shell.pendingMailboxCauseId ? (
+                <div
+                  className="mailbox-compose-banner"
+                  data-testid="mailbox-compose-banner"
+                >
+                  This reply is linked to a mailbox item.
+                  <button onClick={shell.clearPendingMailboxCause} type="button">
+                    Cancel link
+                  </button>
+                </div>
+              ) : null}
+              <ChatWorkspace
+                api={bridge.api}
+                activeRequestId={
+                  shell.activeRequestId ?? shell.session?.latestRequestId ?? null
+                }
+                approxSerializedBytes={
+                  shell.snapshot?.client?.approxSerializedBytes ?? 0
+                }
+                canSend={shell.canSendMessage}
+                configuredPeerCount={shell.snapshot?.client?.configuredPeerCount ?? 0}
+                dialedPeerCount={shell.snapshot?.client?.dialedPeerCount ?? 0}
+                draft={shell.draft}
+                interruptVisible={shell.interruptVisible}
+                onDraftChange={shell.setDraft}
+                onRenameConversationTitle={shell.onRenameConversationTitle}
+                onSend={shell.onSendMessage}
+                onRetryMessage={shell.onRetryMessage}
+                onRetryHydration={() => shell.refreshSession(shell.selectedSessionId)}
+                onLoadOlderTimeline={shell.loadOlderSessionTimeline}
+                rowCount={shell.snapshot?.client?.rowCount ?? 0}
+                runtimeHealth={shell.runtimeHealth}
+                sendHint={
+                  shell.sendStatus.kind === "disabled" ? shell.sendStatus.hint : null
+                }
+                retryUnavailableHint={
+                  shell.sendStatus.kind === "disabled" &&
+                  shell.sendStatus.reason === "behaviorUnavailable"
+                    ? shell.sendStatus.hint
+                    : null
+                }
+                selectedBehaviorId={shell.selectedBehaviorId}
+                selectedConversationTitle={
+                  shell.session
+                    ? (shell.session.title ?? null)
+                    : (shell.selectedConversation?.title ?? null)
+                }
+                selectedDeployment={shell.selectedDeployment}
+                selectedSessionId={shell.selectedSessionId}
+                sending={shell.sending}
+                session={shell.session}
+                optimisticPendingTurn={shell.optimisticPendingTurn}
+                turnState={shell.turnState ?? shell.session?.turnState ?? null}
+                onOpenMobileNavigation={() => setMobileChatPane("navigation")}
+                onInterruptAccepted={async () => {
+                  await shell.refreshSession(shell.selectedSessionId);
+                }}
+              />
+            </section>
+          </section>
+        ) : (
+          <section className="config-page">
+            <ConfigWorkspace
+              api={bridge.api}
+              backLabel={
+                configReturnView === "fleet" ? "Back to Fleet" : "Back to Chat"
+              }
+              bootstrap={shell.snapshot?.bootstrap ?? null}
+              onBack={navigateBack}
+              onDirtyChange={configNavigation.reportDirty}
+              onDeleteSkillConfig={shell.onDeleteSkillConfig}
+              onDeleteTaskConfig={shell.onDeleteTaskConfig}
+              onDeleteScheduleConfig={shell.onDeleteScheduleConfig}
+              onDeleteEventTriggerConfig={shell.onDeleteEventTriggerConfig}
+              onDeleteBackendConfig={shell.onDeleteBackendConfig}
+              onDeleteInferenceProfileConfig={shell.onDeleteInferenceProfileConfig}
+              onDeleteToolSelectionConfig={shell.onDeleteToolSelectionConfig}
+              onDeleteToolServiceConfig={shell.onDeleteToolServiceConfig}
+              onDeleteBehaviorConfig={shell.onDeleteBehaviorConfig}
+              onSaveAgentConfig={shell.onSaveAgentConfig}
+              onRunTask={shell.onRunTask}
+              onSaveBackendConfig={shell.onSaveBackendConfig}
+              onSaveBehaviorConfig={shell.onSaveBehaviorConfig}
+              onSaveEventTriggerConfig={shell.onSaveEventTriggerConfig}
+              onSaveInferenceProfileConfig={shell.onSaveInferenceProfileConfig}
+              onSaveScheduleConfig={shell.onSaveScheduleConfig}
+              onSaveSkillConfig={shell.onSaveSkillConfig}
+              onSaveTaskConfig={shell.onSaveTaskConfig}
+              onSaveToolSelectionConfig={shell.onSaveToolSelectionConfig}
+              onSaveToolServiceConfig={shell.onSaveToolServiceConfig}
+              onTestToolService={shell.onTestToolService}
+              requestNavigation={requestConfigNavigation}
+              onRunSchedule={shell.onRunSchedule}
+              runningTask={shell.runningTask}
+              saving={shell.savingConfig}
+              selectedBehaviorId={shell.selectedBehaviorId}
+              selectedDeployment={shell.selectedDeployment}
+            />
+          </section>
+        )}
+      </section>
     </main>
   );
 }

--- a/apps/gents-desktop/src/components/ShortcutsHelp.tsx
+++ b/apps/gents-desktop/src/components/ShortcutsHelp.tsx
@@ -36,10 +36,15 @@ export function ShortcutsHelp({
     return null;
   }
   return (
-    <div className="dialog-backdrop open" role="presentation" onClick={onClose}>
+    <div
+      className="dialog-backdrop viewport-overlay open"
+      role="presentation"
+      onClick={onClose}
+    >
       <div
         aria-label="Keyboard shortcuts"
-        className="dialog shortcuts-help"
+        className="dialog shortcuts-help viewport-overlay-surface"
+        data-scroll-owner="dialog"
         data-testid="shortcuts-help"
         role="dialog"
         onClick={(event) => event.stopPropagation()}

--- a/apps/gents-desktop/src/components/Sidebar.tsx
+++ b/apps/gents-desktop/src/components/Sidebar.tsx
@@ -122,7 +122,7 @@ export function Sidebar({
           {mailboxItems.length === 0 ? (
             <p className="empty-state">Nothing needs your attention.</p>
           ) : (
-            <div className="list">
+            <div className="list" data-scroll-owner="section-list">
               {mailboxItems.map((item) => (
                 <article className="list-item mailbox-item" key={item.itemId}>
                   <div className="list-item-title">{item.title}</div>

--- a/apps/gents-desktop/src/components/SyncHealthIndicator.tsx
+++ b/apps/gents-desktop/src/components/SyncHealthIndicator.tsx
@@ -35,7 +35,8 @@ export function SyncHealthIndicator({
         <span>{label}</span>
       </summary>
       <div
-        className="sync-health-details"
+        className="sync-health-details mobile-viewport-popover"
+        data-scroll-owner="popover"
         data-testid="sync-health-details"
         role="region"
         aria-label="Sync diagnostics"

--- a/apps/gents-desktop/src/components/sidebar-widgets/BehaviorEnvironmentSection.tsx
+++ b/apps/gents-desktop/src/components/sidebar-widgets/BehaviorEnvironmentSection.tsx
@@ -31,7 +31,7 @@ export function BehaviorEnvironmentSection({
         Each behavior is an environment with its own model, workspace, and tool
         boundary.
       </p>
-      <div className="behavior-environment-list">
+      <div className="behavior-environment-list" data-scroll-owner="section-list">
         {environments.map((environment) => (
           <article
             className={

--- a/apps/gents-desktop/src/components/sidebar-widgets/ConversationListSection.tsx
+++ b/apps/gents-desktop/src/components/sidebar-widgets/ConversationListSection.tsx
@@ -96,7 +96,11 @@ export function ConversationListSection({
       ) : !filteredConversations.length ? (
         <p className="muted">No sessions match the search.</p>
       ) : (
-        <div className="conversation-list" data-testid="session-list">
+        <div
+          className="conversation-list"
+          data-scroll-owner="section-list"
+          data-testid="session-list"
+        >
           <SessionGroupList
             conversations={grouped.attention}
             environmentById={environmentById}
@@ -141,7 +145,7 @@ function SessionGroupList({
   return (
     <section className="session-group">
       <h3>{label}</h3>
-      <div className="list session-group-list">
+      <div className="session-group-list">
         {conversations.map((conversation) => {
           const when = conversation.updatedAt ?? conversation.createdAt;
           const environment = conversation.behaviorId

--- a/apps/gents-desktop/src/hooks/useMobileVisualViewport.ts
+++ b/apps/gents-desktop/src/hooks/useMobileVisualViewport.ts
@@ -7,6 +7,7 @@ const LEFT = "--mobile-visual-viewport-left";
 const MIN_USEFUL_DIMENSION = 64;
 const FOCUSED_CONTROL_SELECTOR =
   'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled]), [contenteditable="true"]';
+const SCROLL_OWNER_SELECTOR = "[data-scroll-owner]";
 const FOCUSED_CONTROL_MARGIN = 16;
 const KEYBOARD_SETTLE_DELAY_MS = 350;
 
@@ -22,14 +23,21 @@ function revealFocusedControl(viewport: VisualViewport) {
   if (!(control instanceof HTMLElement) || !control.matches(FOCUSED_CONTROL_SELECTOR)) {
     return;
   }
+  const owner = control.closest<HTMLElement>(SCROLL_OWNER_SELECTOR);
+  if (!owner) return;
 
   const rect = control.getBoundingClientRect();
-  const visibleTop = Math.max(0, viewport.offsetTop) + FOCUSED_CONTROL_MARGIN;
+  const ownerRect = owner.getBoundingClientRect();
+  const viewportTop = Math.max(0, viewport.offsetTop);
+  const viewportBottom = viewportTop + viewport.height;
+  const visibleTop = Math.max(viewportTop, ownerRect.top) + FOCUSED_CONTROL_MARGIN;
   const visibleBottom =
-    Math.max(0, viewport.offsetTop) + viewport.height - FOCUSED_CONTROL_MARGIN;
+    Math.min(viewportBottom, ownerRect.bottom) - FOCUSED_CONTROL_MARGIN;
+  if (visibleBottom <= visibleTop) return;
   if (rect.top >= visibleTop && rect.bottom <= visibleBottom) return;
 
-  control.scrollIntoView({ behavior: "auto", block: "center", inline: "nearest" });
+  owner.scrollTop +=
+    rect.top < visibleTop ? rect.top - visibleTop : rect.bottom - visibleBottom;
 }
 
 /**

--- a/apps/gents-desktop/src/styles/config/documents.css
+++ b/apps/gents-desktop/src/styles/config/documents.css
@@ -50,4 +50,11 @@
     align-content: start;
     overflow: auto;
   }
+
+  @media (max-width: 760px) {
+    .config-document-list-body,
+    .config-editor {
+      overflow: visible;
+    }
+  }
 }

--- a/apps/gents-desktop/src/styles/config/workspace.css
+++ b/apps/gents-desktop/src/styles/config/workspace.css
@@ -204,7 +204,8 @@
     display: flex;
     align-items: center;
     gap: 0;
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     min-height: 36px;
     border: 1px solid var(--border-default);
     background: var(--color-surface-row);
@@ -293,9 +294,26 @@
   }
 
   @media (max-width: 760px) {
+    .config-page,
+    .config-workspace,
+    .config-workspace-full,
+    .config-tab-panel,
+    .config-layout,
+    .config-single-layout,
+    .config-list {
+      height: auto;
+      min-height: 0;
+      overflow: visible;
+    }
+
     .config-workspace,
     .config-workspace-full {
       gap: var(--space-5);
+      grid-template-rows: auto;
+    }
+
+    .config-layout {
+      grid-template-rows: auto;
     }
 
     .config-header,

--- a/apps/gents-desktop/src/styles/primitives/layout.css
+++ b/apps/gents-desktop/src/styles/primitives/layout.css
@@ -23,7 +23,6 @@
   .list {
     align-content: start;
     min-height: 0;
-    overflow: auto;
   }
 
   .list-item {

--- a/apps/gents-desktop/src/styles/shell.css
+++ b/apps/gents-desktop/src/styles/shell.css
@@ -436,10 +436,6 @@
       -webkit-overflow-scrolling: touch;
     }
 
-    .app-route-slot-locked {
-      overflow: hidden;
-    }
-
     .workspace {
       grid-template-columns: minmax(0, 1fr);
       grid-template-rows: minmax(0, 1fr);

--- a/apps/gents-desktop/src/styles/shell.css
+++ b/apps/gents-desktop/src/styles/shell.css
@@ -69,8 +69,10 @@
     height: 100vh;
     padding: var(--space-8);
     display: grid;
-    gap: var(--space-6);
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 0;
     overflow: hidden;
+    overflow: clip;
     background:
       linear-gradient(
         180deg,
@@ -111,6 +113,23 @@
   .app-shell > * {
     position: relative;
     z-index: 1;
+  }
+
+  .app-notice-slot {
+    grid-row: 1;
+    min-width: 0;
+  }
+
+  .app-notice-slot:not(:empty) {
+    padding-bottom: var(--space-6);
+  }
+
+  .app-route-slot {
+    grid-row: 2;
+    display: grid;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .startup-screen {
@@ -390,15 +409,35 @@
       width: var(--mobile-visual-viewport-width, 100dvw);
       height: var(--mobile-visual-viewport-height, 100dvh);
       min-height: 0;
-      padding: calc(var(--space-5) + env(safe-area-inset-top))
-        calc(var(--space-5) + env(safe-area-inset-right))
-        calc(var(--space-5) + env(safe-area-inset-bottom))
-        calc(var(--space-5) + env(safe-area-inset-left));
-      gap: var(--space-5);
+      padding: calc(
+          var(--space-5) + var(--mobile-safe-area-top, env(safe-area-inset-top, 0rem))
+        )
+        calc(
+          var(--space-5) +
+            var(--mobile-safe-area-right, env(safe-area-inset-right, 0rem))
+        )
+        calc(
+          var(--space-5) +
+            var(--mobile-safe-area-bottom, env(safe-area-inset-bottom, 0rem))
+        )
+        calc(
+          var(--space-5) + var(--mobile-safe-area-left, env(safe-area-inset-left, 0rem))
+        );
+    }
+
+    .app-notice-slot:not(:empty) {
+      padding-bottom: var(--space-5);
+    }
+
+    .app-route-slot-scroll {
       overflow-x: hidden;
       overflow-y: auto;
       overscroll-behavior-y: contain;
       -webkit-overflow-scrolling: touch;
+    }
+
+    .app-route-slot-locked {
+      overflow: hidden;
     }
 
     .workspace {
@@ -423,11 +462,20 @@
     }
 
     .app-shell.app-view-chat {
-      padding: calc(var(--space-3) + env(safe-area-inset-top))
-        calc(var(--space-3) + env(safe-area-inset-right))
-        calc(var(--space-3) + env(safe-area-inset-bottom))
-        calc(var(--space-3) + env(safe-area-inset-left));
-      overflow: hidden;
+      padding: calc(
+          var(--space-3) + var(--mobile-safe-area-top, env(safe-area-inset-top, 0rem))
+        )
+        calc(
+          var(--space-3) +
+            var(--mobile-safe-area-right, env(safe-area-inset-right, 0rem))
+        )
+        calc(
+          var(--space-3) +
+            var(--mobile-safe-area-bottom, env(safe-area-inset-bottom, 0rem))
+        )
+        calc(
+          var(--space-3) + var(--mobile-safe-area-left, env(safe-area-inset-left, 0rem))
+        );
     }
 
     .workspace-tabs {

--- a/apps/gents-desktop/src/styles/sidebar/conversations.css
+++ b/apps/gents-desktop/src/styles/sidebar/conversations.css
@@ -61,6 +61,9 @@
 
   .session-group-list {
     display: grid;
+    gap: var(--space-4);
+    align-content: start;
+    min-height: 0;
   }
 
   .session-list-item {

--- a/apps/gents-desktop/src/styles/sync-health.css
+++ b/apps/gents-desktop/src/styles/sync-health.css
@@ -118,27 +118,7 @@
 
   @media (max-width: 760px) {
     .sync-health-details {
-      position: fixed;
-      top: calc(
-        var(--mobile-visual-viewport-top, 0px) +
-          var(--mobile-safe-area-top, env(safe-area-inset-top, 0px)) + 4rem
-      );
-      right: auto;
-      left: calc(
-        var(--mobile-visual-viewport-left, 0px) +
-          var(--mobile-safe-area-left, env(safe-area-inset-left, 0px)) + 0.5rem
-      );
-      width: calc(
-        var(--mobile-visual-viewport-width, 100dvw) -
-          var(--mobile-safe-area-left, env(safe-area-inset-left, 0px)) -
-          var(--mobile-safe-area-right, env(safe-area-inset-right, 0px)) - 1rem
-      );
-      max-height: calc(
-        var(--mobile-visual-viewport-height, 100dvh) -
-          var(--mobile-safe-area-top, env(safe-area-inset-top, 0px)) -
-          var(--mobile-safe-area-bottom, env(safe-area-inset-bottom, 0px)) - 5rem
-      );
-      overflow: auto;
+      --mobile-popover-top-clearance: 4rem;
     }
   }
 }

--- a/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-layout.spec.ts
@@ -206,7 +206,9 @@ test.describe("desktop responsive layout guardrails", () => {
 
     const submit = page.getByTestId("fleet-fetch-status");
     await expect(submit).toBeAttached();
-    await submit.scrollIntoViewIfNeeded();
+    await page.getByTestId("app-route-slot").evaluate((owner) => {
+      owner.scrollTop = owner.scrollHeight;
+    });
     await expect(submit).toBeVisible();
     await submit.click({ trial: true });
 
@@ -243,26 +245,17 @@ test.describe("desktop responsive layout guardrails", () => {
         offsetTop: 0,
         offsetLeft: 0,
       });
-      const originalScrollIntoView = Element.prototype.scrollIntoView;
       Object.defineProperty(window, "visualViewport", {
         configurable: true,
         value: viewport,
       });
       Object.assign(window, {
-        __focusedControlRevealCount: 0,
-        __setTestVisualViewport(height: number) {
+        __setTestVisualViewport(height: number, offsetTop: number) {
           viewport.height = height;
+          viewport.offsetTop = offsetTop;
           viewport.dispatchEvent(new Event("resize"));
         },
       });
-      Element.prototype.scrollIntoView = function (options) {
-        if (this === document.activeElement) {
-          (
-            window as typeof window & { __focusedControlRevealCount: number }
-          ).__focusedControlRevealCount += 1;
-        }
-        return originalScrollIntoView.call(this, options);
-      };
     });
 
     await gotoHarness(page, "empty-fleet");
@@ -272,30 +265,34 @@ test.describe("desktop responsive layout guardrails", () => {
       .click();
     const address = page.getByTestId("fleet-add-server-address");
     await address.focus();
+    const route = page.getByTestId("app-route-slot");
+    await route.evaluate((owner) => {
+      owner.scrollTop = 0;
+    });
     await page.evaluate(() => {
       (
         window as typeof window & {
-          __setTestVisualViewport: (height: number) => void;
+          __setTestVisualViewport: (height: number, offsetTop: number) => void;
         }
-      ).__setTestVisualViewport(360);
+      ).__setTestVisualViewport(360, 24);
     });
 
     await expect
-      .poll(() =>
-        page.evaluate(
-          () =>
-            (window as typeof window & { __focusedControlRevealCount: number })
-              .__focusedControlRevealCount,
-        ),
-      )
+      .poll(() => route.evaluate((owner) => owner.scrollTop))
       .toBeGreaterThan(0);
     await expect(page.locator(".app-shell")).toHaveCSS("height", "360px");
     const addressRect = await address.evaluate((element) => {
       const rect = element.getBoundingClientRect();
       return { bottom: rect.bottom, top: rect.top };
     });
-    expect(addressRect.top).toBeGreaterThanOrEqual(0);
-    expect(addressRect.bottom).toBeLessThanOrEqual(360);
+    expect(addressRect.top).toBeGreaterThanOrEqual(24);
+    expect(addressRect.bottom).toBeLessThanOrEqual(384);
+    expect(await page.locator(".app-shell").evaluate((shell) => shell.scrollTop)).toBe(
+      0,
+    );
+    expect(
+      await page.getByTestId("fleet-empty").evaluate((fleet) => fleet.scrollTop),
+    ).toBe(0);
   });
 
   test("populated-fleet status discovery stays reachable on mobile", async ({
@@ -311,11 +308,16 @@ test.describe("desktop responsive layout guardrails", () => {
 
     const address = page.getByTestId("fleet-add-server-address");
     const fetchStatus = page.getByTestId("fleet-fetch-status");
-    await address.scrollIntoViewIfNeeded();
+    const route = page.getByTestId("app-route-slot");
+    await route.evaluate((owner) => {
+      owner.scrollTop = owner.scrollHeight;
+    });
     await expect(address).toBeVisible();
     await address.fill("http://studio-1:9191");
 
-    await fetchStatus.scrollIntoViewIfNeeded();
+    await route.evaluate((owner) => {
+      owner.scrollTop = owner.scrollHeight;
+    });
     await expect(fetchStatus).toBeVisible();
     await fetchStatus.click({ trial: true });
 

--- a/apps/gents-desktop/tests/playwright/desktop-viewport-ownership.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-viewport-ownership.spec.ts
@@ -1,0 +1,313 @@
+import {
+  expect,
+  gotoHarness,
+  openChat,
+  openChatNavigation,
+  openConfig,
+  openConfigTab,
+  test,
+  type Page,
+} from "./desktopTest";
+
+const phoneViewports = [
+  { width: 320, height: 568 },
+  { width: 430, height: 932 },
+] as const;
+
+async function expectShellClipsToRouteOwner(page: Page) {
+  const state = await page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>(".app-shell");
+    const route = document.querySelector<HTMLElement>("[data-testid='app-route-slot']");
+    if (!shell || !route) throw new Error("shell ownership geometry missing");
+    shell.scrollTop = 100;
+    const routeElements = [route, ...route.querySelectorAll<HTMLElement>("*")];
+    return {
+      declaredOwners: routeElements
+        .filter(
+          (element) =>
+            element.dataset.scrollOwner &&
+            element.getClientRects().length > 0 &&
+            !element.closest("details:not([open])"),
+        )
+        .map((element) => element.dataset.scrollOwner),
+      rogueActiveScrollers: routeElements
+        .filter((element) => {
+          const overflowY = getComputedStyle(element).overflowY;
+          return (
+            /^(auto|scroll)$/.test(overflowY) &&
+            element.scrollHeight > element.clientHeight + 1 &&
+            !element.dataset.scrollOwner
+          );
+        })
+        .map((element) => element.className),
+      routeOwner: route.dataset.scrollOwner,
+      routeOverflowY: getComputedStyle(route).overflowY,
+      shellOverflowY: getComputedStyle(shell).overflowY,
+      shellScrollTop: shell.scrollTop,
+    };
+  });
+  expect(state).toEqual({
+    declaredOwners: ["route"],
+    rogueActiveScrollers: [],
+    routeOwner: "route",
+    routeOverflowY: "auto",
+    shellOverflowY: "clip",
+    shellScrollTop: 0,
+  });
+}
+
+async function installVisualViewport(
+  page: Page,
+  geometry = { height: 500, width: 360, offsetTop: 24, offsetLeft: 8 },
+) {
+  await page.addInitScript((initialGeometry) => {
+    const viewport = new EventTarget() as EventTarget & {
+      height: number;
+      width: number;
+      offsetTop: number;
+      offsetLeft: number;
+    };
+    Object.assign(viewport, initialGeometry);
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: viewport,
+    });
+    Object.assign(window, {
+      __setTestVisualViewport(height: number, offsetTop: number) {
+        viewport.height = height;
+        viewport.offsetTop = offsetTop;
+        viewport.dispatchEvent(new Event("resize"));
+      },
+    });
+  }, geometry);
+}
+
+async function setTestSafeArea(page: Page) {
+  await page.evaluate(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--mobile-safe-area-top", "47px");
+    root.style.setProperty("--mobile-safe-area-right", "13px");
+    root.style.setProperty("--mobile-safe-area-bottom", "34px");
+    root.style.setProperty("--mobile-safe-area-left", "11px");
+  });
+}
+
+async function expectVisualViewportOverlay(page: Page, testId: string) {
+  const geometry = await page.getByTestId(testId).evaluate((element) => {
+    const overlayElement = element.closest<HTMLElement>(".viewport-overlay");
+    if (!overlayElement) throw new Error("viewport overlay ownership missing");
+    const overlay = overlayElement.getBoundingClientRect();
+    const surface = element.matches("[data-scroll-owner='dialog']")
+      ? (element as HTMLElement)
+      : element.querySelector<HTMLElement>("[data-scroll-owner='dialog']");
+    if (!surface) throw new Error("dialog surface ownership missing");
+    const surfaceRect = surface.getBoundingClientRect();
+    return {
+      overlay: overlay.toJSON(),
+      surface: surfaceRect.toJSON(),
+      surfaceOverflowY: getComputedStyle(surface).overflowY,
+    };
+  });
+  expect(geometry.overlay.top).toBeCloseTo(24, 0);
+  expect(geometry.overlay.left).toBeCloseTo(8, 0);
+  expect(geometry.overlay.width).toBeCloseTo(360, 0);
+  expect(geometry.overlay.height).toBeCloseTo(500, 0);
+  expect(geometry.surface.top).toBeGreaterThanOrEqual(24 + 47);
+  expect(geometry.surface.left).toBeGreaterThanOrEqual(8 + 11);
+  expect(geometry.surface.right).toBeLessThanOrEqual(8 + 360 - 13);
+  expect(geometry.surface.bottom).toBeLessThanOrEqual(24 + 500 - 34);
+  expect(geometry.surfaceOverflowY).toBe("auto");
+}
+
+test.describe("mobile viewport ownership", () => {
+  test.beforeEach(({ page }) => {
+    test.skip(
+      (page.viewportSize()?.width ?? Number.POSITIVE_INFINITY) > 760,
+      "mobile viewport ownership guardrail",
+    );
+  });
+
+  test("startup, fleet, and config use the route as their only page scroll owner", async ({
+    page,
+  }) => {
+    for (const viewport of phoneViewports) {
+      await page.setViewportSize(viewport);
+
+      await gotoHarness(page, "bridge-unavailable");
+      await expectShellClipsToRouteOwner(page);
+
+      await gotoHarness(page);
+      await expectShellClipsToRouteOwner(page);
+      await expect(page.getByTestId("fleet-dashboard")).toHaveCSS(
+        "overflow-y",
+        "visible",
+      );
+
+      await openConfig(page);
+      await expectShellClipsToRouteOwner(page);
+      for (const selector of [
+        ".config-page",
+        ".config-workspace",
+        ".config-tab-panel",
+        ".config-editor",
+      ]) {
+        await expect(page.locator(selector).first()).toHaveCSS("overflow-y", "visible");
+      }
+    }
+  });
+
+  test("chat locks the route and delegates scrolling to its visible section", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "long-content");
+    await openChat(page);
+
+    const route = page.getByTestId("app-route-slot");
+    expect(await route.getAttribute("data-scroll-owner")).toBeNull();
+    await expect(route).toHaveCSS("overflow-y", "hidden");
+    await expect(page.getByTestId("transcript-panel")).toHaveAttribute(
+      "data-scroll-owner",
+      "transcript",
+    );
+    expect(
+      await page
+        .locator("[data-scroll-owner]:visible")
+        .evaluateAll((elements) =>
+          elements.map((element) => element.dataset.scrollOwner),
+        ),
+    ).toEqual(["transcript"]);
+
+    await openChatNavigation(page);
+    await expect(page.locator(".conversation-list")).toHaveAttribute(
+      "data-scroll-owner",
+      "section-list",
+    );
+    await expect(page.locator(".session-group-list")).not.toHaveAttribute(
+      "data-scroll-owner",
+      /.+/,
+    );
+    await expect(page.locator(".session-group-list")).toHaveCSS(
+      "overflow-y",
+      "visible",
+    );
+    expect(
+      await page
+        .locator("[data-scroll-owner]:visible")
+        .evaluateAll((elements) =>
+          elements.map((element) => element.dataset.scrollOwner),
+        ),
+    ).toEqual(["section-list"]);
+  });
+
+  test("an error notice gets its own shell track without becoming a scroll owner", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "save-error");
+    await openConfig(page);
+    await openConfigTab(page, "behavior");
+    await page
+      .getByTestId("behavior-system-prompt")
+      .fill("Trigger the rejected save viewport fixture.");
+    await page.getByTestId("behavior-save").click();
+    await expect(page.getByTestId("error-banner")).toBeVisible();
+
+    const geometry = await page.evaluate(() => {
+      const shell = document.querySelector<HTMLElement>(".app-shell");
+      const notice = document.querySelector<HTMLElement>(".app-notice-slot");
+      const route = document.querySelector<HTMLElement>(".app-route-slot");
+      if (!shell || !notice || !route) throw new Error("notice geometry missing");
+      return {
+        notice: notice.getBoundingClientRect().toJSON(),
+        route: route.getBoundingClientRect().toJSON(),
+        shell: shell.getBoundingClientRect().toJSON(),
+        noticeOwner: notice.dataset.scrollOwner ?? null,
+        routeOwner: route.dataset.scrollOwner ?? null,
+      };
+    });
+    expect(geometry.noticeOwner).toBeNull();
+    expect(geometry.routeOwner).toBe("route");
+    expect(geometry.route.top).toBeGreaterThanOrEqual(geometry.notice.bottom);
+    expect(geometry.route.bottom).toBeLessThanOrEqual(geometry.shell.bottom);
+  });
+
+  test("dialogs consume one shared visual-viewport and safe-area primitive", async ({
+    page,
+  }) => {
+    await installVisualViewport(page);
+    await gotoHarness(page);
+    await setTestSafeArea(page);
+
+    await page.keyboard.press("ControlOrMeta+/");
+    await expect(page.getByTestId("shortcuts-help")).toBeVisible();
+    await expectVisualViewportOverlay(page, "shortcuts-help");
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Add Agent", exact: true }).click();
+    await page.locator(".fleet-alternative-disclosure > summary").click();
+    await page.getByTestId("app-route-slot").evaluate((owner) => {
+      owner.scrollTop = owner.scrollHeight;
+    });
+    await page.getByTestId("fleet-pair-scan").click();
+    await expect(page.getByTestId("fleet-qr-scanner")).toBeVisible();
+    await expectVisualViewportOverlay(page, "fleet-qr-scanner");
+  });
+
+  test("context and sync popovers share visual-viewport containment", async ({
+    page,
+  }) => {
+    await installVisualViewport(page);
+    await gotoHarness(page, "long-content");
+    await setTestSafeArea(page);
+    await openChat(page);
+    await page.locator("[data-testid='context-meter'] > summary").click();
+    const context = page.locator(".context-meter-popover");
+    await expect(context).toHaveAttribute("data-scroll-owner", "popover");
+    const contextBounds = await context.evaluate((element) =>
+      element.getBoundingClientRect().toJSON(),
+    );
+    expect(contextBounds.top).toBeGreaterThanOrEqual(24 + 47);
+    expect(contextBounds.left).toBeGreaterThanOrEqual(8 + 11);
+    expect(contextBounds.right).toBeLessThanOrEqual(8 + 360 - 13);
+    expect(contextBounds.bottom).toBeLessThanOrEqual(24 + 500 - 34);
+
+    await gotoHarness(page, "sync-stalled");
+    await setTestSafeArea(page);
+    await page.getByTestId("sync-health-summary").click();
+    const details = page.getByTestId("sync-health-details");
+    const bounds = await details.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return rect.toJSON();
+    });
+    expect(bounds.top).toBeGreaterThanOrEqual(24 + 47);
+    expect(bounds.left).toBeGreaterThanOrEqual(8 + 11);
+    expect(bounds.right).toBeLessThanOrEqual(8 + 360 - 13);
+    expect(bounds.bottom).toBeLessThanOrEqual(24 + 500 - 34);
+  });
+
+  test("chat composer stays visible without turning the locked route into an owner", async ({
+    page,
+  }) => {
+    await installVisualViewport(page);
+    await gotoHarness(page, "long-content");
+    await openChat(page);
+    const composer = page.getByTestId("composer-input");
+    await composer.focus();
+    await page.evaluate(() => {
+      (
+        window as typeof window & {
+          __setTestVisualViewport: (height: number, offsetTop: number) => void;
+        }
+      ).__setTestVisualViewport(300, 24);
+    });
+
+    await expect(page.locator(".app-shell")).toHaveCSS("height", "300px");
+    const bounds = await composer.evaluate((element) =>
+      element.getBoundingClientRect().toJSON(),
+    );
+    expect(bounds.top).toBeGreaterThanOrEqual(24);
+    expect(bounds.bottom).toBeLessThanOrEqual(324);
+    expect(
+      await page.getByTestId("app-route-slot").getAttribute("data-scroll-owner"),
+    ).toBeNull();
+  });
+});

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -238,6 +238,22 @@ export function createDesktopUiHarness(
     },
     pendingTurn: null,
     activeResponseOverlay: null,
+    context:
+      scenario === "long-content"
+        ? {
+            estimatedDurableTokens: 142_031,
+            estimatedConversationTokens: 142_031,
+            contextWindow: 480_000,
+            compactionThreshold: 0.75,
+            compactionThresholdTokens: 360_000,
+            compactionStrategy: "StripThenSummarize",
+            durableMessageCount: 8,
+            providerMessageCount: 8,
+            totalCompactedMessages: 0,
+            compactions: [],
+            lastRequest: null,
+          }
+        : undefined,
     timelineItems: [
       {
         kind: "assistantMessage",

--- a/packages/gents-desktop-chat/src/components/cancelUx/CascadeCancelDialog.tsx
+++ b/packages/gents-desktop-chat/src/components/cancelUx/CascadeCancelDialog.tsx
@@ -195,7 +195,6 @@ export function CascadeCancelDialog(
               </span>
             ) : null}
           </div>
-          {}
           <div
             role="status"
             aria-live="polite"

--- a/packages/gents-desktop-chat/src/components/cancelUx/CascadeCancelDialog.tsx
+++ b/packages/gents-desktop-chat/src/components/cancelUx/CascadeCancelDialog.tsx
@@ -162,13 +162,14 @@ export function CascadeCancelDialog(
   return (
     <div
       ref={backdropRef}
-      className="dialog-backdrop open"
+      className="dialog-backdrop viewport-overlay open"
       role="presentation"
       onClick={onBackdropClick}
     >
       <div
         ref={dialogRef}
-        className="dialog"
+        className="dialog viewport-overlay-surface"
+        data-scroll-owner="dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="cascade-cancel-title"
@@ -194,7 +195,7 @@ export function CascadeCancelDialog(
               </span>
             ) : null}
           </div>
-          { }
+          {}
           <div
             role="status"
             aria-live="polite"

--- a/packages/gents-desktop-chat/src/components/chat/ChatHeader.tsx
+++ b/packages/gents-desktop-chat/src/components/chat/ChatHeader.tsx
@@ -79,7 +79,10 @@ function ContextMeter({
       <summary className="chip" title={title}>
         Context ≈{formatTokens(used)} / {formatTokens(window)}
       </summary>
-      <div className="context-meter-popover">
+      <div
+        className="context-meter-popover mobile-viewport-popover"
+        data-scroll-owner="popover"
+      >
         <div className="context-meter-heading">
           <strong>
             {lastRequest ? "Last provider request" : "Conversation context"}

--- a/packages/gents-desktop-chat/src/components/chat/ChatTranscriptPanel.tsx
+++ b/packages/gents-desktop-chat/src/components/chat/ChatTranscriptPanel.tsx
@@ -356,6 +356,7 @@ export function ChatTranscriptPanel({
   return (
     <section
       className="panel transcript-panel"
+      data-scroll-owner="transcript"
       data-testid="transcript-panel"
       onScroll={handleTranscriptScroll}
       ref={transcriptPanelRef}

--- a/packages/gents-desktop-chat/styles/chat.css
+++ b/packages/gents-desktop-chat/styles/chat.css
@@ -384,11 +384,8 @@
     }
 
     .context-meter-popover {
-      position: fixed;
-      top: calc(var(--space-10) * 2);
-      right: var(--space-4);
-      left: var(--space-4);
-      width: auto;
+      --mobile-popover-top-clearance: calc(var(--space-10) * 2);
+      --mobile-popover-gutter: var(--space-4);
     }
 
     .chat-status .chip:last-child {

--- a/packages/gents-desktop-fleet/src/InferenceSetupWizard.tsx
+++ b/packages/gents-desktop-fleet/src/InferenceSetupWizard.tsx
@@ -11,12 +11,13 @@ export function InferenceSetupWizard(props: InferenceSetupWizardProps) {
 
   return (
     <div
-      className="dialog-backdrop open"
+      className="dialog-backdrop viewport-overlay open"
       role="presentation"
       onClick={setup.cancelAndClose}
     >
       <div
-        className="dialog inference-wizard"
+        className="dialog inference-wizard viewport-overlay-surface"
+        data-scroll-owner="dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="inference-wizard-title"

--- a/packages/gents-desktop-fleet/src/components/QrScannerDialog.tsx
+++ b/packages/gents-desktop-fleet/src/components/QrScannerDialog.tsx
@@ -184,11 +184,14 @@ export function QrScannerDialog({
     <div
       aria-label="Scan pairing invite"
       aria-modal="true"
-      className="fleet-qr-backdrop"
+      className="fleet-qr-backdrop viewport-overlay"
       data-testid="fleet-qr-scanner"
       role="dialog"
     >
-      <section className="fleet-qr-dialog panel">
+      <section
+        className="fleet-qr-dialog panel viewport-overlay-surface"
+        data-scroll-owner="dialog"
+      >
         <header>
           <div>
             <p className="eyebrow">Secure pairing</p>

--- a/packages/gents-desktop-fleet/styles/layout/responsive.css
+++ b/packages/gents-desktop-fleet/styles/layout/responsive.css
@@ -2,10 +2,8 @@
   @media (max-width: 760px) {
     .fleet-dashboard {
       gap: var(--space-5);
-      overflow-x: hidden;
-      overflow-y: auto;
-      overscroll-behavior-y: contain;
-      -webkit-overflow-scrolling: touch;
+      grid-template-rows: auto;
+      overflow: visible;
     }
 
     .fleet-brand {
@@ -42,7 +40,6 @@
 
     .fleet-empty {
       height: auto;
-      min-height: 100%;
       place-content: start center;
       overflow: visible;
       padding-block: var(--space-2);

--- a/packages/gents-desktop-operations/src/components/operations/HoldsPanel.tsx
+++ b/packages/gents-desktop-operations/src/components/operations/HoldsPanel.tsx
@@ -123,7 +123,7 @@ export function HoldsPanel({
           No tool calls awaiting approval.
         </p>
       ) : null}
-      <ul className="holds-panel-list">
+      <ul className="holds-panel-list" data-scroll-owner="holds">
         {(holds ?? []).map((hold) => {
           const fullArgs = normalizedArgs(hold.args);
           const preview = fullArgs ? argsPreview(fullArgs) : null;

--- a/packages/gents-desktop-ui/src/ConfirmDialog.tsx
+++ b/packages/gents-desktop-ui/src/ConfirmDialog.tsx
@@ -61,12 +61,13 @@ export function ConfirmDialog({
 
   return (
     <div
-      className="dialog-backdrop open"
+      className="dialog-backdrop viewport-overlay open"
       role="presentation"
       onClick={onCancel}
     >
       <div
-        className="dialog confirm-dialog"
+        className="dialog confirm-dialog viewport-overlay-surface"
+        data-scroll-owner="dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-dialog-title"

--- a/packages/gents-desktop-ui/styles.css
+++ b/packages/gents-desktop-ui/styles.css
@@ -226,6 +226,10 @@
     animation: gents-dialog-fade-in var(--motion-fast) ease-out;
   }
 
+  .viewport-overlay {
+    box-sizing: border-box;
+  }
+
   .dialog-backdrop.open {
     display: flex;
   }
@@ -247,6 +251,73 @@
     max-height: calc(100vh - 128px);
     overflow: auto;
     box-shadow: 0 24px 60px rgb(var(--scrim-rgb) / 0.5);
+  }
+
+  @media (max-width: 760px) {
+    .viewport-overlay {
+      position: fixed;
+      inset: auto;
+      top: var(--mobile-visual-viewport-top, 0px);
+      left: var(--mobile-visual-viewport-left, 0px);
+      width: var(--mobile-visual-viewport-width, 100dvw);
+      height: var(--mobile-visual-viewport-height, 100dvh);
+      padding: calc(
+          var(--space-5) +
+            var(--mobile-safe-area-top, env(safe-area-inset-top, 0rem))
+        )
+        calc(
+          var(--space-5) +
+            var(--mobile-safe-area-right, env(safe-area-inset-right, 0rem))
+        )
+        calc(
+          var(--space-5) +
+            var(--mobile-safe-area-bottom, env(safe-area-inset-bottom, 0rem))
+        )
+        calc(
+          var(--space-5) +
+            var(--mobile-safe-area-left, env(safe-area-inset-left, 0rem))
+        );
+      overflow: hidden;
+      overscroll-behavior: contain;
+    }
+
+    .viewport-overlay-surface {
+      max-width: 100%;
+      max-height: 100%;
+      overflow: auto;
+    }
+
+    .mobile-viewport-popover.mobile-viewport-popover {
+      position: fixed;
+      top: calc(
+        var(--mobile-visual-viewport-top, 0px) +
+          var(--mobile-safe-area-top, env(safe-area-inset-top, 0rem)) +
+          var(--mobile-popover-top-clearance, 4rem)
+      );
+      right: auto;
+      left: calc(
+        var(--mobile-visual-viewport-left, 0px) +
+          var(--mobile-safe-area-left, env(safe-area-inset-left, 0rem)) +
+          var(--mobile-popover-gutter, 0.5rem)
+      );
+      width: calc(
+        var(--mobile-visual-viewport-width, 100dvw) -
+          var(--mobile-safe-area-left, env(safe-area-inset-left, 0rem)) -
+          var(--mobile-safe-area-right, env(safe-area-inset-right, 0rem)) -
+          var(--mobile-popover-gutter, 0.5rem) -
+          var(--mobile-popover-gutter, 0.5rem)
+      );
+      max-height: calc(
+        var(--mobile-visual-viewport-height, 100dvh) -
+          var(--mobile-safe-area-top, env(safe-area-inset-top, 0rem)) -
+          var(--mobile-safe-area-bottom, env(safe-area-inset-bottom, 0rem)) -
+          var(--mobile-popover-top-clearance, 4rem) -
+          var(--mobile-popover-gutter, 0.5rem) -
+          var(--mobile-popover-gutter, 0.5rem)
+      );
+      overflow: auto;
+      overscroll-behavior: contain;
+    }
   }
 
   .dialog header {


### PR DESCRIPTION
## Summary
- make the application shell the sole visual-viewport geometry owner
- give startup, fleet, and config one route scroll owner while chat delegates to its active transcript or navigation list
- reserve a separate shell track for global notices so errors cannot displace or clip route content
- centralize dialog, QR, context, and sync overlay geometry in one visualViewport/safe-area primitive
- reveal focused controls by moving their nearest declared scroll owner instead of scrolling arbitrary ancestors
- remove superseded nested page scrollers, duplicated overlay math, duplicate mobile resets, and stale layout declarations
- add structural browser invariants that reject rogue scroll owners and verify keyboard, safe-area, overlay, and notice geometry

## Ownership contract
- shell: visual viewport geometry; never a page scroller
- startup/fleet/config: route slot owns vertical page scrolling
- chat: route locked; transcript or visible navigation section owns scrolling
- overlays: shared viewport overlay owns containment; surface/popover owns bounded content scrolling
- focus: nearest declared owner is the only element moved to reveal a control

## Deletion audit
Against stack base f04e4b9d:
- production: +420/-255 (net +165)
- tests: +356/-25
- total: +776/-280

The production residue is the new route/notice structure, shared overlay primitive, explicit ownership metadata, and focused-control owner logic. Independent deletion review found the remaining growth justified; its two residual cleanup items were removed before this head.

## Validation
- desktop package and production builds
- UI/chat/fleet/operations package tests
- full desktop Vitest: 340 passed, 15 live-only skipped
- focused Playwright matrix: 111 cases across desktop, laptop, and narrow viewports
- independent post-review narrow ownership/layout: 30 passed
- independent desktop/laptop layout: 36 passed, 12 expected mobile-only skips
- final focused ownership suite after cleanup: 6 passed
- Prettier and diff checks

## Review
- Grok: substantive findings incorporated
- Claude: substantive findings incorporated
- independent exact-range review: clean
- workstation-1 GLM-5.3-Flash graph review attempted twice with immutable read-only tooling; both runs reproduced empty tool arguments before any source could be inspected. Final evidence run: 34e233f2-7aa5-4daa-a3ab-c70e21f5e728; tracked as #1298. No GLM verdict is claimed.

Closes #1286.
Closes #1287.
Closes #1288.
Part of #1285.

Stack 3, based on #1283.
