### PR TITLE
feat(eth): add JSON-RPC client and chain query CLI

### DIFF
--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -3353,6 +3353,23 @@ pub(crate) enum ChainCommand {
         #[command(subcommand)]
         command: ChainKeyCommand,
     },
+    #[command(about = "Run an allowlisted eth_* JSON-RPC read against an EthTool endpoint")]
+    Query(ChainQueryArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct ChainQueryArgs {
+    #[arg(long, help = "EthTool.tool_id")]
+    pub(crate) tool_id: String,
+    #[arg(help = "JSON-RPC method, e.g. eth_blockNumber")]
+    pub(crate) method: String,
+    #[arg(
+        value_name = "PARAMS_JSON",
+        help = "JSON array of RPC params. Default: []"
+    )]
+    pub(crate) params: Option<String>,
+    #[command(flatten)]
+    pub(crate) access: ChainKeyAccessArgs,
 }
 
 #[derive(Subcommand)]

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -856,6 +856,30 @@ fn chain_key_commands_parse() {
     }
 }
 
+#[test]
+fn chain_query_command_parses() {
+    let parsed = Cli::try_parse_from([
+        "gents",
+        "chain",
+        "query",
+        "--tool-id",
+        "base-read",
+        "eth_blockNumber",
+        "[]",
+    ])
+    .expect("query");
+    match parsed.command {
+        Command::Chain {
+            command: ChainCommand::Query(args),
+        } => {
+            assert_eq!(args.tool_id, "base-read");
+            assert_eq!(args.method, "eth_blockNumber");
+            assert_eq!(args.params.as_deref(), Some("[]"));
+        }
+        _ => panic!("expected chain query"),
+    }
+}
+
 fn deprecated_path_required_args(path: &[&str]) -> Vec<String> {
     match path {
         ["config", "task"] => vec!["list".to_string()],

--- a/crates/gents-cli/src/commands/chain/mod.rs
+++ b/crates/gents-cli/src/commands/chain/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod key;
+pub(crate) mod query;
 
 use anyhow::Result;
 
@@ -7,5 +8,6 @@ use crate::cli::args::ChainCommand;
 pub(crate) async fn dispatch(command: ChainCommand) -> Result<()> {
     match command {
         ChainCommand::Key { command } => key::dispatch(command).await,
+        ChainCommand::Query(args) => query::dispatch(args).await,
     }
 }

--- a/crates/gents-cli/src/commands/chain/query.rs
+++ b/crates/gents-cli/src/commands/chain/query.rs
@@ -1,0 +1,99 @@
+use anyhow::{bail, Context, Result};
+use gents::config_client::ConfigAccess;
+use gents::{eth_tool_by_id_query, EthToolDocument, HttpEthRpc};
+use serde_json::{json, Value};
+
+use crate::cli::args::ChainQueryArgs;
+use crate::{print_json, resolve_agent_did, resolve_config_access};
+
+pub(crate) async fn dispatch(args: ChainQueryArgs) -> Result<()> {
+    let principal = resolve_agent_did(args.access.home.as_deref(), None)?;
+    let (access, _) =
+        resolve_config_access(args.access.home.as_deref(), args.access.graphql.as_deref()).await?;
+    let doc = load_eth_tool(&access, &args.tool_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("EthTool {:?} not found", args.tool_id))?;
+    if doc.agent_did != principal {
+        bail!("EthTool is not owned by the local principal");
+    }
+    if !doc.enabled {
+        bail!("EthTool {:?} is disabled", args.tool_id);
+    }
+    let rpc_url = doc
+        .rpc_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("EthTool {:?} has an empty rpc_url", args.tool_id))?;
+    let chain_id = doc
+        .chain_id
+        .ok_or_else(|| anyhow::anyhow!("EthTool {:?} has no chain_id", args.tool_id))?;
+    if chain_id <= 0 {
+        bail!("EthTool {:?} chain_id must be positive", args.tool_id);
+    }
+    let methods = doc.query_methods.clone().unwrap_or_default();
+    if methods.is_empty() {
+        bail!(
+            "EthTool {:?} query_methods is empty; eth_query is denied",
+            args.tool_id
+        );
+    }
+    let params = parse_params(args.params.as_deref())?;
+    let client = HttpEthRpc::http(rpc_url, chain_id as u64, &methods)?;
+    let result = client
+        .call(&args.method, params)
+        .await
+        .with_context(|| format!("calling {} on {}", args.method, args.tool_id))?;
+    print_json(&json!({
+        "tool_id": args.tool_id,
+        "method": args.method,
+        "result": result,
+    }))
+}
+
+fn parse_params(raw: Option<&str>) -> Result<Value> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => Ok(json!([])),
+        Some(text) => {
+            let value: Value = serde_json::from_str(text).context("parsing RPC params JSON")?;
+            if !value.is_array() {
+                bail!("RPC params must be a JSON array");
+            }
+            Ok(value)
+        }
+    }
+}
+
+async fn load_eth_tool(access: &ConfigAccess, tool_id: &str) -> Result<Option<EthToolDocument>> {
+    decode_eth_tool_rows(&access.execute(&eth_tool_by_id_query(tool_id)).await?)
+        .map(|rows| rows.into_iter().next())
+}
+
+fn decode_eth_tool_rows(value: &Value) -> Result<Vec<EthToolDocument>> {
+    let rows = value
+        .pointer("/data/EthTool")
+        .or_else(|| value.get("EthTool"))
+        .cloned()
+        .unwrap_or(Value::Array(Vec::new()));
+    if rows.is_null() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_value(rows).context("decoding EthTool rows")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_params_defaults_to_empty_array() {
+        assert_eq!(parse_params(None).expect("none"), json!([]));
+        assert_eq!(parse_params(Some("")).expect("empty"), json!([]));
+        assert_eq!(parse_params(Some("[]")).expect("arr"), json!([]));
+        assert_eq!(
+            parse_params(Some(r#"["0x1"]"#)).expect("one"),
+            json!(["0x1"])
+        );
+        assert!(parse_params(Some(r#"{"to":"0x"}"#)).is_err());
+    }
+}

--- a/crates/gents/src/document_config/eth_tool.rs
+++ b/crates/gents/src/document_config/eth_tool.rs
@@ -65,6 +65,15 @@ pub(crate) async fn list_eth_tool_records(
     Ok(rows_with_doc_id(resp.data.as_ref(), "EthTool"))
 }
 
+pub fn eth_tool_by_id_query(tool_id: &str) -> String {
+    let escaped = escape_graphql_string(tool_id);
+    format!(
+        r#"{{
+            EthTool(filter: {{ tool_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{{TOOL_FIELDS}}}
+        }}"#
+    )
+}
+
 pub(crate) async fn load_eth_tool_by_doc_id(
     node: &EmbeddedNode,
     doc_id: &str,

--- a/crates/gents/src/document_config/mod.rs
+++ b/crates/gents/src/document_config/mod.rs
@@ -71,8 +71,9 @@ pub(crate) use datastore_tool_surface::{
     list_datastore_tool_surface_records, load_datastore_tool_surface_by_doc_id,
 };
 pub use datastore_tool_surface::{list_datastore_tool_surfaces, DatastoreToolSurfaceDocument};
+pub use eth_tool::{eth_tool_by_id_query, EthToolDocument};
 #[allow(dead_code, unused_imports)]
-pub(crate) use eth_tool::{list_eth_tool_records, load_eth_tool_by_doc_id, EthToolDocument};
+pub(crate) use eth_tool::{list_eth_tool_records, load_eth_tool_by_doc_id};
 #[allow(unused_imports)]
 pub(crate) use skill::{list_skill_records, load_skill_by_doc_id, SkillDocument};
 

--- a/crates/gents/src/eth/methods.rs
+++ b/crates/gents/src/eth/methods.rs
@@ -1,0 +1,157 @@
+//! Builtin read-only JSON-RPC ceiling for `query_methods`.
+//!
+//! Operator allowlists are intersected with this set. Send/sign/debug methods
+//! are rejected even if listed.
+
+use std::collections::BTreeSet;
+
+use anyhow::{bail, Result};
+
+/// Read-only methods safe to expose against a pruned public endpoint.
+pub const BUILTIN_QUERY_METHODS: &[&str] = &[
+    "eth_chainId",
+    "eth_blockNumber",
+    "eth_syncing",
+    "eth_gasPrice",
+    "eth_maxPriorityFeePerGas",
+    "eth_feeHistory",
+    "eth_getBalance",
+    "eth_getTransactionCount",
+    "eth_getCode",
+    "eth_getStorageAt",
+    "eth_call",
+    "eth_estimateGas",
+    "eth_getBlockByNumber",
+    "eth_getBlockByHash",
+    "eth_getBlockReceipts",
+    "eth_getTransactionByHash",
+    "eth_getTransactionByBlockHashAndIndex",
+    "eth_getTransactionByBlockNumberAndIndex",
+    "eth_getTransactionReceipt",
+    "eth_getLogs",
+    "web3_clientVersion",
+    "net_version",
+];
+
+const FORBIDDEN_EXACT: &[&str] = &[
+    "eth_sendRawTransaction",
+    "eth_sendTransaction",
+    "eth_sign",
+    "eth_signTransaction",
+    "eth_accounts",
+    "eth_subscribe",
+    "eth_unsubscribe",
+];
+
+/// Normalize and intersect configured methods with the builtin ceiling.
+///
+/// Empty input is deny-all (returns empty). Unknown or send/sign methods fail.
+pub fn validate_query_methods(configured: &[String]) -> Result<Vec<String>> {
+    let ceiling: BTreeSet<&str> = BUILTIN_QUERY_METHODS.iter().copied().collect();
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    for raw in configured {
+        let method = normalize_method(raw);
+        if method.is_empty() {
+            continue;
+        }
+        reject_forbidden(&method)?;
+        if !ceiling.contains(method.as_str()) {
+            bail!("query method {method} is not in the builtin read-only ceiling");
+        }
+        if seen.insert(method.clone()) {
+            out.push(method);
+        }
+    }
+    Ok(out)
+}
+
+/// True when `method` is in the intersection of `configured` and the ceiling.
+pub fn method_permitted(method: &str, configured: &[String]) -> Result<bool> {
+    let allowed = validate_query_methods(configured)?;
+    Ok(allowed.iter().any(|item| item == &normalize_method(method)))
+}
+
+pub fn normalize_method(method: &str) -> String {
+    method.trim().to_string()
+}
+
+pub fn reject_forbidden(method: &str) -> Result<()> {
+    let method = normalize_method(method);
+    if FORBIDDEN_EXACT.contains(&method.as_str())
+        || method.starts_with("eth_signTypedData")
+        || method.starts_with("debug_")
+        || method.starts_with("trace_")
+        || method.starts_with("eth_send")
+        || method.starts_with("eth_sign")
+    {
+        bail!("query method {method} is not a read-only JSON-RPC method");
+    }
+    Ok(())
+}
+
+/// Methods whose last argument is an optional block tag.
+/// Value is the full arity including the block.
+pub fn optional_trailing_block_arity(method: &str) -> Option<usize> {
+    match normalize_method(method).as_str() {
+        "eth_getBalance" | "eth_getTransactionCount" | "eth_getCode" | "eth_call" => Some(2),
+        "eth_getStorageAt" => Some(3),
+        "eth_estimateGas" => Some(2),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_configured_is_deny_all() {
+        assert!(validate_query_methods(&[]).expect("ok").is_empty());
+    }
+
+    #[test]
+    fn ceiling_keeps_reads_and_rejects_send() {
+        let allowed =
+            validate_query_methods(&["eth_chainId".to_string(), "eth_getBalance".to_string()])
+                .expect("ok");
+        assert_eq!(allowed, vec!["eth_chainId", "eth_getBalance"]);
+        let err =
+            validate_query_methods(&["eth_sendRawTransaction".to_string()]).expect_err("send");
+        assert!(err.to_string().contains("not a read-only"));
+    }
+
+    #[test]
+    fn debug_and_sign_typed_data_are_forbidden() {
+        for method in [
+            "debug_traceTransaction",
+            "trace_block",
+            "eth_signTypedData_v4",
+            "eth_accounts",
+            "eth_subscribe",
+        ] {
+            let err = validate_query_methods(&[method.to_string()]).expect_err(method);
+            assert!(
+                err.to_string().contains("not a read-only"),
+                "{method}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_read_is_rejected() {
+        let err = validate_query_methods(&["eth_getProof".to_string()]).expect_err("proof");
+        assert!(err.to_string().contains("ceiling"));
+    }
+
+    #[test]
+    fn duplicates_and_whitespace_normalize() {
+        let allowed = validate_query_methods(&[
+            " eth_chainId ".to_string(),
+            "eth_chainId".to_string(),
+            "eth_blockNumber".to_string(),
+        ])
+        .expect("ok");
+        assert_eq!(allowed, vec!["eth_chainId", "eth_blockNumber"]);
+    }
+}

--- a/crates/gents/src/eth/mod.rs
+++ b/crates/gents/src/eth/mod.rs
@@ -1,9 +1,15 @@
 //! Native EVM surface: chain keys, JSON-RPC, and generated tools.
 
 pub mod keys;
+pub mod methods;
+pub(crate) mod rpc;
 
 pub use keys::{
     address_from_secret, address_from_uncompressed_pubkey, attestation_payload,
     binding_storage_key, encode_attestation, generate_secp256k1_secret, ChainKeyMaterialStore,
     KeyringChainKeyStore, KEYRING_SERVICE, KEY_BACKEND_KEYRING,
 };
+pub use methods::{
+    method_permitted, normalize_method, validate_query_methods, BUILTIN_QUERY_METHODS,
+};
+pub use rpc::{HttpEthRpc, ETH_USER_AGENT};

--- a/crates/gents/src/eth/rpc.rs
+++ b/crates/gents/src/eth/rpc.rs
@@ -1,0 +1,657 @@
+//! JSON-RPC client for a single EthTool endpoint.
+//!
+//! User-Agent is required (public Base returns 403 without one). Chain id is
+//! checked against the document and cached. `eth_getLogs` is preflighted
+//! before the wire.
+
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use super::methods::{
+    normalize_method, optional_trailing_block_arity, reject_forbidden, validate_query_methods,
+};
+
+pub const ETH_USER_AGENT: &str = concat!("gents-eth/", env!("CARGO_PKG_VERSION"));
+pub const ETH_GET_LOGS_MAX_RANGE: u64 = 1000;
+
+#[async_trait]
+pub trait JsonRpcTransport: Send + Sync {
+    async fn post(&self, url: &str, body: &Value) -> Result<Value>;
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpJsonRpc {
+    client: reqwest::Client,
+}
+
+impl HttpJsonRpc {
+    pub fn new() -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .user_agent(ETH_USER_AGENT)
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("building eth JSON-RPC HTTP client")?;
+        Ok(Self { client })
+    }
+}
+
+#[async_trait]
+impl JsonRpcTransport for HttpJsonRpc {
+    async fn post(&self, url: &str, body: &Value) -> Result<Value> {
+        let response = self
+            .client
+            .post(url)
+            .json(body)
+            .send()
+            .await
+            .with_context(|| format!("posting eth JSON-RPC to {url}"))?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .with_context(|| format!("reading eth JSON-RPC body from {url}"))?;
+        if status.as_u16() == 403 {
+            bail!(
+                "eth JSON-RPC {url} returned 403; public endpoints (e.g. Base) require User-Agent {ETH_USER_AGENT}"
+            );
+        }
+        if !status.is_success() {
+            bail!("eth JSON-RPC {url} failed with {status}: {text}");
+        }
+        serde_json::from_str(&text)
+            .with_context(|| format!("decoding eth JSON-RPC body from {url}: {text}"))
+    }
+}
+
+pub struct EthRpcClient<T> {
+    rpc_url: String,
+    expected_chain_id: u64,
+    allowed_methods: BTreeSet<String>,
+    cached_chain_id: Mutex<Option<u64>>,
+    transport: T,
+}
+
+pub type HttpEthRpc = EthRpcClient<HttpJsonRpc>;
+
+impl HttpEthRpc {
+    pub fn http(
+        rpc_url: impl Into<String>,
+        expected_chain_id: u64,
+        query_methods: &[String],
+    ) -> Result<Self> {
+        Self::new(
+            rpc_url,
+            expected_chain_id,
+            query_methods,
+            HttpJsonRpc::new()?,
+        )
+    }
+}
+
+impl<T: JsonRpcTransport> EthRpcClient<T> {
+    pub fn new(
+        rpc_url: impl Into<String>,
+        expected_chain_id: u64,
+        query_methods: &[String],
+        transport: T,
+    ) -> Result<Self> {
+        let rpc_url = rpc_url.into();
+        if rpc_url.trim().is_empty() {
+            bail!("eth RPC URL is empty");
+        }
+        if expected_chain_id == 0 {
+            bail!("eth chain_id must be a positive integer");
+        }
+        let allowed = validate_query_methods(query_methods)?;
+        Ok(Self {
+            rpc_url,
+            expected_chain_id,
+            allowed_methods: allowed.into_iter().collect(),
+            cached_chain_id: Mutex::new(None),
+            transport,
+        })
+    }
+
+    pub fn user_agent() -> &'static str {
+        ETH_USER_AGENT
+    }
+
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value> {
+        let method = normalize_method(method);
+        reject_forbidden(&method)?;
+        if !self.allowed_methods.contains(&method) {
+            bail!("eth method {method} is not in the configured query_methods ∩ builtin ceiling");
+        }
+        let params = default_block_if_needed(&method, params)?;
+        if method == "eth_getLogs" {
+            preflight_get_logs(&params)?;
+        }
+        self.ensure_chain_id().await?;
+        self.rpc(&method, params).await
+    }
+
+    async fn ensure_chain_id(&self) -> Result<()> {
+        if let Some(cached) = *self
+            .cached_chain_id
+            .lock()
+            .expect("eth chain id cache lock poisoned")
+        {
+            if cached != self.expected_chain_id {
+                bail!(
+                    "eth chain_id mismatch: document {}, endpoint {:#x}",
+                    self.expected_chain_id,
+                    cached
+                );
+            }
+            return Ok(());
+        }
+        let result = self.rpc("eth_chainId", json!([])).await?;
+        let actual = parse_hex_u64(&value_as_quantity(&result)?).context("decoding eth_chainId")?;
+        *self
+            .cached_chain_id
+            .lock()
+            .expect("eth chain id cache lock poisoned") = Some(actual);
+        if actual != self.expected_chain_id {
+            bail!(
+                "eth chain_id mismatch: document {}, endpoint {actual} ({:#x})",
+                self.expected_chain_id,
+                actual
+            );
+        }
+        Ok(())
+    }
+
+    async fn rpc(&self, method: &str, params: Value) -> Result<Value> {
+        let params = match params {
+            Value::Array(_) => params,
+            Value::Null => json!([]),
+            other => bail!("eth JSON-RPC params must be an array, got {other}"),
+        };
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        });
+        let response = self.transport.post(&self.rpc_url, &body).await?;
+        decode_rpc_result(response)
+    }
+}
+
+fn decode_rpc_result(response: Value) -> Result<Value> {
+    if let Some(error) = response.get("error").filter(|error| !error.is_null()) {
+        let message = error
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("eth JSON-RPC error")
+            .to_string();
+        let code = error.get("code").cloned().unwrap_or(Value::Null);
+        if is_pruned_history_message(&message) {
+            bail!("eth pruned-history error (not retried): {message}");
+        }
+        bail!("eth JSON-RPC error {code}: {message}");
+    }
+    response
+        .get("result")
+        .cloned()
+        .ok_or_else(|| anyhow!("eth JSON-RPC response missing result: {response}"))
+}
+
+pub fn is_pruned_history_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("metadata is not found")
+        || lower.contains("missing trie node")
+        || lower.contains("historical state")
+        || lower.contains("only latest")
+        || lower.contains("header not found")
+        || lower.contains("block is not available")
+        || lower.contains("unknown block")
+        || lower.contains("pruned")
+}
+
+fn default_block_if_needed(method: &str, params: Value) -> Result<Value> {
+    let mut params = match params {
+        Value::Null => Vec::new(),
+        Value::Array(items) => items,
+        other => bail!("eth JSON-RPC params must be an array, got {other}"),
+    };
+    if let Some(arity) = optional_trailing_block_arity(method) {
+        if params.len() + 1 == arity {
+            params.push(json!("latest"));
+        }
+    }
+    Ok(Value::Array(params))
+}
+
+pub fn preflight_get_logs(params: &Value) -> Result<()> {
+    let filter = params
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(Value::as_object)
+        .ok_or_else(|| anyhow!("eth_getLogs requires a filter object as params[0]"))?;
+
+    let address_ok = match filter.get("address") {
+        Some(Value::String(value)) if is_eth_address(value) => true,
+        Some(Value::Array(values))
+            if values
+                .iter()
+                .any(|item| item.as_str().is_some_and(is_eth_address)) =>
+        {
+            true
+        }
+        _ => false,
+    };
+    let topics_ok = filter.get("topics").is_some_and(topic_filter_constrains);
+    if !address_ok && !topics_ok {
+        bail!("eth_getLogs requires address and/or topics; unfiltered log queries are rejected");
+    }
+
+    if let Some(block_hash) = filter.get("blockHash") {
+        if filter.contains_key("fromBlock") || filter.contains_key("toBlock") {
+            bail!("eth_getLogs blockHash cannot be combined with fromBlock/toBlock");
+        }
+        if !is_block_hash(block_hash) {
+            bail!("eth_getLogs blockHash must be a 32-byte hex string");
+        }
+        return Ok(());
+    }
+
+    let from = block_tag(filter.get("fromBlock"))?.default_latest();
+    let to = block_tag(filter.get("toBlock"))?.default_latest();
+    match (from, to) {
+        (BlockTag::Earliest, _) | (_, BlockTag::Earliest) => {
+            bail!("eth_getLogs fromBlock/toBlock earliest is unbounded and rejected")
+        }
+        (BlockTag::Number(from_num), BlockTag::Number(to_num)) => {
+            if to_num < from_num {
+                bail!("eth_getLogs toBlock is before fromBlock");
+            }
+            let distance = to_num - from_num;
+            if distance >= ETH_GET_LOGS_MAX_RANGE {
+                bail!(
+                    "eth_getLogs range {} exceeds max {ETH_GET_LOGS_MAX_RANGE} blocks",
+                    distance.saturating_add(1)
+                );
+            }
+        }
+        (from_tag, to_tag) if from_tag == to_tag => {}
+        _ => {
+            bail!(
+                "eth_getLogs numeric-to-dynamic or mixed dynamic ranges are unbounded and rejected"
+            )
+        }
+    }
+    Ok(())
+}
+
+fn topic_filter_constrains(value: &Value) -> bool {
+    match value {
+        Value::String(topic) => !topic.trim().is_empty(),
+        Value::Array(values) => values.iter().any(topic_filter_constrains),
+        _ => false,
+    }
+}
+
+fn is_block_hash(value: &Value) -> bool {
+    value.as_str().is_some_and(|value| {
+        let hex = value.strip_prefix("0x").unwrap_or(value);
+        hex.len() == 64 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+    })
+}
+
+fn is_eth_address(value: &str) -> bool {
+    let hex = value.strip_prefix("0x").unwrap_or(value);
+    hex.len() == 40 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BlockTag {
+    Number(u64),
+    Latest,
+    Pending,
+    Safe,
+    Finalized,
+    Earliest,
+    Missing,
+}
+
+impl BlockTag {
+    fn default_latest(self) -> Self {
+        match self {
+            Self::Missing => Self::Latest,
+            other => other,
+        }
+    }
+}
+
+fn block_tag(value: Option<&Value>) -> Result<BlockTag> {
+    let Some(value) = value else {
+        return Ok(BlockTag::Missing);
+    };
+    match value {
+        Value::Null => Ok(BlockTag::Missing),
+        Value::String(tag) => parse_block_tag(tag),
+        Value::Number(number) => {
+            let n = number
+                .as_u64()
+                .ok_or_else(|| anyhow!("eth block number {number} is not a u64"))?;
+            Ok(BlockTag::Number(n))
+        }
+        other => bail!("eth block tag must be a string or number, got {other}"),
+    }
+}
+
+fn parse_block_tag(tag: &str) -> Result<BlockTag> {
+    match tag.trim() {
+        "" => Ok(BlockTag::Missing),
+        "latest" => Ok(BlockTag::Latest),
+        "pending" => Ok(BlockTag::Pending),
+        "safe" => Ok(BlockTag::Safe),
+        "finalized" => Ok(BlockTag::Finalized),
+        "earliest" => Ok(BlockTag::Earliest),
+        hex => Ok(BlockTag::Number(parse_hex_u64(hex)?)),
+    }
+}
+
+fn value_as_quantity(value: &Value) -> Result<String> {
+    match value {
+        Value::String(text) => Ok(text.clone()),
+        Value::Number(number) => Ok(number.to_string()),
+        other => bail!("expected hex quantity, got {other}"),
+    }
+}
+
+pub fn parse_hex_u64(value: &str) -> Result<u64> {
+    let text = value.trim();
+    if let Some(hex) = text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16).with_context(|| format!("parsing hex quantity {value}"))
+    } else {
+        text.parse::<u64>()
+            .with_context(|| format!("parsing quantity {value}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    #[derive(Clone)]
+    struct Scripted {
+        responses: Arc<Mutex<VecDeque<Value>>>,
+        calls: Arc<Mutex<Vec<Value>>>,
+    }
+
+    impl Scripted {
+        fn new(responses: Vec<Value>) -> Self {
+            Self {
+                responses: Arc::new(Mutex::new(responses.into())),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl JsonRpcTransport for Scripted {
+        async fn post(&self, _url: &str, body: &Value) -> Result<Value> {
+            self.calls.lock().expect("calls").push(body.clone());
+            self.responses
+                .lock()
+                .expect("responses")
+                .pop_front()
+                .ok_or_else(|| anyhow!("scripted eth RPC has no remaining responses"))
+        }
+    }
+
+    fn client(methods: &[&str], transport: Scripted) -> EthRpcClient<Scripted> {
+        EthRpcClient::new(
+            "http://127.0.0.1:1",
+            8453,
+            &methods.iter().map(|m| m.to_string()).collect::<Vec<_>>(),
+            transport,
+        )
+        .expect("client")
+    }
+
+    fn ok_result(value: Value) -> Value {
+        json!({"jsonrpc":"2.0","id":1,"result": value})
+    }
+
+    #[tokio::test]
+    async fn unfiltered_logs_rejected_before_wire() {
+        let transport = Scripted::new(vec![]);
+        let calls = Arc::clone(&transport.calls);
+        let rpc = client(&["eth_getLogs"], transport);
+        let err = rpc
+            .call("eth_getLogs", json!([{"fromBlock":"0x1","toBlock":"0x2"}]))
+            .await
+            .expect_err("unfiltered");
+        assert!(err.to_string().contains("unfiltered"));
+        assert!(calls.lock().expect("calls").is_empty());
+    }
+
+    #[tokio::test]
+    async fn logs_range_over_1000_rejected_before_wire() {
+        let transport = Scripted::new(vec![]);
+        let calls = Arc::clone(&transport.calls);
+        let rpc = client(&["eth_getLogs"], transport);
+        let err = rpc
+            .call(
+                "eth_getLogs",
+                json!([{
+                    "fromBlock": "0x1",
+                    "toBlock": "0x3ea",
+                    "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+                }]),
+            )
+            .await
+            .expect_err("range");
+        assert!(err.to_string().contains("exceeds max"));
+        assert!(calls.lock().expect("calls").is_empty());
+    }
+
+    #[test]
+    fn wildcard_topics_do_not_make_a_log_query_filtered() {
+        let error = preflight_get_logs(&json!([{
+            "fromBlock": "latest",
+            "toBlock": "latest",
+            "topics": [null]
+        }]))
+        .expect_err("wildcard topics");
+        assert!(error.to_string().contains("unfiltered"));
+    }
+
+    #[test]
+    fn numeric_to_latest_log_range_is_rejected() {
+        let error = preflight_get_logs(&json!([{
+            "fromBlock": "0x1",
+            "toBlock": "latest",
+            "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+        }]))
+        .expect_err("unbounded mixed range");
+        assert!(error.to_string().contains("unbounded"));
+    }
+
+    #[test]
+    fn inclusive_log_range_is_bounded_to_1000_blocks() {
+        let address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913";
+        preflight_get_logs(&json!([{
+            "fromBlock": "0x1",
+            "toBlock": "0x3e8",
+            "address": address
+        }]))
+        .expect("exactly 1000 blocks");
+        assert!(preflight_get_logs(&json!([{
+            "fromBlock": "0x1",
+            "toBlock": "0x3e9",
+            "address": address
+        }]))
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn chain_id_mismatch_fails() {
+        let transport = Scripted::new(vec![ok_result(json!("0x1"))]);
+        let rpc = client(&["eth_blockNumber"], transport);
+        let err = rpc
+            .call("eth_blockNumber", json!([]))
+            .await
+            .expect_err("mismatch");
+        assert!(err.to_string().contains("chain_id mismatch"));
+    }
+
+    #[tokio::test]
+    async fn matching_chain_id_then_method() {
+        let transport = Scripted::new(vec![ok_result(json!("0x2105")), ok_result(json!("0x10"))]);
+        let rpc = client(&["eth_blockNumber"], transport);
+        let result = rpc.call("eth_blockNumber", json!([])).await.expect("call");
+        assert_eq!(result, json!("0x10"));
+    }
+
+    #[tokio::test]
+    async fn send_method_rejected_even_if_listed() {
+        let err = match EthRpcClient::new(
+            "http://127.0.0.1:1",
+            1,
+            &["eth_sendRawTransaction".to_string()],
+            Scripted::new(vec![]),
+        ) {
+            Ok(_) => panic!("send method must fail construction"),
+            Err(error) => error,
+        };
+        assert!(err.to_string().contains("not a read-only"));
+    }
+
+    #[tokio::test]
+    async fn pruned_history_is_typed_failure() {
+        let transport = Scripted::new(vec![
+            ok_result(json!("0x2105")),
+            json!({"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"metadata is not found"}}),
+        ]);
+        let rpc = client(&["eth_call"], transport);
+        let err = rpc
+            .call(
+                "eth_call",
+                json!([{"to":"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913","data":"0x"}, "0x1"]),
+            )
+            .await
+            .expect_err("pruned");
+        assert!(err.to_string().contains("pruned-history"));
+        assert!(!err.to_string().contains("retry"));
+    }
+
+    #[tokio::test]
+    async fn omitted_block_defaults_to_latest() {
+        let transport = Scripted::new(vec![ok_result(json!("0x2105")), ok_result(json!("0x1"))]);
+        let calls = Arc::clone(&transport.calls);
+        let rpc = client(&["eth_getBalance"], transport);
+        let _ = rpc
+            .call(
+                "eth_getBalance",
+                json!(["0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"]),
+            )
+            .await
+            .expect("call");
+        let calls = calls.lock().expect("calls");
+        let balance = calls
+            .iter()
+            .find(|body| body["method"] == "eth_getBalance")
+            .expect("balance call");
+        assert_eq!(
+            balance["params"],
+            json!(["0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", "latest"])
+        );
+    }
+
+    #[tokio::test]
+    async fn http_sends_gents_eth_user_agent() {
+        let (url, requests) = spawn_json_rpc_server(ok_result(json!("0x2105"))).await;
+        let rpc = HttpEthRpc::http(&url, 8453, &["eth_chainId".to_string()]).expect("http client");
+        let result = rpc.call("eth_chainId", json!([])).await.expect("call");
+        assert_eq!(result, json!("0x2105"));
+        let request = requests.lock().expect("requests")[0].clone();
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains(&format!("user-agent: {ETH_USER_AGENT}").to_ascii_lowercase()),
+            "missing User-Agent in {request}"
+        );
+    }
+
+    async fn spawn_json_rpc_server(body: Value) -> (String, Arc<Mutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock eth rpc");
+        let addr = listener.local_addr().expect("addr");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captures = Arc::clone(&requests);
+        let payload = serde_json::to_string(&body).expect("json");
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let Ok(request) = read_http_request(&mut stream).await else {
+                    continue;
+                };
+                captures.lock().expect("requests").push(request);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    payload.len(),
+                    payload
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+        (format!("http://{addr}"), requests)
+    }
+
+    async fn read_http_request(stream: &mut TcpStream) -> std::io::Result<String> {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut chunk).await?;
+            if n == 0 {
+                return Err(std::io::ErrorKind::UnexpectedEof.into());
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if let Some(header_end) = find_bytes(&buf, b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&buf[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        (name.eq_ignore_ascii_case("content-length"))
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                let body_start = header_end + 4;
+                while buf.len() < body_start + content_length {
+                    let n = stream.read(&mut chunk).await?;
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+                break;
+            }
+        }
+        Ok(String::from_utf8_lossy(&buf).to_string())
+    }
+
+    fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+}

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -118,7 +118,8 @@ pub use callback::reject_secret_bearing_callback_fields;
 pub use collection::{Collection, DESIRED_STATE_APPLY_ORDER};
 pub use eth::{
     address_from_secret, attestation_payload, binding_storage_key, encode_attestation,
-    generate_secp256k1_secret, ChainKeyMaterialStore, KeyringChainKeyStore, KEYRING_SERVICE,
+    generate_secp256k1_secret, method_permitted, validate_query_methods, ChainKeyMaterialStore,
+    HttpEthRpc, KeyringChainKeyStore, BUILTIN_QUERY_METHODS, ETH_USER_AGENT, KEYRING_SERVICE,
     KEY_BACKEND_KEYRING,
 };
 
@@ -169,16 +170,17 @@ pub use document_config::{
     chain_key_binding_by_id_query, create_chain_key_binding_mutation,
     default_behavior_id_for_agent, default_inference_profile_id_for_behavior,
     default_tool_selection_id_for_behavior, delete_chain_key_binding_mutation,
-    deserialize_dual_shape, ensure_agent_principal, is_reserved_builtin_tool_name,
-    list_agent_behaviors, list_chain_key_bindings_query, list_datastore_tool_surfaces,
-    list_inference_profile_records, load_agent_behavior, load_agent_principal,
-    load_inference_profile, load_tool_selection, merge_datastore_tool_surfaces,
-    subagent_target_entry, upsert_agent_behavior, upsert_agent_principal, upsert_chain_key_binding,
-    upsert_chain_key_binding_mutation, upsert_inference_profile, upsert_tool_selection,
-    wide_open_tool_selection_document, wide_open_tool_selection_id_for_agent,
-    AgentBehavior as AgentBehaviorDocument, ChainKeyBindingDocument, DatastoreToolSurfaceDocument,
-    InferenceProfile, MergedSurfaceTools, PrincipalBootstrap, QueryToolDecl, SubagentTarget,
-    SurfaceToolDecl, ToolSelectionDocument, WriteToolDecl, WriteToolField, WriteToolFieldFill,
+    deserialize_dual_shape, ensure_agent_principal, eth_tool_by_id_query,
+    is_reserved_builtin_tool_name, list_agent_behaviors, list_chain_key_bindings_query,
+    list_datastore_tool_surfaces, list_inference_profile_records, load_agent_behavior,
+    load_agent_principal, load_inference_profile, load_tool_selection,
+    merge_datastore_tool_surfaces, subagent_target_entry, upsert_agent_behavior,
+    upsert_agent_principal, upsert_chain_key_binding, upsert_chain_key_binding_mutation,
+    upsert_inference_profile, upsert_tool_selection, wide_open_tool_selection_document,
+    wide_open_tool_selection_id_for_agent, AgentBehavior as AgentBehaviorDocument,
+    ChainKeyBindingDocument, DatastoreToolSurfaceDocument, EthToolDocument, InferenceProfile,
+    MergedSurfaceTools, PrincipalBootstrap, QueryToolDecl, SubagentTarget, SurfaceToolDecl,
+    ToolSelectionDocument, WriteToolDecl, WriteToolField, WriteToolFieldFill,
     WriteToolOutputObligation, WriteToolOutputObligationScope,
 };
 pub use external_adapter_capture::{


### PR DESCRIPTION
## Summary

PR 3 of the EthTool stack (#1217). RPC client and operator CLI; no agent-facing tool yet.

- Builtin read-only method ceiling; send/sign/debug methods fail config
- HTTP JSON-RPC with `User-Agent: gents-eth/<version>` (Base 403 without it)
- `eth_chainId` must match `EthTool.chain_id` (cached)
- `eth_getLogs` requires address and/or topics; max range 1000; unfiltered rejected before the wire
- Pruned-history RPC errors map to a typed failure and are not retried
- Default block tag `"latest"` when omitted on trailing-block methods
- `gents chain query --tool-id ID METHOD [params JSON]`

## Stack

Stacked GitHub PRs (each `--base` is the PR below):

1. #1299 schema (`eth-wallet` → `main`)
2. #1300 keys (`eth-wallet-keys` → `eth-wallet`)
3. **this PR** RPC (`eth-wallet-rpc` → `eth-wallet-keys`)
4. native `{tool_id}_query` + ToolPolicy (next)
5. `any_read` + declared reads
6. submission runtime
7. declared writes / `native_transfer`
8. `sign_typed_data`

Part of #1217.

## Test plan

- [x] `cargo test -p gents --lib eth::`
- [x] `cargo test -p gents-cli --lib chain`
- [ ] `cargo check --workspace --all-targets` (CI)