### PR TITLE
CliTool subprocesses run under managed_exec (#1337)

### DIFF
--- a/crates/gents/src/tool_call_lifecycle/runtime.rs
+++ b/crates/gents/src/tool_call_lifecycle/runtime.rs
@@ -503,6 +503,38 @@ pub(crate) fn current_tool_runtime_context() -> Option<CurrentToolRuntimeContext
     })
 }
 
+/// The deadline/cancellation/live-output triple every managed subprocess
+/// spawn needs, derived once from the ambient runtime context so `bash` and
+/// `CliTool` (and any future managed-exec caller) share one computation
+/// instead of each re-deriving it: the request's deadline (if any) minned
+/// with `now + command_timeout`, the context's cancellation token (or a
+/// fresh, never-cancelled one), and the context's live-output sink.
+pub(crate) struct ToolExecutionBounds {
+    pub(crate) deadline_at: Option<DateTime<Utc>>,
+    pub(crate) cancellation_token: CancellationToken,
+    pub(crate) live_output: Option<LiveToolOutputWriter>,
+}
+
+pub(crate) fn tool_execution_bounds(command_timeout: Duration) -> ToolExecutionBounds {
+    let runtime = current_tool_runtime_context();
+    let request_deadline = runtime.as_ref().and_then(|runtime| runtime.deadline_at);
+    let command_deadline = Utc::now()
+        + chrono::Duration::from_std(command_timeout)
+            .unwrap_or_else(|_| chrono::Duration::days(36_500));
+    let deadline_at =
+        Some(request_deadline.map_or(command_deadline, |deadline| deadline.min(command_deadline)));
+    let cancellation_token = runtime
+        .as_ref()
+        .map(|runtime| runtime.cancellation_token.clone())
+        .unwrap_or_default();
+    let live_output = runtime.and_then(|runtime| runtime.live_output);
+    ToolExecutionBounds {
+        deadline_at,
+        cancellation_token,
+        live_output,
+    }
+}
+
 /// Execute `tool` under the ambient runtime scope's deadline/cancellation
 /// envelope, returning the typed outcome. This (together with the foreground
 /// dispatcher's own envelope) is the only path a managed terminal can take:
@@ -887,5 +919,29 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(observed, "background-session");
+    }
+
+    #[tokio::test]
+    async fn tool_execution_bounds_without_context_uses_the_command_timeout() {
+        let before = Utc::now();
+        let bounds = tool_execution_bounds(Duration::from_secs(30));
+        let after = Utc::now();
+        let deadline = bounds.deadline_at.expect("deadline");
+        assert!(deadline >= before + chrono::Duration::seconds(30));
+        assert!(deadline <= after + chrono::Duration::seconds(30));
+        assert!(!bounds.cancellation_token.is_cancelled());
+        assert!(bounds.live_output.is_none());
+    }
+
+    #[tokio::test]
+    async fn tool_execution_bounds_prefers_the_earlier_request_deadline() {
+        let request_deadline = Utc::now() + chrono::Duration::seconds(5);
+        let token = CancellationToken::new();
+        let bounds = scope_request_tool_execution(Some(request_deadline), token, async {
+            tool_execution_bounds(Duration::from_secs(3600))
+        })
+        .await;
+        assert_eq!(bounds.deadline_at, Some(request_deadline));
+        assert!(!bounds.cancellation_token.is_cancelled());
     }
 }

--- a/crates/gents/src/tool_call_lifecycle/runtime.rs
+++ b/crates/gents/src/tool_call_lifecycle/runtime.rs
@@ -513,6 +513,12 @@ pub(crate) struct ToolExecutionBounds {
     pub(crate) deadline_at: Option<DateTime<Utc>>,
     pub(crate) cancellation_token: CancellationToken,
     pub(crate) live_output: Option<LiveToolOutputWriter>,
+    /// The owning request's own deadline, unminned with the command
+    /// timeout — callers that need to distinguish "the request's deadline
+    /// elapsed" (the envelope's concern) from "the tool's local timeout
+    /// elapsed" read it from here instead of querying the runtime context a
+    /// second time.
+    pub(crate) request_deadline_at: Option<DateTime<Utc>>,
 }
 
 pub(crate) fn tool_execution_bounds(command_timeout: Duration) -> ToolExecutionBounds {
@@ -532,6 +538,7 @@ pub(crate) fn tool_execution_bounds(command_timeout: Duration) -> ToolExecutionB
         deadline_at,
         cancellation_token,
         live_output,
+        request_deadline_at: request_deadline,
     }
 }
 

--- a/crates/gents/src/toolset/cli_tool.rs
+++ b/crates/gents/src/toolset/cli_tool.rs
@@ -4,7 +4,7 @@ use crate::llm::tool::BoxFuture;
 use crate::llm::tool::ToolDefinition;
 use crate::llm::tool::{ToolDyn, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
-use crate::tool_call_lifecycle::runtime::current_tool_runtime_context;
+use crate::tool_call_lifecycle::runtime::tool_execution_bounds;
 use anyhow::{bail, Context, Result};
 
 use super::args::CliToolArgs;
@@ -111,31 +111,20 @@ async fn run_cli_command(config: &CliToolConfig, argv: &[String]) -> Result<Stri
     };
 
     let timeout_secs = config.timeout_secs.max(1);
-    let runtime = current_tool_runtime_context();
-    let request_deadline = runtime.as_ref().and_then(|runtime| runtime.deadline_at);
-    let command_deadline = chrono::Utc::now()
-        + chrono::Duration::from_std(std::time::Duration::from_secs(timeout_secs))
-            .unwrap_or_else(|_| chrono::Duration::days(36_500));
-    let deadline_at =
-        Some(request_deadline.map_or(command_deadline, |deadline| deadline.min(command_deadline)));
-    let cancellation_token = runtime
-        .as_ref()
-        .map(|runtime| runtime.cancellation_token.clone())
-        .unwrap_or_default();
-    let live_output = runtime.and_then(|runtime| runtime.live_output);
+    let bounds = tool_execution_bounds(std::time::Duration::from_secs(timeout_secs));
 
     let outcome = run_managed_exec(ManagedExecRequest {
         argv: std::iter::once(config.binary_path.display().to_string())
             .chain(argv.iter().cloned())
             .collect::<Vec<_>>(),
         cwd: cwd.clone(),
-        deadline_at,
-        cancellation_token,
+        deadline_at: bounds.deadline_at,
+        cancellation_token: bounds.cancellation_token,
         max_output_bytes: usize::MAX,
         stdin: Vec::new(),
         environment: Some(cli_tool_environment(config)),
         tool_name: Some(config.name.clone()),
-        live_output,
+        live_output: bounds.live_output,
     })
     .await;
 

--- a/crates/gents/src/toolset/cli_tool.rs
+++ b/crates/gents/src/toolset/cli_tool.rs
@@ -1,11 +1,11 @@
-use std::process::Stdio;
-use std::time::Duration;
+use std::collections::HashMap;
 
 use crate::llm::tool::BoxFuture;
 use crate::llm::tool::ToolDefinition;
 use crate::llm::tool::{ToolDyn, ToolError};
+use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
+use crate::tool_call_lifecycle::runtime::current_tool_runtime_context;
 use anyhow::{bail, Context, Result};
-use tokio::process::Command;
 
 use super::args::CliToolArgs;
 use super::shared::{cap_output, ToolError as LocalToolError};
@@ -82,24 +82,20 @@ fn validate_argv_policy(config: &CliToolConfig, argv: &[String]) -> Result<()> {
     )
 }
 
-async fn run_cli_command(config: &CliToolConfig, argv: &[String]) -> Result<String> {
-    let mut command = Command::new(&config.binary_path);
-    command
-        .args(argv)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env("PAGER", "cat")
-        .env("GIT_PAGER", "cat")
-        .env("NO_COLOR", "1")
-        .env("CLICOLOR", "0")
-        .env("TERM", "dumb")
-        .kill_on_drop(true);
-
+fn cli_tool_environment(config: &CliToolConfig) -> HashMap<String, String> {
+    let mut env: HashMap<String, String> = std::env::vars().collect();
+    env.insert("PAGER".to_string(), "cat".to_string());
+    env.insert("GIT_PAGER".to_string(), "cat".to_string());
+    env.insert("NO_COLOR".to_string(), "1".to_string());
+    env.insert("CLICOLOR".to_string(), "0".to_string());
+    env.insert("TERM".to_string(), "dumb".to_string());
     for (key, value) in &config.env_vars {
-        command.env(key, value);
+        env.insert(key.clone(), value.clone());
     }
+    env
+}
 
+async fn run_cli_command(config: &CliToolConfig, argv: &[String]) -> Result<String> {
     let cwd = match config.working_dir.as_ref() {
         Some(path) => {
             if !path.is_dir() {
@@ -113,24 +109,60 @@ async fn run_cli_command(config: &CliToolConfig, argv: &[String]) -> Result<Stri
         }
         None => std::env::current_dir().context("determining current working directory")?,
     };
-    command.current_dir(&cwd);
 
-    let output = tokio::time::timeout(
-        Duration::from_secs(config.timeout_secs.max(1)),
-        command.output(),
-    )
-    .await
-    .with_context(|| format!("timed out after {}s", config.timeout_secs.max(1)))??;
+    let timeout_secs = config.timeout_secs.max(1);
+    let runtime = current_tool_runtime_context();
+    let request_deadline = runtime.as_ref().and_then(|runtime| runtime.deadline_at);
+    let command_deadline = chrono::Utc::now()
+        + chrono::Duration::from_std(std::time::Duration::from_secs(timeout_secs))
+            .unwrap_or_else(|_| chrono::Duration::days(36_500));
+    let deadline_at =
+        Some(request_deadline.map_or(command_deadline, |deadline| deadline.min(command_deadline)));
+    let cancellation_token = runtime
+        .as_ref()
+        .map(|runtime| runtime.cancellation_token.clone())
+        .unwrap_or_default();
+    let live_output = runtime.and_then(|runtime| runtime.live_output);
+
+    let outcome = run_managed_exec(ManagedExecRequest {
+        argv: std::iter::once(config.binary_path.display().to_string())
+            .chain(argv.iter().cloned())
+            .collect::<Vec<_>>(),
+        cwd: cwd.clone(),
+        deadline_at,
+        cancellation_token,
+        max_output_bytes: usize::MAX,
+        stdin: Vec::new(),
+        environment: Some(cli_tool_environment(config)),
+        tool_name: Some(config.name.clone()),
+        live_output,
+    })
+    .await;
+
+    let (exit_code, stdout_bytes, stderr_bytes) = match outcome {
+        ManagedExecOutcome::Exited {
+            code,
+            stdout,
+            stderr,
+            ..
+        } => (code.unwrap_or(-1), stdout, stderr),
+        ManagedExecOutcome::TimedOut { .. } => {
+            bail!("timed out after {timeout_secs}s")
+        }
+        ManagedExecOutcome::Cancelled { .. } => {
+            bail!("command cancelled by the owning request")
+        }
+        ManagedExecOutcome::SpawnFailed { error } => bail!(error),
+    };
 
     let (stdout, _) = cap_output(
-        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&stdout_bytes),
         super::DEFAULT_MAX_COMMAND_CHARS,
     );
     let (stderr, _) = cap_output(
-        &String::from_utf8_lossy(&output.stderr),
+        &String::from_utf8_lossy(&stderr_bytes),
         super::DEFAULT_MAX_COMMAND_CHARS,
     );
-    let exit_code = output.status.code().unwrap_or(-1);
     let command_line = std::iter::once(config.binary_path.display().to_string())
         .chain(argv.iter().cloned())
         .collect::<Vec<_>>()
@@ -152,4 +184,63 @@ async fn run_cli_command(config: &CliToolConfig, argv: &[String]) -> Result<Stri
             &stderr
         },
     ))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn config(timeout_secs: u64) -> CliToolConfig {
+        CliToolConfig {
+            name: "sh".into(),
+            binary_path: "/bin/sh".into(),
+            description: String::new(),
+            allowed_argv_prefixes: vec![],
+            env_vars: HashMap::from([("GENTS_T".to_string(), "1".to_string())]),
+            working_dir: None,
+            timeout_secs,
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_exit_code_and_output_and_env() {
+        let out = run_cli_command(
+            &config(5),
+            &["-c".into(), "echo $GENTS_T; echo err 1>&2; exit 3".into()],
+        )
+        .await
+        .unwrap();
+        assert!(out.contains("exit_code: 3"), "{out}");
+        assert!(out.contains("stdout:\n1"), "{out}");
+        assert!(out.contains("stderr:\nerr"), "{out}");
+    }
+
+    #[tokio::test]
+    async fn tool_timeout_kills_the_process_group() {
+        let err = run_cli_command(&config(1), &["-c".into(), "sleep 30".into()])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("timed out after 1s"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn request_cancellation_stops_the_command() {
+        use crate::tool_call_lifecycle::runtime::scope_request_tool_execution;
+
+        let token = tokio_util::sync::CancellationToken::new();
+        let cancel = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            cancel.cancel();
+        });
+        let err = scope_request_tool_execution(
+            None,
+            token,
+            run_cli_command(&config(30), &["-c".into(), "sleep 30".into()]),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("cancelled"), "{err}");
+    }
 }

--- a/crates/gents/src/toolset/lsp/actions.rs
+++ b/crates/gents/src/toolset/lsp/actions.rs
@@ -929,23 +929,20 @@ pub(crate) async fn run_linter_diagnostics(
             .ok()?;
     let mut full = vec![program.to_string_lossy().into_owned()];
     full.extend(rest);
-    let runtime = crate::tool_call_lifecycle::runtime::current_tool_runtime_context();
-    let command_deadline = chrono::Utc::now()
-        + chrono::Duration::from_std(timeout).unwrap_or_else(|_| chrono::Duration::days(36_500));
-    let deadline_at = Some(
-        runtime
-            .as_ref()
-            .and_then(|scope| scope.deadline_at)
-            .map_or(command_deadline, |deadline| deadline.min(command_deadline)),
-    );
-    let cancellation_token = runtime
-        .map(|scope| scope.cancellation_token)
-        .unwrap_or_default();
+    // Best-effort supplementary probe layered onto one file's diagnostics
+    // section (run_linter_diagnostics is called once per matched file, up to
+    // MAX_GLOB_TARGETS times, inside a single diagnostics tool call): its raw
+    // stdout is reformatted into a single `"{linter}: {trimmed}"` line, or
+    // dropped entirely when empty, rather than surfaced verbatim. Streaming
+    // it live would interleave per-file linter noise into the enclosing
+    // tool call's live output that doesn't match what the tool ultimately
+    // returns, so this deliberately does not thread live_output.
+    let bounds = crate::tool_call_lifecycle::runtime::tool_execution_bounds(timeout);
     let outcome = crate::managed_exec::run_managed_exec(crate::managed_exec::ManagedExecRequest {
         argv: full,
         cwd: workspace,
-        deadline_at,
-        cancellation_token,
+        deadline_at: bounds.deadline_at,
+        cancellation_token: bounds.cancellation_token,
         max_output_bytes: 64 * 1024,
         stdin: Vec::new(),
         environment: Some(env),

--- a/crates/gents/src/toolset/shared/command.rs
+++ b/crates/gents/src/toolset/shared/command.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use super::context::{ToolContext, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
-use crate::tool_call_lifecycle::runtime::{current_tool_runtime_context, tool_execution_bounds};
+use crate::tool_call_lifecycle::runtime::tool_execution_bounds;
 use crate::tool_call_lifecycle::FailureClass;
 use crate::toolset::{CommandPolicyDenial, DenialReason};
 use crate::truncation::{truncate, TruncationLimits, TruncationMode};
@@ -563,8 +563,8 @@ pub(crate) async fn run_command(
     let root = context.root();
     let (program, command_args, sandbox) =
         sandboxed_command_for_policy(&root, command_name, args, &policy)?;
-    let request_deadline = current_tool_runtime_context().and_then(|runtime| runtime.deadline_at);
     let bounds = tool_execution_bounds(timeout);
+    let request_deadline = bounds.request_deadline_at;
     let started = Instant::now();
     let outcome = run_managed_exec(ManagedExecRequest {
         argv: std::iter::once(program)

--- a/crates/gents/src/toolset/shared/command.rs
+++ b/crates/gents/src/toolset/shared/command.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use super::context::{ToolContext, ToolError};
 use crate::managed_exec::{run_managed_exec, ManagedExecOutcome, ManagedExecRequest};
-use crate::tool_call_lifecycle::runtime::current_tool_runtime_context;
+use crate::tool_call_lifecycle::runtime::{current_tool_runtime_context, tool_execution_bounds};
 use crate::tool_call_lifecycle::FailureClass;
 use crate::toolset::{CommandPolicyDenial, DenialReason};
 use crate::truncation::{truncate, TruncationLimits, TruncationMode};
@@ -563,30 +563,21 @@ pub(crate) async fn run_command(
     let root = context.root();
     let (program, command_args, sandbox) =
         sandboxed_command_for_policy(&root, command_name, args, &policy)?;
-    let runtime = current_tool_runtime_context();
-    let request_deadline = runtime.as_ref().and_then(|runtime| runtime.deadline_at);
-    let command_deadline = chrono::Utc::now()
-        + chrono::Duration::from_std(timeout).unwrap_or_else(|_| chrono::Duration::days(36_500));
-    let deadline_at =
-        Some(request_deadline.map_or(command_deadline, |deadline| deadline.min(command_deadline)));
-    let cancellation_token = runtime
-        .as_ref()
-        .map(|runtime| runtime.cancellation_token.clone())
-        .unwrap_or_default();
-    let live_output = runtime.and_then(|runtime| runtime.live_output);
+    let request_deadline = current_tool_runtime_context().and_then(|runtime| runtime.deadline_at);
+    let bounds = tool_execution_bounds(timeout);
     let started = Instant::now();
     let outcome = run_managed_exec(ManagedExecRequest {
         argv: std::iter::once(program)
             .chain(command_args)
             .collect::<Vec<_>>(),
         cwd: cwd.clone(),
-        deadline_at,
-        cancellation_token,
+        deadline_at: bounds.deadline_at,
+        cancellation_token: bounds.cancellation_token,
         max_output_bytes: usize::MAX,
         stdin: Vec::new(),
         environment: Some(build_shell_env()),
         tool_name: Some(tool_name.to_string()),
-        live_output,
+        live_output: bounds.live_output,
     })
     .await;
     let duration_ms = elapsed_ms(started);


### PR DESCRIPTION
Closes #1337. Stacked on #1347 (base branch `so/1340-init-summary`).

## What changed

`CliTool` subprocesses run under `managed_exec`, the same owner that runs `bash` tool commands. The local `tokio::process::Command` + `tokio::time::timeout` + `kill_on_drop` lifecycle in `toolset/cli_tool.rs` is deleted.

- The request deadline (min'd with the tool's own `timeout_secs`) and the request cancellation token now bound a `CliTool` call; interrupting the owning request stops it, and process groups are reaped.
- Output report format (`cwd:`, `command:`, `exit_code:`, `stdout:`, `stderr:`), environment overrides, and working-directory validation are unchanged. Timeout and cancellation are reported distinctly.

Review found the deadline/cancellation derivation from the tool runtime context copied at three sites (bash, CliTool, LSP linter probe); it now has one owner, `tool_call_lifecycle::runtime::tool_execution_bounds`, with unit tests.

## Verification

Unit tests for exit-code/output/env, tool timeout, and request cancellation (the cancellation case failed before the change). `cargo test -p gents --lib toolset:: managed_exec`, `cargo check --workspace --all-targets`, `cargo fmt --all --check`; no `tokio::process::Command` remains under `toolset/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eatk66c9sS6vPq2nasHJVd
