### PR TITLE
chore(release): DefraDB v0.19 and Gents v0.15.0

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.14.0"
+        default: "0.15.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.14.0"
+        default: "0.15.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.15.0 - 2026-09-01
+
+### Breaking changes
+
+- Advance the Rust and npm desktop package train together to 0.15.0 and the
+  desktop bridge contract from 1.5 to 4.0.
+- Replace the retired Lark/RocksDB storage backends with Regolith through the
+  DefraDB v0.19.0 cutover. Existing legacy data directories are rejected at
+  startup; reset runtime state, or use Gents v0.14.0 to export data first.
+- Remove legacy bearer pairing, local mobile-runtime request creation, and
+  unsigned authority paths. Enrollment, routing, readiness, and mobile
+  requests now require authenticated runtime-owned state (#1310-#1313).
+
+### Mobile authority and hydration
+
+- Bind enrollment signatures, leases, revocation, replay protection, and
+  generation changes to the final authority boundary, and prevent offline or
+  accumulated authorizations from starving an active enrollment (#1312).
+- Make the runtime the sole readiness authority and require requester-bound,
+  terminally complete two-node hydration with explicit ordering and counts
+  before the desktop projects success (#1310, #1311).
+- Tag and authenticate every request source, remove the mobile local-runtime
+  path, and replace compatibility pairing UI with status-based enrollment
+  controls and actionable hold diagnostics (#1313).
+
+### Runtime, research, and reliability
+
+- Add the web deep-research graph pack, external dependency projection, live
+  qualification harness, and the open-source research gateway integration
+  (#1277, #1294, #1296).
+- Harden Ethereum wallet submission and mobile first-run, idle hydration, and
+  viewport ownership behavior (#1282, #1283, #1297, #1309).
+- Evaluate readiness freshness against an injected observation clock so stale
+  state still fails closed without making deterministic CLI tests wall-clock
+  dependent (#1317).
+
+### Dependencies
+
+- Upgrade every DefraDB crate to the v0.19.0 tag (`03e1035f`), adopt Regolith
+  as the sole durable backend, require transport-routable gossip origins, and
+  enable verified post-merge rebroadcast for Gents' multi-hop deployments.
+
 ## 0.14.0 - 2026-08-28
 
 ### Bridge contract
@@ -280,6 +322,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 | Tag        | Bridge crate | npm packages | contract_version | Notes                                         |
 | ---------- | ------------ | ------------ | ---------------- | --------------------------------------------- |
+| v0.15.0    | 0.15.0       | 0.15.0       | 4.0              | Authenticated mobile authority; Regolith; DefraDB v0.19.0 |
 | v0.14.0    | 0.14.0       | 0.14.0       | 1.5              | Mobile sync health, graph review, clarity refactors; DefraDB `81ff3cee` |
 | v0.13.0    | 0.13.0       | 0.13.0       | 1.3              | Hydration, bounded mobile transcripts, graph pipeline; DefraDB `54b629b1` |
 | v0.12.0    | 0.12.0       | 0.12.0       | 0.9              | Mobile pairing convergence; eager session index; DefraDB `f928b300` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2047,9 +2047,10 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-trait",
+ "bytes",
  "defra-core",
  "serde",
  "serde_json",
@@ -2093,16 +2094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,7 +2108,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -2244,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -2395,10 +2386,11 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-lock",
  "async-trait",
+ "bytes",
  "cid",
  "storage",
  "thiserror 2.0.18",
@@ -2409,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "anyhow",
@@ -2474,7 +2466,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2499,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "async-stream",
@@ -2534,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "anyhow",
@@ -2547,6 +2539,7 @@ dependencies = [
  "defra-p2p-adapter",
  "events",
  "identity",
+ "kms",
  "lens",
  "p2p",
  "query",
@@ -2567,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "async-trait",
@@ -2599,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "serde",
 ]
@@ -2848,7 +2841,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3179,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3349,7 +3342,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3734,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "acp",
  "alloy-dyn-abi",
@@ -3808,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "gents-chatgpt-login"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.2",
@@ -3826,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -3877,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "gents-codex-protocol"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3888,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3902,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3930,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3986,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -3999,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -4011,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -4028,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -4046,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4065,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.14.0"
+version = "0.15.0"
 
 [[package]]
 name = "getrandom"
@@ -4867,7 +4860,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -5581,13 +5574,14 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "async-channel",
  "async-lock",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "ciborium",
  "cid",
  "crypto",
@@ -5622,6 +5616,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "kovan"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069314825b47e60f2882bf6fc90ab66e3eb37ee5e4407de6357a124842fc3b26"
+dependencies = [
+ "once_cell",
+ "portable-atomic",
+]
+
+[[package]]
+name = "kovan-channel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d105d382f56b3e8ece40ef1de7246205a419513333ac71e42832766240d8a47"
+dependencies = [
+ "crossbeam-utils",
+ "kovan",
+ "kovan-queue",
+]
+
+[[package]]
+name = "kovan-map"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaba93d80fa57cdb3525198c0b61abeeb689ec0ac346b6d8da6a7c108bf608d4"
+dependencies = [
+ "foldhash 0.2.0",
+ "kovan",
+]
+
+[[package]]
+name = "kovan-mvcc"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bda37cfe1a4e6a1cf6737aaab3f601b0a245098beaa2c278630beadb8eec5b"
+dependencies = [
+ "kovan",
+ "kovan-map",
+ "parking_lot",
+ "uuid",
+]
+
+[[package]]
+name = "kovan-queue"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f72e2bdab247e2f7d53e41bcd2abd6a53daac69727511d1223abf41f0c9b7f"
+dependencies = [
+ "crossbeam-utils",
+ "kovan",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,22 +5678,6 @@ dependencies = [
  "html5ever 0.29.1",
  "indexmap 2.14.0",
  "selectors 0.24.0",
-]
-
-[[package]]
-name = "lark-kv"
-version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/lark.git?rev=d1ec2e727bad6c160e6c1d71e2cbb163892b3a02#d1ec2e727bad6c160e6c1d71e2cbb163892b3a02"
-dependencies = [
- "crossbeam-skiplist",
- "lru 0.16.4",
- "lz4_flex",
- "parking_lot",
- "rustix",
- "snap",
- "thiserror 1.0.69",
- "tracing",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -5664,7 +5695,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6915,7 +6946,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "anyhow",
@@ -6937,6 +6968,8 @@ dependencies = [
  "iroh",
  "iroh-gossip",
  "iroh-tickets",
+ "kms",
+ "kovan-map",
  "lru 0.16.4",
  "multihash-codetable",
  "noq",
@@ -7755,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "acp",
  "async-graphql",
@@ -7763,6 +7796,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bm25",
+ "bytes",
  "chrono",
  "ciborium",
  "cid",
@@ -8046,15 +8080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "redb"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8167,9 +8192,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "regolith"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78ac133f988e47a96a6d9df82e22247b382cd92f785425377ca5b33a47d68b1"
+dependencies = [
+ "js-sys",
+ "kovan",
+ "kovan-channel",
+ "kovan-map",
+ "kovan-mvcc",
+ "kovan-queue",
+ "loom",
+ "lz4_flex",
+ "portable-atomic",
+ "rustix",
+ "snap",
+ "thiserror 1.0.69",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "p2p",
  "query",
@@ -8628,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "cid",
  "defra-core",
@@ -9463,21 +9512,22 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-lock",
  "async-trait",
  "bm25",
+ "bytes",
  "chrono",
  "cid",
  "crypto",
  "defra-core",
  "document",
+ "futures",
  "getrandom 0.2.17",
  "hex",
- "lark-kv",
  "parking_lot",
- "redb",
+ "regolith",
  "schema",
  "serde",
  "serde_json",
@@ -10043,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "tracing",
 ]
@@ -12493,7 +12543,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=6441ca8384c9cd4063ce77443cdfccea87a4a045#6441ca8384c9cd4063ce77443cdfccea87a4a045"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"
@@ -54,12 +54,13 @@ bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 clap = { version = "4", features = ["derive", "env"] }
-# DefraDB v0.18.0 includes signed explicit transactions and default node query
-# identity. Its iterative parent-DAG replay remains required on iOS:
-# a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
+# DefraDB v0.19.0 replaces the retired storage backends with Regolith and binds
+# gossip fetch obligations to transport-routable origins. Its iterative
+# parent-DAG replay remains required on iOS: a deep collection history otherwise
+# exhausts even a 32 MiB Tokio worker stack.
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-codex-protocol = { path = "crates/gents-codex-protocol" }
@@ -69,12 +70,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -82,8 +83,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "6441ca8384c9cd4063ce77443cdfccea87a4a045" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.14.0",
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-fleet": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0",
+    "@source-inc/gents-desktop-chat": "0.15.0",
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-fleet": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -51,14 +51,14 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-chat": "0.14.0",
-    "@source-inc/gents-desktop-fleet": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0"
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-chat": "0.15.0",
+    "@source-inc/gents-desktop-fleet": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-operations": "0.14.0",
+    "@source-inc/gents-desktop-operations": "0.15.0",
     "@antithesishq/bombadil": "^0.6.0",
     "@playwright/test": "^1.61.0",
     "@tauri-apps/cli": "2.10.1",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.14.0</string>
+	<string>0.15.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.14.0</string>
+	<string>0.15.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.14.0
-        CFBundleVersion: "0.14.0"
+        CFBundleShortVersionString: 0.15.0
+        CFBundleVersion: "0.15.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/review-demo/package.json
+++ b/apps/review-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/review-demo-ui",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite --strictPort --host 127.0.0.1",
@@ -10,8 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -309,7 +309,7 @@
     "desktop://managed-server-updated",
     "desktop://managed-server-tray-stop"
   ],
-  "packageVersion": "0.14.0",
+  "packageVersion": "0.15.0",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/crates/gents-cli/src/commands/codex_shim/background.rs
+++ b/crates/gents-cli/src/commands/codex_shim/background.rs
@@ -370,7 +370,7 @@ mod tests {
         let node = Arc::new(
             EmbeddedNode::builder()
                 .data_path(tempdir.path().join("node"))
-                .with_storage_backend(gents::defra_node::StorageBackend::Lark)
+                .with_storage_backend(gents::defra_node::StorageBackend::Regolith)
                 .build()
                 .await
                 .expect("embedded node"),
@@ -436,11 +436,9 @@ mod tests {
         let node = Arc::new(
             EmbeddedNode::builder()
                 .data_path(tempdir.path().join("node"))
-                // Explicit backend, matching this crate's convention
-                // (`persistent_node_builder`): the builder's default is Redb,
-                // whose defra-node feature is only transitively enabled — the
-                // CI cli shard builds without it.
-                .with_storage_backend(gents::defra_node::StorageBackend::Lark)
+                // Pin the sole durable backend explicitly so this test cannot
+                // silently drift if another backend is introduced later.
+                .with_storage_backend(gents::defra_node::StorageBackend::Regolith)
                 .build()
                 .await
                 .expect("embedded node"),

--- a/crates/gents-cli/src/commands/config/behavior.rs
+++ b/crates/gents-cli/src/commands/config/behavior.rs
@@ -467,11 +467,9 @@ mod tests {
         let tempdir = tempfile::tempdir()?;
         let node = EmbeddedNode::builder()
             .data_path(tempdir.path().join("data"))
-            // Explicit backend, matching this crate's convention
-            // (`persistent_node_builder`): the builder's default is Redb,
-            // whose defra-node feature is only transitively enabled — the CI
-            // cli shard builds without it.
-            .with_storage_backend(StorageBackend::Lark)
+            // Pin the sole durable backend explicitly so this test cannot
+            // silently drift if another backend is introduced later.
+            .with_storage_backend(StorageBackend::Regolith)
             .build()
             .await
             .expect("embedded node boots");

--- a/crates/gents-cli/src/commands/serve.rs
+++ b/crates/gents-cli/src/commands/serve.rs
@@ -1290,6 +1290,9 @@ fn resolve_server_p2p_config(
         rate_limit_rate,
         max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
         max_pending_dags,
+        // Gents deployments may be multi-hop. DefraDB verifies every block
+        // before a relay re-announces it as a transport-routable origin.
+        rebroadcast_on_merge: true,
     }))
 }
 

--- a/crates/gents-cli/src/config_import/tests.rs
+++ b/crates/gents-cli/src/config_import/tests.rs
@@ -212,7 +212,7 @@ async fn generic_override_recreates_a_tombstoned_tool_selection() -> Result<()> 
     let tempdir = tempfile::tempdir()?;
     let node = EmbeddedNode::builder()
         .data_path(tempdir.path().join("data"))
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;

--- a/crates/gents-cli/src/desired_state/tests/live/apply.rs
+++ b/crates/gents-cli/src/desired_state/tests/live/apply.rs
@@ -12,7 +12,7 @@ async fn all_subagent_fields_persist_and_apply_is_idempotent() -> Result<()> {
     let data_dir = tempdir.path().join("data");
     let node = EmbeddedNode::builder()
         .data_path(&data_dir)
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;
@@ -210,7 +210,7 @@ async fn behavior_description_and_summary_persist_and_apply_is_idempotent() -> R
     let data_dir = tempdir.path().join("data");
     let node = EmbeddedNode::builder()
         .data_path(&data_dir)
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;

--- a/crates/gents-cli/src/desired_state/tests/live/prune.rs
+++ b/crates/gents-cli/src/desired_state/tests/live/prune.rs
@@ -28,7 +28,7 @@ async fn diff_prune_detects_and_deletes_live_only_inference_backends() -> Result
     let tempdir = tempfile::tempdir()?;
     let node = EmbeddedNode::builder()
         .data_path(tempdir.path().join("data"))
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;
@@ -128,7 +128,7 @@ async fn prune_spares_backends_referenced_by_other_agents() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let node = EmbeddedNode::builder()
         .data_path(tempdir.path().join("data"))
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;

--- a/crates/gents-cli/src/desired_state/tests/live/validation.rs
+++ b/crates/gents-cli/src/desired_state/tests/live/validation.rs
@@ -7,7 +7,7 @@ async fn live_validate_rejects_invalid_event_trigger_collection_identifier() -> 
     let tempdir = tempfile::tempdir()?;
     let node = EmbeddedNode::builder()
         .data_path(tempdir.path().join("data"))
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;
@@ -49,7 +49,7 @@ async fn live_validate_does_not_resolve_remote_subagent_target() -> Result<()> {
     let data_dir = tempdir.path().join("data");
     let node = EmbeddedNode::builder()
         .data_path(&data_dir)
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;
@@ -79,7 +79,7 @@ async fn live_validate_passes_for_known_subagent_target() -> Result<()> {
     let data_dir = tempdir.path().join("data");
     let node = EmbeddedNode::builder()
         .data_path(&data_dir)
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await?;
     ensure_runtime_schemas(&node).await?;

--- a/crates/gents-cli/src/http/enrollment.rs
+++ b/crates/gents-cli/src/http/enrollment.rs
@@ -477,7 +477,7 @@ mod tests {
         let node = Arc::new(
             EmbeddedNode::builder()
                 .data_path(path)
-                .with_storage_backend(StorageBackend::Lark)
+                .with_storage_backend(StorageBackend::Regolith)
                 .build()
                 .await
                 .expect("nonce test node"),

--- a/crates/gents-cli/src/lib.rs
+++ b/crates/gents-cli/src/lib.rs
@@ -599,10 +599,10 @@ pub(crate) async fn resolve_config_access(
 }
 
 pub(crate) fn persistent_node_builder(data_dir: &Path) -> Result<NodeBuilder> {
-    gents::storage_backend::reject_legacy_rocksdb_store(data_dir)?;
+    gents::storage_backend::reject_legacy_store(data_dir)?;
     Ok(EmbeddedNode::builder()
         .data_path(data_dir)
-        .with_storage_backend(StorageBackend::Lark))
+        .with_storage_backend(StorageBackend::Regolith))
 }
 
 pub(crate) fn persistent_node_builder_with_stored_identity(

--- a/crates/gents-cli/tests/suites/cli_adapter_interop_roundtrip.rs
+++ b/crates/gents-cli/tests/suites/cli_adapter_interop_roundtrip.rs
@@ -80,7 +80,7 @@ async fn external_adapter_native_captures_roundtrip_through_gents_binary() -> Re
         {
             let node = EmbeddedNode::builder()
                 .data_path(&data_dir)
-                .with_storage_backend(StorageBackend::Lark)
+                .with_storage_backend(StorageBackend::Regolith)
                 .build()
                 .await
                 .context("opening embedded node")?;
@@ -232,7 +232,7 @@ async fn negative_external_capture_imports_reject_bad_mappings_without_partial_r
         let data_dir = tempdir.path().join("data");
         let node = EmbeddedNode::builder()
             .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::Lark)
+            .with_storage_backend(StorageBackend::Regolith)
             .build()
             .await
             .with_context(|| format!("opening embedded node for {name}"))?;

--- a/crates/gents-cli/tests/suites/cli_diagnose.rs
+++ b/crates/gents-cli/tests/suites/cli_diagnose.rs
@@ -141,20 +141,37 @@ async fn live_diagnose_uses_authoritative_readiness_and_rejects_malformed_rows()
         Some(true)
     );
 
+    // Exercise malformed live state under an unowned identity. Mutating the
+    // real row races the authoritative publisher, which may repair it before
+    // the diagnose subprocess reads it.
+    let malformed_agent_did = format!("did:key:malformed-diagnose-{}", Uuid::new_v4().simple());
     graphql_query(
         &graphql,
         &format!(
             r#"mutation {{
-                update_AgentBehaviorReadiness(
-                    filter: {{ agent_did: {{ _eq: "{}" }} }},
-                    input: {{ snapshot_json: "{{}}" }}
-                ) {{ _docID }}
+                create_AgentRuntime(input: {{
+                    agent_did: "{agent_did}",
+                    reconcile_phase: "ready"
+                }}) {{ _docID }}
+                create_AgentBehaviorReadiness(input: {{
+                    agent_did: "{agent_did}",
+                    snapshot_json: "{{}}"
+                }}) {{ _docID }}
             }}"#,
-            escape_graphql_string(&agent_did),
+            agent_did = escape_graphql_string(&malformed_agent_did),
         ),
     )
     .await?;
-    let malformed = run_cli_json(&home_dir, &["diagnose", "--graphql", &graphql])?;
+    let malformed = run_cli_json(
+        &home_dir,
+        &[
+            "diagnose",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &malformed_agent_did,
+        ],
+    )?;
     assert_eq!(
         malformed.get("status").and_then(Value::as_str),
         Some("degraded")
@@ -236,9 +253,8 @@ async fn diagnose_with_explicit_graphql_does_not_reuse_unrelated_local_p2p_state
 
     let port = allocate_port()?;
     let agent_name = format!("cli-p2p-diagnose-{}", Uuid::new_v4().simple());
-    let graphql = graphql_url(port);
 
-    let init = run_init_json(
+    run_init_json(
         &home_dir,
         &[
             "--agent-name",
@@ -248,8 +264,7 @@ async fn diagnose_with_explicit_graphql_does_not_reuse_unrelated_local_p2p_state
             mock_endpoint.endpoint(),
         ],
     )?;
-    let agent_did = agent_did_from_init(&init)?;
-    let mut serve = spawn_server_with_env(
+    let (_serve, readiness) = spawn_server_with_ready_json(
         &home_dir,
         port,
         &[
@@ -264,8 +279,13 @@ async fn diagnose_with_explicit_graphql_does_not_reuse_unrelated_local_p2p_state
         ],
         &[],
     )?;
-    wait_for_port(port, &mut serve)?;
-    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    assert!(
+        readiness
+            .get("p2p_peer_id")
+            .and_then(Value::as_str)
+            .is_some_and(|peer_id| !peer_id.is_empty()),
+        "server readiness did not establish unrelated local P2P state: {readiness}"
+    );
 
     let output = run_cli_json(
         &home_dir,

--- a/crates/gents-cli/tests/suites/cli_subagent_cancel.rs
+++ b/crates/gents-cli/tests/suites/cli_subagent_cancel.rs
@@ -296,7 +296,7 @@ async fn enable_default_subagents_before_server(
     let data_dir = home_dir.join(".gents").join("data");
     let node = EmbeddedNode::builder()
         .data_path(&data_dir)
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .build()
         .await
         .with_context(|| format!("opening embedded node at {}", data_dir.display()))?;
@@ -322,7 +322,7 @@ async fn open_local_node(home_dir: &std::path::Path) -> Result<Arc<EmbeddedNode>
     Ok(Arc::new(
         EmbeddedNode::builder()
             .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::Lark)
+            .with_storage_backend(StorageBackend::Regolith)
             .build()
             .await
             .with_context(|| format!("opening embedded node at {}", data_dir.display()))?,

--- a/crates/gents-cli/tests/suites/cli_trace_export.rs
+++ b/crates/gents-cli/tests/suites/cli_trace_export.rs
@@ -1244,7 +1244,7 @@ async fn initialized_trace_node(
 
     EmbeddedNode::builder()
         .data_path(agent_home.join("data"))
-        .with_storage_backend(StorageBackend::Lark)
+        .with_storage_backend(StorageBackend::Regolith)
         .with_node_identity_did(agent_did)
         .build()
         .await

--- a/crates/gents-cli/tests/support/mod.rs
+++ b/crates/gents-cli/tests/support/mod.rs
@@ -73,7 +73,7 @@ pub async fn initialized_agent_node(
 
     gents::defra_node::EmbeddedNode::builder()
         .data_path(agent_home.join("data"))
-        .with_storage_backend(gents::defra_node::StorageBackend::Lark)
+        .with_storage_backend(gents::defra_node::StorageBackend::Regolith)
         .with_node_identity_did(&agent_did)
         .build()
         .await

--- a/crates/gents-desktop-core/Cargo.toml
+++ b/crates/gents-desktop-core/Cargo.toml
@@ -15,7 +15,7 @@ crypto.workspace = true
 gents = { path = "../gents" }
 gents-migration = { path = "../gents-migration" }
 gents-protocol.workspace = true
-defra-node = { workspace = true, features = ["p2p", "lark"] }
+defra-node = { workspace = true, features = ["p2p"] }
 defra-p2p-adapter.workspace = true
 dirs.workspace = true
 events.workspace = true

--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -42,13 +42,13 @@ impl ClientCore {
         options: ClientCoreOptions,
     ) -> Result<Self> {
         paths.ensure_root_dirs().await?;
-        gents::storage_backend::reject_legacy_rocksdb_store(paths.node_data_dir())?;
+        gents::storage_backend::reject_legacy_store(paths.node_data_dir())?;
 
         let principal = PrincipalIdentity::load_or_create(&paths).await?;
         let node = Arc::new(
             NodeBuilder::default()
                 .data_path(paths.node_data_dir())
-                .with_storage_backend(StorageBackend::Lark)
+                .with_storage_backend(StorageBackend::Regolith)
                 .with_p2p(desktop_p2p_config(&paths, &options))
                 .with_node_identity_did(principal.did())
                 .build()
@@ -163,6 +163,10 @@ fn desktop_p2p_config(paths: &DesktopPaths, options: &ClientCoreOptions) -> P2PC
         rate_limit_rate: options.rate_limit_rate,
         max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
         max_pending_dags: options.max_pending_dags,
+        // Desktop peers commonly sit behind a runtime relay. Re-announce only
+        // after DefraDB has verified and merged the block so downstream peers
+        // can fetch it from a transport-routable origin.
+        rebroadcast_on_merge: true,
     }
 }
 

--- a/crates/gents-migration/Cargo.toml
+++ b/crates/gents-migration/Cargo.toml
@@ -20,7 +20,7 @@ sha2.workspace = true
 hex = "0.4"
 
 [dev-dependencies]
-defra-node = { workspace = true, features = ["redb"] }
+defra-node.workspace = true
 gents-lens-fixture-add-label = { path = "../gents-lenses/fixture_add_label", default-features = false }
 tempfile = "3"
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -14,10 +14,8 @@ default = [
     "defra-node/http",
     "defra-node/p2p",
     "defra-node/wasmtime-runtime",
-    "lark",
 ]
 agent-memory = []
-lark = ["defra-node/lark"]
 # Gates the e2e_live test binary out of default builds: every test in it is
 # live-inference-gated, so default runs paid a ~160MB link to execute nothing.
 live-e2e = []
@@ -107,7 +105,7 @@ windows-sys = { version = "0.61.2", features = [
 [dev-dependencies]
 acp.workspace = true
 axum = "0.8"
-defra-node = { workspace = true, features = ["redb"] }
+defra-node.workspace = true
 proptest = "1"
 tar = "0.4"
 zstd = "0.13"

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -388,6 +388,7 @@ mod tests {
                 rate_limit_rate: p2p::sync::DEFAULT_RATE_LIMIT_RATE,
                 max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
                 max_pending_dags: p2p::sync::DEFAULT_MAX_PENDING_DAGS,
+                rebroadcast_on_merge: false,
             });
         if let Some(did) = node_identity_did {
             builder = builder.with_node_identity_did(did);

--- a/crates/gents/src/agent/runtime/tests/support.rs
+++ b/crates/gents/src/agent/runtime/tests/support.rs
@@ -569,7 +569,7 @@ pub(super) async fn wait_for_inference_call_state(
     loop {
         let query = format!(
             r#"{{
-                InferenceCall(filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }}, limit: 1) {{
+                InferenceCall(filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }}) {{
                     call_state
                     failure_reason
                 }}
@@ -581,27 +581,30 @@ pub(super) async fn wait_for_inference_call_state(
             "InferenceCall query failed: {:?}",
             response.errors
         );
-        let row = response
+        let rows = response
             .data
             .as_ref()
             .and_then(|data| data.get("InferenceCall"))
             .and_then(Value::as_array)
-            .and_then(|rows| rows.first())
-            .cloned();
-        let state = row
-            .as_ref()
-            .and_then(|row| row.get("call_state"))
-            .and_then(Value::as_str)
+            .cloned()
             .unwrap_or_default();
-        if state == expected_state {
+        // A request can own both its main inference and optional title call.
+        // Neither DefraDB nor this assertion promises an implicit row order,
+        // so observe the complete request-owned set instead of whichever row
+        // an unordered `limit: 1` happens to return.
+        if rows.iter().any(|row| {
+            row.get("call_state")
+                .and_then(Value::as_str)
+                .is_some_and(|state| state == expected_state)
+        }) {
             return;
         }
         assert!(
             tokio::time::Instant::now() < deadline,
-            "timed out waiting for InferenceCall request_id={} to reach call_state={}, last row={:?}",
+            "timed out waiting for InferenceCall request_id={} to reach call_state={}, last rows={:?}",
             request_id,
             expected_state,
-            row
+            rows
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }

--- a/crates/gents/src/config_client/tool_selection.rs
+++ b/crates/gents/src/config_client/tool_selection.rs
@@ -75,7 +75,7 @@ mod tests {
         let data_dir = tempdir.path().join("data");
         let node = EmbeddedNode::builder()
             .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::Lark)
+            .with_storage_backend(StorageBackend::Regolith)
             .build()
             .await?;
         ensure_runtime_schemas(&node).await?;
@@ -163,7 +163,7 @@ mod tests {
         let data_dir = tempdir.path().join("data");
         let node = EmbeddedNode::builder()
             .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::Lark)
+            .with_storage_backend(StorageBackend::Regolith)
             .build()
             .await?;
         ensure_runtime_schemas(&node).await?;
@@ -261,7 +261,7 @@ mod tests {
         let data_dir = tempdir.path().join("data");
         let node = EmbeddedNode::builder()
             .data_path(&data_dir)
-            .with_storage_backend(StorageBackend::Lark)
+            .with_storage_backend(StorageBackend::Regolith)
             .build()
             .await?;
         ensure_runtime_schemas(&node).await?;

--- a/crates/gents/src/eth/submit.rs
+++ b/crates/gents/src/eth/submit.rs
@@ -868,7 +868,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let node = EmbeddedNode::builder()
             .data_path(temp.path().join("data"))
-            .with_storage_backend(defra_node::StorageBackend::Lark)
+            .with_storage_backend(defra_node::StorageBackend::Regolith)
             .build()
             .await
             .expect("node");

--- a/crates/gents/src/storage_backend.rs
+++ b/crates/gents/src/storage_backend.rs
@@ -1,19 +1,41 @@
+use std::io::Read;
 use std::path::Path;
 
 use anyhow::Result;
 
-/// Reject a data directory created by the legacy RocksDB runtime backend.
+/// Reject a data directory created by a retired runtime storage backend.
 ///
-/// Lark and RocksDB use incompatible on-disk formats. Lark would otherwise
-/// create its own files beside an existing RocksDB store and make the runtime
-/// appear empty, so callers must fail before opening the directory.
-pub fn reject_legacy_rocksdb_store(data_path: &Path) -> Result<()> {
+/// Regolith, Lark, and RocksDB use incompatible on-disk formats. Regolith
+/// would otherwise try to open legacy files as its own store, so callers must
+/// fail before opening the directory.
+pub fn reject_legacy_store(data_path: &Path) -> Result<()> {
     let current = data_path.join("CURRENT");
     if current.is_file() {
         anyhow::bail!(
-            "{} contains a legacy RocksDB Gents store; this release uses Lark and cannot open it. Reset the runtime state or use an older Gents release to export any data you need first",
+            "{} contains a legacy RocksDB Gents store; this release uses Regolith and cannot open it. Reset the runtime state or use an older Gents release to export any data you need first",
             data_path.display()
         );
+    }
+
+    let lark_path = data_path.join("data.lark");
+    if lark_path.exists() {
+        anyhow::bail!(
+            "{} contains a legacy Lark Gents store; this release uses Regolith and cannot open it. Reset the runtime state or use an older Gents release to export any data you need first",
+            data_path.display()
+        );
+    }
+
+    let manifest_path = data_path.join("MANIFEST");
+    if manifest_path.is_file() {
+        let mut manifest = std::fs::File::open(&manifest_path)?;
+        let mut magic = [0_u8; 7];
+        let read = manifest.read(&mut magic)?;
+        if read != magic.len() || magic != *b"REGOMAN" {
+            anyhow::bail!(
+                "{} contains an unsupported or corrupt Gents store; this release uses Regolith and cannot open it. Reset the runtime state or use an older Gents release to export any data you need first",
+                data_path.display()
+            );
+        }
     }
     Ok(())
 }
@@ -27,17 +49,37 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         std::fs::write(tempdir.path().join("CURRENT"), "MANIFEST-000005\n").unwrap();
 
-        let error = reject_legacy_rocksdb_store(tempdir.path()).unwrap_err();
+        let error = reject_legacy_store(tempdir.path()).unwrap_err();
 
         assert!(error.to_string().contains("legacy RocksDB Gents store"));
     }
 
     #[test]
-    fn accepts_empty_or_lark_data_directory() {
+    fn rejects_lark_manifest() {
         let tempdir = tempfile::tempdir().unwrap();
-        reject_legacy_rocksdb_store(tempdir.path()).unwrap();
+        std::fs::create_dir(tempdir.path().join("data.lark")).unwrap();
 
-        std::fs::write(tempdir.path().join("MANIFEST"), "lark").unwrap();
-        reject_legacy_rocksdb_store(tempdir.path()).unwrap();
+        let error = reject_legacy_store(tempdir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("legacy Lark Gents store"));
+    }
+
+    #[test]
+    fn rejects_unknown_manifest_format() {
+        let tempdir = tempfile::tempdir().unwrap();
+        std::fs::write(tempdir.path().join("MANIFEST"), "unknown").unwrap();
+
+        let error = reject_legacy_store(tempdir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("unsupported or corrupt"));
+    }
+
+    #[test]
+    fn accepts_empty_or_regolith_data_directory() {
+        let tempdir = tempfile::tempdir().unwrap();
+        reject_legacy_store(tempdir.path()).unwrap();
+
+        std::fs::write(tempdir.path().join("MANIFEST"), b"REGOMAN\x01rest").unwrap();
+        reject_legacy_store(tempdir.path()).unwrap();
     }
 }

--- a/crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs
+++ b/crates/gents/tests/e2e_lifecycle/merge_parked_unique_boot_e2e.rs
@@ -182,7 +182,7 @@ async fn merge_parked_unique_conflict_does_not_brick_boot() {
     // the P2P pending-DAG sweep loops (`run_pending_dag_resync`, 60s cadence,
     // spawned untracked in defra-node's `setup_p2p`), so the coordinator —
     // and through it the store — stays alive until the loop's next wake, and
-    // the in-process redb lock can lag shutdown by up to one sweep interval.
+    // the in-process storage lock can lag shutdown by up to one sweep interval.
     // A real process restart has no such lag (the OS drops the lock), so the
     // retry models process exit, not a race in the code under test.
     let reopen_deadline = Instant::now() + Duration::from_secs(90);

--- a/crates/gents/tests/e2e_live/steward_loop_live.rs
+++ b/crates/gents/tests/e2e_live/steward_loop_live.rs
@@ -36,7 +36,7 @@
 //!
 //! ```bash
 //! GENTS_D4F_LIVE=1 cargo test --test e2e_live \
-//!   --features defra-node/http,defra-node/p2p,lark \
+//!   --features defra-node/http,defra-node/p2p \
 //!   d4f_backend_probes_healthy_and_completes \
 //!   -- --ignored --test-threads=1 --nocapture
 //! ```

--- a/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
+++ b/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
@@ -10,7 +10,7 @@
         },
         "model_name": "deepseek-ai/DeepSeek-V4-Flash-0731",
         "name": "terminal-bench",
-        "version": "0.14.0"
+        "version": "0.15.0"
       },
       "extra": {
         "source_projection_id": "run_timeline",

--- a/crates/gents/tests/support/mod.rs
+++ b/crates/gents/tests/support/mod.rs
@@ -348,6 +348,7 @@ pub async fn test_p2p_db_with_admission(name: &str, admission: TestP2pAdmission)
                 rate_limit_rate: admission.rate_limit_rate,
                 max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
                 max_pending_dags: admission.max_pending_dags,
+                rebroadcast_on_merge: false,
             })
             .build()
             .await

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.14.0
-docker run --rm ghcr.io/source-inc/gents:v0.14.0 version
+docker pull ghcr.io/source-inc/gents:v0.15.0
+docker run --rm ghcr.io/source-inc/gents:v0.15.0 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.14.0 \
+  ghcr.io/source-inc/gents:v0.15.0 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.14.0 \
+  ghcr.io/source-inc/gents:v0.15.0 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -19,13 +19,13 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.14.0",
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-fleet": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-chat": "0.15.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-fleet": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,16 +43,16 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.14.0",
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-fleet": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-chat": "0.15.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-fleet": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -64,7 +64,7 @@
       "devDependencies": {
         "@antithesishq/bombadil": "^0.6.0",
         "@playwright/test": "^1.61.0",
-        "@source-inc/gents-desktop-operations": "0.14.0",
+        "@source-inc/gents-desktop-operations": "0.15.0",
         "@tauri-apps/cli": "2.10.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -82,10 +82,10 @@
     },
     "apps/review-demo": {
       "name": "@source-inc/review-demo-ui",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -5097,12 +5097,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5112,9 +5112,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5124,7 +5124,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5136,12 +5136,12 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5150,21 +5150,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5173,24 +5173,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.14.0",
-        "@source-inc/gents-desktop-tokens": "0.14.0",
-        "@source-inc/gents-desktop-ui": "0.14.0",
+        "@source-inc/gents-desktop-client": "0.15.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
+        "@source-inc/gents-desktop-ui": "0.15.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.14.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5202,7 +5202,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.14.0",
+        "@source-inc/gents-desktop-tokens": "0.15.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0"
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0",
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -12,7 +12,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.14.0";
+export const PACKAGE_VERSION = "0.15.0";
 // Runtime-authored behavior readiness is required and the duplicate runtime
 // counters are gone and status pairing is authenticated enrollment, so this
 // client requires the breaking 4.0 bridge.

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Reusable authenticated enrollment, connection health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -36,14 +36,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0"
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0",
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Focused holds, health, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0"
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.14.0",
-    "@source-inc/gents-desktop-tokens": "0.14.0",
-    "@source-inc/gents-desktop-ui": "0.14.0",
+    "@source-inc/gents-desktop-client": "0.15.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
+    "@source-inc/gents-desktop-ui": "0.15.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.14.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.14.0",
+    "@source-inc/gents-desktop-tokens": "0.15.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary

- pin every DefraDB workspace crate to the v0.19.0 tag commit (`03e1035f`)
- replace retired Lark/Redb configuration with Regolith and reject legacy or unknown durable stores before open
- enable verified post-merge P2P rebroadcast for Gents' multi-hop runtime and desktop deployments
- advance the Rust, npm, Tauri, iOS, bridge package, release workflow, docs, and fixture train to breaking version `0.15.0`
- document the authenticated mobile authority cut and DefraDB/storage break in the changelog
- remove unordered/timing assumptions exposed by Regolith from runtime and CLI integration helpers

## Breaking behavior

Existing Lark or RocksDB data directories do not open under v0.15.0. Startup fails with an actionable export/reset message; there is no backward-compatibility storage seam.

## Validation

- `cargo test -p gents` (1966 unit, 329 conformance, 44 lifecycle E2E, 57 runtime E2E, 107 subagent E2E, 8 trigger E2E, 36 misc; expected ignores only)
- Lean proof build replayed successfully (962 targets, zero failures/sorries)
- `cargo test -p gents-cli` (629 unit plus all non-live CLI integration suites; expected ignores only)
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `npm run check:package-boundaries`
- `npm run build:packages`
- `npm run test:packages`
- `npm run pack:packages` (packed consumer executed all entrypoints and verified CSS artifacts)
- `git diff --check`
