### PR TITLE
feat(eth): add chain key CLI and keyring custody

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -178,7 +178,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2277,7 +2277,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2601,7 +2601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3160,6 +3160,8 @@ dependencies = [
  "hostname",
  "identity",
  "jsonschema",
+ "k256",
+ "keyring",
  "libc",
  "minijinja",
  "opentelemetry",
@@ -3176,6 +3178,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sha3 0.10.9",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -4862,6 +4865,15 @@ dependencies = [
 
 [[package]]
 name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
@@ -4879,6 +4891,16 @@ dependencies = [
  "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]
@@ -5373,7 +5395,7 @@ dependencies = [
  "ripemd",
  "sha1 0.11.0",
  "sha2 0.11.0",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -5694,7 +5716,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5823,7 +5845,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7616,7 +7638,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7675,7 +7697,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7696,7 +7718,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7897,7 +7919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8260,12 +8282,22 @@ dependencies = [
 
 [[package]]
 name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -8380,7 +8412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9086,7 +9118,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9783,7 +9815,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10638,7 +10670,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -180,6 +180,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: GoalCommand,
     },
+    #[command(about = "Manage EVM chain keys, endpoints, and queries")]
+    Chain {
+        #[command(subcommand)]
+        command: ChainCommand,
+    },
     #[command(about = "List and resolve human-attention mailbox items")]
     Mailbox {
         #[command(subcommand)]
@@ -3339,6 +3344,50 @@ pub(crate) struct GoalSetArgs {
     pub(crate) clear_token_budget: bool,
     #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
     pub(crate) output: OutputFormat,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum ChainCommand {
+    #[command(about = "Create, list, show, and revoke chain keys")]
+    Key {
+        #[command(subcommand)]
+        command: ChainKeyCommand,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum ChainKeyCommand {
+    #[command(about = "Generate a secp256k1 chain key in the OS keyring")]
+    Generate(ChainKeyGenerateArgs),
+    #[command(about = "List chain-key bindings for the local principal")]
+    List(ChainKeyAccessArgs),
+    #[command(about = "Show one chain-key binding (never prints key material)")]
+    Show(ChainKeyShowArgs),
+    #[command(about = "Revoke a binding and delete the keyring secret")]
+    Revoke(ChainKeyShowArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct ChainKeyAccessArgs {
+    #[arg(long)]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint for a running runtime")]
+    pub(crate) graphql: Option<String>,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct ChainKeyGenerateArgs {
+    #[command(flatten)]
+    pub(crate) access: ChainKeyAccessArgs,
+    #[arg(long, help = "Stable binding id. Default: a UUID.")]
+    pub(crate) name: Option<String>,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct ChainKeyShowArgs {
+    pub(crate) binding_id: String,
+    #[command(flatten)]
+    pub(crate) access: ChainKeyAccessArgs,
 }
 
 #[derive(Subcommand)]

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -811,6 +811,51 @@ fn deprecated_path_still_parses(path: &[&str]) -> bool {
     !matches!(path, ["p2p", "pair"] | ["p2p", "unpair"])
 }
 
+#[test]
+fn chain_key_commands_parse() {
+    let list = Cli::try_parse_from(["gents", "chain", "key", "list"]).expect("list");
+    assert!(matches!(
+        list.command,
+        Command::Chain {
+            command: ChainCommand::Key {
+                command: ChainKeyCommand::List(_),
+            },
+        }
+    ));
+    let generate = Cli::try_parse_from(["gents", "chain", "key", "generate", "--name", "hot"])
+        .expect("generate");
+    match generate.command {
+        Command::Chain {
+            command:
+                ChainCommand::Key {
+                    command: ChainKeyCommand::Generate(args),
+                },
+        } => assert_eq!(args.name.as_deref(), Some("hot")),
+        _ => panic!("expected chain key generate"),
+    }
+    let show = Cli::try_parse_from(["gents", "chain", "key", "show", "bind-1"]).expect("show");
+    match show.command {
+        Command::Chain {
+            command:
+                ChainCommand::Key {
+                    command: ChainKeyCommand::Show(args),
+                },
+        } => assert_eq!(args.binding_id, "bind-1"),
+        _ => panic!("expected chain key show"),
+    }
+    let revoke =
+        Cli::try_parse_from(["gents", "chain", "key", "revoke", "bind-1"]).expect("revoke");
+    match revoke.command {
+        Command::Chain {
+            command:
+                ChainCommand::Key {
+                    command: ChainKeyCommand::Revoke(args),
+                },
+        } => assert_eq!(args.binding_id, "bind-1"),
+        _ => panic!("expected chain key revoke"),
+    }
+}
+
 fn deprecated_path_required_args(path: &[&str]) -> Vec<String> {
     match path {
         ["config", "task"] => vec!["list".to_string()],

--- a/crates/gents-cli/src/commands/chain/key.rs
+++ b/crates/gents-cli/src/commands/chain/key.rs
@@ -1,0 +1,280 @@
+use anyhow::{bail, Context, Result};
+use gents::config_client::ConfigAccess;
+use gents::{
+    address_from_secret, attestation_payload, binding_storage_key, chain_key_binding_by_id_query,
+    create_chain_key_binding_mutation, delete_chain_key_binding_mutation, encode_attestation,
+    generate_secp256k1_secret, list_chain_key_bindings_query, upsert_chain_key_binding_mutation,
+    ChainKeyBindingDocument, ChainKeyMaterialStore, KeyringChainKeyStore, KEY_BACKEND_KEYRING,
+};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::cli::args::{
+    ChainKeyAccessArgs, ChainKeyCommand, ChainKeyGenerateArgs, ChainKeyShowArgs,
+};
+use crate::home_state::{load_initialized_home_identity, read_init_config, resolve_home_dir};
+use crate::{print_json, resolve_agent_did, resolve_config_access};
+
+pub(crate) async fn dispatch(command: ChainKeyCommand) -> Result<()> {
+    match command {
+        ChainKeyCommand::Generate(args) => generate(args).await,
+        ChainKeyCommand::List(args) => list(args).await,
+        ChainKeyCommand::Show(args) => show(args).await,
+        ChainKeyCommand::Revoke(args) => revoke(args).await,
+    }
+}
+
+async fn generate(args: ChainKeyGenerateArgs) -> Result<()> {
+    let home_dir = resolve_home_dir(args.access.home.as_deref());
+    let init = read_init_config(&home_dir)?
+        .ok_or_else(|| anyhow::anyhow!("no initialized home at {}", home_dir.display()))?;
+    let identity = load_initialized_home_identity(&home_dir, &init)?;
+    let principal_did = identity.did().to_string();
+    let (access, _) =
+        resolve_config_access(args.access.home.as_deref(), args.access.graphql.as_deref()).await?;
+
+    let binding_id = args
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+    if load_binding(&access, &binding_id).await?.is_some() {
+        bail!(
+            "chain key binding {:?} already exists; choose another --name",
+            binding_id
+        );
+    }
+
+    let mut secret = generate_secp256k1_secret();
+    let address = address_from_secret(&secret).context("deriving Ethereum address")?;
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let payload = attestation_payload(
+        &binding_id,
+        &principal_did,
+        &address,
+        KEY_BACKEND_KEYRING,
+        &created_at,
+    );
+    let signature = identity
+        .sign(&payload)
+        .await
+        .context("attesting chain key with principal DID")?;
+
+    let doc = ChainKeyBindingDocument {
+        binding_id: binding_id.clone(),
+        principal_did: principal_did.clone(),
+        address: address.clone(),
+        key_backend: Some(KEY_BACKEND_KEYRING.to_string()),
+        attestation: Some(encode_attestation(&signature)),
+        created_at: Some(created_at),
+        revoked_at: None,
+    };
+    if let Err(error) = create_binding(&access, &doc).await {
+        secret.fill(0);
+        return Err(error);
+    }
+
+    let store = KeyringChainKeyStore;
+    let storage_key = binding_storage_key(&principal_did, &binding_id);
+    if let Err(error) = store.store_new(&storage_key, &secret) {
+        secret.fill(0);
+        let cleanup = delete_binding(&access, &binding_id).await;
+        return match cleanup {
+            Ok(()) => Err(error).context("storing chain key in OS keyring"),
+            Err(cleanup_error) => Err(error).context(format!(
+                "storing chain key in OS keyring; cleanup also failed: {cleanup_error:#}"
+            )),
+        };
+    }
+    secret.fill(0);
+
+    print_json(&json!({
+        "binding_id": binding_id,
+        "address": address,
+        "key_backend": KEY_BACKEND_KEYRING,
+        "principal_did": principal_did,
+    }))
+}
+
+async fn list(args: ChainKeyAccessArgs) -> Result<()> {
+    let principal = resolve_agent_did(args.home.as_deref(), None)?;
+    let (access, _) = resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
+    let docs = load_bindings(&access, &principal).await?;
+    print_json(&json!({
+        "principal_did": principal,
+        "count": docs.len(),
+        "bindings": docs.iter().map(public_binding_json).collect::<Vec<_>>(),
+    }))
+}
+
+async fn show(args: ChainKeyShowArgs) -> Result<()> {
+    let principal = resolve_agent_did(args.access.home.as_deref(), None)?;
+    let (access, _) =
+        resolve_config_access(args.access.home.as_deref(), args.access.graphql.as_deref()).await?;
+    let doc = load_binding(&access, &args.binding_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("chain key binding {:?} not found", args.binding_id))?;
+    if doc.principal_did != principal {
+        bail!("chain key binding is not owned by the local principal");
+    }
+    print_json(&public_binding_json(&doc))
+}
+
+async fn revoke(args: ChainKeyShowArgs) -> Result<()> {
+    let principal = resolve_agent_did(args.access.home.as_deref(), None)?;
+    let (access, _) =
+        resolve_config_access(args.access.home.as_deref(), args.access.graphql.as_deref()).await?;
+    let mut doc = load_binding(&access, &args.binding_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("chain key binding {:?} not found", args.binding_id))?;
+    if doc.principal_did != principal {
+        bail!("chain key binding is not owned by the local principal");
+    }
+    let already_revoked = doc
+        .revoked_at
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty());
+    if !already_revoked {
+        doc.revoked_at = Some(chrono::Utc::now().to_rfc3339());
+        write_binding(&access, &doc).await?;
+    }
+    KeyringChainKeyStore
+        .delete(&binding_storage_key(&doc.principal_did, &args.binding_id))
+        .context("deleting revoked chain key from OS keyring")?;
+    print_json(&json!({
+        "binding_id": doc.binding_id,
+        "address": doc.address,
+        "revoked_at": doc.revoked_at,
+    }))
+}
+
+fn public_binding_json(doc: &ChainKeyBindingDocument) -> Value {
+    json!({
+        "binding_id": doc.binding_id,
+        "principal_did": doc.principal_did,
+        "address": doc.address,
+        "key_backend": doc.key_backend,
+        "created_at": doc.created_at,
+        "revoked_at": doc.revoked_at,
+    })
+}
+
+async fn write_binding(access: &ConfigAccess, doc: &ChainKeyBindingDocument) -> Result<()> {
+    access
+        .execute_mutation(
+            &upsert_chain_key_binding_mutation(doc),
+            "upsert ChainKeyBinding",
+        )
+        .await?;
+    Ok(())
+}
+
+async fn create_binding(access: &ConfigAccess, doc: &ChainKeyBindingDocument) -> Result<()> {
+    access
+        .execute_mutation(
+            &create_chain_key_binding_mutation(doc),
+            "create ChainKeyBinding",
+        )
+        .await?;
+    Ok(())
+}
+
+async fn delete_binding(access: &ConfigAccess, binding_id: &str) -> Result<()> {
+    access
+        .execute_mutation(
+            &delete_chain_key_binding_mutation(binding_id),
+            "delete incomplete ChainKeyBinding",
+        )
+        .await?;
+    Ok(())
+}
+
+async fn load_bindings(
+    access: &ConfigAccess,
+    principal_did: &str,
+) -> Result<Vec<ChainKeyBindingDocument>> {
+    decode_binding_rows(
+        &access
+            .execute(&list_chain_key_bindings_query(principal_did))
+            .await?,
+    )
+}
+
+async fn load_binding(
+    access: &ConfigAccess,
+    binding_id: &str,
+) -> Result<Option<ChainKeyBindingDocument>> {
+    Ok(decode_binding_rows(
+        &access
+            .execute(&chain_key_binding_by_id_query(binding_id))
+            .await?,
+    )?
+    .into_iter()
+    .next())
+}
+
+fn decode_binding_rows(value: &Value) -> Result<Vec<ChainKeyBindingDocument>> {
+    let rows = value
+        .pointer("/data/ChainKeyBinding")
+        .or_else(|| value.get("ChainKeyBinding"))
+        .cloned()
+        .unwrap_or(Value::Array(Vec::new()));
+    if rows.is_null() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_value(rows).context("decoding ChainKeyBinding rows")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_binding_json_omits_attestation_and_key_material() {
+        let doc = ChainKeyBindingDocument {
+            binding_id: "bind-1".to_string(),
+            principal_did: "did:key:zAlice".to_string(),
+            address: "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".to_string(),
+            key_backend: Some(KEY_BACKEND_KEYRING.to_string()),
+            attestation: Some("0xdeadbeef".to_string()),
+            created_at: Some("2026-08-28T00:00:00Z".to_string()),
+            revoked_at: None,
+        };
+        let json = public_binding_json(&doc);
+        let text = json.to_string();
+        assert!(!text.contains("attestation"));
+        assert!(!text.contains("deadbeef"));
+        assert!(!text.contains("secret"));
+        assert!(!text.contains("private"));
+        assert_eq!(json["binding_id"], "bind-1");
+        assert_eq!(
+            json["address"],
+            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+        );
+    }
+
+    #[test]
+    fn decode_binding_rows_ignores_doc_id_and_null() {
+        let value = json!({
+            "data": {
+                "ChainKeyBinding": [{
+                    "_docID": "bae-1",
+                    "binding_id": "bind-1",
+                    "principal_did": "did:key:zAlice",
+                    "address": "0xabc",
+                    "key_backend": "keyring",
+                    "attestation": "0xsig",
+                    "created_at": "t0",
+                    "revoked_at": null
+                }]
+            }
+        });
+        let rows = decode_binding_rows(&value).expect("decode");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].binding_id, "bind-1");
+        let empty = json!({ "data": { "ChainKeyBinding": null } });
+        assert!(decode_binding_rows(&empty).expect("null").is_empty());
+    }
+}

--- a/crates/gents-cli/src/commands/chain/mod.rs
+++ b/crates/gents-cli/src/commands/chain/mod.rs
@@ -1,0 +1,11 @@
+pub(crate) mod key;
+
+use anyhow::Result;
+
+use crate::cli::args::ChainCommand;
+
+pub(crate) async fn dispatch(command: ChainCommand) -> Result<()> {
+    match command {
+        ChainCommand::Key { command } => key::dispatch(command).await,
+    }
+}

--- a/crates/gents-cli/src/commands/mod.rs
+++ b/crates/gents-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod background;
+pub(crate) mod chain;
 pub(crate) mod chat;
 pub(crate) mod codex;
 pub(crate) mod codex_auth_probe;

--- a/crates/gents-cli/src/config_bundle.rs
+++ b/crates/gents-cli/src/config_bundle.rs
@@ -838,6 +838,17 @@ pub(crate) fn sanitize_import_document(
         "ToolSelection" => {
             desired_state::strip_retired_tool_selection_fields(&mut object);
         }
+        "ChainKeyBinding" if for_update => {
+            // Revocation is a tombstone. An active desired-state document may
+            // update its public metadata, but it must never clear a live
+            // revocation by writing null back over it.
+            if object
+                .get("revoked_at")
+                .is_none_or(|value| value.is_null() || value.as_str().is_some_and(str::is_empty))
+            {
+                object.remove("revoked_at");
+            }
+        }
         "Task" => {
             for field in ["created_at", "updated_at"] {
                 object.remove(field);
@@ -1008,6 +1019,25 @@ mod tests {
         .unwrap();
         assert_eq!(updated.get("skill_refs"), Some(&Value::Null));
         assert_eq!(updated.get("skill_excludes"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn active_chain_key_import_does_not_clear_revocation() {
+        let updated = sanitize_import_document(
+            "ChainKeyBinding",
+            &json!({ "binding_id": "bind-1", "revoked_at": null }),
+            true,
+        )
+        .unwrap();
+        assert!(updated.get("revoked_at").is_none());
+
+        let revoked = sanitize_import_document(
+            "ChainKeyBinding",
+            &json!({ "binding_id": "bind-1", "revoked_at": "2026-08-28T00:00:00Z" }),
+            true,
+        )
+        .unwrap();
+        assert_eq!(revoked["revoked_at"], "2026-08-28T00:00:00Z");
     }
 
     #[test]

--- a/crates/gents-cli/src/config_import/lean_apply_write_boundary_tests.rs
+++ b/crates/gents-cli/src/config_import/lean_apply_write_boundary_tests.rs
@@ -927,8 +927,8 @@ fn desired_chain_key_binding(
         principal_did: agent_did.to_string(),
         address: "0x0000000000000000000000000000000000000001".to_string(),
         key_backend: "keyring".to_string(),
-        attestation: None,
-        created_at: None,
+        attestation: Some("0x00".to_string()),
+        created_at: Some("2026-08-28T00:00:00Z".to_string()),
         revoked_at: None,
     }
 }

--- a/crates/gents-cli/src/desired_state/diff.rs
+++ b/crates/gents-cli/src/desired_state/diff.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use super::{
-    DesiredAgentPrincipal, DesiredPeerPairing, DesiredStateCollectionDiff,
+    DesiredAgentPrincipal, DesiredChainKeyBinding, DesiredPeerPairing, DesiredStateCollectionDiff,
     DesiredStateDiffCollections, DesiredStateDiffReport, DesiredStateManifest, HasUniqueId,
 };
 
@@ -27,7 +27,7 @@ pub(crate) fn diff_manifests(
             &desired.datastore_tool_surfaces,
             &live.datastore_tool_surfaces,
         ),
-        chain_key_bindings: diff_manifest_collection(
+        chain_key_bindings: diff_chain_key_bindings(
             &desired.chain_key_bindings,
             &live.chain_key_bindings,
         ),
@@ -83,6 +83,22 @@ pub(crate) fn diff_manifests(
         counts,
         collections,
     }
+}
+
+fn diff_chain_key_bindings(
+    desired: &[DesiredChainKeyBinding],
+    live: &[DesiredChainKeyBinding],
+) -> DesiredStateCollectionDiff {
+    let mut comparable_live = live.to_vec();
+    for live_binding in &mut comparable_live {
+        if desired.iter().any(|desired_binding| {
+            desired_binding.binding_id == live_binding.binding_id
+                && desired_binding.revoked_at.is_none()
+        }) {
+            live_binding.revoked_at = None;
+        }
+    }
+    diff_manifest_collection(desired, &comparable_live)
 }
 
 fn diff_peer_pairings(

--- a/crates/gents-cli/src/desired_state/validate/tooling.rs
+++ b/crates/gents-cli/src/desired_state/validate/tooling.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use gents::{
     is_reserved_builtin_tool_name, CommandExecutionMode, CommandNetworkMode, SubagentTarget,
-    SurfaceToolDecl, WriteToolDecl,
+    SurfaceToolDecl, WriteToolDecl, KEY_BACKEND_KEYRING,
 };
 
 use super::super::{
@@ -58,15 +58,35 @@ pub(super) fn validate_eth_tools(
                 binding.binding_id
             ));
         }
-        if binding.address.trim().is_empty() {
+        if !is_eth_address(&binding.address) {
             errors.push(format!(
-                "ChainKeyBinding {} has empty address",
+                "ChainKeyBinding {} has an invalid Ethereum address",
                 binding.binding_id
             ));
         }
-        if binding.key_backend.trim().is_empty() {
+        if binding.key_backend.trim() != KEY_BACKEND_KEYRING {
             errors.push(format!(
-                "ChainKeyBinding {} has empty key_backend",
+                "ChainKeyBinding {} has unsupported key_backend {:?}",
+                binding.binding_id, binding.key_backend
+            ));
+        }
+        if binding
+            .attestation
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            errors.push(format!(
+                "ChainKeyBinding {} has no principal attestation",
+                binding.binding_id
+            ));
+        }
+        if binding
+            .created_at
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            errors.push(format!(
+                "ChainKeyBinding {} has no created_at timestamp",
                 binding.binding_id
             ));
         }
@@ -95,12 +115,14 @@ pub(super) fn validate_eth_tools(
                 tool.tool_id
             ));
         }
-        if let Some(binding_id) = tool
-            .key_binding_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
+        if let Some(binding_id) = tool.key_binding_id.as_deref().map(str::trim) {
+            if binding_id.is_empty() {
+                errors.push(format!(
+                    "EthTool {} has an empty key_binding_id",
+                    tool.tool_id
+                ));
+                continue;
+            }
             if !binding_ids.contains(binding_id) {
                 errors.push(format!(
                     "EthTool {} references missing ChainKeyBinding {}",
@@ -109,6 +131,13 @@ pub(super) fn validate_eth_tools(
             }
         }
     }
+}
+
+fn is_eth_address(value: &str) -> bool {
+    let value = value.trim();
+    value.len() == 42
+        && value.starts_with("0x")
+        && value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 pub(super) fn validate_tool_selections(

--- a/crates/gents-cli/src/lib.rs
+++ b/crates/gents-cli/src/lib.rs
@@ -466,6 +466,7 @@ async fn async_main() -> Result<()> {
         Command::Response { command } => commands::response::dispatch(command).await,
         Command::Session { command } => commands::session::dispatch(command).await,
         Command::Goal { command } => commands::goal::dispatch(command).await,
+        Command::Chain { command } => commands::chain::dispatch(command).await,
         Command::Mailbox { command } => commands::mailbox::dispatch(command).await,
         Command::Subagent { command } => commands::subagent::dispatch(command).await,
         Command::Demo(args) => commands::demo::demo(args).await,

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -51,6 +51,9 @@ events.workspace = true
 futures = "0.3"
 hostname.workspace = true
 identity.workspace = true
+k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
+keyring = "3"
+sha3 = "0.10"
 libc = "0.2"
 minijinja.workspace = true
 opentelemetry.workspace = true

--- a/crates/gents/src/document_config/chain_key_binding.rs
+++ b/crates/gents/src/document_config/chain_key_binding.rs
@@ -1,11 +1,12 @@
 //! Apply-owned `ChainKeyBinding` documents. Key material is not stored here.
-#![allow(dead_code)]
 
 use anyhow::Result;
 use defra_node::EmbeddedNode;
 use serde::{Deserialize, Serialize};
 
-use crate::graphql::escape_graphql_string;
+use crate::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
+
+use super::graphql_fields;
 
 use super::serde_helpers::{first_row_with_doc_id, rows_with_doc_id};
 
@@ -32,7 +33,7 @@ const BINDING_FIELDS: &str = r#"
                 revoked_at
 "#;
 
-pub(crate) async fn list_chain_key_binding_records(
+pub async fn list_chain_key_binding_records(
     node: &EmbeddedNode,
     principal_did: &str,
 ) -> Result<Vec<(String, ChainKeyBindingDocument)>> {
@@ -53,7 +54,7 @@ pub(crate) async fn list_chain_key_binding_records(
     Ok(rows_with_doc_id(resp.data.as_ref(), "ChainKeyBinding"))
 }
 
-pub(crate) async fn load_chain_key_binding_by_doc_id(
+pub async fn load_chain_key_binding_by_doc_id(
     node: &EmbeddedNode,
     doc_id: &str,
 ) -> Result<Option<(String, ChainKeyBindingDocument)>> {
@@ -68,4 +69,139 @@ pub(crate) async fn load_chain_key_binding_by_doc_id(
         anyhow::bail!("query ChainKeyBinding by _docID failed: {:?}", resp.errors);
     }
     Ok(first_row_with_doc_id(resp.data.as_ref(), "ChainKeyBinding"))
+}
+
+pub fn list_chain_key_bindings_query(principal_did: &str) -> String {
+    let escaped_did = escape_graphql_string(principal_did);
+    format!(
+        r#"{{
+            ChainKeyBinding(
+                filter: {{ principal_did: {{ _eq: "{escaped_did}" }} }}
+            ) {{{BINDING_FIELDS}}}
+        }}"#
+    )
+}
+
+pub fn chain_key_binding_by_id_query(binding_id: &str) -> String {
+    let escaped = escape_graphql_string(binding_id);
+    format!(
+        r#"{{
+            ChainKeyBinding(filter: {{ binding_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{{BINDING_FIELDS}}}
+        }}"#
+    )
+}
+
+pub fn upsert_chain_key_binding_mutation(doc: &ChainKeyBindingDocument) -> String {
+    let escaped_binding_id = escape_graphql_string(&doc.binding_id);
+    let escaped_principal = escape_graphql_string(&doc.principal_did);
+    let escaped_address = escape_graphql_string(&doc.address);
+    let backend = graphql_fields::graphql_string_field("key_backend", doc.key_backend.as_deref())
+        .unwrap_or_else(|| r#"key_backend: """#.to_string());
+    let attestation =
+        graphql_fields::graphql_string_field("attestation", doc.attestation.as_deref())
+            .unwrap_or_else(|| r#"attestation: """#.to_string());
+    let created_at = graphql_fields::graphql_string_field("created_at", doc.created_at.as_deref())
+        .unwrap_or_else(|| r#"created_at: """#.to_string());
+    let revoked_add =
+        graphql_fields::graphql_nullable_string_field("revoked_at", doc.revoked_at.as_deref());
+    let revoked_update =
+        graphql_fields::graphql_string_field("revoked_at", doc.revoked_at.as_deref())
+            .map(|field| format!("{field},"))
+            .unwrap_or_default();
+    format!(
+        r#"mutation {{
+            upsert_ChainKeyBinding(
+                filter: {{ binding_id: {{ _eq: "{escaped_binding_id}" }} }},
+                add: {{
+                    binding_id: "{escaped_binding_id}",
+                    principal_did: "{escaped_principal}",
+                    address: "{escaped_address}",
+                    {backend},
+                    {attestation},
+                    {created_at},
+                    {revoked_add}
+                }},
+                update: {{
+                    principal_did: "{escaped_principal}",
+                    address: "{escaped_address}",
+                    {backend},
+                    {attestation},
+                    {revoked_update}
+                }}
+            ) {{ _docID }}
+        }}"#
+    )
+}
+
+pub fn create_chain_key_binding_mutation(doc: &ChainKeyBindingDocument) -> String {
+    let escaped_binding_id = escape_graphql_string(&doc.binding_id);
+    let escaped_principal = escape_graphql_string(&doc.principal_did);
+    let escaped_address = escape_graphql_string(&doc.address);
+    let backend = graphql_fields::graphql_string_field("key_backend", doc.key_backend.as_deref())
+        .unwrap_or_else(|| r#"key_backend: """#.to_string());
+    let attestation =
+        graphql_fields::graphql_string_field("attestation", doc.attestation.as_deref())
+            .unwrap_or_else(|| r#"attestation: """#.to_string());
+    let created_at = graphql_fields::graphql_string_field("created_at", doc.created_at.as_deref())
+        .unwrap_or_else(|| r#"created_at: """#.to_string());
+    format!(
+        r#"mutation {{
+            create_ChainKeyBinding(input: {{
+                binding_id: "{escaped_binding_id}",
+                principal_did: "{escaped_principal}",
+                address: "{escaped_address}",
+                {backend},
+                {attestation},
+                {created_at},
+                revoked_at: null
+            }}) {{ _docID }}
+        }}"#
+    )
+}
+
+pub fn delete_chain_key_binding_mutation(binding_id: &str) -> String {
+    let escaped_binding_id = escape_graphql_string(binding_id);
+    format!(
+        r#"mutation {{
+            delete_ChainKeyBinding(filter: {{ binding_id: {{ _eq: "{escaped_binding_id}" }} }}) {{ _docID }}
+        }}"#
+    )
+}
+
+pub async fn upsert_chain_key_binding(
+    node: &EmbeddedNode,
+    doc: &ChainKeyBindingDocument,
+) -> Result<()> {
+    let mutation = upsert_chain_key_binding_mutation(doc);
+    graphql_mutation_with_transaction_retry(node, &mutation, "upsert ChainKeyBinding").await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(revoked_at: Option<&str>) -> ChainKeyBindingDocument {
+        ChainKeyBindingDocument {
+            binding_id: "bind-1".to_string(),
+            principal_did: "did:key:zAlice".to_string(),
+            address: "0x1111111111111111111111111111111111111111".to_string(),
+            key_backend: Some("keyring".to_string()),
+            attestation: Some("0xsig".to_string()),
+            created_at: Some("2026-08-28T00:00:00Z".to_string()),
+            revoked_at: revoked_at.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn active_upsert_never_clears_a_live_revocation() {
+        let mutation = upsert_chain_key_binding_mutation(&binding(None));
+        assert_eq!(mutation.matches("revoked_at: null").count(), 1);
+    }
+
+    #[test]
+    fn revoked_upsert_writes_the_tombstone_on_add_and_update() {
+        let mutation = upsert_chain_key_binding_mutation(&binding(Some("t1")));
+        assert_eq!(mutation.matches("revoked_at: \"t1\"").count(), 2);
+    }
 }

--- a/crates/gents/src/document_config/mod.rs
+++ b/crates/gents/src/document_config/mod.rs
@@ -61,9 +61,11 @@ pub(crate) use tool_selection::{
 
 pub use subagent_target::{subagent_target_entry, SubagentTarget};
 
-#[allow(dead_code, unused_imports)]
-pub(crate) use chain_key_binding::{
-    list_chain_key_binding_records, load_chain_key_binding_by_doc_id, ChainKeyBindingDocument,
+pub use chain_key_binding::{
+    chain_key_binding_by_id_query, create_chain_key_binding_mutation,
+    delete_chain_key_binding_mutation, list_chain_key_binding_records,
+    list_chain_key_bindings_query, load_chain_key_binding_by_doc_id, upsert_chain_key_binding,
+    upsert_chain_key_binding_mutation, ChainKeyBindingDocument,
 };
 pub(crate) use datastore_tool_surface::{
     list_datastore_tool_surface_records, load_datastore_tool_surface_by_doc_id,

--- a/crates/gents/src/eth/keys.rs
+++ b/crates/gents/src/eth/keys.rs
@@ -1,0 +1,281 @@
+//! Chain-key material and Ethereum address derivation.
+//!
+//! Private keys never enter agent context. Documents hold the address and a
+//! DID attestation only; the secret lives behind [`ChainKeyMaterialStore`].
+
+#[cfg(test)]
+use std::collections::HashMap;
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
+
+#[cfg(test)]
+use anyhow::anyhow;
+use anyhow::{bail, Context, Result};
+use k256::ecdsa::SigningKey;
+use k256::elliptic_curve::rand_core::OsRng;
+use k256::elliptic_curve::zeroize::Zeroizing;
+use sha3::{Digest, Keccak256};
+
+pub const KEYRING_SERVICE: &str = "gents-chain-key";
+pub const KEY_BACKEND_KEYRING: &str = "keyring";
+const UNCOMPRESSED_PREFIX: u8 = 0x04;
+
+/// Store for 32-byte secp256k1 secrets, keyed by an opaque custody key.
+pub trait ChainKeyMaterialStore: Send + Sync {
+    fn store_new(&self, storage_key: &str, secret: &[u8; 32]) -> Result<()>;
+    fn load(&self, binding_id: &str) -> Result<[u8; 32]>;
+    fn delete(&self, binding_id: &str) -> Result<()>;
+}
+
+/// Namespace OS-keyring accounts by principal so separate gents homes cannot
+/// overwrite each other's identically named bindings.
+pub fn binding_storage_key(principal_did: &str, binding_id: &str) -> String {
+    format!("{}:{}", principal_did.trim(), binding_id.trim())
+}
+
+/// In-memory store for tests. Never used in production CLI paths.
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct MemoryChainKeyStore {
+    inner: Arc<Mutex<HashMap<String, [u8; 32]>>>,
+}
+
+#[cfg(test)]
+impl ChainKeyMaterialStore for MemoryChainKeyStore {
+    fn store_new(&self, storage_key: &str, secret: &[u8; 32]) -> Result<()> {
+        let mut entries = self.inner.lock().expect("chain key store lock poisoned");
+        if entries.contains_key(storage_key) {
+            bail!("chain key material already exists for {storage_key}");
+        }
+        entries.insert(storage_key.to_string(), *secret);
+        Ok(())
+    }
+
+    fn load(&self, binding_id: &str) -> Result<[u8; 32]> {
+        self.inner
+            .lock()
+            .expect("chain key store lock poisoned")
+            .get(binding_id)
+            .copied()
+            .ok_or_else(|| anyhow!("no chain key material for binding {binding_id}"))
+    }
+
+    fn delete(&self, binding_id: &str) -> Result<()> {
+        self.inner
+            .lock()
+            .expect("chain key store lock poisoned")
+            .remove(binding_id);
+        Ok(())
+    }
+}
+
+/// OS keyring custody. Secret is stored as lowercase hex.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct KeyringChainKeyStore;
+
+impl ChainKeyMaterialStore for KeyringChainKeyStore {
+    fn store_new(&self, storage_key: &str, secret: &[u8; 32]) -> Result<()> {
+        let entry = keyring::Entry::new(KEYRING_SERVICE, storage_key)
+            .context("opening OS keyring entry")?;
+        match entry.get_password() {
+            Ok(_) => bail!("chain key material already exists for {storage_key}"),
+            Err(keyring::Error::NoEntry) => {}
+            Err(error) => return Err(error).context("checking OS keyring for an existing key"),
+        }
+        let encoded = Zeroizing::new(lowercase_hex(secret));
+        entry
+            .set_password(&encoded)
+            .context("storing chain key in OS keyring")?;
+        Ok(())
+    }
+
+    fn load(&self, binding_id: &str) -> Result<[u8; 32]> {
+        let entry =
+            keyring::Entry::new(KEYRING_SERVICE, binding_id).context("opening OS keyring entry")?;
+        let hex = Zeroizing::new(
+            entry
+                .get_password()
+                .context("loading chain key from OS keyring")?,
+        );
+        parse_secret_hex(&hex)
+            .with_context(|| format!("decoding chain key for binding {binding_id}"))
+    }
+
+    fn delete(&self, binding_id: &str) -> Result<()> {
+        let entry =
+            keyring::Entry::new(KEYRING_SERVICE, binding_id).context("opening OS keyring entry")?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error).context("deleting chain key from OS keyring"),
+        }
+    }
+}
+
+pub fn generate_secp256k1_secret() -> [u8; 32] {
+    let signing_key = SigningKey::random(&mut OsRng);
+    signing_key.to_bytes().into()
+}
+
+pub fn uncompressed_pubkey(secret: &[u8; 32]) -> Result<[u8; 65]> {
+    let signing_key = SigningKey::from_bytes(secret.into()).context("loading secp256k1 secret")?;
+    let point = signing_key.verifying_key().to_encoded_point(false);
+    let bytes = point.as_bytes();
+    if bytes.len() != 65 {
+        bail!(
+            "uncompressed secp256k1 public key must be 65 bytes, got {}",
+            bytes.len()
+        );
+    }
+    let mut out = [0u8; 65];
+    out.copy_from_slice(bytes);
+    Ok(out)
+}
+
+/// Ethereum address: `0x` + keccak256(uncompressed_pubkey_without_04)[12..].
+pub fn address_from_uncompressed_pubkey(uncompressed: &[u8]) -> Result<String> {
+    let body = match uncompressed {
+        [UNCOMPRESSED_PREFIX, rest @ ..] if rest.len() == 64 => rest,
+        rest if rest.len() == 64 => rest,
+        other => bail!(
+            "expected 64-byte uncompressed secp256k1 public key, got {} bytes",
+            other.len()
+        ),
+    };
+    let hash = Keccak256::digest(body);
+    Ok(format!("0x{}", lowercase_hex(&hash[12..])))
+}
+
+pub fn address_from_secret(secret: &[u8; 32]) -> Result<String> {
+    address_from_uncompressed_pubkey(&uncompressed_pubkey(secret)?)
+}
+
+/// Canonical attestation payload signed by the principal DID.
+pub fn attestation_payload(
+    binding_id: &str,
+    principal_did: &str,
+    address: &str,
+    key_backend: &str,
+    created_at: &str,
+) -> Vec<u8> {
+    format!(
+        "gents-chain-key-attestation-v1\n{binding_id}\n{principal_did}\n{address}\n{key_backend}\n{created_at}"
+    )
+    .into_bytes()
+}
+
+pub fn encode_attestation(signature: &[u8]) -> String {
+    format!("0x{}", lowercase_hex(signature))
+}
+
+fn parse_secret_hex(value: &str) -> Result<[u8; 32]> {
+    let hex = value.strip_prefix("0x").unwrap_or(value).trim();
+    if hex.len() != 64 {
+        bail!(
+            "chain key secret must be 32 bytes hex, got {} chars",
+            hex.len()
+        );
+    }
+    let mut secret = [0u8; 32];
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let text = std::str::from_utf8(chunk).context("chain key hex is not utf8")?;
+        secret[i] = u8::from_str_radix(text, 16).context("chain key hex is invalid")?;
+    }
+    Ok(secret)
+}
+
+fn lowercase_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Anvil / Foundry default account #0.
+    const ANVIL0_SECRET: [u8; 32] = [
+        0xac, 0x09, 0x74, 0xbe, 0xc3, 0x9a, 0x17, 0xe3, 0x6b, 0xa4, 0xa6, 0xb4, 0xd2, 0x38, 0xff,
+        0x94, 0x4b, 0xac, 0xb4, 0x78, 0xcb, 0xed, 0x5e, 0xfc, 0xae, 0x78, 0x4d, 0x7b, 0xf4, 0xf2,
+        0xff, 0x80,
+    ];
+    const ANVIL0_ADDRESS: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+    #[test]
+    fn anvil_account_zero_derives_known_address() {
+        let address = address_from_secret(&ANVIL0_SECRET).expect("derive");
+        assert_eq!(address, ANVIL0_ADDRESS);
+    }
+
+    #[test]
+    fn uncompressed_form_with_and_without_prefix_match() {
+        let with_prefix = uncompressed_pubkey(&ANVIL0_SECRET).expect("pubkey");
+        assert_eq!(with_prefix[0], UNCOMPRESSED_PREFIX);
+        let from_prefix = address_from_uncompressed_pubkey(&with_prefix).expect("with prefix");
+        let from_body = address_from_uncompressed_pubkey(&with_prefix[1..]).expect("body");
+        assert_eq!(from_prefix, from_body);
+        assert_eq!(from_prefix, ANVIL0_ADDRESS);
+    }
+
+    #[test]
+    fn memory_store_round_trips_and_delete_forgets() {
+        let store = MemoryChainKeyStore::default();
+        store.store_new("bind-1", &ANVIL0_SECRET).expect("store");
+        assert!(store.store_new("bind-1", &ANVIL0_SECRET).is_err());
+        assert_eq!(store.load("bind-1").expect("load"), ANVIL0_SECRET);
+        store.delete("bind-1").expect("delete");
+        assert!(store.load("bind-1").is_err());
+    }
+
+    #[test]
+    fn attestation_payload_is_stable_and_binds_every_field() {
+        let payload = attestation_payload(
+            "bind-1",
+            "did:key:zAlice",
+            ANVIL0_ADDRESS,
+            KEY_BACKEND_KEYRING,
+            "2026-08-28T00:00:00Z",
+        );
+        let text = String::from_utf8(payload).expect("utf8");
+        assert!(text.starts_with("gents-chain-key-attestation-v1\n"));
+        assert!(text.contains("bind-1"));
+        assert!(text.contains("did:key:zAlice"));
+        assert!(text.contains(ANVIL0_ADDRESS));
+        assert!(text.contains(KEY_BACKEND_KEYRING));
+        assert!(text.contains("2026-08-28T00:00:00Z"));
+        let other = attestation_payload(
+            "bind-2",
+            "did:key:zAlice",
+            ANVIL0_ADDRESS,
+            KEY_BACKEND_KEYRING,
+            "2026-08-28T00:00:00Z",
+        );
+        assert_ne!(text.as_bytes(), other);
+    }
+
+    #[test]
+    fn generated_secret_has_a_derivable_address() {
+        let secret = generate_secp256k1_secret();
+        let address = address_from_secret(&secret).expect("derive");
+        assert!(address.starts_with("0x"));
+        assert_eq!(address.len(), 42);
+        assert_ne!(address, ANVIL0_ADDRESS);
+    }
+
+    #[test]
+    fn storage_keys_are_principal_scoped() {
+        assert_eq!(
+            binding_storage_key("did:key:zAlice", "treasury"),
+            "did:key:zAlice:treasury"
+        );
+        assert_ne!(
+            binding_storage_key("did:key:zAlice", "treasury"),
+            binding_storage_key("did:key:zBob", "treasury")
+        );
+    }
+}

--- a/crates/gents/src/eth/mod.rs
+++ b/crates/gents/src/eth/mod.rs
@@ -1,0 +1,9 @@
+//! Native EVM surface: chain keys, JSON-RPC, and generated tools.
+
+pub mod keys;
+
+pub use keys::{
+    address_from_secret, address_from_uncompressed_pubkey, attestation_payload,
+    binding_storage_key, encode_attestation, generate_secp256k1_secret, ChainKeyMaterialStore,
+    KeyringChainKeyStore, KEYRING_SERVICE, KEY_BACKEND_KEYRING,
+};

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -28,6 +28,7 @@ pub mod descendant_graph;
 pub mod desired_fields;
 pub mod document_config;
 pub mod error;
+pub mod eth;
 pub mod event_delivery_contract;
 pub mod external_adapter_capture;
 pub mod goal;
@@ -115,6 +116,11 @@ pub mod workspace;
 
 pub use callback::reject_secret_bearing_callback_fields;
 pub use collection::{Collection, DESIRED_STATE_APPLY_ORDER};
+pub use eth::{
+    address_from_secret, attestation_payload, binding_storage_key, encode_attestation,
+    generate_secp256k1_secret, ChainKeyMaterialStore, KeyringChainKeyStore, KEYRING_SERVICE,
+    KEY_BACKEND_KEYRING,
+};
 
 pub use adapter_projection::{
     adapter_projection_eval_jsonl_record_schema, adapter_projection_eval_jsonl_records,
@@ -160,17 +166,20 @@ pub use descendant_graph::{
 };
 pub use desired_fields::{DesiredFields, LiveFields};
 pub use document_config::{
+    chain_key_binding_by_id_query, create_chain_key_binding_mutation,
     default_behavior_id_for_agent, default_inference_profile_id_for_behavior,
-    default_tool_selection_id_for_behavior, deserialize_dual_shape, ensure_agent_principal,
-    is_reserved_builtin_tool_name, list_agent_behaviors, list_datastore_tool_surfaces,
+    default_tool_selection_id_for_behavior, delete_chain_key_binding_mutation,
+    deserialize_dual_shape, ensure_agent_principal, is_reserved_builtin_tool_name,
+    list_agent_behaviors, list_chain_key_bindings_query, list_datastore_tool_surfaces,
     list_inference_profile_records, load_agent_behavior, load_agent_principal,
     load_inference_profile, load_tool_selection, merge_datastore_tool_surfaces,
-    subagent_target_entry, upsert_agent_behavior, upsert_agent_principal, upsert_inference_profile,
-    upsert_tool_selection, wide_open_tool_selection_document,
-    wide_open_tool_selection_id_for_agent, AgentBehavior as AgentBehaviorDocument,
-    DatastoreToolSurfaceDocument, InferenceProfile, MergedSurfaceTools, PrincipalBootstrap,
-    QueryToolDecl, SubagentTarget, SurfaceToolDecl, ToolSelectionDocument, WriteToolDecl,
-    WriteToolField, WriteToolFieldFill, WriteToolOutputObligation, WriteToolOutputObligationScope,
+    subagent_target_entry, upsert_agent_behavior, upsert_agent_principal, upsert_chain_key_binding,
+    upsert_chain_key_binding_mutation, upsert_inference_profile, upsert_tool_selection,
+    wide_open_tool_selection_document, wide_open_tool_selection_id_for_agent,
+    AgentBehavior as AgentBehaviorDocument, ChainKeyBindingDocument, DatastoreToolSurfaceDocument,
+    InferenceProfile, MergedSurfaceTools, PrincipalBootstrap, QueryToolDecl, SubagentTarget,
+    SurfaceToolDecl, ToolSelectionDocument, WriteToolDecl, WriteToolField, WriteToolFieldFill,
+    WriteToolOutputObligation, WriteToolOutputObligationScope,
 };
 pub use external_adapter_capture::{
     import_external_adapter_capture_to_timeline_rows, ExternalAdapterCapture,


### PR DESCRIPTION
## Summary

PR 2 of the EthTool stack (#1217). Operator CLI for chain keys; no RPC and no agent tools yet.

- `gents chain key generate|list|show|revoke`
- OS keyring custody (`gents-chain-key` / `binding_id`)
- Address derivation: keccak256(uncompressed secp256k1 pubkey without `0x04`)[12..]
- Principal DID attestation on the `ChainKeyBinding` document
- Never prints key material or mnemonics
- Revoke sets `revoked_at` and deletes the keyring entry

## Stack

Stacked GitHub PRs (each `--base` is the PR below):

1. #1299 schema (`eth-wallet` → `main`)
2. **this PR** keys (`eth-wallet-keys` → `eth-wallet`)
3. RPC client + `gents chain query` (next)
4. native `{tool_id}_query` + ToolPolicy
5. `any_read` + declared reads
6. submission runtime
7. declared writes / `native_transfer`
8. `sign_typed_data`

Part of #1217.

## Test plan

- [x] `cargo test -p gents --lib eth::keys::`
- [x] `cargo test -p gents-cli --lib chain`
- [ ] `cargo check --workspace --all-targets` (CI)