### PR TITLE
feat(eth): add sign_typed_data for EIP-712

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
+ "derive_more 2.1.1",
  "itoa",
  "serde",
  "serde_json",

--- a/crates/gents-cli/src/desired_state/tests.rs
+++ b/crates/gents-cli/src/desired_state/tests.rs
@@ -98,6 +98,39 @@ fn backend(id: &str) -> DesiredInferenceBackend {
     }
 }
 
+fn chain_key_binding(id: &str, revoked_at: Option<&str>) -> DesiredChainKeyBinding {
+    DesiredChainKeyBinding {
+        binding_id: id.to_string(),
+        principal_did: "did:test:test".to_string(),
+        address: "0x1111111111111111111111111111111111111111".to_string(),
+        key_backend: "keyring".to_string(),
+        attestation: Some("0xsig".to_string()),
+        created_at: Some("2026-08-28T00:00:00Z".to_string()),
+        revoked_at: revoked_at.map(ToOwned::to_owned),
+    }
+}
+
+#[test]
+fn chain_key_revocation_is_sticky_in_desired_state_diff() {
+    let mut desired = empty_manifest("did:test:test");
+    desired
+        .chain_key_bindings
+        .push(chain_key_binding("bind-1", None));
+    let mut live = desired.clone();
+    live.chain_key_bindings[0].revoked_at = Some("2026-08-28T01:00:00Z".to_string());
+
+    let diff = diff_manifests(
+        &PathBuf::from("/tmp/fake-root"),
+        "local",
+        &desired,
+        Some(&live.agent_principal),
+        &live,
+        false,
+    );
+    assert_eq!(diff.collections.chain_key_bindings.unchanged, ["bind-1"]);
+    assert!(diff.collections.chain_key_bindings.update.is_empty());
+}
+
 fn profile(id: &str) -> DesiredInferenceProfile {
     DesiredInferenceProfile {
         profile_id: id.to_string(),
@@ -342,6 +375,67 @@ fn prune_deletes_unreferenced_orphan_backend() {
         gents::Collection::InferenceBackend,
         "k-orphan"
     ));
+}
+
+#[test]
+fn prune_keeps_chain_binding_until_its_eth_tool_is_gone() {
+    let desired = empty_manifest("did:test:test");
+    let mut live = empty_manifest("did:test:test");
+    live.chain_key_bindings
+        .push(chain_key_binding("bind-1", None));
+    live.eth_tools.push(DesiredEthTool {
+        tool_id: "base".to_string(),
+        agent_did: "did:test:test".to_string(),
+        display_name: None,
+        enabled: true,
+        chain_id: 8453,
+        rpc_url: "http://127.0.0.1:8545".to_string(),
+        query_methods: Vec::new(),
+        calls: Vec::new(),
+        key_binding_id: Some("bind-1".to_string()),
+    });
+
+    let deletes = super::prune::prune_safe_deletes(&desired, &live);
+    assert!(deletes_contain(
+        &deletes,
+        gents::Collection::EthTool,
+        "base"
+    ));
+    assert!(
+        !deletes_contain(&deletes, gents::Collection::ChainKeyBinding, "bind-1"),
+        "a live EthTool reference must keep its key binding for this prune pass"
+    );
+}
+
+#[test]
+fn prune_keeps_eth_tool_until_its_selection_is_gone() {
+    let desired = empty_manifest("did:test:test");
+    let mut live = empty_manifest("did:test:test");
+    live.eth_tools.push(DesiredEthTool {
+        tool_id: "base".to_string(),
+        agent_did: "did:test:test".to_string(),
+        display_name: None,
+        enabled: true,
+        chain_id: 8453,
+        rpc_url: "http://127.0.0.1:8545".to_string(),
+        query_methods: Vec::new(),
+        calls: Vec::new(),
+        key_binding_id: None,
+    });
+    let mut selection = sample_tool_selection("default");
+    selection.eth_tool_ids.push("base".to_string());
+    live.tool_selections.push(selection);
+
+    let deletes = super::prune::prune_safe_deletes(&desired, &live);
+    assert!(deletes_contain(
+        &deletes,
+        gents::Collection::ToolSelection,
+        "default"
+    ));
+    assert!(
+        !deletes_contain(&deletes, gents::Collection::EthTool, "base"),
+        "a live ToolSelection reference must keep its EthTool for this prune pass"
+    );
 }
 
 #[test]

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -55,7 +55,7 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 keyring = "3"
 sha3 = "0.10"
 alloy-primitives = "1.0"
-alloy-dyn-abi = "1.0"
+alloy-dyn-abi = { version = "1.0", features = ["eip712"] }
 alloy-json-abi = "1.0"
 libc = "0.2"
 minijinja.workspace = true

--- a/crates/gents/src/eth/call_tool.rs
+++ b/crates/gents/src/eth/call_tool.rs
@@ -18,8 +18,8 @@ use crate::llm::tool::{BoxFuture, ToolDefinition, ToolDyn, ToolError};
 use crate::tool_call_lifecycle::FailureClass;
 
 use super::calls::{
-    compile_params, native_transfer_function, parse_abi_function, parse_u128, require_address,
-    CallDecl, CompiledParam,
+    compile_params, compile_typed_params, native_transfer_function, parse_abi_function, parse_u128,
+    require_address, CallDecl, CompiledParam,
 };
 use super::keys::{
     address_from_secret, attestation_payload, binding_storage_key, decode_attestation,
@@ -45,7 +45,10 @@ pub struct ResolvedEthCall {
 
 impl ResolvedEthCall {
     pub(crate) fn is_signing(&self) -> bool {
-        matches!(self.kind, ResolvedCallKind::Write { .. })
+        matches!(
+            self.kind,
+            ResolvedCallKind::Write { .. } | ResolvedCallKind::SignTypedData { .. }
+        )
     }
 }
 
@@ -60,6 +63,12 @@ pub(crate) enum ResolvedCallKind {
     Write {
         to: Option<String>,
         function: Option<Function>,
+        params: Vec<CompiledParam>,
+    },
+    SignTypedData {
+        domain: Value,
+        types: Value,
+        primary_type: String,
         params: Vec<CompiledParam>,
     },
 }
@@ -180,6 +189,46 @@ impl ResolvedEthCall {
                         caps: gas_caps(*max_gas, max_fee_per_gas.as_deref())?,
                     });
                 }
+                CallDecl::SignTypedData {
+                    tool_name,
+                    domain,
+                    types,
+                    primary_type,
+                    params,
+                    description,
+                } => {
+                    let Some(binding_id) = binding_id.clone() else {
+                        bail!("sign_typed_data {tool_name} requires a chain key binding");
+                    };
+                    match typed_domain_chain_id(domain)? {
+                        Some(domain_chain_id) if domain_chain_id == chain_id => {}
+                        Some(_) => bail!(
+                            "sign_typed_data {tool_name} domain chainId does not match EthTool chain_id {chain_id}"
+                        ),
+                        None => bail!(
+                            "sign_typed_data {tool_name} domain requires chainId matching EthTool chain_id {chain_id}"
+                        ),
+                    }
+                    let params = compile_typed_params(types, primary_type, params, true)?;
+                    out.push(Self {
+                        eth_tool_id: tool_id.to_string(),
+                        tool_name: tool_name.clone(),
+                        chain_id,
+                        rpc_url: rpc_url.to_string(),
+                        description: description.clone().unwrap_or_else(|| {
+                            format!("sign EIP-712 {primary_type}; nothing is submitted")
+                        }),
+                        kind: ResolvedCallKind::SignTypedData {
+                            domain: domain.clone(),
+                            types: types.clone(),
+                            primary_type: primary_type.clone(),
+                            params,
+                        },
+                        principal_did: principal_did.to_string(),
+                        binding_id: Some(binding_id),
+                        caps: GasCaps::default(),
+                    });
+                }
             }
         }
         Ok(out)
@@ -244,9 +293,9 @@ fn call_parameters(kind: &ResolvedCallKind) -> Value {
             "required": ["to", "signature"],
             "additionalProperties": false
         }),
-        ResolvedCallKind::Declared { params, .. } | ResolvedCallKind::Write { params, .. } => {
-            declared_schema(params)
-        }
+        ResolvedCallKind::Declared { params, .. }
+        | ResolvedCallKind::Write { params, .. }
+        | ResolvedCallKind::SignTypedData { params, .. } => declared_schema(params),
     }
 }
 
@@ -342,7 +391,71 @@ async fn execute_call(
             )
             .await
         }
+        ResolvedCallKind::SignTypedData {
+            domain,
+            types,
+            primary_type,
+            params,
+        } => {
+            execute_sign_typed_data(node, resolved, domain, types, primary_type, params, args).await
+        }
     }
+}
+
+async fn execute_sign_typed_data(
+    node: &EmbeddedNode,
+    resolved: &ResolvedEthCall,
+    domain: &Value,
+    types: &Value,
+    primary_type: &str,
+    params: &[CompiledParam],
+    args: &str,
+) -> Result<String, ToolError> {
+    require_runtime_principal(resolved)?;
+    let parsed: BTreeMap<String, Value> = crate::llm::tool::parse_tool_args(args)?;
+    let secret = Zeroizing::new(
+        load_signing_key(node, resolved)
+            .await
+            .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?,
+    );
+    let from = address_from_secret(&secret)
+        .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?;
+    let bound = bind_params(params, &parsed, Some(&from))
+        .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?;
+    let mut message = serde_json::Map::new();
+    for (index, param) in params.iter().enumerate() {
+        if let Some(value) = bound.get(index) {
+            message.insert(param.name.clone(), value.clone());
+        }
+    }
+    let typed = json!({
+        "types": types,
+        "primaryType": primary_type,
+        "domain": domain,
+        "message": message,
+    });
+    let typed: alloy_dyn_abi::TypedData = serde_json::from_value(typed)
+        .map_err(|error| reported(FailureClass::ArgumentInvalid, error.to_string()))?;
+    let hash = typed
+        .eip712_signing_hash()
+        .map_err(|error| reported(FailureClass::ArgumentInvalid, error.to_string()))?;
+    let mut digest = [0u8; 32];
+    digest.copy_from_slice(hash.as_slice());
+    let (r, s, y_parity) = crate::eth::sign_prehash_recoverable(&secret, &digest)
+        .map_err(|error| reported(FailureClass::PolicyDenied, error.to_string()))?;
+    let v = if y_parity { 28u8 } else { 27 };
+    let mut sig = Vec::with_capacity(65);
+    sig.extend_from_slice(&r);
+    sig.extend_from_slice(&s);
+    sig.push(v);
+    serde_json::to_string(&json!({
+        "address": from,
+        "primary_type": primary_type,
+        "digest": format!("0x{}", hex_encode(&digest)),
+        "signature": format!("0x{}", hex_encode(&sig)),
+        "submitted": false,
+    }))
+    .map_err(ToolError::JsonError)
 }
 
 async fn execute_write(
@@ -354,19 +467,7 @@ async fn execute_write(
     params: &[CompiledParam],
     args: &str,
 ) -> Result<String, ToolError> {
-    let runtime =
-        crate::tool_call_lifecycle::runtime::current_tool_runtime_context().ok_or_else(|| {
-            reported(
-                FailureClass::PolicyDenied,
-                "eth write has no runtime identity".to_string(),
-            )
-        })?;
-    if runtime.agent_did.as_deref() != Some(resolved.principal_did.as_str()) {
-        return Err(reported(
-            FailureClass::PolicyDenied,
-            "eth write runtime principal does not own its key binding".to_string(),
-        ));
-    }
+    require_runtime_principal(resolved)?;
     let parsed: BTreeMap<String, Value> = crate::llm::tool::parse_tool_args(args)?;
     let secret = Zeroizing::new(
         load_signing_key(node, resolved)
@@ -404,6 +505,8 @@ async fn execute_write(
             })?;
         (Some(destination.to_string()), Vec::new(), value)
     };
+    let runtime = crate::tool_call_lifecycle::runtime::current_tool_runtime_context()
+        .expect("runtime principal was checked before signing");
     let request_id = runtime
         .request_id
         .filter(|value| !value.trim().is_empty())
@@ -479,6 +582,23 @@ fn write_idempotency_key(
         "data": format!("0x{}", hex_encode(data)),
     }))?;
     Ok(format!("{}:{:#x}", request_id, keccak256(semantic_action)))
+}
+
+fn require_runtime_principal(resolved: &ResolvedEthCall) -> Result<(), ToolError> {
+    let runtime =
+        crate::tool_call_lifecycle::runtime::current_tool_runtime_context().ok_or_else(|| {
+            reported(
+                FailureClass::PolicyDenied,
+                "Ethereum signing has no runtime identity".to_string(),
+            )
+        })?;
+    if runtime.agent_did.as_deref() != Some(resolved.principal_did.as_str()) {
+        return Err(reported(
+            FailureClass::PolicyDenied,
+            "Ethereum signing runtime principal does not own its key binding".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 async fn load_signing_key(node: &EmbeddedNode, resolved: &ResolvedEthCall) -> Result<[u8; 32]> {
@@ -672,6 +792,29 @@ fn gas_caps(max_gas: Option<u64>, max_fee_per_gas: Option<&str>) -> Result<GasCa
         max_gas,
         max_fee_per_gas,
     })
+}
+
+fn typed_domain_chain_id(domain: &Value) -> Result<Option<u64>> {
+    let Some(value) = domain.get("chainId") else {
+        return Ok(None);
+    };
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .map(Some)
+            .ok_or_else(|| anyhow!("EIP-712 domain chainId is not a positive integer")),
+        Value::String(text) => {
+            let parsed = if let Some(hex) = text.strip_prefix("0x") {
+                u64::from_str_radix(hex, 16)
+            } else {
+                text.parse()
+            };
+            parsed
+                .map(Some)
+                .map_err(|error| anyhow!("invalid EIP-712 domain chainId {text:?}: {error}"))
+        }
+        other => bail!("EIP-712 domain chainId must be a string or integer, got {other}"),
+    }
 }
 
 fn encode_function(function: &Function, args: &[Value]) -> Result<String> {
@@ -906,6 +1049,60 @@ mod tests {
         let parameters = call_parameters(&resolved[0].kind);
         assert!(parameters["properties"].get("data").is_none());
         assert!(parameters["properties"].get("amount").is_some());
+    }
+
+    #[test]
+    fn sign_typed_data_is_generated_and_does_not_submit() {
+        let decls = crate::eth::parse_call_decls(Some(&[r#"{"kind":"sign_typed_data","tool_name":"permit","primary_type":"Permit","domain":{"name":"Token","version":"1","chainId":1},"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"}],"Permit":[{"name":"spender","type":"address"},{"name":"value","type":"uint256"}]},"params":{"spender":{"source":"model","address_allowlist":["0x1111111111111111111111111111111111111111"]},"value":{"source":"model","max":"1000"}}}"#.to_string()])).unwrap();
+        crate::eth::validate_call_decls(&decls).unwrap();
+        let resolved = ResolvedEthCall::from_decls(
+            "base",
+            1,
+            "http://127.0.0.1",
+            &decls,
+            "did:key:zAlice",
+            Some("bind-1"),
+        )
+        .unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].is_signing());
+        assert!(matches!(
+            resolved[0].kind,
+            ResolvedCallKind::SignTypedData { .. }
+        ));
+        let parameters = call_parameters(&resolved[0].kind);
+        assert!(parameters["properties"].get("data").is_none());
+        assert!(parameters["properties"].get("spender").is_some());
+    }
+
+    #[test]
+    fn sign_typed_data_rejects_a_different_domain_chain() {
+        let decls = crate::eth::parse_call_decls(Some(&[r#"{"kind":"sign_typed_data","tool_name":"permit","primary_type":"Mail","domain":{"chainId":"0x1"},"types":{"EIP712Domain":[{"name":"chainId","type":"uint256"}],"Mail":[{"name":"message","type":"string"}]},"params":{"message":{"source":"model"}}}"#.to_string()])).unwrap();
+        let error = ResolvedEthCall::from_decls(
+            "base",
+            8453,
+            "http://127.0.0.1",
+            &decls,
+            "did:key:zAlice",
+            Some("bind-1"),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("does not match"));
+    }
+
+    #[test]
+    fn sign_typed_data_requires_a_domain_chain() {
+        let decls = crate::eth::parse_call_decls(Some(&[r#"{"kind":"sign_typed_data","tool_name":"permit","primary_type":"Mail","domain":{"name":"Mail"},"types":{"EIP712Domain":[{"name":"name","type":"string"}],"Mail":[{"name":"message","type":"string"}]},"params":{"message":{"source":"model"}}}"#.to_string()])).unwrap();
+        let error = ResolvedEthCall::from_decls(
+            "base",
+            8453,
+            "http://127.0.0.1",
+            &decls,
+            "did:key:zAlice",
+            Some("bind-1"),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("requires chainId"));
     }
 
     #[test]

--- a/crates/gents/src/eth/calls.rs
+++ b/crates/gents/src/eth/calls.rs
@@ -47,11 +47,25 @@ pub enum CallDecl {
         #[serde(default)]
         max_fee_per_gas: Option<String>,
     },
+    SignTypedData {
+        tool_name: String,
+        domain: Value,
+        types: Value,
+        #[serde(alias = "primaryType")]
+        primary_type: String,
+        #[serde(default)]
+        params: BTreeMap<String, ParamDecl>,
+        #[serde(default)]
+        description: Option<String>,
+    },
 }
 
 impl CallDecl {
     pub(crate) fn requires_key_binding(&self) -> bool {
-        matches!(self, Self::Write { .. } | Self::NativeTransfer { .. })
+        matches!(
+            self,
+            Self::Write { .. } | Self::NativeTransfer { .. } | Self::SignTypedData { .. }
+        )
     }
 }
 
@@ -161,6 +175,26 @@ pub fn validate_call_decls(decls: &[CallDecl]) -> Result<()> {
                 validate_gas_caps(tool_name, *max_gas, max_fee_per_gas.as_deref())?;
                 let function = native_transfer_function()?;
                 compile_params(&function, params, true)?;
+            }
+            CallDecl::SignTypedData {
+                tool_name,
+                domain,
+                types,
+                primary_type,
+                params,
+                ..
+            } => {
+                require_tool_name(tool_name, &mut names)?;
+                if primary_type.trim().is_empty() {
+                    bail!("sign_typed_data.primary_type is empty");
+                }
+                if !domain.is_object() {
+                    bail!("sign_typed_data.domain must be an object");
+                }
+                if !types.is_object() {
+                    bail!("sign_typed_data.types must be an object");
+                }
+                compile_typed_params(types, primary_type, params, true)?;
             }
         }
     }
@@ -418,6 +452,54 @@ pub(crate) fn native_transfer_function() -> Result<Function> {
     parse_abi_function("nativeTransfer(address to,uint256 value)")
 }
 
+pub(crate) fn compile_typed_params(
+    types: &Value,
+    primary_type: &str,
+    params: &BTreeMap<String, ParamDecl>,
+    require_write_limits: bool,
+) -> Result<Vec<CompiledParam>> {
+    let fields = types
+        .get(primary_type)
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("sign_typed_data.types has no {primary_type:?} field list"))?;
+    if fields.len() != params.len() {
+        bail!(
+            "EIP-712 {primary_type} has {} fields but {} parameter declarations",
+            fields.len(),
+            params.len()
+        );
+    }
+    let mut seen = BTreeSet::new();
+    let mut compiled = Vec::with_capacity(fields.len());
+    for field in fields {
+        let name = field
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("EIP-712 {primary_type} field has no name"))?;
+        let solidity_type = field
+            .get("type")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("EIP-712 {primary_type}.{name} has no type"))?;
+        if !seen.insert(name.to_string()) {
+            bail!("EIP-712 {primary_type} has duplicate field {name:?}");
+        }
+        let decl = params
+            .get(name)
+            .ok_or_else(|| anyhow!("EIP-712 field {name:?} has no parameter declaration"))?;
+        validate_param(name, solidity_type, decl, require_write_limits)?;
+        compiled.push(CompiledParam {
+            name: name.to_string(),
+            solidity_type: solidity_type.to_string(),
+            decl: decl.clone(),
+        });
+    }
+    Ok(compiled)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -491,5 +573,81 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("max_gas"));
+    }
+
+    #[test]
+    fn typed_params_follow_eip712_field_order() {
+        let types = serde_json::json!({
+            "Mail": [
+                { "name": "sender", "type": "address" },
+                { "name": "amount", "type": "uint256" }
+            ]
+        });
+        let params = BTreeMap::from([
+            ("amount".to_string(), ParamDecl::default()),
+            ("sender".to_string(), ParamDecl::default()),
+        ]);
+        let compiled = compile_typed_params(&types, "Mail", &params, false).unwrap();
+        assert_eq!(
+            compiled
+                .iter()
+                .map(|param| param.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sender", "amount"]
+        );
+    }
+
+    #[test]
+    fn typed_params_reject_nested_structs() {
+        let types = serde_json::json!({
+            "Mail": [{ "name": "sender", "type": "Person" }],
+            "Person": [{ "name": "wallet", "type": "address" }]
+        });
+        let params = BTreeMap::from([("sender".to_string(), ParamDecl::default())]);
+        assert!(compile_typed_params(&types, "Mail", &params, false)
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported Solidity type"));
+    }
+
+    #[test]
+    fn typed_signatures_require_write_grade_limits() {
+        let types = serde_json::json!({
+            "Permit": [
+                { "name": "spender", "type": "address" },
+                { "name": "value", "type": "uint256" }
+            ]
+        });
+        let params = BTreeMap::from([
+            ("spender".to_string(), ParamDecl::default()),
+            ("value".to_string(), ParamDecl::default()),
+        ]);
+        assert!(compile_typed_params(&types, "Permit", &params, true)
+            .unwrap_err()
+            .to_string()
+            .contains("no allowlist"));
+    }
+
+    #[test]
+    fn writes_require_allowlisted_string_and_bytes_values() {
+        for solidity_type in ["string", "bytes", "bytes32"] {
+            let params = BTreeMap::from([("payload".to_string(), ParamDecl::default())]);
+            let function =
+                parse_abi_function(&format!("execute({solidity_type} payload)")).unwrap();
+            assert!(compile_params(&function, &params, true)
+                .unwrap_err()
+                .to_string()
+                .contains("no enum"));
+        }
+    }
+
+    #[test]
+    fn integer_types_are_exact() {
+        for valid in ["uint", "uint8", "uint256", "int", "int8", "int256"] {
+            assert!(integer_kind(valid).is_some(), "{valid}");
+        }
+        for invalid in ["uint0", "uint7", "uint264", "uint256[]", "Interval"] {
+            assert!(integer_kind(invalid).is_none(), "{invalid}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR 8 of the EthTool stack (#1217). Off-chain EIP-712 signatures (permits / orders). Nothing is submitted.

- Declared `kind: sign_typed_data` pins `domain`, `types`, and `primary_type`
- Domain `chainId` is required and must equal the EthTool chain
- Model fills declared message fields only, with the same deny-by-default limits used for writes
- Signing-time key reload rechecks the live tool, binding, attestation, revocation, principal, and address
- Return `{signature, digest, address, submitted: false}`; no transaction is sent

## Stack

1. #1299 schema
2. #1300 keys
3. #1301 RPC
4. #1302 query tool
5. #1303 reads
6. #1304 submit
7. #1305 writes
8. **this PR** typed data (`eth-wallet-typed-data` → `eth-wallet-writes`)

Part of #1217.

## Test plan

- [x] `cargo test -p gents --lib eth::`
