### PR TITLE
feat(eth): generate declared write and native_transfer tools

### DIFF
--- a/crates/gents-cli/src/desired_state/validate/tooling.rs
+++ b/crates/gents-cli/src/desired_state/validate/tooling.rs
@@ -121,7 +121,9 @@ pub(super) fn validate_eth_tools(
                 tool.tool_id
             ));
         }
-        if let Err(error) = gents::validate_eth_call_declarations(&tool.calls) {
+        if let Err(error) =
+            gents::validate_eth_call_declarations(&tool.calls, tool.key_binding_id.as_deref())
+        {
             errors.push(format!(
                 "EthTool {} has invalid calls: {error}",
                 tool.tool_id

--- a/crates/gents/src/agent/daemon/inference.rs
+++ b/crates/gents/src/agent/daemon/inference.rs
@@ -719,6 +719,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
             request.requester_did.clone(),
             Some(request.agent_did.clone()),
             Some(behavior_id.to_string()),
+            Some(request.request_id.clone()),
             crate::tool_call_lifecycle::runtime::scope_request_tool_execution_with_workspace_overlay(
                 request_deadline,
                 request_token.clone(),

--- a/crates/gents/src/agent/document_view/mod.rs
+++ b/crates/gents/src/agent/document_view/mod.rs
@@ -423,8 +423,14 @@ pub(crate) fn expand_eth_tools(
         let rpc_url = doc.rpc_url.as_deref().unwrap_or("");
         let chain_id = doc.chain_id.unwrap_or(0).max(0) as u64;
         if !rpc_url.trim().is_empty() && chain_id > 0 {
-            let calls =
-                crate::eth::ResolvedEthCall::from_decls(&doc.tool_id, chain_id, rpc_url, &decls)?;
+            let calls = crate::eth::ResolvedEthCall::from_decls(
+                &doc.tool_id,
+                chain_id,
+                rpc_url,
+                &decls,
+                &doc.agent_did,
+                doc.key_binding_id.as_deref(),
+            )?;
             for call in calls {
                 if !tool_names.insert(call.tool_name.clone()) {
                     bail!(

--- a/crates/gents/src/document_config/chain_key_binding.rs
+++ b/crates/gents/src/document_config/chain_key_binding.rs
@@ -71,6 +71,29 @@ pub async fn load_chain_key_binding_by_doc_id(
     Ok(first_row_with_doc_id(resp.data.as_ref(), "ChainKeyBinding"))
 }
 
+pub(crate) async fn load_chain_key_binding(
+    node: &EmbeddedNode,
+    binding_id: &str,
+) -> Result<Option<ChainKeyBindingDocument>> {
+    let escaped = escape_graphql_string(binding_id);
+    let query = format!(
+        r#"{{
+            ChainKeyBinding(filter: {{ binding_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{{BINDING_FIELDS}}}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query ChainKeyBinding by binding_id failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(
+        first_row_with_doc_id(response.data.as_ref(), "ChainKeyBinding")
+            .map(|(_, binding)| binding),
+    )
+}
+
 pub fn list_chain_key_bindings_query(principal_did: &str) -> String {
     let escaped_did = escape_graphql_string(principal_did);
     format!(

--- a/crates/gents/src/document_config/eth_tool.rs
+++ b/crates/gents/src/document_config/eth_tool.rs
@@ -1,6 +1,4 @@
 //! Apply-owned `EthTool` documents.
-#![allow(dead_code)]
-
 use anyhow::Result;
 use defra_node::EmbeddedNode;
 use serde::{Deserialize, Serialize};
@@ -72,6 +70,18 @@ pub fn eth_tool_by_id_query(tool_id: &str) -> String {
             EthTool(filter: {{ tool_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{{TOOL_FIELDS}}}
         }}"#
     )
+}
+
+pub(crate) async fn load_eth_tool(
+    node: &EmbeddedNode,
+    tool_id: &str,
+) -> Result<Option<EthToolDocument>> {
+    let query = eth_tool_by_id_query(tool_id);
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!("query EthTool by tool_id failed: {:?}", response.errors);
+    }
+    Ok(first_row_with_doc_id(response.data.as_ref(), "EthTool").map(|(_, tool)| tool))
 }
 
 pub(crate) async fn load_eth_tool_by_doc_id(

--- a/crates/gents/src/document_config/mod.rs
+++ b/crates/gents/src/document_config/mod.rs
@@ -16,6 +16,7 @@ mod surface_tool;
 mod task;
 mod tool_selection;
 
+pub(crate) use chain_key_binding::load_chain_key_binding;
 pub use principal::{load_agent_principal, upsert_agent_principal, AgentPrincipal};
 pub(crate) use principal::{load_agent_principal_by_doc_id, load_agent_principal_record};
 
@@ -72,7 +73,7 @@ pub(crate) use datastore_tool_surface::{
 };
 pub use datastore_tool_surface::{list_datastore_tool_surfaces, DatastoreToolSurfaceDocument};
 pub use eth_tool::{eth_tool_by_id_query, EthToolDocument};
-pub(crate) use eth_tool::{list_eth_tool_records, load_eth_tool_by_doc_id};
+pub(crate) use eth_tool::{list_eth_tool_records, load_eth_tool, load_eth_tool_by_doc_id};
 #[allow(unused_imports)]
 pub(crate) use skill::{list_skill_records, load_skill_by_doc_id, SkillDocument};
 

--- a/crates/gents/src/eth/call_tool.rs
+++ b/crates/gents/src/eth/call_tool.rs
@@ -2,27 +2,51 @@
 //! when the runtime snapshot is built, then reused for schema and execution.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, I256, U256};
+use alloy_primitives::{keccak256, Address, I256, U256};
 use anyhow::{anyhow, bail, Context, Result};
+use k256::elliptic_curve::zeroize::Zeroizing;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::defra_node::EmbeddedNode;
+use crate::document_config::{load_chain_key_binding, load_eth_tool};
 use crate::llm::tool::{BoxFuture, ToolDefinition, ToolDyn, ToolError};
 use crate::tool_call_lifecycle::FailureClass;
 
-use super::calls::{compile_params, parse_abi_function, require_address, CallDecl, CompiledParam};
+use super::calls::{
+    compile_params, native_transfer_function, parse_abi_function, parse_u128, require_address,
+    CallDecl, CompiledParam,
+};
+use super::keys::{
+    address_from_secret, attestation_payload, binding_storage_key, decode_attestation,
+    ChainKeyMaterialStore, KeyringChainKeyStore, KEY_BACKEND_KEYRING,
+};
 use super::rpc::HttpEthRpc;
+use super::submit::{
+    global_nonce_gate, submit_transaction, GasCaps, SubmitOptions, SubmitRequest, SubmitStatus,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedEthCall {
+    pub(crate) eth_tool_id: String,
     pub(crate) tool_name: String,
     pub(crate) chain_id: u64,
     pub(crate) rpc_url: String,
     pub(crate) description: String,
     pub(crate) kind: ResolvedCallKind,
+    pub(crate) principal_did: String,
+    pub(crate) binding_id: Option<String>,
+    pub(crate) caps: GasCaps,
+}
+
+impl ResolvedEthCall {
+    pub(crate) fn is_signing(&self) -> bool {
+        matches!(self.kind, ResolvedCallKind::Write { .. })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,6 +57,11 @@ pub(crate) enum ResolvedCallKind {
         function: Function,
         params: Vec<CompiledParam>,
     },
+    Write {
+        to: Option<String>,
+        function: Option<Function>,
+        params: Vec<CompiledParam>,
+    },
 }
 
 impl ResolvedEthCall {
@@ -41,17 +70,27 @@ impl ResolvedEthCall {
         chain_id: u64,
         rpc_url: &str,
         decls: &[CallDecl],
+        principal_did: &str,
+        binding_id: Option<&str>,
     ) -> Result<Vec<Self>> {
         let mut out = Vec::new();
+        let binding_id = binding_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
         for decl in decls {
             match decl {
                 CallDecl::AnyRead => out.push(Self {
+                    eth_tool_id: tool_id.to_string(),
                     tool_name: format!("{tool_id}_any_read"),
                     chain_id,
                     rpc_url: rpc_url.to_string(),
                     description: "ABI-encoded primitive eth_call. Supply a signature and arguments; raw calldata is never accepted."
                         .to_string(),
                     kind: ResolvedCallKind::AnyRead,
+                    principal_did: principal_did.to_string(),
+                    binding_id: None,
+                    caps: GasCaps::default(),
                 }),
                 CallDecl::Read {
                     tool_name,
@@ -63,6 +102,7 @@ impl ResolvedEthCall {
                     let function = parse_abi_function(signature)?;
                     let params = compile_params(&function, params, false)?;
                     out.push(Self {
+                        eth_tool_id: tool_id.to_string(),
                         tool_name: tool_name.clone(),
                         chain_id,
                         rpc_url: rpc_url.to_string(),
@@ -74,6 +114,70 @@ impl ResolvedEthCall {
                             function,
                             params,
                         },
+                        principal_did: principal_did.to_string(),
+                        binding_id: None,
+                        caps: GasCaps::default(),
+                    });
+                }
+                CallDecl::Write {
+                    tool_name,
+                    to,
+                    signature,
+                    params,
+                    description,
+                    max_gas,
+                    max_fee_per_gas,
+                } => {
+                    let Some(binding_id) = binding_id.clone() else {
+                        bail!("write tool {tool_name} requires a chain key binding");
+                    };
+                    let function = parse_abi_function(signature)?;
+                    let params = compile_params(&function, params, true)?;
+                    out.push(Self {
+                        eth_tool_id: tool_id.to_string(),
+                        tool_name: tool_name.clone(),
+                        chain_id,
+                        rpc_url: rpc_url.to_string(),
+                        description: description
+                            .clone()
+                            .unwrap_or_else(|| format!("send {signature} to {to}")),
+                        kind: ResolvedCallKind::Write {
+                            to: Some(to.clone()),
+                            function: Some(function),
+                            params,
+                        },
+                        principal_did: principal_did.to_string(),
+                        binding_id: Some(binding_id),
+                        caps: gas_caps(*max_gas, max_fee_per_gas.as_deref())?,
+                    });
+                }
+                CallDecl::NativeTransfer {
+                    tool_name,
+                    params,
+                    description,
+                    max_gas,
+                    max_fee_per_gas,
+                } => {
+                    let Some(binding_id) = binding_id.clone() else {
+                        bail!("native_transfer {tool_name} requires a chain key binding");
+                    };
+                    let params = compile_params(&native_transfer_function()?, params, true)?;
+                    out.push(Self {
+                        eth_tool_id: tool_id.to_string(),
+                        tool_name: tool_name.clone(),
+                        chain_id,
+                        rpc_url: rpc_url.to_string(),
+                        description: description
+                            .clone()
+                            .unwrap_or_else(|| "send native value".to_string()),
+                        kind: ResolvedCallKind::Write {
+                            to: None,
+                            function: None,
+                            params,
+                        },
+                        principal_did: principal_did.to_string(),
+                        binding_id: Some(binding_id),
+                        caps: gas_caps(*max_gas, max_fee_per_gas.as_deref())?,
                     });
                 }
             }
@@ -95,11 +199,12 @@ struct AnyReadArgs {
 
 pub(crate) struct EthCallTool {
     resolved: ResolvedEthCall,
+    node: Arc<EmbeddedNode>,
 }
 
 impl EthCallTool {
-    pub(crate) fn new(resolved: ResolvedEthCall) -> Self {
-        Self { resolved }
+    pub(crate) fn new(resolved: ResolvedEthCall, node: Arc<EmbeddedNode>) -> Self {
+        Self { resolved, node }
     }
 }
 
@@ -111,31 +216,37 @@ impl ToolDyn for EthCallTool {
     fn definition(&self, _prompt: String) -> BoxFuture<'_, ToolDefinition> {
         let resolved = self.resolved.clone();
         Box::pin(async move {
-            let parameters = match &resolved.kind {
-                ResolvedCallKind::AnyRead => json!({
-                    "type": "object",
-                    "properties": {
-                        "to": { "type": "string", "description": "20-byte contract address" },
-                        "signature": { "type": "string", "description": "Primitive ABI signature, e.g. balanceOf(address)" },
-                        "args": { "type": "array", "description": "ABI arguments matching the signature" },
-                        "block": { "type": "string", "description": "Block tag. Default latest." }
-                    },
-                    "required": ["to", "signature"],
-                    "additionalProperties": false
-                }),
-                ResolvedCallKind::Declared { params, .. } => declared_schema(params),
-            };
             ToolDefinition {
                 name: resolved.tool_name,
                 description: resolved.description,
-                parameters,
+                parameters: call_parameters(&resolved.kind),
             }
         })
     }
 
     fn call(&self, args: String) -> BoxFuture<'_, Result<String, ToolError>> {
         let resolved = self.resolved.clone();
-        Box::pin(async move { execute_call(&resolved, &args).await })
+        let node = self.node.clone();
+        Box::pin(async move { execute_call(&node, &resolved, &args).await })
+    }
+}
+
+fn call_parameters(kind: &ResolvedCallKind) -> Value {
+    match kind {
+        ResolvedCallKind::AnyRead => json!({
+            "type": "object",
+            "properties": {
+                "to": { "type": "string", "description": "20-byte contract address" },
+                "signature": { "type": "string", "description": "Primitive ABI signature, e.g. balanceOf(address)" },
+                "args": { "type": "array", "description": "ABI arguments matching the signature" },
+                "block": { "type": "string", "description": "Block tag. Default latest." }
+            },
+            "required": ["to", "signature"],
+            "additionalProperties": false
+        }),
+        ResolvedCallKind::Declared { params, .. } | ResolvedCallKind::Write { params, .. } => {
+            declared_schema(params)
+        }
     }
 }
 
@@ -167,7 +278,11 @@ fn declared_schema(params: &[CompiledParam]) -> Value {
     })
 }
 
-async fn execute_call(resolved: &ResolvedEthCall, args: &str) -> Result<String, ToolError> {
+async fn execute_call(
+    node: &EmbeddedNode,
+    resolved: &ResolvedEthCall,
+    args: &str,
+) -> Result<String, ToolError> {
     let client = HttpEthRpc::http(&resolved.rpc_url, resolved.chain_id, &[])
         .map_err(|error| reported(FailureClass::Transport, error.to_string()))?;
     match &resolved.kind {
@@ -201,7 +316,7 @@ async fn execute_call(resolved: &ResolvedEthCall, args: &str) -> Result<String, 
             params,
         } => {
             let parsed: BTreeMap<String, Value> = crate::llm::tool::parse_tool_args(args)?;
-            let arg_values = bind_params(params, &parsed)
+            let arg_values = bind_params(params, &parsed, None)
                 .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?;
             let data = encode_function(function, &arg_values)
                 .map_err(|error| reported(FailureClass::ArgumentInvalid, error.to_string()))?;
@@ -211,14 +326,242 @@ async fn execute_call(resolved: &ResolvedEthCall, args: &str) -> Result<String, 
                 .map_err(|error| reported(FailureClass::Transport, error.to_string()))?;
             decode_or_hex(function, &result)
         }
+        ResolvedCallKind::Write {
+            to,
+            function,
+            params,
+        } => {
+            execute_write(
+                node,
+                resolved,
+                &client,
+                to.as_deref(),
+                function.as_ref(),
+                params,
+                args,
+            )
+            .await
+        }
     }
+}
+
+async fn execute_write(
+    node: &EmbeddedNode,
+    resolved: &ResolvedEthCall,
+    client: &HttpEthRpc,
+    to: Option<&str>,
+    function: Option<&Function>,
+    params: &[CompiledParam],
+    args: &str,
+) -> Result<String, ToolError> {
+    let runtime =
+        crate::tool_call_lifecycle::runtime::current_tool_runtime_context().ok_or_else(|| {
+            reported(
+                FailureClass::PolicyDenied,
+                "eth write has no runtime identity".to_string(),
+            )
+        })?;
+    if runtime.agent_did.as_deref() != Some(resolved.principal_did.as_str()) {
+        return Err(reported(
+            FailureClass::PolicyDenied,
+            "eth write runtime principal does not own its key binding".to_string(),
+        ));
+    }
+    let parsed: BTreeMap<String, Value> = crate::llm::tool::parse_tool_args(args)?;
+    let secret = Zeroizing::new(
+        load_signing_key(node, resolved)
+            .await
+            .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?,
+    );
+    let from = address_from_secret(&secret)
+        .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?;
+    let bound = bind_params(params, &parsed, Some(&from))
+        .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?;
+    let (to, data, value) = if let Some(function) = function {
+        let encoded = encode_function(function, &bound)
+            .map_err(|error| reported(FailureClass::ArgumentInvalid, error.to_string()))?;
+        let data = decode_hex(&encoded)
+            .map_err(|error| reported(FailureClass::ArgumentInvalid, error.to_string()))?;
+        (to.map(ToOwned::to_owned), data, U256::ZERO)
+    } else {
+        let destination = bound.first().and_then(Value::as_str).ok_or_else(|| {
+            reported(
+                FailureClass::ArgumentInvalid,
+                "native_transfer to must be an address".to_string(),
+            )
+        })?;
+        let value = bound
+            .get(1)
+            .ok_or_else(|| {
+                reported(
+                    FailureClass::ArgumentInvalid,
+                    "native_transfer value is missing".to_string(),
+                )
+            })
+            .and_then(|value| {
+                parse_uint(value)
+                    .map_err(|error| reported(FailureClass::ArgumentInvalid, error.to_string()))
+            })?;
+        (Some(destination.to_string()), Vec::new(), value)
+    };
+    let request_id = runtime
+        .request_id
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            reported(
+                FailureClass::PolicyDenied,
+                "eth write requires a durable request id".to_string(),
+            )
+        })?;
+    let idempotency_key = write_idempotency_key(
+        &request_id,
+        &resolved.tool_name,
+        to.as_deref(),
+        value,
+        &data,
+    )
+    .map_err(ToolError::JsonError)?;
+    let receipt = submit_transaction(
+        node,
+        client,
+        &secret,
+        SubmitRequest {
+            principal_did: resolved.principal_did.clone(),
+            chain_id: resolved.chain_id,
+            from,
+            to,
+            value,
+            data,
+            caps: resolved.caps,
+            idempotency_key,
+        },
+        global_nonce_gate(),
+        SubmitOptions {
+            receipt_attempts: 8,
+            receipt_interval: std::time::Duration::from_millis(500),
+        },
+    )
+    .await;
+    let receipt = receipt.map_err(|error| reported(FailureClass::External, error.to_string()))?;
+    if receipt.status == SubmitStatus::ConfirmedReverted {
+        return Err(reported(
+            FailureClass::External,
+            format!("Ethereum transaction {} reverted", receipt.tx_hash),
+        ));
+    }
+    serde_json::to_string(&json!({
+        "tx_hash": receipt.tx_hash,
+        "status": match receipt.status {
+            SubmitStatus::ConfirmedSuccess => "confirmed_success",
+            SubmitStatus::SubmittedUnknown => "submitted_unknown",
+            SubmitStatus::ConfirmedReverted => unreachable!(),
+        },
+        "receipt": receipt.receipt,
+    }))
+    .map_err(ToolError::JsonError)
+}
+
+fn write_idempotency_key(
+    request_id: &str,
+    tool_name: &str,
+    to: Option<&str>,
+    value: U256,
+    data: &[u8],
+) -> serde_json::Result<String> {
+    // Recovery may mint a fresh in-memory tool-call id. Bind durability to the
+    // request and exact Ethereum action instead; intentionally repeated,
+    // byte-identical transfers belong in separate agent requests.
+    let semantic_action = serde_json::to_vec(&json!({
+        "request_id": request_id,
+        "tool_name": tool_name,
+        "to": to.map(str::to_ascii_lowercase),
+        "value": value.to_string(),
+        "data": format!("0x{}", hex_encode(data)),
+    }))?;
+    Ok(format!("{}:{:#x}", request_id, keccak256(semantic_action)))
+}
+
+async fn load_signing_key(node: &EmbeddedNode, resolved: &ResolvedEthCall) -> Result<[u8; 32]> {
+    let binding_id = resolved
+        .binding_id
+        .as_deref()
+        .ok_or_else(|| anyhow!("write tool has no chain key binding"))?;
+    let tool = load_eth_tool(node, &resolved.eth_tool_id)
+        .await?
+        .ok_or_else(|| anyhow!("EthTool {:?} no longer exists", resolved.eth_tool_id))?;
+    if !tool.enabled {
+        bail!("EthTool {:?} is disabled", resolved.eth_tool_id);
+    }
+    if tool.agent_did != resolved.principal_did {
+        bail!(
+            "EthTool {:?} belongs to another principal",
+            resolved.eth_tool_id
+        );
+    }
+    if tool.chain_id != i64::try_from(resolved.chain_id).ok() {
+        bail!("EthTool {:?} changed chain_id", resolved.eth_tool_id);
+    }
+    if tool.key_binding_id.as_deref() != Some(binding_id) {
+        bail!(
+            "EthTool {:?} no longer selects chain key binding {binding_id:?}",
+            resolved.eth_tool_id
+        );
+    }
+    let binding = load_chain_key_binding(node, binding_id)
+        .await?
+        .ok_or_else(|| anyhow!("chain key binding {binding_id:?} does not exist"))?;
+    if binding.principal_did != resolved.principal_did {
+        bail!("chain key binding {binding_id:?} belongs to another principal");
+    }
+    if binding
+        .revoked_at
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        bail!("chain key binding {binding_id:?} is revoked");
+    }
+    if binding.key_backend.as_deref() != Some(KEY_BACKEND_KEYRING) {
+        bail!("chain key binding {binding_id:?} has an unsupported backend");
+    }
+    let created_at = binding
+        .created_at
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("chain key binding {binding_id:?} has no creation time"))?;
+    let attestation = decode_attestation(
+        binding
+            .attestation
+            .as_deref()
+            .ok_or_else(|| anyhow!("chain key binding {binding_id:?} has no attestation"))?,
+    )?;
+    let payload = attestation_payload(
+        binding_id,
+        &binding.principal_did,
+        &binding.address,
+        KEY_BACKEND_KEYRING,
+        created_at,
+    );
+    if !crate::identity::verify_did_signature(&binding.principal_did, &payload, &attestation)? {
+        bail!("chain key binding {binding_id:?} has an invalid attestation");
+    }
+    let secret =
+        KeyringChainKeyStore.load(&binding_storage_key(&binding.principal_did, binding_id))?;
+    let address = address_from_secret(&secret)?;
+    if !address.eq_ignore_ascii_case(&binding.address) {
+        bail!("chain key material does not match binding {binding_id:?}");
+    }
+    Ok(secret)
 }
 
 fn reported(class: FailureClass, text: String) -> ToolError {
     ToolError::ReportedFailure { class, text }
 }
 
-fn bind_params(params: &[CompiledParam], model: &BTreeMap<String, Value>) -> Result<Vec<Value>> {
+fn bind_params(
+    params: &[CompiledParam],
+    model: &BTreeMap<String, Value>,
+    self_address: Option<&str>,
+) -> Result<Vec<Value>> {
     let model_names: BTreeSet<&str> = params
         .iter()
         .filter(|param| param.decl.source.trim() == "model")
@@ -239,6 +582,9 @@ fn bind_params(params: &[CompiledParam], model: &BTreeMap<String, Value>) -> Res
                 .cloned()
                 .ok_or_else(|| anyhow!("missing model param {}", param.name))?,
             "fixed" => param.decl.value.clone().unwrap_or(Value::Null),
+            "runtime" => {
+                json!(self_address.ok_or_else(|| anyhow!("runtime self_address is unavailable"))?)
+            }
             other => bail!("unsupported param source {other}"),
         };
         enforce_constraints(param, &value)?;
@@ -310,6 +656,22 @@ fn constraint_text(value: &Value) -> Result<String> {
         Value::Bool(value) => Ok(value.to_string()),
         other => bail!("enum constraint does not support value {other}"),
     }
+}
+
+fn gas_caps(max_gas: Option<u64>, max_fee_per_gas: Option<&str>) -> Result<GasCaps> {
+    let max_fee_per_gas = match max_fee_per_gas
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(text) => {
+            Some(parse_u128(text).map_err(|error| anyhow!("max_fee_per_gas {text}: {error}"))?)
+        }
+        None => None,
+    };
+    Ok(GasCaps {
+        max_gas,
+        max_fee_per_gas,
+    })
 }
 
 fn encode_function(function: &Function, args: &[Value]) -> Result<String> {
@@ -489,19 +851,61 @@ mod tests {
 
     #[test]
     fn any_read_schema_has_no_data_field() {
-        let tool = EthCallTool::new(ResolvedEthCall {
+        let resolved = ResolvedEthCall {
+            eth_tool_id: "base".to_string(),
             tool_name: "base_any_read".to_string(),
             chain_id: 8453,
             rpc_url: "http://127.0.0.1".to_string(),
             description: "any".to_string(),
             kind: ResolvedCallKind::AnyRead,
-        });
-        let definition = futures::executor::block_on(tool.definition(String::new()));
-        assert!(definition.parameters["properties"].get("data").is_none());
-        assert!(definition.parameters["properties"]
-            .get("calldata")
-            .is_none());
-        assert_eq!(definition.parameters["additionalProperties"], false);
+            principal_did: "did:key:zAlice".to_string(),
+            binding_id: None,
+            caps: GasCaps::default(),
+        };
+        let parameters = call_parameters(&resolved.kind);
+        assert!(parameters["properties"].get("data").is_none());
+        assert!(parameters["properties"].get("calldata").is_none());
+        assert_eq!(parameters["additionalProperties"], false);
+    }
+
+    #[test]
+    fn write_idempotency_is_stable_per_request_and_semantic_action() {
+        let key = |request_id| {
+            write_idempotency_key(
+                request_id,
+                "base_transfer",
+                Some("0x1111111111111111111111111111111111111111"),
+                U256::from(7),
+                &[],
+            )
+            .unwrap()
+        };
+        assert_eq!(key("request-1"), key("request-1"));
+        assert_ne!(key("request-1"), key("request-2"));
+    }
+
+    #[test]
+    fn write_tools_are_generated_when_keys_present() {
+        let decls = crate::eth::parse_call_decls(Some(&[
+            r#"{"kind":"write","tool_name":"usdc_transfer","to":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","signature":"transfer(address to,uint256 amount)","params":{"to":{"source":"model","address_allowlist":["0x1111111111111111111111111111111111111111"]},"amount":{"source":"model","max":"1000000"}},"max_gas":100000,"max_fee_per_gas":"2000000000"}"#.to_string(),
+        ]))
+        .unwrap();
+        crate::eth::validate_call_decls(&decls).unwrap();
+        let resolved = ResolvedEthCall::from_decls(
+            "base",
+            8453,
+            "http://127.0.0.1",
+            &decls,
+            "did:key:zAlice",
+            Some("bind-1"),
+        )
+        .unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].is_signing());
+        assert_eq!(resolved[0].tool_name, "usdc_transfer");
+        let parameters = call_parameters(&resolved[0].kind);
+        assert!(parameters["properties"].get("data").is_none());
+        assert!(parameters["properties"].get("amount").is_some());
     }
 
     #[test]
@@ -554,16 +958,16 @@ mod tests {
                 json!("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"),
             ),
         ]);
-        let bound = bind_params(&params, &model).expect("bind");
+        let bound = bind_params(&params, &model, None).expect("bind");
         assert_eq!(bound[0], model["recipient"]);
         assert_eq!(bound[1], json!(5));
 
         let mut above_max = model.clone();
         above_max.insert("qty".to_string(), json!(11));
-        assert!(bind_params(&params, &above_max).is_err());
+        assert!(bind_params(&params, &above_max, None).is_err());
 
         let mut outside_enum = model;
         outside_enum.insert("qty".to_string(), json!(7));
-        assert!(bind_params(&params, &outside_enum).is_err());
+        assert!(bind_params(&params, &outside_enum, None).is_err());
     }
 }

--- a/crates/gents/src/eth/calls.rs
+++ b/crates/gents/src/eth/calls.rs
@@ -23,9 +23,39 @@ pub enum CallDecl {
         #[serde(default)]
         description: Option<String>,
     },
+    Write {
+        tool_name: String,
+        to: String,
+        signature: String,
+        #[serde(default)]
+        params: BTreeMap<String, ParamDecl>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        max_gas: Option<u64>,
+        #[serde(default)]
+        max_fee_per_gas: Option<String>,
+    },
+    NativeTransfer {
+        tool_name: String,
+        #[serde(default)]
+        params: BTreeMap<String, ParamDecl>,
+        #[serde(default)]
+        description: Option<String>,
+        #[serde(default)]
+        max_gas: Option<u64>,
+        #[serde(default)]
+        max_fee_per_gas: Option<String>,
+    },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+impl CallDecl {
+    pub(crate) fn requires_key_binding(&self) -> bool {
+        matches!(self, Self::Write { .. } | Self::NativeTransfer { .. })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ParamDecl {
     #[serde(default = "default_model_source")]
@@ -40,6 +70,22 @@ pub struct ParamDecl {
     pub max: Option<String>,
     #[serde(rename = "enum", default)]
     pub enum_values: Option<Vec<String>>,
+    #[serde(default)]
+    pub runtime: Option<String>,
+}
+
+impl Default for ParamDecl {
+    fn default() -> Self {
+        Self {
+            source: default_model_source(),
+            value: None,
+            address_allowlist: None,
+            min: None,
+            max: None,
+            enum_values: None,
+            runtime: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,9 +135,61 @@ pub fn validate_call_decls(decls: &[CallDecl]) -> Result<()> {
                 let function = parse_abi_function(signature)?;
                 compile_params(&function, params, false)?;
             }
+            CallDecl::Write {
+                tool_name,
+                to,
+                signature,
+                params,
+                max_gas,
+                max_fee_per_gas,
+                ..
+            } => {
+                require_tool_name(tool_name, &mut names)?;
+                require_address(to, "write.to")?;
+                validate_gas_caps(tool_name, *max_gas, max_fee_per_gas.as_deref())?;
+                let function = parse_abi_function(signature)?;
+                compile_params(&function, params, true)?;
+            }
+            CallDecl::NativeTransfer {
+                tool_name,
+                params,
+                max_gas,
+                max_fee_per_gas,
+                ..
+            } => {
+                require_tool_name(tool_name, &mut names)?;
+                validate_gas_caps(tool_name, *max_gas, max_fee_per_gas.as_deref())?;
+                let function = native_transfer_function()?;
+                compile_params(&function, params, true)?;
+            }
         }
     }
     Ok(())
+}
+
+fn validate_gas_caps(
+    tool_name: &str,
+    max_gas: Option<u64>,
+    max_fee_per_gas: Option<&str>,
+) -> Result<()> {
+    if max_gas.is_none_or(|value| value == 0) {
+        bail!("write tool {tool_name} requires a positive max_gas");
+    }
+    let fee = max_fee_per_gas
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("write tool {tool_name} requires max_fee_per_gas"))?;
+    if parse_u128(fee).with_context(|| format!("write tool {tool_name} max_fee_per_gas"))? == 0 {
+        bail!("write tool {tool_name} max_fee_per_gas must be positive");
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_u128(value: &str) -> Result<u128> {
+    value
+        .parse::<u128>()
+        .or_else(|_| u128::from_str_radix(value.trim_start_matches("0x"), 16))
+        .map_err(Into::into)
 }
 
 pub(crate) fn compile_params(
@@ -144,11 +242,14 @@ fn validate_param(
     require_write_limits: bool,
 ) -> Result<()> {
     let source = param.source.trim();
-    if !matches!(source, "model" | "fixed") {
+    if !matches!(source, "model" | "fixed" | "runtime") {
         bail!("call param {name} has unsupported source {source:?}");
     }
     if source == "fixed" && param.value.is_none() {
         bail!("call param {name} source=fixed requires value");
+    }
+    if source == "runtime" && param.runtime.as_deref() != Some("self_address") {
+        bail!("call param {name} runtime source must be self_address");
     }
     if !supported_primitive_type(solidity_type) {
         bail!("call param {name} uses unsupported Solidity type {solidity_type}");
@@ -156,6 +257,10 @@ fn validate_param(
 
     let is_address = solidity_type == "address";
     let is_integer = integer_kind(solidity_type).is_some();
+    let is_unbounded_data = solidity_type == "string" || solidity_type.starts_with("bytes");
+    if source == "runtime" && !is_address {
+        bail!("call param {name} runtime self_address requires address type");
+    }
     if let Some(allowlist) = &param.address_allowlist {
         if !is_address {
             bail!("call param {name} has address_allowlist but type is {solidity_type}");
@@ -191,6 +296,14 @@ fn validate_param(
         }
         if is_integer && param.max.is_none() {
             bail!("write param {name} integer has no max (deny-by-default)");
+        }
+        if is_unbounded_data
+            && param
+                .enum_values
+                .as_ref()
+                .is_none_or(|values| values.is_empty())
+        {
+            bail!("write param {name} {solidity_type} has no enum (deny-by-default)");
         }
     }
     Ok(())
@@ -301,6 +414,10 @@ pub(crate) fn parse_abi_function(signature: &str) -> Result<Function> {
         .map_err(|error| anyhow!("invalid ABI signature {signature:?}: {error}"))
 }
 
+pub(crate) fn native_transfer_function() -> Result<Function> {
+    parse_abi_function("nativeTransfer(address to,uint256 value)")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,11 +478,18 @@ mod tests {
     }
 
     #[test]
-    fn unknown_future_call_kinds_are_rejected() {
-        let error = parse_call_decls(Some(
-            &[r#"{"kind":"write","tool_name":"send"}"#.to_string()],
-        ))
-        .unwrap_err();
-        assert!(error.to_string().contains("EthTool.calls"));
+    fn native_transfer_has_explicit_parameter_contract() {
+        let native = r#"{"kind":"native_transfer","tool_name":"send_eth","params":{"to":{"source":"model","address_allowlist":["0x1111111111111111111111111111111111111111"]},"value":{"source":"model","max":"1000"}},"max_gas":21000,"max_fee_per_gas":"2000000000"}"#;
+        let decls = parse_call_decls(Some(&[native.to_string()])).unwrap();
+        validate_call_decls(&decls).unwrap();
+    }
+    #[test]
+    fn writes_require_operator_gas_and_fee_caps() {
+        let write = r#"{"kind":"write","tool_name":"mint","to":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","signature":"mint(uint256 amount)","params":{"amount":{"source":"model","max":"1000"}}}"#;
+        let decls = parse_call_decls(Some(&[write.to_string()])).unwrap();
+        assert!(validate_call_decls(&decls)
+            .unwrap_err()
+            .to_string()
+            .contains("max_gas"));
     }
 }

--- a/crates/gents/src/eth/keys.rs
+++ b/crates/gents/src/eth/keys.rs
@@ -168,6 +168,20 @@ pub fn encode_attestation(signature: &[u8]) -> String {
     format!("0x{}", lowercase_hex(signature))
 }
 
+pub(crate) fn decode_attestation(value: &str) -> Result<Vec<u8>> {
+    let hex = value.strip_prefix("0x").unwrap_or(value).trim();
+    if hex.len() % 2 != 0 {
+        bail!("chain key attestation has odd-length hex");
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| {
+            u8::from_str_radix(&hex[index..index + 2], 16)
+                .context("chain key attestation is invalid hex")
+        })
+        .collect()
+}
+
 /// Recoverable secp256k1 signature over a 32-byte digest (Ethereum prehash).
 pub fn sign_prehash_recoverable(
     secret: &[u8; 32],
@@ -273,6 +287,17 @@ mod tests {
             "2026-08-28T00:00:00Z",
         );
         assert_ne!(text.as_bytes(), other);
+    }
+
+    #[test]
+    fn attestation_encoding_round_trips_and_rejects_bad_hex() {
+        let signature = [0x12, 0xab, 0xcd];
+        assert_eq!(
+            decode_attestation(&encode_attestation(&signature)).unwrap(),
+            signature
+        );
+        assert!(decode_attestation("0xabc").is_err());
+        assert!(decode_attestation("0xzz").is_err());
     }
 
     #[test]

--- a/crates/gents/src/eth/mod.rs
+++ b/crates/gents/src/eth/mod.rs
@@ -6,7 +6,6 @@ pub mod keys;
 pub mod methods;
 pub(crate) mod query;
 pub(crate) mod rpc;
-#[allow(dead_code)] // Wired into generated write tools in the next stack commit.
 pub(crate) mod submit;
 
 pub(crate) use call_tool::{EthCallTool, ResolvedEthCall};
@@ -21,7 +20,16 @@ pub use methods::{
 };
 pub(crate) use query::{EthQueryTool, ResolvedEthQuery};
 pub use rpc::{HttpEthRpc, ETH_USER_AGENT};
-pub fn validate_eth_call_declarations(calls: &[String]) -> anyhow::Result<()> {
+pub fn validate_eth_call_declarations(
+    calls: &[String],
+    key_binding_id: Option<&str>,
+) -> anyhow::Result<()> {
     let declarations = parse_call_decls(Some(calls))?;
-    validate_call_decls(&declarations)
+    validate_call_decls(&declarations)?;
+    if declarations.iter().any(|decl| decl.requires_key_binding())
+        && key_binding_id.is_none_or(|binding_id| binding_id.trim().is_empty())
+    {
+        anyhow::bail!("signing call declarations require key_binding_id");
+    }
+    Ok(())
 }

--- a/crates/gents/src/eth/submit.rs
+++ b/crates/gents/src/eth/submit.rs
@@ -5,7 +5,7 @@
 //! nonce and repeating the action.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use alloy_primitives::{keccak256, Address, U256};
@@ -100,6 +100,11 @@ impl NonceGate {
 pub(crate) struct SubmitOptions {
     pub(crate) receipt_attempts: u32,
     pub(crate) receipt_interval: Duration,
+}
+
+pub(crate) fn global_nonce_gate() -> &'static NonceGate {
+    static GATE: OnceLock<NonceGate> = OnceLock::new();
+    GATE.get_or_init(NonceGate::default)
 }
 
 impl Default for SubmitOptions {

--- a/crates/gents/src/hook/persistence/background_tools.rs
+++ b/crates/gents/src/hook/persistence/background_tools.rs
@@ -187,6 +187,7 @@ impl DefraSessionHook {
                     requester_did,
                     request_agent_did,
                     request_behavior_id,
+                    Some(execution_request_id.clone()),
                     async {
                         crate::tool_call_lifecycle::runtime::scope_request_tool_execution_with_workspace_overlay(
                             Some(background_deadline_at),
@@ -197,13 +198,10 @@ impl DefraSessionHook {
                             correlation,
                             source_fields,
                             true,
-                            async {
-                                crate::tool_call_lifecycle::runtime::call_tool_managed(
-                                    target_tool.as_ref(),
-                                    target_args,
-                                )
-                                .await
-                            },
+                            crate::tool_call_lifecycle::runtime::call_tool_managed(
+                                target_tool.as_ref(),
+                                target_args,
+                            ),
                         )
                         .await
                     },

--- a/crates/gents/src/identity.rs
+++ b/crates/gents/src/identity.rs
@@ -601,6 +601,12 @@ fn verify_with_public_key(
         .with_context(|| format!("verifying payload for {did}"))
 }
 
+/// Verify a signature against the public key identified by a DID without
+/// requiring access to that principal's private signer.
+pub(crate) fn verify_did_signature(did: &str, payload: &[u8], signature: &[u8]) -> Result<bool> {
+    verify_with_public_key(did, known_public_key_for_did(did)?, payload, signature)
+}
+
 fn validate_registered_identity_config(did: &str, config: &SigningConfig) -> Result<()> {
     if !config.has_local_private_key() && !config.has_remote_signer() {
         anyhow::bail!("registered identity {did} has neither a local key nor a remote signer");

--- a/crates/gents/src/tool_call_lifecycle/runtime.rs
+++ b/crates/gents/src/tool_call_lifecycle/runtime.rs
@@ -197,6 +197,7 @@ struct ToolRuntimeScope {
     requester_did: Option<String>,
     agent_did: Option<String>,
     behavior_id: Option<String>,
+    request_id: Option<String>,
 }
 
 #[derive(Clone)]
@@ -214,6 +215,7 @@ pub(crate) struct CurrentToolRuntimeContext {
     pub(crate) requester_did: Option<String>,
     pub(crate) agent_did: Option<String>,
     pub(crate) behavior_id: Option<String>,
+    pub(crate) request_id: Option<String>,
 }
 
 #[derive(Clone, Default)]
@@ -221,6 +223,7 @@ struct ToolRequestIdentityScope {
     requester_did: Option<String>,
     agent_did: Option<String>,
     behavior_id: Option<String>,
+    request_id: Option<String>,
 }
 
 tokio::task_local! {
@@ -246,6 +249,7 @@ fn current_request_identity() -> ToolRequestIdentityScope {
                     requester_did: scope.requester_did.clone(),
                     agent_did: scope.agent_did.clone(),
                     behavior_id: scope.behavior_id.clone(),
+                    request_id: scope.request_id.clone(),
                 })
                 .ok()
         })
@@ -256,6 +260,7 @@ pub(crate) async fn scope_tool_request_identity<F, T>(
     requester_did: Option<String>,
     agent_did: Option<String>,
     behavior_id: Option<String>,
+    request_id: Option<String>,
     future: F,
 ) -> T
 where
@@ -267,6 +272,7 @@ where
                 requester_did: normalized_identity(requester_did),
                 agent_did: normalized_identity(agent_did),
                 behavior_id: normalized_identity(behavior_id),
+                request_id: normalized_identity(request_id),
             },
             future,
         )
@@ -344,6 +350,7 @@ where
                 requester_did: identity.requester_did,
                 agent_did: identity.agent_did,
                 behavior_id: identity.behavior_id,
+                request_id: identity.request_id,
             },
             future,
         )
@@ -385,6 +392,7 @@ where
                 requester_did: identity.requester_did,
                 agent_did: identity.agent_did,
                 behavior_id: identity.behavior_id,
+                request_id: identity.request_id,
             },
             future,
         )
@@ -426,6 +434,7 @@ where
                     requester_did: identity.requester_did,
                     agent_did: identity.agent_did,
                     behavior_id: identity.behavior_id,
+                    request_id: identity.request_id,
                 },
                 future,
             ),
@@ -489,6 +498,7 @@ pub(crate) fn current_tool_runtime_context() -> Option<CurrentToolRuntimeContext
             requester_did: scope.requester_did,
             agent_did: scope.agent_did,
             behavior_id: scope.behavior_id,
+            request_id: scope.request_id,
         }
     })
 }

--- a/crates/gents/src/tool_surface/behavior_config.rs
+++ b/crates/gents/src/tool_surface/behavior_config.rs
@@ -262,7 +262,16 @@ impl BehaviorToolConfig {
             },
             // A hold requirement narrows the surface (dispatch waits on an
             // operator verdict), so no ceiling filtering applies.
-            approval_required_tools: dedupe_strings(approval_required_tools),
+            approval_required_tools: {
+                let mut names = approval_required_tools;
+                names.extend(
+                    eth_calls
+                        .iter()
+                        .filter(|call| call.is_signing())
+                        .map(|call| call.tool_name.clone()),
+                );
+                dedupe_strings(names)
+            },
             custom_tools,
             enable_memory: static_policy.memory && enable_memory,
             enable_context_budget_tool: static_policy.context_budget && enable_context_budget,

--- a/crates/gents/src/tool_surface/mod.rs
+++ b/crates/gents/src/tool_surface/mod.rs
@@ -332,7 +332,7 @@ impl ToolSurface {
             tools.push(Box::new(tool) as Box<dyn ToolDyn>);
         }
         for call in &self.eth_calls {
-            let tool = crate::eth::EthCallTool::new(call.clone());
+            let tool = crate::eth::EthCallTool::new(call.clone(), runtime.node.clone());
             if !registered_names.insert(tool.name()) {
                 anyhow::bail!(
                     "eth call tool `{}` reached registration with a duplicate tool name",


### PR DESCRIPTION
## Summary

PR 7 of the EthTool stack (#1217). Generated write tools on top of the submission runtime.

- Declared `kind: write` and `kind: native_transfer` become native tools
- Model schema contains declared model-sourced parameters only; there is no raw calldata surface
- Named ABI inputs determine order and undeclared model fields are rejected
- Model-sourced addresses require an allowlist, integers require a maximum, and string/bytes values require an enum
- Values use exact chain base units; there are no parameter-name or human-unit conversion heuristics
- Positive `max_gas` and `max_fee_per_gas` caps are mandatory
- Signing-time reload rechecks the enabled EthTool, principal, chain, selected binding, attestation, revocation, and derived address
- Constraint violations use `FailureClass::PolicyDenied`, and every generated write requires approval
- Idempotency is stable across recovery: durable request ID plus the exact semantic Ethereum action

## Stack

1. #1299 schema
2. #1300 keys
3. #1301 RPC
4. #1302 query tool
5. #1303 reads
6. #1304 submit
7. **this PR** writes (`eth-wallet-writes` → `eth-wallet-submit`)
8. `sign_typed_data` (next)

Part of #1217.

## Test plan

- [x] `cargo test -p gents --lib eth::`
- [x] `cargo test -p gents --lib tool_surface::`
