### PR TITLE
fix(prompt): strip id-less reasoning and fork-retry last human turn

### DIFF
--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -3289,9 +3289,14 @@ pub(crate) struct SessionForkArgs {
     #[arg(
         long,
         value_name = "N",
-        help = "0-based user-turn index; fork cuts before this user message"
+        help = "0-based user-turn index among all role=user rows (including tool-result-only); fork cuts before this user message. Mutex with --at-last-human-user-turn."
     )]
-    pub(crate) at_user_turn: u32,
+    pub(crate) at_user_turn: Option<u32>,
+    #[arg(
+        long,
+        help = "Cut before the last human user prompt (skips trailing tool-result-only user rows). Retries that user prompt; does not resume the tool loop. Mutex with --at-user-turn."
+    )]
+    pub(crate) at_last_human_user_turn: bool,
     #[arg(
         long,
         help = "Target behavior_id for the child; omit to inherit the parent's behavior"

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -759,6 +759,42 @@ fn demo_init_parses_pack_and_home() {
     }
 }
 
+fn parse_session_fork(extra: &[&str]) -> SessionForkArgs {
+    let mut argv = vec!["gents", "session", "fork"];
+    argv.extend_from_slice(extra);
+    let cli = Cli::try_parse_from(argv).expect("session fork should parse");
+    match cli.command {
+        Command::Session {
+            command: SessionCommand::Fork(args),
+        } => args,
+        _ => panic!("expected `session fork`"),
+    }
+}
+
+#[test]
+fn session_fork_parses_at_last_human_user_turn() {
+    let args = parse_session_fork(&["--from", "sess-1", "--at-last-human-user-turn"]);
+    assert_eq!(args.from, "sess-1");
+    assert_eq!(args.at_user_turn, None);
+    assert!(args.at_last_human_user_turn);
+}
+
+#[test]
+fn session_fork_parses_at_user_turn() {
+    let args = parse_session_fork(&["--from", "sess-1", "--at-user-turn", "2"]);
+    assert_eq!(args.from, "sess-1");
+    assert_eq!(args.at_user_turn, Some(2));
+    assert!(!args.at_last_human_user_turn);
+}
+
+#[test]
+fn session_fork_requires_from() {
+    assert!(
+        Cli::try_parse_from(["gents", "session", "fork", "--at-last-human-user-turn"]).is_err(),
+        "session fork should still require --from"
+    );
+}
+
 #[test]
 fn every_deprecated_path_warns() {
     use crate::cli::deprecations::{deprecation_warning, DEPRECATED};

--- a/crates/gents-cli/src/commands/codex_shim/thread_routes.rs
+++ b/crates/gents-cli/src/commands/codex_shim/thread_routes.rs
@@ -442,6 +442,7 @@ fn map_fork_error(err: ForkError) -> ThreadRouteError {
         | ForkError::ForkNotSameAgent
         | ForkError::ForkSourceBusy
         | ForkError::ForkAtUserTurnOutOfRange(_, _)
+        | ForkError::ForkNoHumanUserTurn
         | ForkError::ForkBehaviorNotFound(_)
         | ForkError::ForkBehaviorNotOwnedByPrincipal(_, _) => JSONRPC_INVALID_PARAMS,
     };

--- a/crates/gents-cli/src/commands/session.rs
+++ b/crates/gents-cli/src/commands/session.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
-use gents::session::{fork, fork_via_http, ForkError, ForkOutcome, ForkParams};
+use gents::session::{
+    fork, fork_via_http, resolve_fork_at_last_human_user_turn, ForkError, ForkOutcome, ForkParams,
+    HttpGraphqlExecutor,
+};
 use serde_json::{json, Value};
 
 use crate::cli::args::{ConfigListArgs, ConfigShowArgs, SessionCommand, SessionForkArgs};
@@ -77,13 +80,18 @@ async fn session_show(args: ConfigShowArgs) -> Result<()> {
 async fn session_fork(args: SessionForkArgs) -> Result<()> {
     let agent_did = resolve_agent_did(args.home.as_deref(), args.agent_did.as_deref())
         .context("resolving caller agent_did")?;
+    let cut = resolve_session_fork_cut(&args)?;
 
     if let Some(graphql) = args.graphql.as_deref() {
+        let fork_at_user_turn =
+            resolve_fork_at_user_turn_via_executor(&HttpGraphqlExecutor::new(graphql), &args, cut)
+                .await
+                .map_err(|error| map_graphql_fork_error(error, graphql))?;
         let outcome = fork_via_http(
             graphql,
             ForkParams {
                 source_session_id: &args.from,
-                fork_at_user_turn: args.at_user_turn,
+                fork_at_user_turn,
                 caller_agent_did: &agent_did,
                 target_behavior_id: args.behavior.as_deref(),
             },
@@ -91,7 +99,7 @@ async fn session_fork(args: SessionForkArgs) -> Result<()> {
         .await
         .map_err(|error| map_graphql_fork_error(error, graphql))?;
 
-        print_fork_outcome(&args, outcome)?;
+        print_fork_outcome(&args, fork_at_user_turn, outcome)?;
         return Ok(());
     }
 
@@ -116,11 +124,14 @@ async fn session_fork(args: SessionForkArgs) -> Result<()> {
         .await
         .context("ensuring runtime schemas")?;
 
+    let fork_at_user_turn = resolve_fork_at_user_turn_via_executor(&node, &args, cut)
+        .await
+        .map_err(map_fork_error)?;
     let outcome = fork(
         &node,
         ForkParams {
             source_session_id: &args.from,
-            fork_at_user_turn: args.at_user_turn,
+            fork_at_user_turn,
             caller_agent_did: &agent_did,
             target_behavior_id: args.behavior.as_deref(),
         },
@@ -128,8 +139,42 @@ async fn session_fork(args: SessionForkArgs) -> Result<()> {
     .await
     .map_err(map_fork_error)?;
 
-    print_fork_outcome(&args, outcome)?;
+    print_fork_outcome(&args, fork_at_user_turn, outcome)?;
     Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum SessionForkCut {
+    AtUserTurn(u32),
+    AtLastHumanUserTurn,
+}
+
+fn resolve_session_fork_cut(args: &SessionForkArgs) -> Result<SessionForkCut> {
+    match (args.at_user_turn, args.at_last_human_user_turn) {
+        (Some(_), true) => anyhow::bail!(
+            "--at-user-turn and --at-last-human-user-turn are mutually exclusive; \
+             pick one cut. --at-last-human-user-turn retries the last human prompt \
+             and does not resume the tool loop."
+        ),
+        (None, false) => anyhow::bail!(
+            "session fork requires --at-user-turn N or --at-last-human-user-turn"
+        ),
+        (Some(at_user_turn), false) => Ok(SessionForkCut::AtUserTurn(at_user_turn)),
+        (None, true) => Ok(SessionForkCut::AtLastHumanUserTurn),
+    }
+}
+
+async fn resolve_fork_at_user_turn_via_executor(
+    executor: &(impl gents::session::GraphqlExecutor + ?Sized),
+    args: &SessionForkArgs,
+    cut: SessionForkCut,
+) -> Result<u32, ForkError> {
+    match cut {
+        SessionForkCut::AtUserTurn(at_user_turn) => Ok(at_user_turn),
+        SessionForkCut::AtLastHumanUserTurn => {
+            resolve_fork_at_last_human_user_turn(executor, &args.from).await
+        }
+    }
 }
 
 async fn query_sessions(access: &ConfigAccess, session_id: Option<&str>) -> Result<Vec<Value>> {
@@ -290,11 +335,16 @@ fn print_table_row<const N: usize>(cells: &[&str; N], widths: &[usize; N]) {
     println!();
 }
 
-fn print_fork_outcome(args: &SessionForkArgs, outcome: ForkOutcome) -> Result<()> {
+fn print_fork_outcome(
+    args: &SessionForkArgs,
+    fork_at_user_turn: u32,
+    outcome: ForkOutcome,
+) -> Result<()> {
     print_json(&json!({
         "session_id": outcome.session_id,
         "source_session_id": args.from,
-        "fork_at_user_turn": args.at_user_turn,
+        "fork_at_user_turn": fork_at_user_turn,
+        "at_last_human_user_turn": args.at_last_human_user_turn,
         "copied_messages": outcome.copied_messages,
         "copied_tool_calls": outcome.copied_tool_calls,
         "copied_tool_results": outcome.copied_tool_results,
@@ -307,6 +357,7 @@ fn map_fork_error(error: ForkError) -> anyhow::Error {
     match error {
         ForkError::ForkSourceNotFound(_)
         | ForkError::ForkAtUserTurnOutOfRange(_, _)
+        | ForkError::ForkNoHumanUserTurn
         | ForkError::ForkBehaviorNotFound(_)
         | ForkError::ForkBehaviorNotOwnedByPrincipal(_, _)
         | ForkError::ForkNotSameAgent

--- a/crates/gents-cli/src/commands/session.rs
+++ b/crates/gents-cli/src/commands/session.rs
@@ -143,7 +143,7 @@ async fn session_fork(args: SessionForkArgs) -> Result<()> {
     Ok(())
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum SessionForkCut {
     AtUserTurn(u32),
     AtLastHumanUserTurn,
@@ -156,9 +156,9 @@ fn resolve_session_fork_cut(args: &SessionForkArgs) -> Result<SessionForkCut> {
              pick one cut. --at-last-human-user-turn retries the last human prompt \
              and does not resume the tool loop."
         ),
-        (None, false) => anyhow::bail!(
-            "session fork requires --at-user-turn N or --at-last-human-user-turn"
-        ),
+        (None, false) => {
+            anyhow::bail!("session fork requires --at-user-turn N or --at-last-human-user-turn")
+        }
         (Some(at_user_turn), false) => Ok(SessionForkCut::AtUserTurn(at_user_turn)),
         (None, true) => Ok(SessionForkCut::AtLastHumanUserTurn),
     }
@@ -351,6 +351,57 @@ fn print_fork_outcome(
         "copied_compaction_entries": outcome.copied_compaction_entries,
     }))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_session_fork_cut, SessionForkCut};
+    use crate::cli::args::SessionForkArgs;
+
+    fn fork_args(at_user_turn: Option<u32>, at_last_human_user_turn: bool) -> SessionForkArgs {
+        SessionForkArgs {
+            home: None,
+            graphql: None,
+            agent_did: None,
+            from: "sess-1".to_string(),
+            at_user_turn,
+            at_last_human_user_turn,
+            behavior: None,
+        }
+    }
+
+    #[test]
+    fn session_fork_cut_accepts_at_last_human_user_turn() {
+        match resolve_session_fork_cut(&fork_args(None, true)).expect("cut") {
+            SessionForkCut::AtLastHumanUserTurn => {}
+            SessionForkCut::AtUserTurn(_) => panic!("expected last-human cut"),
+        }
+    }
+
+    #[test]
+    fn session_fork_cut_accepts_at_user_turn() {
+        match resolve_session_fork_cut(&fork_args(Some(3), false)).expect("cut") {
+            SessionForkCut::AtUserTurn(3) => {}
+            other => panic!("expected at-user-turn 3, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_fork_cut_rejects_missing_and_mutex() {
+        let missing = resolve_session_fork_cut(&fork_args(None, false)).unwrap_err();
+        assert!(
+            missing
+                .to_string()
+                .contains("--at-user-turn N or --at-last-human-user-turn"),
+            "{missing}"
+        );
+        let mutex = resolve_session_fork_cut(&fork_args(Some(1), true)).unwrap_err();
+        assert!(
+            mutex.to_string().contains("mutually exclusive")
+                && mutex.to_string().contains("does not resume the tool loop"),
+            "{mutex}"
+        );
+    }
 }
 
 fn map_fork_error(error: ForkError) -> anyhow::Error {

--- a/crates/gents-cli/src/lib.rs
+++ b/crates/gents-cli/src/lib.rs
@@ -293,7 +293,10 @@ Examples:
 const SESSION_AFTER_HELP: &str = "\
 Fork a conversation into a new session seeded from a user-turn prefix \
 of the source. Child inherits principal; behavior can be swapped with \
---behavior.";
+--behavior. Use --at-user-turn N for an explicit cut, or \
+--at-last-human-user-turn to retry the last human prompt after a system \
+failure (skips trailing tool-result-only user rows; does not resume the \
+tool loop).";
 const SUBAGENT_AFTER_HELP: &str = "\
 Examples:
   gents subagent list

--- a/crates/gents/proofs/Proofs/PromptAssembly/Content.lean
+++ b/crates/gents/proofs/Proofs/PromptAssembly/Content.lean
@@ -9,7 +9,9 @@ ordinary. That abstraction is deliberately blind to what sits *inside* an
 assistant message.
 
 Production is not. `sanitize_history_for_provider` (`src/compaction.rs`) is a
-composition of THREE transforms, and the outermost one — Rust
+composition of FOUR transforms: drop orphaned tool results, drop unpaired
+tool calls, normalize assistant content order, then strip id-less OpenAI
+Responses reasoning items. The outermost ordering transform — Rust
 `normalize_assistant_content_order` — reorders the items within an assistant
 message to the canonical provider order (text, then reasoning and other
 non-call content, then tool calls). Transcripts persisted before the ordering

--- a/crates/gents/src/compaction.rs
+++ b/crates/gents/src/compaction.rs
@@ -395,8 +395,8 @@ pub fn strip_tool_results(messages: Vec<Message>) -> (Vec<Message>, FileActivity
 }
 
 pub fn sanitize_history_for_provider(messages: Vec<Message>) -> Vec<Message> {
-    history::normalize_assistant_content_order(history::drop_unpaired_tool_calls(
-        history::drop_orphaned_tool_results(messages),
+    history::strip_idless_reasoning(history::normalize_assistant_content_order(
+        history::drop_unpaired_tool_calls(history::drop_orphaned_tool_results(messages)),
     ))
 }
 
@@ -429,10 +429,12 @@ fn provider_view_with_sources(
         })
         .collect();
     let (stripped, activity) = history::strip_tool_results_sourced(sourced);
-    let sanitized = history::normalize_assistant_content_order_sourced(
-        history::drop_unpaired_tool_calls_sourced(history::drop_orphaned_tool_results_sourced(
-            stripped,
-        )),
+    let sanitized = history::strip_idless_reasoning_sourced(
+        history::normalize_assistant_content_order_sourced(
+            history::drop_unpaired_tool_calls_sourced(history::drop_orphaned_tool_results_sourced(
+                stripped,
+            )),
+        ),
     );
     (sanitized, activity)
 }

--- a/crates/gents/src/compaction/history.rs
+++ b/crates/gents/src/compaction/history.rs
@@ -320,9 +320,7 @@ pub(super) fn strip_idless_reasoning(messages: Vec<Message>) -> Vec<Message> {
     messages_only(strip_idless_reasoning_sourced(source_messages(messages)))
 }
 
-pub(super) fn strip_idless_reasoning_sourced(
-    messages: Vec<SourcedMessage>,
-) -> Vec<SourcedMessage> {
+pub(super) fn strip_idless_reasoning_sourced(messages: Vec<SourcedMessage>) -> Vec<SourcedMessage> {
     messages
         .into_iter()
         .filter_map(|sourced| {

--- a/crates/gents/src/compaction/history.rs
+++ b/crates/gents/src/compaction/history.rs
@@ -309,6 +309,54 @@ pub(super) fn normalize_assistant_content_order_sourced(
         .collect()
 }
 
+/// Drop OpenAI Responses reasoning items that lack a provider id.
+///
+/// Durable history may keep `Reasoning { id: None }` after a mid-stream
+/// failure (`persist_partial_turn`). Responses conversion rejects those
+/// items before HTTP (`An OpenAI-generated ID is required…`). The provider
+/// boundary therefore strips them; empty assistant rows that remain are
+/// dropped so the next turn is not bricked.
+pub(super) fn strip_idless_reasoning(messages: Vec<Message>) -> Vec<Message> {
+    messages_only(strip_idless_reasoning_sourced(source_messages(messages)))
+}
+
+pub(super) fn strip_idless_reasoning_sourced(
+    messages: Vec<SourcedMessage>,
+) -> Vec<SourcedMessage> {
+    messages
+        .into_iter()
+        .filter_map(|sourced| {
+            let SourcedMessage {
+                source_index,
+                message,
+            } = sourced;
+            let message = match message {
+                Message::Assistant { id, content } => {
+                    let content: Vec<AssistantContent> = content
+                        .into_iter()
+                        .filter(|item| match item {
+                            AssistantContent::Reasoning(reasoning) => reasoning
+                                .id
+                                .as_ref()
+                                .is_some_and(|value| !value.trim().is_empty()),
+                            _ => true,
+                        })
+                        .collect();
+                    if content.is_empty() {
+                        return None;
+                    }
+                    Message::Assistant { id, content }
+                }
+                other => other,
+            };
+            Some(SourcedMessage {
+                source_index,
+                message,
+            })
+        })
+        .collect()
+}
+
 pub(super) fn pretruncate_tool_results(messages: Vec<Message>, max_chars: usize) -> Vec<Message> {
     messages
         .into_iter()

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -2636,6 +2636,74 @@ fn empty_message_between_a_call_and_its_result_does_not_break_the_pair() {
     );
 }
 
+/// Grok SSE drops can persist `Reasoning { id: None }` via `persist_partial_turn`.
+/// The durable transcript stays permissive; the provider boundary must strip
+/// those id-less blocks so the next Responses conversion cannot brick.
+#[test]
+fn sanitize_history_for_provider_strips_idless_reasoning() {
+    use crate::llm::message::Reasoning;
+
+    let history = vec![
+        text_msg("user", "proceed"),
+        Message::Assistant {
+            id: None,
+            content: vec![
+                AssistantContent::Reasoning(Reasoning::new("partial thought before RST")),
+                AssistantContent::Text(Text {
+                    text: "partial answer".to_string(),
+                }),
+            ],
+        },
+        text_msg("user", "try again"),
+        Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::Reasoning(
+                Reasoning::new("poison only").with_id("rs_ok".to_string()),
+            )],
+        },
+        Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::Reasoning(Reasoning::new(
+                "id-less only — must vanish entirely",
+            ))],
+        },
+    ];
+
+    let out = super::sanitize_history_for_provider(history);
+    assert_eq!(out.len(), 4, "id-less-only assistant row must be dropped: {out:?}");
+
+    let Message::Assistant { content, .. } = &out[1] else {
+        panic!("expected partial assistant at index 1, got {out:?}");
+    };
+    assert!(
+        content.iter().all(|item| match item {
+            AssistantContent::Reasoning(Reasoning { id, .. }) => {
+                id.as_ref().is_some_and(|value| !value.trim().is_empty())
+            }
+            _ => true,
+        }),
+        "no id-less reasoning may remain: {content:?}"
+    );
+    assert!(
+        matches!(
+            content.as_slice(),
+            [AssistantContent::Text(Text { text })] if text == "partial answer"
+        ),
+        "text must survive when id-less reasoning is stripped: {content:?}"
+    );
+
+    let Message::Assistant { content, .. } = &out[3] else {
+        panic!("expected kept reasoning assistant at index 3, got {out:?}");
+    };
+    assert!(
+        matches!(
+            content.as_slice(),
+            [AssistantContent::Reasoning(Reasoning { id: Some(id), .. })] if id == "rs_ok"
+        ),
+        "reasoning with a real id must survive: {content:?}"
+    );
+}
+
 /// A *non-empty* ordinary message does end the turn, so a result arriving after
 /// it is orphaned and both it and its now-unpaired call go.
 #[test]

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -2670,7 +2670,11 @@ fn sanitize_history_for_provider_strips_idless_reasoning() {
     ];
 
     let out = super::sanitize_history_for_provider(history);
-    assert_eq!(out.len(), 4, "id-less-only assistant row must be dropped: {out:?}");
+    assert_eq!(
+        out.len(),
+        4,
+        "id-less-only assistant row must be dropped: {out:?}"
+    );
 
     let Message::Assistant { content, .. } = &out[1] else {
         panic!("expected partial assistant at index 1, got {out:?}");

--- a/crates/gents/src/session.rs
+++ b/crates/gents/src/session.rs
@@ -29,8 +29,9 @@ pub(crate) use conversation::{
     CONVERSATION_TITLE_SOURCE_TASK,
 };
 pub use fork::{
-    fork, fork_via_http, ForkError, ForkOutcome, ForkParams, GraphqlExecuteResponse,
-    GraphqlExecutor, HttpGraphqlExecutor,
+    fork, fork_via_http, is_human_user_message, last_human_user_turn_index,
+    resolve_fork_at_last_human_user_turn, ForkError, ForkOutcome, ForkParams,
+    GraphqlExecuteResponse, GraphqlExecutor, HttpGraphqlExecutor,
 };
 pub use history::load_history;
 #[cfg(test)]

--- a/crates/gents/src/session/fork.rs
+++ b/crates/gents/src/session/fork.rs
@@ -130,12 +130,45 @@ pub enum ForkError {
     ForkSourceBusy,
     #[error("fork_at_user_turn={0} is out of range (parent has only {1} user messages)")]
     ForkAtUserTurnOutOfRange(u32, u32),
+    #[error("no human user turn found in fork source (only tool-result user rows, or none)")]
+    ForkNoHumanUserTurn,
     #[error("target behavior not found: {0}")]
     ForkBehaviorNotFound(String),
     #[error("target behavior {0} is not owned by principal {1}")]
     ForkBehaviorNotOwnedByPrincipal(String, String),
     #[error("fork copy step failed: {0}")]
     ForkCopyFailed(#[from] anyhow::Error),
+}
+
+/// A human user turn is a `role=user` message whose content is not
+/// tool-result-only. Tool-result rows are also stored as `role=user`, so
+/// `--at-user-turn` indexes them; retry-after-failure needs the last *human*
+/// prompt instead.
+pub fn is_human_user_message(message: &crate::llm::message::Message) -> bool {
+    match message {
+        crate::llm::message::Message::User { content } => content
+            .iter()
+            .any(|item| !matches!(item, crate::llm::message::UserContent::ToolResult(_))),
+        _ => false,
+    }
+}
+
+/// Resolve the 0-based index among **all** `role=user` rows for the last human
+/// user turn. That index is what `fork_at_user_turn` / `--at-user-turn` expect:
+/// the cut is *before* that row, so the child excludes the poisoned partial
+/// assistant (and any in-turn tool rows) that follow it.
+///
+/// `user_messages` must be in ascending sequence order and contain only
+/// decoded user-role messages (tool-result-only rows included).
+pub fn last_human_user_turn_index(
+    user_messages: &[crate::llm::message::Message],
+) -> Option<u32> {
+    user_messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, message)| is_human_user_message(message))
+        .map(|(index, _)| index as u32)
 }
 
 async fn load_parent_conversation(
@@ -415,6 +448,52 @@ async fn compute_cut(
         .ok_or_else(|| anyhow::anyhow!("timestamp missing"))?
         .to_string();
     Ok(Ok((seq, ts)))
+}
+
+async fn resolve_last_human_user_turn_index(
+    executor: &(impl GraphqlExecutor + ?Sized),
+    source_session_id: &str,
+) -> Result<Option<u32>> {
+    let escaped = escape_graphql_string(source_session_id);
+    let query = format!(
+        r#"{{
+            AgentMessage(
+                filter: {{
+                    session_id: {{ _eq: "{escaped}" }},
+                    role: {{ _eq: "user" }}
+                }},
+                order: {{ sequence: ASC }}
+            ) {{ content }}
+        }}"#
+    );
+    let resp = executor.execute_graphql(&query).await?;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "resolve_last_human_user_turn_index query failed: {}",
+            render_graphql_errors(&resp)
+        );
+    }
+    let user_messages: Vec<crate::llm::message::Message> = graphql_rows(&resp, "AgentMessage")
+        .into_iter()
+        .map(|row| {
+            let content = row
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            gents_protocol::transcript::decode_persisted_message("user", content)
+        })
+        .collect();
+    Ok(last_human_user_turn_index(&user_messages))
+}
+
+pub async fn resolve_fork_at_last_human_user_turn(
+    executor: &(impl GraphqlExecutor + ?Sized),
+    source_session_id: &str,
+) -> Result<u32, ForkError> {
+    resolve_last_human_user_turn_index(executor, source_session_id)
+        .await
+        .map_err(ForkError::ForkCopyFailed)?
+        .ok_or(ForkError::ForkNoHumanUserTurn)
 }
 
 async fn compute_end_cut(
@@ -954,4 +1033,59 @@ fn json_string_array(value: &serde_json::Value) -> Option<Vec<String>> {
             .filter_map(|value| value.as_str().map(ToOwned::to_owned))
             .collect(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_human_user_message, last_human_user_turn_index};
+    use crate::llm::message::{Message, Text, ToolResult, ToolResultContent, UserContent};
+
+    fn human(text: &str) -> Message {
+        Message::User {
+            content: vec![UserContent::Text(Text {
+                text: text.to_string(),
+            })],
+        }
+    }
+
+    fn tool_result_only(call_id: &str) -> Message {
+        Message::User {
+            content: vec![UserContent::ToolResult(ToolResult {
+                id: call_id.to_string(),
+                call_id: Some(call_id.to_string()),
+                content: vec![ToolResultContent::Text(Text {
+                    text: "ok".to_string(),
+                })],
+            })],
+        }
+    }
+
+    #[test]
+    fn human_user_message_requires_non_tool_result_content() {
+        assert!(is_human_user_message(&human("retry")));
+        assert!(!is_human_user_message(&tool_result_only("c1")));
+        assert!(!is_human_user_message(&Message::Assistant {
+            id: None,
+            content: vec![],
+        }));
+    }
+
+    #[test]
+    fn last_human_user_turn_skips_trailing_tool_result_rows() {
+        let users = vec![
+            human("first"),
+            tool_result_only("c1"),
+            human("poisoned turn"),
+            tool_result_only("c2"),
+            tool_result_only("c3"),
+        ];
+        assert_eq!(last_human_user_turn_index(&users), Some(2));
+    }
+
+    #[test]
+    fn last_human_user_turn_none_when_only_tool_results() {
+        let users = vec![tool_result_only("c1"), tool_result_only("c2")];
+        assert_eq!(last_human_user_turn_index(&users), None);
+        assert_eq!(last_human_user_turn_index(&[]), None);
+    }
 }

--- a/crates/gents/src/session/fork.rs
+++ b/crates/gents/src/session/fork.rs
@@ -160,9 +160,7 @@ pub fn is_human_user_message(message: &crate::llm::message::Message) -> bool {
 ///
 /// `user_messages` must be in ascending sequence order and contain only
 /// decoded user-role messages (tool-result-only rows included).
-pub fn last_human_user_turn_index(
-    user_messages: &[crate::llm::message::Message],
-) -> Option<u32> {
+pub fn last_human_user_turn_index(user_messages: &[crate::llm::message::Message]) -> Option<u32> {
     user_messages
         .iter()
         .enumerate()

--- a/crates/gents/tests/conformance/prompt_assembly.rs
+++ b/crates/gents/tests/conformance/prompt_assembly.rs
@@ -94,7 +94,13 @@ fn assistant_item(item: &LeanPromptAssemblyItem) -> AssistantContent {
         "text" => AssistantContent::Text(Text {
             text: text_body(item.value),
         }),
-        "other" => AssistantContent::Reasoning(Reasoning::new(&reasoning_body(item.value))),
+        "other" => AssistantContent::Reasoning(
+            // Lean's `other` bucket does not model provider reasoning ids.
+            // Production strips id-less reasoning at the provider boundary, so
+            // the fence must mint a synthetic id or the case would be dropped
+            // before the Lean expected output is compared.
+            Reasoning::new(&reasoning_body(item.value)).with_id(format!("rs-lean-{}", item.value)),
+        ),
         "call" => AssistantContent::ToolCall(tool_call(item.value)),
         other => panic!("generated content item has an unmodeled tag: {other}"),
     }

--- a/crates/gents/tests/e2e_runtime/fork_invariants.rs
+++ b/crates/gents/tests/e2e_runtime/fork_invariants.rs
@@ -8,7 +8,13 @@ use gents::adapter_projection::{
 use gents::config_client::ConfigAccess;
 use gents::graphql::escape_graphql_string;
 use gents::run_timeline_fetch::load_run_timeline;
-use gents::session::{fork, fork_via_http, ForkError, ForkParams};
+use gents::llm::message::{
+    AssistantContent, Message, Reasoning, Text, ToolCall, ToolFunction, ToolResult,
+    ToolResultContent, UserContent,
+};
+use gents::session::{
+    fork, fork_via_http, resolve_fork_at_last_human_user_turn, ForkError, ForkParams,
+};
 use serde::Deserialize;
 use tokio::net::TcpListener;
 
@@ -1612,4 +1618,191 @@ async fn fork_of_fork_links_to_immediate_parent_not_grandparent() {
     assert!(!grandchild_messages
         .iter()
         .any(|m| m.session_id == child_outcome.session_id));
+}
+
+#[tokio::test]
+async fn fork_at_last_human_user_turn_cuts_before_poisoned_partial_turn() {
+    let db = test_db("fork-last-human-user-turn").await;
+
+    let parent_session = "parent-last-human";
+    create_agent_session(&db.node, parent_session, AGENT_NAME, "2026-04-21T10:00:00Z").await;
+    create_agent_conversation(&db.node, parent_session, AGENT_NAME, "2026-04-21T10:00:00Z").await;
+    create_agent_behavior(&db.node, AGENT_NAME, AGENT_DID).await;
+
+    let prior_user = Message::User {
+        content: vec![UserContent::Text(Text {
+            text: "prior human".to_string(),
+        })],
+    };
+    let prior_assistant = Message::Assistant {
+        id: None,
+        content: vec![AssistantContent::Text(Text {
+            text: "prior assistant".to_string(),
+        })],
+    };
+    let last_human = Message::User {
+        content: vec![UserContent::Text(Text {
+            text: "retry this human prompt".to_string(),
+        })],
+    };
+    let poisoned_assistant = Message::Assistant {
+        id: None,
+        content: vec![
+            AssistantContent::Reasoning(Reasoning::new("partial thought before RST")),
+            AssistantContent::ToolCall(ToolCall {
+                id: "call_poison".to_string(),
+                call_id: Some("call_poison".to_string()),
+                function: ToolFunction {
+                    name: "bash".to_string(),
+                    arguments: serde_json::json!({ "command": "echo poison" }),
+                },
+                signature: None,
+                additional_params: None,
+            }),
+        ],
+    };
+    let trailing_tool_result = Message::User {
+        content: vec![UserContent::ToolResult(ToolResult {
+            id: "call_poison".to_string(),
+            call_id: Some("call_poison".to_string()),
+            content: vec![ToolResultContent::Text(Text {
+                text: "poison tool output".to_string(),
+            })],
+        })],
+    };
+
+    create_agent_message(
+        &db.node,
+        parent_session,
+        1,
+        "user",
+        &serde_json::to_string(&prior_user).expect("serialize prior user"),
+        "2026-04-21T10:00:01Z",
+    )
+    .await;
+    create_agent_message(
+        &db.node,
+        parent_session,
+        2,
+        "assistant",
+        &serde_json::to_string(&prior_assistant).expect("serialize prior assistant"),
+        "2026-04-21T10:00:02Z",
+    )
+    .await;
+    create_agent_message(
+        &db.node,
+        parent_session,
+        3,
+        "user",
+        &serde_json::to_string(&last_human).expect("serialize last human"),
+        "2026-04-21T10:00:03Z",
+    )
+    .await;
+    create_agent_message(
+        &db.node,
+        parent_session,
+        4,
+        "assistant",
+        &serde_json::to_string(&poisoned_assistant).expect("serialize poisoned assistant"),
+        "2026-04-21T10:00:04Z",
+    )
+    .await;
+    create_agent_message(
+        &db.node,
+        parent_session,
+        5,
+        "user",
+        &serde_json::to_string(&trailing_tool_result).expect("serialize trailing tool result"),
+        "2026-04-21T10:00:05Z",
+    )
+    .await;
+    create_agent_tool_call(
+        &db.node,
+        parent_session,
+        4,
+        "call_poison",
+        "bash",
+        r#"{"command":"echo poison"}"#,
+        "poison tool output",
+        "completed",
+        "2026-04-21T10:00:04Z",
+        "2026-04-21T10:00:05Z",
+    )
+    .await;
+    create_agent_tool_result(
+        &db.node,
+        parent_session,
+        "bash",
+        r#"{"command":"echo poison"}"#,
+        "poison tool output",
+        "2026-04-21T10:00:05Z",
+    )
+    .await;
+
+    let cut = resolve_fork_at_last_human_user_turn(db.node.as_ref(), parent_session)
+        .await
+        .expect("resolve last human user turn");
+    assert_eq!(
+        cut, 1,
+        "last human is the second user row (index 1); trailing tool-result-only user is skipped"
+    );
+
+    let outcome = fork(
+        &db.node,
+        ForkParams {
+            source_session_id: parent_session,
+            fork_at_user_turn: cut,
+            caller_agent_did: AGENT_DID,
+            target_behavior_id: None,
+        },
+    )
+    .await
+    .expect("fork at last human user turn succeeds");
+
+    assert_eq!(outcome.copied_messages, 2);
+    assert_eq!(outcome.copied_tool_calls, 0);
+    assert_eq!(outcome.copied_tool_results, 0);
+
+    let child_messages = fetch_message_snapshots_for_session(&db.node, &outcome.session_id).await;
+    assert_eq!(child_messages.len(), 2);
+    assert!(
+        child_messages[0].content.contains("prior human"),
+        "child keeps history before the last human prompt: {:?}",
+        child_messages[0].content
+    );
+    assert!(
+        child_messages[1].content.contains("prior assistant"),
+        "child keeps history before the last human prompt: {:?}",
+        child_messages[1].content
+    );
+    assert!(
+        !child_messages
+            .iter()
+            .any(|m| m.content.contains("retry this human prompt")),
+        "cut is before the last human prompt so the child can retry it"
+    );
+    assert!(
+        !child_messages
+            .iter()
+            .any(|m| m.content.contains("partial thought before RST")
+                || m.content.contains("call_poison")
+                || m.content.contains("poison tool output")),
+        "child must exclude poisoned partial assistant / in-turn tool rows"
+    );
+
+    let child_tool_calls =
+        fetch_tool_call_snapshots_for_session(&db.node, &outcome.session_id).await;
+    let child_tool_results =
+        fetch_tool_result_snapshots_for_session(&db.node, &outcome.session_id).await;
+    assert!(child_tool_calls.is_empty());
+    assert!(child_tool_results.is_empty());
+
+    let child_conv = fetch_conversation_snapshot(&db.node, &outcome.session_id)
+        .await
+        .expect("child conversation exists");
+    assert_eq!(
+        child_conv.forked_from_session_id.as_deref(),
+        Some(parent_session)
+    );
+    assert_eq!(child_conv.fork_at_user_turn, Some(1));
 }

--- a/crates/gents/tests/e2e_runtime/fork_invariants.rs
+++ b/crates/gents/tests/e2e_runtime/fork_invariants.rs
@@ -7,11 +7,11 @@ use gents::adapter_projection::{
 };
 use gents::config_client::ConfigAccess;
 use gents::graphql::escape_graphql_string;
-use gents::run_timeline_fetch::load_run_timeline;
 use gents::llm::message::{
     AssistantContent, Message, Reasoning, Text, ToolCall, ToolFunction, ToolResult,
     ToolResultContent, UserContent,
 };
+use gents::run_timeline_fetch::load_run_timeline;
 use gents::session::{
     fork, fork_via_http, resolve_fork_at_last_human_user_turn, ForkError, ForkParams,
 };


### PR DESCRIPTION
## Summary

Grok Responses SSE can RST mid-turn. `persist_partial_turn` may then write `Reasoning { id: None }` as `"id": null`. The next Responses call dies locally with:

```
An OpenAI-generated ID is required when using OpenAI reasoning items
```

This PR is the automatic recovery plus an operator retry cut. 

1. **Sanitize (automatic).** `sanitize_history_for_provider` drops id-less Reasoning (and empty assistant rows that remain) at the provider boundary. Durable history stays permissive. Same-session continue can work after this commit.
2. **Fork CLI (operator).** `gents session fork --from <id> --at-last-human-user-turn` cuts **before** the last human user prompt (`role=user` that is not tool-result-only). The child retries that prompt. Mutex with `--at-user-turn N`.

**Semantics lock:** fork is **turn retry**, not stream resume. It does **not** resume the tool loop. Continuing a poisoned in-flight tool loop would be a different primitive (copy through last completed tool outputs, drop the partial/id-null assistant). Do not treat `--at-last-human-user-turn` as that.

## Validation

```
TMPDIR=$PWD/.scratch/tmp GENTS_SKIP_LENS_BUILD=1 GENTS_SKIP_CALLBACK_WASM_BUILD=1
```

- `cargo test -p gents --lib sanitize_history_for_provider_strips_idless_reasoning`
- `cargo test -p gents --lib last_human_user`
- `cargo test -p gents --lib human_user_message_requires`
- `cargo test -p gents --test e2e_runtime fork_at_last_human_user_turn`
- `cargo test -p gents-cli --lib session_fork`
- `cargo check --workspace --all-targets` (pre-rebase; rebase onto current main was conflict-free)

Not run here: Lean-generated `prompt_assembly` cases (`generated_sanitize_cases_drive_the_production_sanitizer`, `generated_rows_round_trip_through_production_messages`) — `lake` is not on PATH in this worktree. The Lean `Content.lean` change is comment-only (four transforms); the fence mints synthetic `rs-lean-*` ids so Lean `other` cases are not stripped.


## Out of scope
- Per-turn transport retry budget

Closes #1328
