### PR TITLE
feat(eth): advertise native eth_query tool and ToolPolicy scopes

### DIFF
--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/ToolPolicy.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/ToolPolicy.lean
@@ -64,7 +64,11 @@ def surfaceViewJson (v : SurfaceView) : String :=
     ++ "\"query_scope_kind\":" ++ jsonString v.queryScopeKind ++ ","
     ++ "\"query_grants\":"
       ++ jsonArray (v.queryGrants.map writeGrantViewJson) ++ ","
-    ++ "\"query_fields\":" ++ jsonArray (v.queryFields.map jsonString)
+    ++ "\"query_fields\":" ++ jsonArray (v.queryFields.map jsonString) ++ ","
+    ++ "\"eth_query_methods_kind\":" ++ jsonString v.ethQueryMethodsKind ++ ","
+    ++ "\"eth_query_methods_keys\":" ++ jsonStringArray v.ethQueryMethodsKeys ++ ","
+    ++ "\"eth_call_tools_kind\":" ++ jsonString v.ethCallToolsKind ++ ","
+    ++ "\"eth_call_tools_keys\":" ++ jsonStringArray v.ethCallToolsKeys
   ++ "}"
 
 def toolPolicyCaseJson (c : Case) : String :=

--- a/crates/gents/proofs/Proofs/ToolPolicy/Cases.lean
+++ b/crates/gents/proofs/Proofs/ToolPolicy/Cases.lean
@@ -54,6 +54,10 @@ structure SurfaceView where
   queryScopeKind : String
   queryGrants : List WriteGrantView
   queryFields : List String
+  ethQueryMethodsKind : String
+  ethQueryMethodsKeys : List String
+  ethCallToolsKind : String
+  ethCallToolsKeys : List String
   deriving Repr
 
 structure Case where
@@ -90,6 +94,9 @@ def knownWriteKeys : List (String × String) :=
 def knownQueryKeys : List (String × String) :=
   [("qt", "coll")]
 
+def knownEthMethods : List String :=
+  ["eth_blockNumber", "eth_call", "eth_chainId"]
+
 def probeQuery : String × String := ("qt", "coll")
 
 def knownSelfConfigCategories : List String :=
@@ -106,6 +113,11 @@ def fieldList (fields : Finset String) : List String :=
 
 def toolScopeKeys {V : Type} : EndpointScope ToolId V → List String
   | .only keys _ => knownToolIds.filter (fun key => decide (key ∈ keys))
+  | .all => []
+  | .none => []
+
+def ethMethodKeys {V : Type} : EndpointScope String V → List String
+  | .only keys _ => knownEthMethods.filter (fun key => decide (key ∈ keys))
   | .all => []
   | .none => []
 
@@ -223,7 +235,9 @@ def surface (file : FileCap) (bash : BashPolicy)
   , subagentTargets := .all
   , backgroundTools := .all
   , writeTools := write
-  , queryTools := .all }
+  , queryTools := .all
+  , ethQueryMethods := .none
+  , ethCallTools := .none }
 
 def view (s : Surface) (mcpProbe : String) (writeProbe : String × String) : SurfaceView :=
   { fileRank := s.file.rank
@@ -272,7 +286,11 @@ def view (s : Surface) (mcpProbe : String) (writeProbe : String × String) : Sur
   , queryGrants := queryGrantViews s.queryTools
   , queryFields := match s.queryTools.lookup probeQuery with
       | some fields => fieldList fields
-      | none => [] }
+      | none => []
+  , ethQueryMethodsKind := scopeKind s.ethQueryMethods
+  , ethQueryMethodsKeys := ethMethodKeys s.ethQueryMethods
+  , ethCallToolsKind := scopeKind s.ethCallTools
+  , ethCallToolsKeys := toolScopeKeys s.ethCallTools }
 
 def probeWrite : String × String := ("wt", "coll")
 
@@ -423,6 +441,21 @@ def writeAllNoQuery : Surface :=
     writeTools := .all
     queryTools := .none }
 
+def ethMethodsA : EndpointScope String Unit :=
+  unitOnly ["eth_chainId", "eth_blockNumber"].toFinset
+
+def ethMethodsB : EndpointScope String Unit :=
+  unitOnly ["eth_blockNumber", "eth_call"].toFinset
+
+def behaviorEthA : Surface :=
+  { wideOpen with ethQueryMethods := ethMethodsA }
+
+def ceilingEthB : Surface :=
+  { wideOpen with ethQueryMethods := ethMethodsB }
+
+def runtimeEthAll : Surface :=
+  { wideOpen with ethQueryMethods := .all, ethCallTools := .all }
+
 def mkCase (name : String) (b c : Surface) (r : Avail)
     (mcpProbe : String) (writeProbe : String × String) : Case :=
   { name := name
@@ -456,6 +489,8 @@ def cases : List Case :=
       behaviorQueryB ceilingQueryA wideOpen "svc-a" probeWrite
   , mkCase "write_all_does_not_grant_query"
       behaviorQueryA writeAllNoQuery wideOpen "svc-a" probeWrite
+  , mkCase "eth_query_methods_intersect"
+      behaviorEthA ceilingEthB runtimeEthAll "svc-a" probeWrite
   ]
 
 end ToolPolicy.ContractCases

--- a/crates/gents/proofs/Proofs/ToolPolicy/Instances.lean
+++ b/crates/gents/proofs/Proofs/ToolPolicy/Instances.lean
@@ -33,7 +33,9 @@ def Surface.meet (a b : Surface) : Surface :=
   , subagentTargets := a.subagentTargets.meet unitVM b.subagentTargets
   , backgroundTools := a.backgroundTools.meet unitVM b.backgroundTools
   , writeTools := a.writeTools.meet fieldsVM b.writeTools
-  , queryTools := a.queryTools.meet fieldsVM b.queryTools }
+  , queryTools := a.queryTools.meet fieldsVM b.queryTools
+  , ethQueryMethods := a.ethQueryMethods.meet unitVM b.ethQueryMethods
+  , ethCallTools := a.ethCallTools.meet unitVM b.ethCallTools }
 
 def effective (behavior ceiling : Surface) (runtime : Avail) : Surface :=
   (behavior.meet ceiling).meet runtime

--- a/crates/gents/proofs/Proofs/ToolPolicy/Types.lean
+++ b/crates/gents/proofs/Proofs/ToolPolicy/Types.lean
@@ -66,6 +66,8 @@ structure Surface where
   backgroundTools : EndpointScope ToolId Unit
   writeTools : EndpointScope (String × String) (Finset String)
   queryTools : EndpointScope (String × String) (Finset String)
+  ethQueryMethods : EndpointScope String Unit
+  ethCallTools : EndpointScope ToolId Unit
 
 abbrev Avail := Surface
 

--- a/crates/gents/src/agent/document_view/apply.rs
+++ b/crates/gents/src/agent/document_view/apply.rs
@@ -4,7 +4,7 @@ use defra_node::EmbeddedNode;
 use crate::backend_registry::lookup_backend_by_doc_id;
 use crate::document_config::{
     load_agent_behavior_by_doc_id, load_agent_principal_by_doc_id,
-    load_datastore_tool_surface_by_doc_id, load_event_trigger_by_doc_id,
+    load_datastore_tool_surface_by_doc_id, load_eth_tool_by_doc_id, load_event_trigger_by_doc_id,
     load_graph_definition_by_doc_id, load_graph_run_pin_by_doc_id,
     load_inference_profile_by_doc_id, load_schedule_by_doc_id, load_skill_by_doc_id,
     load_task_by_doc_id, load_tool_selection_by_doc_id,
@@ -158,6 +158,28 @@ pub(crate) async fn apply_control_update(
     }
     if view.has_datastore_tool_surface_doc_id(doc_id) {
         view.remove_datastore_tool_surface_by_doc_id(doc_id);
+        return Ok(ControlUpdateOutcome::Applied);
+    }
+
+    if let Some((loaded_doc_id, tool)) = load_eth_tool_by_doc_id(node, doc_id).await? {
+        if tool.agent_did != agent_did {
+            if view.remove_eth_tool_by_doc_id(doc_id) {
+                return Ok(ControlUpdateOutcome::Applied);
+            }
+            return Ok(ControlUpdateOutcome::Irrelevant);
+        }
+        view.remove_eth_tool_by_doc_id(doc_id);
+        view.eth_tools.insert(
+            tool.tool_id.trim().to_string(),
+            DocumentRecord {
+                doc_id: loaded_doc_id,
+                value: tool,
+            },
+        );
+        return Ok(ControlUpdateOutcome::Applied);
+    }
+    if view.has_eth_tool_doc_id(doc_id) {
+        view.remove_eth_tool_by_doc_id(doc_id);
         return Ok(ControlUpdateOutcome::Applied);
     }
 

--- a/crates/gents/src/agent/document_view/load.rs
+++ b/crates/gents/src/agent/document_view/load.rs
@@ -4,10 +4,10 @@ use defra_node::EmbeddedNode;
 use crate::backend_registry::list_backend_records;
 use crate::document_config::{
     ensure_agent_principal, list_agent_behavior_records, list_all_tool_selection_records,
-    list_datastore_tool_surface_records, list_event_trigger_records, list_graph_definition_records,
-    list_graph_run_pin_records, list_inference_profile_records, list_schedule_records,
-    list_skill_records, list_task_records, list_tool_selection_records, load_tool_selection_record,
-    ToolSelectionDocument,
+    list_datastore_tool_surface_records, list_eth_tool_records, list_event_trigger_records,
+    list_graph_definition_records, list_graph_run_pin_records, list_inference_profile_records,
+    list_schedule_records, list_skill_records, list_task_records, list_tool_selection_records,
+    load_tool_selection_record, ToolSelectionDocument,
 };
 
 use super::{DocumentRecord, DocumentRuntimeView};
@@ -32,6 +32,7 @@ pub(crate) async fn load_document_runtime_view(
         behaviors: HashMap::new(),
         skills: HashMap::new(),
         datastore_tool_surfaces: HashMap::new(),
+        eth_tools: HashMap::new(),
         tool_selections: HashMap::new(),
         inference_profiles: HashMap::new(),
         backends: HashMap::new(),
@@ -196,6 +197,34 @@ pub(crate) async fn load_document_runtime_view(
                 agent_did = %agent_did,
                 error = %error,
                 "runtime document view could not load DatastoreToolSurface documents; treating as empty"
+            );
+        }
+    }
+
+    match list_eth_tool_records(node, agent_did).await {
+        Ok(records) => {
+            for (doc_id, tool) in records {
+                if tool.tool_id.trim().is_empty() {
+                    tracing::warn!(
+                        doc_id = %doc_id,
+                        "runtime document view skipped EthTool with empty tool_id"
+                    );
+                    continue;
+                }
+                view.eth_tools.insert(
+                    tool.tool_id.trim().to_string(),
+                    DocumentRecord {
+                        doc_id,
+                        value: tool,
+                    },
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                agent_did = %agent_did,
+                error = %error,
+                "runtime document view could not load EthTool documents; treating as empty"
             );
         }
     }

--- a/crates/gents/src/agent/document_view/mod.rs
+++ b/crates/gents/src/agent/document_view/mod.rs
@@ -11,8 +11,9 @@ use std::collections::{BTreeSet, HashMap};
 use crate::backend_registry::InferenceBackend;
 use crate::chatgpt_codex::OAuthCredential;
 use crate::document_config::{
-    AgentBehavior, AgentPrincipal, DatastoreToolSurfaceDocument, EventTrigger, GraphDefinition,
-    GraphRunPin, InferenceProfile, Schedule, SkillDocument, Task, ToolSelectionDocument,
+    AgentBehavior, AgentPrincipal, DatastoreToolSurfaceDocument, EthToolDocument, EventTrigger,
+    GraphDefinition, GraphRunPin, InferenceProfile, Schedule, SkillDocument, Task,
+    ToolSelectionDocument,
 };
 
 #[derive(Debug, Clone)]
@@ -28,6 +29,7 @@ pub(crate) struct DocumentRuntimeView {
     pub(crate) skills: HashMap<String, DocumentRecord<SkillDocument>>,
     pub(crate) datastore_tool_surfaces:
         HashMap<String, DocumentRecord<DatastoreToolSurfaceDocument>>,
+    pub(crate) eth_tools: HashMap<String, DocumentRecord<EthToolDocument>>,
     pub(crate) tool_selections: HashMap<String, DocumentRecord<ToolSelectionDocument>>,
     pub(crate) inference_profiles: HashMap<String, DocumentRecord<InferenceProfile>>,
     pub(crate) backends: HashMap<String, DocumentRecord<InferenceBackend>>,
@@ -87,6 +89,12 @@ impl DocumentRuntimeView {
 
     fn has_datastore_tool_surface_doc_id(&self, doc_id: &str) -> bool {
         self.datastore_tool_surfaces
+            .values()
+            .any(|record| record.doc_id == doc_id)
+    }
+
+    fn has_eth_tool_doc_id(&self, doc_id: &str) -> bool {
+        self.eth_tools
             .values()
             .any(|record| record.doc_id == doc_id)
     }
@@ -161,6 +169,14 @@ impl DocumentRuntimeView {
                 (record.doc_id == doc_id).then_some(surface_id.clone())
             });
         key.is_some_and(|surface_id| self.datastore_tool_surfaces.remove(&surface_id).is_some())
+    }
+
+    fn remove_eth_tool_by_doc_id(&mut self, doc_id: &str) -> bool {
+        let key = self
+            .eth_tools
+            .iter()
+            .find_map(|(tool_id, record)| (record.doc_id == doc_id).then_some(tool_id.clone()));
+        key.is_some_and(|tool_id| self.eth_tools.remove(&tool_id).is_some())
     }
 
     fn remove_inference_profile_by_doc_id(&mut self, doc_id: &str) -> bool {
@@ -338,4 +354,62 @@ pub(crate) fn merge_surface_tools(
             .values()
             .map(|record| &record.value),
     )
+}
+
+/// Expand `eth_tool_ids` into query tools. Missing / foreign ids fail closed.
+/// Disabled EthTools and empty `query_methods` are skipped (no advertise).
+pub(crate) fn expand_eth_tools(
+    selection: &ToolSelectionDocument,
+    view: &DocumentRuntimeView,
+) -> anyhow::Result<Vec<crate::eth::ResolvedEthQuery>> {
+    use anyhow::{anyhow, bail};
+    use std::collections::HashSet;
+
+    let mut out = Vec::new();
+    let mut linked_ids: HashSet<&str> = HashSet::new();
+    let mut tool_names: HashSet<String> = HashSet::new();
+    for tool_id in selection.eth_tool_ids.as_deref().unwrap_or(&[]) {
+        let tool_id = tool_id.trim();
+        if tool_id.is_empty() {
+            bail!(
+                "ToolSelection {} has an empty eth_tool_ids entry",
+                selection.selection_id
+            );
+        }
+        if !linked_ids.insert(tool_id) {
+            bail!(
+                "ToolSelection {} lists EthTool {} more than once",
+                selection.selection_id,
+                tool_id
+            );
+        }
+        let record = view.eth_tools.get(tool_id).ok_or_else(|| {
+            anyhow!(
+                "ToolSelection {} references missing EthTool {}",
+                selection.selection_id,
+                tool_id
+            )
+        })?;
+        let doc = &record.value;
+        if doc.agent_did.trim() != selection.agent_did.trim() {
+            bail!(
+                "ToolSelection {} references EthTool {} owned by a different agent",
+                selection.selection_id,
+                tool_id
+            );
+        }
+        let Some(resolved) = crate::eth::ResolvedEthQuery::from_document(doc)? else {
+            continue;
+        };
+        if !tool_names.insert(resolved.tool_name()) {
+            bail!(
+                "duplicate eth tool name {:?} after expanding EthTool {} for ToolSelection {}",
+                resolved.tool_name(),
+                tool_id,
+                selection.selection_id
+            );
+        }
+        out.push(resolved);
+    }
+    Ok(out)
 }

--- a/crates/gents/src/agent/document_view/snapshot.rs
+++ b/crates/gents/src/agent/document_view/snapshot.rs
@@ -180,6 +180,8 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
                         validate_subagent_targets_resolve(&selection, view)?;
                         let mut tool_selection = tool_selection_from_document(&selection)?;
                         tool_selection.query_tools = merged.query_tools;
+                        tool_selection.eth_queries =
+                            crate::agent::document_view::expand_eth_tools(&record.value, view)?;
                         (
                             tool_selection,
                             subagent_tool_config_from_document(&selection),

--- a/crates/gents/src/agent/document_view/tests.rs
+++ b/crates/gents/src/agent/document_view/tests.rs
@@ -1761,6 +1761,7 @@ fn empty_runtime_view(agent_did: &str) -> DocumentRuntimeView {
         behaviors: Default::default(),
         skills: Default::default(),
         datastore_tool_surfaces: Default::default(),
+        eth_tools: Default::default(),
         tool_selections: Default::default(),
         inference_profiles: Default::default(),
         backends: Default::default(),
@@ -2192,4 +2193,94 @@ async fn apply_control_update_evicts_surface_when_ownership_moves_away() {
         view.datastore_tool_surfaces.is_empty(),
         "surface must be evicted once it is owned by another principal"
     );
+}
+
+fn sample_eth_tool(
+    agent_did: &str,
+    tool_id: &str,
+    enabled: bool,
+    methods: &[&str],
+) -> crate::document_config::EthToolDocument {
+    crate::document_config::EthToolDocument {
+        tool_id: tool_id.to_string(),
+        agent_did: agent_did.to_string(),
+        display_name: Some(tool_id.to_string()),
+        enabled,
+        chain_id: Some(8453),
+        rpc_url: Some("https://mainnet.base.org".to_string()),
+        query_methods: Some(methods.iter().map(|m| m.to_string()).collect()),
+        calls: None,
+        key_binding_id: None,
+        created_at: None,
+    }
+}
+
+#[test]
+fn expand_eth_tools_skips_disabled_and_empty_methods() {
+    let agent_did = "did:key:zEth";
+    let selection = ToolSelectionDocument {
+        selection_id: "sel".to_string(),
+        agent_did: agent_did.to_string(),
+        eth_tool_ids: Some(vec![
+            "base-read".to_string(),
+            "disabled".to_string(),
+            "no-methods".to_string(),
+        ]),
+        ..Default::default()
+    };
+    let mut view = empty_runtime_view(agent_did);
+    view.eth_tools.insert(
+        "base-read".to_string(),
+        DocumentRecord {
+            doc_id: "e1".to_string(),
+            value: sample_eth_tool(agent_did, "base-read", true, &["eth_chainId"]),
+        },
+    );
+    view.eth_tools.insert(
+        "disabled".to_string(),
+        DocumentRecord {
+            doc_id: "e2".to_string(),
+            value: sample_eth_tool(agent_did, "disabled", false, &["eth_chainId"]),
+        },
+    );
+    view.eth_tools.insert(
+        "no-methods".to_string(),
+        DocumentRecord {
+            doc_id: "e3".to_string(),
+            value: sample_eth_tool(agent_did, "no-methods", true, &[]),
+        },
+    );
+    let expanded = expand_eth_tools(&selection, &view).expect("expand");
+    assert_eq!(expanded.len(), 1);
+    assert_eq!(expanded[0].tool_name(), "base-read_query");
+}
+
+#[test]
+fn expand_eth_tools_fails_closed_on_missing_and_foreign() {
+    let agent_did = "did:key:zEth";
+    let missing = ToolSelectionDocument {
+        selection_id: "sel".to_string(),
+        agent_did: agent_did.to_string(),
+        eth_tool_ids: Some(vec!["nope".to_string()]),
+        ..Default::default()
+    };
+    let err = expand_eth_tools(&missing, &empty_runtime_view(agent_did)).unwrap_err();
+    assert!(err.to_string().contains("missing"));
+
+    let foreign = ToolSelectionDocument {
+        selection_id: "sel".to_string(),
+        agent_did: agent_did.to_string(),
+        eth_tool_ids: Some(vec!["other".to_string()]),
+        ..Default::default()
+    };
+    let mut view = empty_runtime_view(agent_did);
+    view.eth_tools.insert(
+        "other".to_string(),
+        DocumentRecord {
+            doc_id: "e1".to_string(),
+            value: sample_eth_tool("did:key:zOther", "other", true, &["eth_chainId"]),
+        },
+    );
+    let err = expand_eth_tools(&foreign, &view).unwrap_err();
+    assert!(err.to_string().contains("different agent"));
 }

--- a/crates/gents/src/agent/reconcile/tests.rs
+++ b/crates/gents/src/agent/reconcile/tests.rs
@@ -1067,6 +1067,7 @@ async fn generation_supervisor_rotates_dispatcher_on_tool_surface_change() {
                 self_config_dry_run: false,
                 enable_lsp: false,
                 lsp_config: None,
+                eth_queries: Vec::new(),
             },
             &ToolCeiling::readonly(),
             Vec::new(),

--- a/crates/gents/src/document_config/mod.rs
+++ b/crates/gents/src/document_config/mod.rs
@@ -72,7 +72,6 @@ pub(crate) use datastore_tool_surface::{
 };
 pub use datastore_tool_surface::{list_datastore_tool_surfaces, DatastoreToolSurfaceDocument};
 pub use eth_tool::{eth_tool_by_id_query, EthToolDocument};
-#[allow(dead_code, unused_imports)]
 pub(crate) use eth_tool::{list_eth_tool_records, load_eth_tool_by_doc_id};
 #[allow(unused_imports)]
 pub(crate) use skill::{list_skill_records, load_skill_by_doc_id, SkillDocument};

--- a/crates/gents/src/eth/mod.rs
+++ b/crates/gents/src/eth/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod keys;
 pub mod methods;
+pub(crate) mod query;
 pub(crate) mod rpc;
 
 pub use keys::{
@@ -12,4 +13,5 @@ pub use keys::{
 pub use methods::{
     method_permitted, normalize_method, validate_query_methods, BUILTIN_QUERY_METHODS,
 };
+pub(crate) use query::{EthQueryTool, ResolvedEthQuery};
 pub use rpc::{HttpEthRpc, ETH_USER_AGENT};

--- a/crates/gents/src/eth/query.rs
+++ b/crates/gents/src/eth/query.rs
@@ -1,0 +1,213 @@
+//! Native `{tool_id}_query` tool. Allowlisted JSON-RPC reads only.
+
+use anyhow::{anyhow, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::llm::tool::{BoxFuture, ToolDefinition, ToolDyn, ToolError};
+use crate::tool_call_lifecycle::FailureClass;
+
+use super::methods::validate_query_methods;
+use super::rpc::HttpEthRpc;
+
+/// Expanded, runtime-ready query surface for one EthTool document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedEthQuery {
+    pub tool_id: String,
+    pub chain_id: u64,
+    pub rpc_url: String,
+    pub methods: Vec<String>,
+}
+
+impl ResolvedEthQuery {
+    pub fn tool_name(&self) -> String {
+        format!("{}_query", self.tool_id)
+    }
+
+    pub fn from_document(doc: &crate::document_config::EthToolDocument) -> Result<Option<Self>> {
+        if !doc.enabled {
+            return Ok(None);
+        }
+        let methods = validate_query_methods(doc.query_methods.as_deref().unwrap_or(&[]))?;
+        if methods.is_empty() {
+            return Ok(None);
+        }
+        let rpc_url = doc
+            .rpc_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("EthTool {} has an empty rpc_url", doc.tool_id))?
+            .to_string();
+        let chain_id = doc
+            .chain_id
+            .ok_or_else(|| anyhow!("EthTool {} has no chain_id", doc.tool_id))?;
+        if chain_id <= 0 {
+            anyhow::bail!("EthTool {} chain_id must be positive", doc.tool_id);
+        }
+        Ok(Some(Self {
+            tool_id: doc.tool_id.clone(),
+            chain_id: chain_id as u64,
+            rpc_url,
+            methods,
+        }))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EthQueryArgs {
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+pub struct EthQueryTool {
+    resolved: ResolvedEthQuery,
+}
+
+impl EthQueryTool {
+    pub fn new(resolved: ResolvedEthQuery) -> Self {
+        Self { resolved }
+    }
+}
+
+impl ToolDyn for EthQueryTool {
+    fn name(&self) -> String {
+        self.resolved.tool_name()
+    }
+
+    fn definition(&self, _prompt: String) -> BoxFuture<'_, ToolDefinition> {
+        let name = self.resolved.tool_name();
+        let methods = self.resolved.methods.clone();
+        Box::pin(async move {
+            ToolDefinition {
+                name,
+                description: "Call an allowlisted read-only Ethereum JSON-RPC method. \
+                     Params is a JSON array. Block tags default to \"latest\". \
+                     Unfiltered eth_getLogs is rejected."
+                    .to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "method": {
+                            "type": "string",
+                            "enum": methods,
+                            "description": "JSON-RPC method from the EthTool query_methods allowlist."
+                        },
+                        "params": {
+                            "type": "array",
+                            "description": "JSON-RPC params array. Default: []"
+                        }
+                    },
+                    "required": ["method"]
+                }),
+            }
+        })
+    }
+
+    fn call(&self, args: String) -> BoxFuture<'_, Result<String, ToolError>> {
+        let resolved = self.resolved.clone();
+        Box::pin(async move {
+            let parsed: EthQueryArgs = crate::llm::tool::parse_tool_args(&args)?;
+            let params = match parsed.params {
+                Value::Null => json!([]),
+                Value::Array(_) => parsed.params,
+                other => {
+                    return Err(ToolError::ReportedFailure {
+                        class: FailureClass::PolicyDenied,
+                        text: format!("eth_query params must be a JSON array, got {other}"),
+                    });
+                }
+            };
+            let client = HttpEthRpc::http(&resolved.rpc_url, resolved.chain_id, &resolved.methods)
+                .map_err(|error| ToolError::ReportedFailure {
+                    class: FailureClass::Transport,
+                    text: error.to_string(),
+                })?;
+            let result = client.call(&parsed.method, params).await.map_err(|error| {
+                let text = error.to_string();
+                let class = if text.contains("not in the configured query_methods")
+                    || text.contains("not a read-only")
+                    || text.contains("unfiltered")
+                    || text.contains("exceeds max")
+                {
+                    FailureClass::PolicyDenied
+                } else if text.contains("pruned-history") {
+                    FailureClass::External
+                } else {
+                    FailureClass::Transport
+                };
+                ToolError::ReportedFailure { class, text }
+            })?;
+            serde_json::to_string(&result).map_err(ToolError::JsonError)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document_config::EthToolDocument;
+
+    fn doc(enabled: bool, methods: &[&str]) -> EthToolDocument {
+        EthToolDocument {
+            tool_id: "base-read".to_string(),
+            agent_did: "did:key:zAlice".to_string(),
+            display_name: Some("base".to_string()),
+            enabled,
+            chain_id: Some(8453),
+            rpc_url: Some("https://mainnet.base.org".to_string()),
+            query_methods: Some(methods.iter().map(|m| m.to_string()).collect()),
+            calls: None,
+            key_binding_id: None,
+            created_at: None,
+        }
+    }
+
+    #[test]
+    fn disabled_or_empty_methods_do_not_advertise() {
+        assert!(
+            ResolvedEthQuery::from_document(&doc(false, &["eth_chainId"]))
+                .expect("ok")
+                .is_none()
+        );
+        assert!(ResolvedEthQuery::from_document(&doc(true, &[]))
+            .expect("ok")
+            .is_none());
+    }
+
+    #[test]
+    fn enabled_with_methods_names_query_tool() {
+        let resolved =
+            ResolvedEthQuery::from_document(&doc(true, &["eth_chainId", "eth_blockNumber"]))
+                .expect("ok")
+                .expect("advertised");
+        assert_eq!(resolved.tool_name(), "base-read_query");
+        assert_eq!(resolved.methods, vec!["eth_chainId", "eth_blockNumber"]);
+    }
+
+    #[test]
+    fn send_method_fails_resolve() {
+        let err = ResolvedEthQuery::from_document(&doc(true, &["eth_sendRawTransaction"]))
+            .expect_err("send");
+        assert!(err.to_string().contains("not a read-only"));
+    }
+
+    #[tokio::test]
+    async fn definition_has_method_enum_and_no_data_field() {
+        let resolved = ResolvedEthQuery::from_document(&doc(true, &["eth_chainId"]))
+            .expect("ok")
+            .expect("advertised");
+        let tool = EthQueryTool::new(resolved);
+        let definition = tool.definition(String::new()).await;
+        assert_eq!(definition.name, "base-read_query");
+        let params = &definition.parameters;
+        assert_eq!(
+            params["properties"]["method"]["enum"],
+            json!(["eth_chainId"])
+        );
+        assert!(params["properties"].get("data").is_none());
+        assert!(params["properties"].get("calldata").is_none());
+    }
+}

--- a/crates/gents/src/lean_vocab_test/tool_policy.rs
+++ b/crates/gents/src/lean_vocab_test/tool_policy.rs
@@ -60,6 +60,14 @@ pub(crate) struct LeanToolPolicySurfaceView {
     pub(crate) query_grants: Vec<LeanToolPolicyWriteGrant>,
     #[serde(default)]
     pub(crate) query_fields: Vec<String>,
+    #[serde(default)]
+    pub(crate) eth_query_methods_kind: String,
+    #[serde(default)]
+    pub(crate) eth_query_methods_keys: Vec<String>,
+    #[serde(default)]
+    pub(crate) eth_call_tools_kind: String,
+    #[serde(default)]
+    pub(crate) eth_call_tools_keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/gents/src/tool_surface/behavior_config.rs
+++ b/crates/gents/src/tool_surface/behavior_config.rs
@@ -34,6 +34,7 @@ pub struct BehaviorToolConfig {
     defra_query_collections: Vec<String>,
     write_tools: Vec<WriteToolDecl>,
     query_tools: Vec<QueryToolDecl>,
+    eth_queries: Vec<crate::eth::ResolvedEthQuery>,
     self_config: super::SelfConfigToolConfig,
     behavior_policy: ToolPolicySurface,
     ceiling_policy: ToolPolicySurface,
@@ -68,6 +69,7 @@ impl BehaviorToolConfig {
             defra_query_collections: Vec::new(),
             write_tools: Vec::new(),
             query_tools: Vec::new(),
+            eth_queries: Vec::new(),
             self_config: super::SelfConfigToolConfig::default(),
             behavior_policy: behavior_policy.clone(),
             ceiling_policy: ToolPolicySurface::legacy_non_host_wide(
@@ -181,6 +183,7 @@ impl BehaviorToolConfig {
             self_config_dry_run,
             enable_lsp: _,
             lsp_config,
+            eth_queries,
         } = selection;
         let file_tools =
             downgrade_file_tools(behavior_name, requested_file_tools, static_policy.file);
@@ -265,6 +268,7 @@ impl BehaviorToolConfig {
             defra_query_collections: static_policy.defra_query_collections_for_runtime(),
             write_tools: static_policy.write_decls_for_runtime(&write_tools),
             query_tools: static_policy.query_decls_for_runtime(&query_tools),
+            eth_queries,
             // `behavior_name` is the behavior_id on the document path
             // (agent.rs `behavior_config_from_documents`): the identity anchor
             // for "my config". Programmatic builder surfaces that enable
@@ -405,6 +409,20 @@ impl BehaviorToolConfig {
             defra_query_scope: effective_policy.defra_query_collection_scope(),
             write_tools: effective_policy.write_decls_for_runtime(&self.write_tools),
             query_tools: effective_policy.query_decls_for_runtime(&self.query_tools),
+            eth_queries: if effective_policy.eth_query_methods.is_deny_all() {
+                Vec::new()
+            } else {
+                self.eth_queries
+                    .iter()
+                    .cloned()
+                    .filter_map(|mut query| {
+                        query
+                            .methods
+                            .retain(|method| effective_policy.eth_query_methods.permits(method));
+                        (!query.methods.is_empty()).then_some(query)
+                    })
+                    .collect()
+            },
             enable_skills: effective_policy.skills,
             self_config: super::SelfConfigToolConfig {
                 enabled: effective_policy.include_self_config(),

--- a/crates/gents/src/tool_surface/mod.rs
+++ b/crates/gents/src/tool_surface/mod.rs
@@ -56,6 +56,7 @@ pub struct ToolSurface {
     pub(super) defra_query_scope: CollectionScope,
     pub(super) write_tools: Vec<WriteToolDecl>,
     pub(super) query_tools: Vec<QueryToolDecl>,
+    pub(super) eth_queries: Vec<crate::eth::ResolvedEthQuery>,
     pub(super) enable_skills: bool,
     pub(super) self_config: SelfConfigToolConfig,
     pub(super) lsp: Option<crate::toolset::lsp::LspToolConfig>,
@@ -206,6 +207,7 @@ impl ToolSurface {
                 names.push(decl.tool_name.clone());
             }
         }
+        names.extend(self.eth_queries.iter().map(|query| query.tool_name()));
         build::dedupe_strings(names)
     }
 
@@ -317,6 +319,16 @@ impl ToolSurface {
             }
             tools.push(Box::new(tool) as Box<dyn ToolDyn>);
         }
+        for query in &self.eth_queries {
+            let tool = crate::eth::EthQueryTool::new(query.clone());
+            if !registered_names.insert(tool.name()) {
+                anyhow::bail!(
+                    "eth query tool `{}` reached registration with a duplicate tool name",
+                    tool.name()
+                );
+            }
+            tools.push(Box::new(tool) as Box<dyn ToolDyn>);
+        }
         Ok(tools)
     }
 }
@@ -350,6 +362,7 @@ impl std::fmt::Debug for ToolSurface {
             .field("defra_query_scope", &self.defra_query_scope)
             .field("write_tools", &self.write_tools)
             .field("query_tools", &self.query_tools)
+            .field("eth_queries", &self.eth_queries)
             .field("enable_skills", &self.enable_skills)
             .field("self_config", &self.self_config)
             .finish()

--- a/crates/gents/src/tool_surface/policy.rs
+++ b/crates/gents/src/tool_surface/policy.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::defra_query::CollectionScope;
 use crate::document_config::{QueryToolDecl, SubagentTarget, WriteToolDecl, WriteToolField};
+use crate::eth::ResolvedEthQuery;
 use crate::toolset::{CommandExecutionMode, CommandNetworkMode};
 
 use super::modes::{BashMode, FileToolMode};
@@ -216,6 +217,8 @@ pub struct ToolPolicySurface {
     pub background_tools: EndpointScope<String, ()>,
     pub write_tools: EndpointScope<(String, String), BTreeSet<String>>,
     pub query_tools: EndpointScope<(String, String), BTreeSet<String>>,
+    pub eth_query_methods: EndpointScope<String, ()>,
+    pub eth_call_tools: EndpointScope<String, ()>,
 }
 
 impl ToolPolicySurface {
@@ -243,6 +246,8 @@ impl ToolPolicySurface {
             background_tools: EndpointScope::none(),
             write_tools: EndpointScope::none(),
             query_tools: EndpointScope::none(),
+            eth_query_methods: EndpointScope::none(),
+            eth_call_tools: EndpointScope::none(),
         }
     }
 
@@ -282,6 +287,8 @@ impl ToolPolicySurface {
             background_tools: EndpointScope::all(),
             write_tools: EndpointScope::all(),
             query_tools: EndpointScope::all(),
+            eth_query_methods: EndpointScope::all(),
+            eth_call_tools: EndpointScope::all(),
         }
     }
 
@@ -309,6 +316,8 @@ impl ToolPolicySurface {
             background_tools: EndpointScope::all(),
             write_tools: EndpointScope::all(),
             query_tools: EndpointScope::all(),
+            eth_query_methods: EndpointScope::all(),
+            eth_call_tools: EndpointScope::all(),
         }
     }
 
@@ -434,6 +443,8 @@ impl ToolPolicySurface {
             ),
             write_tools: write_scope_from_decls(&selection.write_tools),
             query_tools: query_scope_from_decls(&selection.query_tools),
+            eth_query_methods: eth_query_scope_from_resolved(&selection.eth_queries),
+            eth_call_tools: eth_call_scope_from_resolved(&selection.eth_queries),
         }
     }
 
@@ -481,6 +492,12 @@ impl ToolPolicySurface {
                 .meet_with(&other.query_tools, |left, right| {
                     left.intersection(right).cloned().collect()
                 }),
+            eth_query_methods: self
+                .eth_query_methods
+                .meet_with(&other.eth_query_methods, |(), ()| ()),
+            eth_call_tools: self
+                .eth_call_tools
+                .meet_with(&other.eth_call_tools, |(), ()| ()),
         }
     }
 
@@ -693,6 +710,23 @@ fn write_scope_from_decls(
         );
     }
     EndpointScope::Only(grants)
+}
+
+fn eth_query_scope_from_resolved(queries: &[ResolvedEthQuery]) -> EndpointScope<String, ()> {
+    let mut methods = BTreeSet::new();
+    for query in queries {
+        methods.extend(query.methods.iter().cloned());
+    }
+    if methods.is_empty() {
+        EndpointScope::none()
+    } else {
+        EndpointScope::<String, ()>::only_units(methods)
+    }
+}
+
+fn eth_call_scope_from_resolved(_queries: &[ResolvedEthQuery]) -> EndpointScope<String, ()> {
+    // Call tools are generated in a later PR. Empty is deny-all.
+    EndpointScope::none()
 }
 
 fn query_scope_from_decls(

--- a/crates/gents/src/tool_surface/selection.rs
+++ b/crates/gents/src/tool_surface/selection.rs
@@ -122,6 +122,7 @@ pub struct ToolSelection {
     pub self_config_dry_run: bool,
     pub enable_lsp: bool,
     pub lsp_config: Option<String>,
+    pub eth_queries: Vec<crate::eth::ResolvedEthQuery>,
 }
 
 impl Default for ToolSelection {
@@ -150,6 +151,7 @@ impl Default for ToolSelection {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         }
     }
 }
@@ -220,6 +222,7 @@ impl ToolSelection {
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(ToOwned::to_owned),
+            eth_queries: Vec::new(),
         })
     }
 }

--- a/crates/gents/src/tool_surface/tests.rs
+++ b/crates/gents/src/tool_surface/tests.rs
@@ -38,6 +38,7 @@ fn selection_file_tool_root_clamps_within_operator_root() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root.clone()),
         Vec::new(),
@@ -110,6 +111,7 @@ fn build_tools_does_not_bake_a_per_request_workspace_root() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root.clone()),
         Vec::new(),
@@ -165,6 +167,7 @@ fn command_timeout_ceiling_reaches_selected_bash_tool() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ceiling,
         Vec::new(),
@@ -210,6 +213,7 @@ fn command_timeout_max_ceiling_reaches_selected_bash_tool() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ceiling,
         Vec::new(),
@@ -254,6 +258,7 @@ fn selection_file_tool_root_rejects_escape_outside_operator_root() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root),
         Vec::new(),
@@ -297,6 +302,7 @@ fn readonly_selection_file_tool_root_rejects_escape_outside_operator_root() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readonly_at(operator_root),
         Vec::new(),
@@ -340,6 +346,7 @@ fn downgraded_off_selection_ignores_stale_file_tool_root() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::meta_only(),
         Vec::new(),
@@ -381,6 +388,7 @@ fn readonly_ceiling_clamps_unrestricted_bash_policy() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readonly(),
         Vec::new(),
@@ -420,6 +428,7 @@ fn selection_without_root_inherits_operator_root() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root.clone()),
         Vec::new(),
@@ -472,6 +481,7 @@ fn selection_cli_tools_require_ceiling_entries() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root),
         Vec::new(),
@@ -521,6 +531,7 @@ fn selection_cli_tools_expose_only_ceiling_entries() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ceiling,
         Vec::new(),
@@ -573,6 +584,7 @@ fn selection_mcp_service_allowlist_is_deduped() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::meta_only(),
         Vec::new(),
@@ -686,6 +698,7 @@ fn background_tool_allowlist_registers_r6_tools() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readonly(),
         Vec::new(),
@@ -726,6 +739,7 @@ fn background_tool_allowlist_rejects_non_backgroundable_tools() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readonly(),
         Vec::new(),
@@ -774,6 +788,7 @@ fn selection_file_tool_root_rejects_symlink_escape_for_missing_child() {
             self_config_dry_run: false,
             enable_lsp: false,
             lsp_config: None,
+            eth_queries: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root),
         Vec::new(),
@@ -2058,4 +2073,33 @@ async fn agent_config_alias_expands_to_config_scope() {
             "{denied} must stay outside the agent-config preset"
         );
     }
+}
+
+#[test]
+fn eth_query_tools_advertise_when_selection_has_resolved_queries() {
+    let query = crate::eth::ResolvedEthQuery {
+        tool_id: "base-read".to_string(),
+        chain_id: 8453,
+        rpc_url: "https://mainnet.base.org".to_string(),
+        methods: vec!["eth_chainId".to_string(), "eth_blockNumber".to_string()],
+    };
+    let config = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection {
+            eth_queries: vec![query],
+            ..Default::default()
+        },
+        &ToolCeiling::meta_only(),
+        Vec::new(),
+    )
+    .unwrap();
+    assert!(config
+        .static_policy()
+        .eth_query_methods
+        .permits(&"eth_chainId".to_string()));
+    assert!(!config
+        .static_policy()
+        .eth_query_methods
+        .permits(&"eth_sendRawTransaction".to_string()));
+    assert!(config.static_policy().eth_call_tools.is_deny_all());
 }

--- a/crates/gents/tests/conformance/tool_policy.rs
+++ b/crates/gents/tests/conformance/tool_policy.rs
@@ -132,5 +132,23 @@ pub(super) fn generated_tool_policy_cases_match_lean_composition() {
         if case.name == "bash_all_allowed_kind_idempotent" {
             assert_eq!(case.expected.bash_allowed_kind, "all");
         }
+        if case.name == "eth_query_methods_intersect" {
+            assert_eq!(case.behavior.eth_query_methods_kind, "only");
+            assert_eq!(case.ceiling.eth_query_methods_kind, "only");
+            assert!(case
+                .behavior
+                .eth_query_methods_keys
+                .contains(&"eth_chainId".to_string()));
+            assert!(case
+                .ceiling
+                .eth_query_methods_keys
+                .contains(&"eth_call".to_string()));
+            assert_eq!(
+                case.expected.eth_query_methods_keys,
+                vec!["eth_blockNumber".to_string()]
+            );
+            assert_eq!(case.expected.eth_query_methods_kind, "only");
+            assert_eq!(case.expected.eth_call_tools_kind, "none");
+        }
     }
 }

--- a/crates/gents/tests/conformance/tool_policy_mirror.rs
+++ b/crates/gents/tests/conformance/tool_policy_mirror.rs
@@ -215,6 +215,22 @@ fn surface_from_view(view: &View) -> ToolPolicySurface {
             },
             &view.query_grants,
         ),
+        eth_query_methods: unit_scope_from_strings(
+            if view.eth_query_methods_kind.is_empty() {
+                "none"
+            } else {
+                &view.eth_query_methods_kind
+            },
+            &view.eth_query_methods_keys,
+        ),
+        eth_call_tools: unit_scope_from_strings(
+            if view.eth_call_tools_kind.is_empty() {
+                "none"
+            } else {
+                &view.eth_call_tools_kind
+            },
+            &view.eth_call_tools_keys,
+        ),
     }
 }
 
@@ -287,6 +303,10 @@ fn view_from_surface(
             .lookup(&query_probe)
             .map(|fields| fields.iter().cloned().collect())
             .unwrap_or_default(),
+        eth_query_methods_kind: surface.eth_query_methods.kind().to_string(),
+        eth_query_methods_keys: surface.eth_query_methods.keys(),
+        eth_call_tools_kind: surface.eth_call_tools.kind().to_string(),
+        eth_call_tools_keys: surface.eth_call_tools.keys(),
     }
 }
 


### PR DESCRIPTION
## Summary

PR 4 of the EthTool stack (#1217). Agent-facing `{tool_id}_query` plus Lean/Rust ToolPolicy scopes. No contract-call tools yet.

- Expand `ToolSelection.eth_tool_ids` at snapshot time
- Fail closed on missing / wrong-agent ids; skip disabled and empty `query_methods`
- Native `ToolDyn` `{tool_id}_query`: `method` enum ∩ ceiling, `params` JSON array, no `data` field
- Policy denials use `FailureClass::PolicyDenied`
- Lean `Surface` gains `ethQueryMethods` / `ethCallTools`; meet is existing `EndpointScope.meet`
- Conformance case `eth_query_methods_intersect`
- Default off, never backfill

## Stack

Stacked GitHub PRs (each `--base` is the PR below):

1. #1299 schema (`eth-wallet` → `main`)
2. #1300 keys (`eth-wallet-keys` → `eth-wallet`)
3. #1301 RPC (`eth-wallet-rpc` → `eth-wallet-keys`)
4. **this PR** query tool (`eth-wallet-query-tool` → `eth-wallet-rpc`)
5. `any_read` + declared reads (next)
6. submission runtime
7. declared writes / `native_transfer`
8. `sign_typed_data`

Part of #1217.

## Test plan

- [x] `cargo test -p gents --lib eth::`
- [x] `cargo test -p gents --lib expand_eth_tools`
- [x] `cargo test -p gents --lib tool_surface::`
- [x] `cargo test -p gents --test conformance generated_tool_policy_cases_match_lean_composition`
- [x] `lake build Proofs.ToolPolicy.Cases Proofs.Conformance.Contracts`