### PR TITLE
One signed AgentRequestCreate constructor for runtime writers (#1336)

### DIFF
--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -1480,6 +1480,26 @@ pub async fn submit_goal_backed_request(
     }
 }
 
+/// The `Goal`/`GoalCreationClaim` selection shared by
+/// `goal_backed_request_recovery_query` (combined with an `AgentRequest`
+/// selection in one round trip) and `goal_creation_claim_recovery_query`
+/// (issued alone, after a separate `AgentRequest` retry-key match) — same
+/// filters and fields, so this selection text exists exactly once.
+fn goal_creation_claim_selection(agent_did: &str, session_id: &str) -> String {
+    format!(
+        r#"Goal(
+            filter: {{ agent_did: {{ _eq: "{}" }}, session_id: {{ _eq: "{}" }} }},
+            order: [{{ created_at: ASC }}, {{ goal_id: ASC }}]
+        ) {{ {GOAL_FIELDS} }}
+        GoalCreationClaim(filter: {{ creation_key: {{ _eq: "{}" }} }}, limit: 2) {{
+            goal_id agent_did session_id objective token_budget
+        }}"#,
+        escape_graphql_string(agent_did),
+        escape_graphql_string(session_id),
+        escape_graphql_string(&deterministic_goal_creation_key(agent_did, session_id)),
+    )
+}
+
 fn goal_backed_request_recovery_query(
     agent_did: &str,
     session_id: &str,
@@ -1494,18 +1514,10 @@ fn goal_backed_request_recovery_query(
             AgentRequest(filter: {{ retry_key: {{ _eq: "{}" }} }}, limit: 2) {{
                 _docID {GOAL_BACKED_REQUEST_FINGERPRINT_FIELDS}
             }}
-            Goal(
-                filter: {{ agent_did: {{ _eq: "{}" }}, session_id: {{ _eq: "{}" }} }},
-                order: [{{ created_at: ASC }}, {{ goal_id: ASC }}]
-            ) {{ {GOAL_FIELDS} }}
-            GoalCreationClaim(filter: {{ creation_key: {{ _eq: "{}" }} }}, limit: 2) {{
-                goal_id agent_did session_id objective token_budget
-            }}
+            {}
         }}"#,
         escape_graphql_string(retry_key),
-        escape_graphql_string(agent_did),
-        escape_graphql_string(session_id),
-        escape_graphql_string(&deterministic_goal_creation_key(agent_did, session_id)),
+        goal_creation_claim_selection(agent_did, session_id),
     ))
 }
 
@@ -1687,21 +1699,21 @@ async fn load_goal_backed_request_by_retry_key_from_access(
 
 fn goal_creation_claim_recovery_query(agent_did: &str, session_id: &str) -> String {
     format!(
-        r#"{{
-            Goal(
-                filter: {{ agent_did: {{ _eq: "{}" }}, session_id: {{ _eq: "{}" }} }},
-                order: [{{ created_at: ASC }}, {{ goal_id: ASC }}]
-            ) {{ {GOAL_FIELDS} }}
-            GoalCreationClaim(filter: {{ creation_key: {{ _eq: "{}" }} }}, limit: 2) {{
-                goal_id agent_did session_id objective token_budget
-            }}
-        }}"#,
-        escape_graphql_string(agent_did),
-        escape_graphql_string(session_id),
-        escape_graphql_string(&deterministic_goal_creation_key(agent_did, session_id)),
+        "{{ {} }}",
+        goal_creation_claim_selection(agent_did, session_id)
     )
 }
 
+/// Recover a goal-backed request by its retry key after an ambiguous local
+/// commit, using two round trips instead of `load_goal_backed_request_by_retry_key_from_access`'s
+/// one: first the shared `load_agent_request_by_retry_key` AgentRequest
+/// match, then — only once that matches — the `Goal`/`GoalCreationClaim`
+/// cross-check. This is safe to split because `stage_goal_backed_request`
+/// commits the goal, its creation claim, and the request in one durable
+/// transaction: if the `AgentRequest` row is visible with this retry key,
+/// the `Goal` and `GoalCreationClaim` rows committed alongside it are
+/// visible too, so there is no window where the first query could observe
+/// a match the second query then fails to find.
 async fn load_goal_backed_request_by_retry_key(
     node: &EmbeddedNode,
     agent_did: &str,

--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -1509,29 +1509,65 @@ fn goal_backed_request_recovery_query(
     ))
 }
 
-fn decode_goal_backed_request_recovery(
+/// Decode the `AgentRequest` rows from a retry-key lookup, matching the
+/// unique row (if any) against `expected`. Fails closed if the retry key is
+/// not unique or if the persisted row's immutable fields differ from
+/// `expected`. Returns the row's document id if a matching row exists,
+/// `None` if none exists yet.
+fn decode_agent_request_by_retry_key(
+    rows: &[serde_json::Value],
+    expected: &GoalBackedRequestFingerprint,
+) -> Result<Option<String>> {
+    anyhow::ensure!(rows.len() <= 1, "AgentRequest retry key is not unique");
+    let Some(row) = rows.first() else {
+        return Ok(None);
+    };
+    let persisted: GoalBackedRequestFingerprint =
+        serde_json::from_value(row.clone()).context("decoding AgentRequest fingerprint")?;
+    anyhow::ensure!(
+        persisted == *expected,
+        "AgentRequest retry key conflicts with a different immutable request"
+    );
+    row.get("_docID")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .context("AgentRequest matched by retry key has no document ID")
+        .map(Some)
+}
+
+/// Query one `AgentRequest` by `retry_key`, decode it into a
+/// `GoalBackedRequestFingerprint`, and compare it against `expected`.
+/// Shared by goal creation/continuation recovery, both of which query an
+/// `AgentRequest` by its unique `retry_key` and need the same fail-closed
+/// uniqueness and immutable-field checks before trusting an existing row.
+pub(crate) async fn load_agent_request_by_retry_key(
+    node: &EmbeddedNode,
+    retry_key: &str,
+    expected: &GoalBackedRequestFingerprint,
+) -> Result<Option<String>> {
+    let query = format!(
+        r#"{{ AgentRequest(filter: {{ retry_key: {{ _eq: "{}" }} }}, limit: 2) {{
+            _docID {GOAL_BACKED_REQUEST_FINGERPRINT_FIELDS}
+        }} }}"#,
+        escape_graphql_string(retry_key),
+    );
+    let response =
+        graphql_with_transaction_retry(node, &query, "load AgentRequest by retry key").await?;
+    decode_agent_request_by_retry_key(&rows(&response, "AgentRequest")?, expected)
+}
+
+/// Verify that the durable `Goal`/`GoalCreationClaim` rows in `response`
+/// match the goal a goal-backed request is meant to belong to. Separate
+/// from the `AgentRequest` retry-key match above: an existing request row
+/// only proves the request was staged, not that it landed on the goal this
+/// caller expects.
+fn verify_goal_creation_claim_cross_check(
     response: &serde_json::Value,
     agent_did: &str,
     session_id: &str,
     objective: &str,
     token_budget: Option<i64>,
-    request: &gents_protocol::request_admission::AgentRequestCreate,
-) -> Result<Option<crate::lifecycle::materialize::EnqueuedAgentRequest>> {
-    let rows = response
-        .pointer("/data/AgentRequest")
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    anyhow::ensure!(rows.len() <= 1, "goal request retry key is not unique");
-    let Some(row) = rows.first() else {
-        return Ok(None);
-    };
-    let persisted: GoalBackedRequestFingerprint =
-        serde_json::from_value(row.clone()).context("decoding goal-backed request fingerprint")?;
-    anyhow::ensure!(
-        persisted == GoalBackedRequestFingerprint::from_create(request)?,
-        "goal request retry key conflicts with different immutable request fields"
-    );
+) -> Result<()> {
     let expected_claim = GoalCreationFingerprint {
         owner: agent_did.to_string(),
         session: session_id.to_string(),
@@ -1595,11 +1631,33 @@ fn decode_goal_backed_request_recovery(
             && claim == expected_claim,
         "goal-backed request conflicts with its durable goal claim"
     );
-    let doc_id = row
-        .get("_docID")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-        .context("goal-backed request has no document ID")?;
+    Ok(())
+}
+
+fn decode_goal_backed_request_recovery(
+    response: &serde_json::Value,
+    agent_did: &str,
+    session_id: &str,
+    objective: &str,
+    token_budget: Option<i64>,
+    request: &gents_protocol::request_admission::AgentRequestCreate,
+) -> Result<Option<crate::lifecycle::materialize::EnqueuedAgentRequest>> {
+    let rows = response
+        .pointer("/data/AgentRequest")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let expected = GoalBackedRequestFingerprint::from_create(request)?;
+    let Some(doc_id) = decode_agent_request_by_retry_key(&rows, &expected)? else {
+        return Ok(None);
+    };
+    verify_goal_creation_claim_cross_check(
+        response,
+        agent_did,
+        session_id,
+        objective,
+        token_budget,
+    )?;
     Ok(Some(crate::lifecycle::materialize::EnqueuedAgentRequest {
         doc_id,
         request_id: request.request_id.clone(),
@@ -1627,6 +1685,23 @@ async fn load_goal_backed_request_by_retry_key_from_access(
     )
 }
 
+fn goal_creation_claim_recovery_query(agent_did: &str, session_id: &str) -> String {
+    format!(
+        r#"{{
+            Goal(
+                filter: {{ agent_did: {{ _eq: "{}" }}, session_id: {{ _eq: "{}" }} }},
+                order: [{{ created_at: ASC }}, {{ goal_id: ASC }}]
+            ) {{ {GOAL_FIELDS} }}
+            GoalCreationClaim(filter: {{ creation_key: {{ _eq: "{}" }} }}, limit: 2) {{
+                goal_id agent_did session_id objective token_budget
+            }}
+        }}"#,
+        escape_graphql_string(agent_did),
+        escape_graphql_string(session_id),
+        escape_graphql_string(&deterministic_goal_creation_key(agent_did, session_id)),
+    )
+}
+
 async fn load_goal_backed_request_by_retry_key(
     node: &EmbeddedNode,
     agent_did: &str,
@@ -1635,21 +1710,33 @@ async fn load_goal_backed_request_by_retry_key(
     token_budget: Option<i64>,
     request: &gents_protocol::request_admission::AgentRequestCreate,
 ) -> Result<Option<crate::lifecycle::materialize::EnqueuedAgentRequest>> {
-    let query = goal_backed_request_recovery_query(agent_did, session_id, request)?;
+    let retry_key = request
+        .retry_key
+        .as_deref()
+        .context("goal-backed request requires a stable retry_key")?;
+    let expected = GoalBackedRequestFingerprint::from_create(request)?;
+    let Some(doc_id) = load_agent_request_by_retry_key(node, retry_key, &expected).await? else {
+        return Ok(None);
+    };
+    let query = goal_creation_claim_recovery_query(agent_did, session_id);
     let response =
-        graphql_with_transaction_retry(node, &query, "load goal-backed request by retry key")
+        graphql_with_transaction_retry(node, &query, "load goal-backed request creation claim")
             .await?;
     let response = serde_json::json!({
         "data": response.data.unwrap_or(serde_json::Value::Null),
     });
-    decode_goal_backed_request_recovery(
+    verify_goal_creation_claim_cross_check(
         &response,
         agent_did,
         session_id,
         objective,
         token_budget,
-        request,
-    )
+    )?;
+    Ok(Some(crate::lifecycle::materialize::EnqueuedAgentRequest {
+        doc_id,
+        request_id: request.request_id.clone(),
+        session_id: request.session_id.clone(),
+    }))
 }
 
 /// Embedded-runtime counterpart of [`submit_goal_backed_request`].

--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -19,6 +19,8 @@ pub(crate) mod queue;
 mod recovery;
 mod rows;
 mod task_title;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod transition;
 
 pub use manual::{write_manual_agent_request, write_manual_agent_request_with_conversation_title};

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -399,35 +399,66 @@ async fn redrive_mutation(
             &candidate.agent_did,
             &candidate.request_id,
         );
-    let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-        request_id,
-        &candidate.agent_did,
-        &candidate.agent_did,
-        &candidate.behavior_id,
-        &candidate.session_id,
-        BACKGROUND_COMPLETION_WAKE_PROMPT,
-        "scheduled",
-        &now,
+    // Reused for both subagent_depth/parent linkage: a redrive successor is
+    // not a subagent, but it carries the same "linked to one parent request,
+    // at some depth" shape `SubagentLink` was built for.
+    let parent_link = crate::lifecycle::materialize::SubagentLink {
+        depth: candidate.subagent_depth.unwrap_or_default(),
+        parent_request_id: candidate.request_id.clone(),
+        parent_request_doc_id: candidate.doc_id.clone(),
+        parent_tool_call_id: None,
+        parent_tool_call_doc_id: None,
+    };
+    let spec = crate::lifecycle::materialize::RequestSpec {
+        identity: crate::lifecycle::materialize::RequestIdentity {
+            request_id: request_id.to_string(),
+            agent_did: candidate.agent_did.clone(),
+            requester_did: None,
+            behavior_id: candidate.behavior_id.clone(),
+            session_id: candidate.session_id.clone(),
+            content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
+            execution_origin: crate::lifecycle::ExecutionOrigin::Scheduled,
+            created_at: now.clone(),
+        },
         admission,
-    );
-    create.retry_parent_request = Some(candidate.request_id.clone());
-    create.retry_parent_request_doc_id = Some(candidate.doc_id.clone());
-    create.retry_root_request = Some(retry_root.to_string());
-    create.retry_key = Some(retry_key.to_string());
-    create.temperature = candidate.temperature;
-    create.top_p = candidate.top_p;
-    create.top_k = candidate.top_k;
-    create.seed = candidate.seed;
-    create.max_tokens = candidate.max_tokens;
-    create.max_total_tokens = candidate.max_total_tokens;
-    create.metadata = candidate.metadata.clone();
-    create.backend_id = candidate.backend_id.clone();
-    create.retry_count = candidate.retry_count + 1;
-    create.max_retries = candidate.max_retries;
-    create.subagent_depth = candidate.subagent_depth.unwrap_or_default();
-    create.caused_by_parent_request_id = Some(candidate.request_id.clone());
-    create.caused_by_parent_request_doc_id = Some(candidate.doc_id.clone());
-    crate::sign_agent_request_create_as_registered_target(&mut create).await?;
+        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
+        trigger_lineage: crate::lifecycle::TriggerLineage::default(),
+        trigger_doc_id: None,
+        workspace: None,
+        subagent: Some(parent_link),
+        retry: Some(crate::lifecycle::materialize::RetryLink {
+            parent_request_id: candidate.request_id.clone(),
+            parent_request_doc_id: candidate.doc_id.clone(),
+            root_request_id: retry_root.to_string(),
+            retry_count: candidate.retry_count + 1,
+            max_retries: candidate.max_retries,
+        }),
+        sampling: Some(crate::lifecycle::materialize::SamplingCarryover {
+            temperature: candidate.temperature,
+            top_p: candidate.top_p,
+            top_k: candidate.top_k,
+            seed: candidate.seed,
+            max_tokens: candidate.max_tokens,
+            max_total_tokens: candidate.max_total_tokens,
+            // `backend_id` is normally never persisted as `Some("")` (the
+            // only production writer that sets it, materialize.rs's
+            // `materialize_claimed_with_execution_binding`, guards the same
+            // way), but this is a durable read of whatever is on the failed
+            // row, so normalize defensively rather than assume.
+            backend_id: candidate
+                .backend_id
+                .clone()
+                .filter(|value| !value.is_empty()),
+        }),
+        metadata: candidate.metadata.clone(),
+        retry_key: Some(retry_key.to_string()),
+        valid_until: None,
+    };
+    let create = crate::lifecycle::materialize::build_signed_request(
+        spec,
+        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+    )
+    .await?;
     let request_fields = create.graphql_input_fields().map_err(anyhow::Error::msg)?;
     Ok(format!(
         r#"mutation {{

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -8,8 +8,8 @@ use crate::background_completion::BACKGROUND_COMPLETION_WAKE_PROMPT;
 use crate::config_client::ConfigApplyTxn;
 use crate::graphql::escape_graphql_string;
 use crate::lifecycle::materialize::{
-    build_signed_request, RequestIdentity, RequestSigner, RequestSpec, RetryLink,
-    SamplingCarryover, SubagentLink,
+    build_signed_request, ParentLink, RequestIdentity, RequestSigner, RequestSpec, RetryLink,
+    SamplingCarryover,
 };
 use crate::lifecycle::ExecutionOrigin;
 
@@ -404,8 +404,7 @@ async fn redrive_mutation(
             &candidate.agent_did,
             &candidate.request_id,
         );
-    // Not a subagent, but the same "one parent request, at some depth" shape.
-    let parent_link = SubagentLink {
+    let parent_link = ParentLink {
         depth: candidate.subagent_depth.unwrap_or_default(),
         parent_request_id: candidate.request_id.clone(),
         parent_request_doc_id: candidate.doc_id.clone(),
@@ -414,7 +413,6 @@ async fn redrive_mutation(
     let identity = RequestIdentity {
         request_id: request_id.to_string(),
         agent_did: candidate.agent_did.clone(),
-        requester_did: None,
         behavior_id: candidate.behavior_id.clone(),
         session_id: candidate.session_id.clone(),
         content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
@@ -437,12 +435,7 @@ async fn redrive_mutation(
             seed: candidate.seed,
             max_tokens: candidate.max_tokens,
             max_total_tokens: candidate.max_total_tokens,
-            // Durable read of a possibly-legacy row; normalize Some("")
-            // the same way materialize.rs's writer does.
-            backend_id: candidate
-                .backend_id
-                .clone()
-                .filter(|value| !value.is_empty()),
+            backend_id: candidate.backend_id.clone(),
         }),
         metadata: candidate.metadata.clone(),
         retry_key: Some(retry_key.to_string()),
@@ -483,23 +476,7 @@ async fn redrive_mutation(
 #[cfg(test)]
 mod pin_tests {
     use super::*;
-    use crate::identity::AgentIdentity;
-
-    const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
-    const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
-
-    fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
-        let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
-            .step_by(2)
-            .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
-            .collect();
-        let path = dir.join("pinning.key");
-        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
-        let identity =
-            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
-        assert_eq!(identity.did(), PIN_FIXED_DID);
-        identity
-    }
+    use crate::lifecycle::test_support::{pin_fixed_signing_identity, PIN_FIXED_DID};
 
     #[tokio::test]
     async fn pin_redrive_mutation_dto_construction() {
@@ -548,7 +525,6 @@ mod pin_tests {
             identity: crate::lifecycle::materialize::RequestIdentity {
                 request_id: request_id.clone(),
                 agent_did: candidate.agent_did.clone(),
-                requester_did: None,
                 behavior_id: candidate.behavior_id.clone(),
                 session_id: candidate.session_id.clone(),
                 content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
@@ -561,7 +537,7 @@ mod pin_tests {
             trigger_lineage: crate::lifecycle::TriggerLineage::default(),
             trigger_doc_id: None,
             workspace: None,
-            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+            subagent: Some(crate::lifecycle::materialize::ParentLink {
                 depth: candidate.subagent_depth.unwrap_or_default(),
                 parent_request_id: candidate.request_id.clone(),
                 parent_request_doc_id: candidate.doc_id.clone(),

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -7,6 +7,12 @@ use serde::Deserialize;
 use crate::background_completion::BACKGROUND_COMPLETION_WAKE_PROMPT;
 use crate::config_client::ConfigApplyTxn;
 use crate::graphql::escape_graphql_string;
+use crate::lifecycle::materialize::{
+    build_signed_request, RequestIdentity, RequestSigner, RequestSpec, RetryLink,
+    SamplingCarryover, SubagentLink,
+};
+use crate::lifecycle::{ExecutionOrigin, TriggerLineage};
+use gents_protocol::request_lifecycle::RequestLifecycleState;
 
 use super::queue::{parse_queue_hints, QueuePolicy, QueueSource};
 use super::{BackgroundWakeRedriveReport, RequestLifecycle};
@@ -402,38 +408,38 @@ async fn redrive_mutation(
     // Reused for both subagent_depth/parent linkage: a redrive successor is
     // not a subagent, but it carries the same "linked to one parent request,
     // at some depth" shape `SubagentLink` was built for.
-    let parent_link = crate::lifecycle::materialize::SubagentLink {
+    let parent_link = SubagentLink {
         depth: candidate.subagent_depth.unwrap_or_default(),
         parent_request_id: candidate.request_id.clone(),
         parent_request_doc_id: candidate.doc_id.clone(),
         parent_tool_call_id: None,
         parent_tool_call_doc_id: None,
     };
-    let spec = crate::lifecycle::materialize::RequestSpec {
-        identity: crate::lifecycle::materialize::RequestIdentity {
+    let spec = RequestSpec {
+        identity: RequestIdentity {
             request_id: request_id.to_string(),
             agent_did: candidate.agent_did.clone(),
             requester_did: None,
             behavior_id: candidate.behavior_id.clone(),
             session_id: candidate.session_id.clone(),
             content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
-            execution_origin: crate::lifecycle::ExecutionOrigin::Scheduled,
+            execution_origin: ExecutionOrigin::Scheduled,
             created_at: now.clone(),
         },
         admission,
-        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
-        trigger_lineage: crate::lifecycle::TriggerLineage::default(),
+        initial_lifecycle_state: RequestLifecycleState::Pending,
+        trigger_lineage: TriggerLineage::default(),
         trigger_doc_id: None,
         workspace: None,
         subagent: Some(parent_link),
-        retry: Some(crate::lifecycle::materialize::RetryLink {
+        retry: Some(RetryLink {
             parent_request_id: candidate.request_id.clone(),
             parent_request_doc_id: candidate.doc_id.clone(),
             root_request_id: retry_root.to_string(),
             retry_count: candidate.retry_count + 1,
             max_retries: candidate.max_retries,
         }),
-        sampling: Some(crate::lifecycle::materialize::SamplingCarryover {
+        sampling: Some(SamplingCarryover {
             temperature: candidate.temperature,
             top_p: candidate.top_p,
             top_k: candidate.top_k,
@@ -454,11 +460,7 @@ async fn redrive_mutation(
         retry_key: Some(retry_key.to_string()),
         valid_until: None,
     };
-    let create = crate::lifecycle::materialize::build_signed_request(
-        spec,
-        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
-    )
-    .await?;
+    let create = build_signed_request(spec, RequestSigner::RegisteredTarget).await?;
     let request_fields = create.graphql_input_fields().map_err(anyhow::Error::msg)?;
     Ok(format!(
         r#"mutation {{

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -505,54 +505,74 @@ mod pin_tests {
             max_retries: 5,
             terminalized_at: Some("2029-12-31T23:59:59Z".to_string()),
         };
-        let request_id = "redrive-request-1";
-        let retry_key = "redrive-retry-key-1";
+        let request_id = "redrive-request-1".to_string();
+        let retry_key = "redrive-retry-key-1".to_string();
 
-        // --- reproduces redrive_mutation's DTO construction, with a fixed
-        // `now` in place of `Utc::now()` ---
+        // Driven through `build_signed_request` with the equivalent
+        // `RequestSpec` (a fixed `now` in place of `Utc::now()`), asserting
+        // against the output pinned by reproducing `redrive_mutation`'s
+        // DTO-construction statements directly.
         let now = "2030-01-01T00:00:00Z".to_string();
         let retry_root = candidate
             .retry_root_request
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or(&candidate.request_id);
+            .clone()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| candidate.request_id.clone());
         let admission =
             gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
                 &candidate.agent_did,
                 &candidate.request_id,
             );
-        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-            request_id,
-            &candidate.agent_did,
-            &candidate.agent_did,
-            &candidate.behavior_id,
-            &candidate.session_id,
-            BACKGROUND_COMPLETION_WAKE_PROMPT,
-            "scheduled",
-            &now,
+        let spec = crate::lifecycle::materialize::RequestSpec {
+            identity: crate::lifecycle::materialize::RequestIdentity {
+                request_id: request_id.clone(),
+                agent_did: candidate.agent_did.clone(),
+                requester_did: None,
+                behavior_id: candidate.behavior_id.clone(),
+                session_id: candidate.session_id.clone(),
+                content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
+                execution_origin: crate::lifecycle::ExecutionOrigin::Scheduled,
+                created_at: now,
+            },
             admission,
-        );
-        create.retry_parent_request = Some(candidate.request_id.clone());
-        create.retry_parent_request_doc_id = Some(candidate.doc_id.clone());
-        create.retry_root_request = Some(retry_root.to_string());
-        create.retry_key = Some(retry_key.to_string());
-        create.temperature = candidate.temperature;
-        create.top_p = candidate.top_p;
-        create.top_k = candidate.top_k;
-        create.seed = candidate.seed;
-        create.max_tokens = candidate.max_tokens;
-        create.max_total_tokens = candidate.max_total_tokens;
-        create.metadata = candidate.metadata.clone();
-        create.backend_id = candidate.backend_id.clone();
-        create.retry_count = candidate.retry_count + 1;
-        create.max_retries = candidate.max_retries;
-        create.subagent_depth = candidate.subagent_depth.unwrap_or_default();
-        create.caused_by_parent_request_id = Some(candidate.request_id.clone());
-        create.caused_by_parent_request_doc_id = Some(candidate.doc_id.clone());
-        crate::sign_agent_request_create_as_registered_target(&mut create)
-            .await
-            .expect("sign redrive request");
+            initial_lifecycle_state:
+                gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
+            trigger_lineage: crate::lifecycle::TriggerLineage::default(),
+            trigger_doc_id: None,
+            workspace: None,
+            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+                depth: candidate.subagent_depth.unwrap_or_default(),
+                parent_request_id: candidate.request_id.clone(),
+                parent_request_doc_id: candidate.doc_id.clone(),
+                parent_tool_call_id: None,
+                parent_tool_call_doc_id: None,
+            }),
+            retry: Some(crate::lifecycle::materialize::RetryLink {
+                parent_request_id: candidate.request_id.clone(),
+                parent_request_doc_id: candidate.doc_id.clone(),
+                root_request_id: retry_root,
+                retry_count: candidate.retry_count + 1,
+                max_retries: candidate.max_retries,
+            }),
+            sampling: Some(crate::lifecycle::materialize::SamplingCarryover {
+                temperature: candidate.temperature,
+                top_p: candidate.top_p,
+                top_k: candidate.top_k,
+                seed: candidate.seed,
+                max_tokens: candidate.max_tokens,
+                max_total_tokens: candidate.max_total_tokens,
+                backend_id: candidate.backend_id.clone(),
+            }),
+            metadata: candidate.metadata.clone(),
+            retry_key: Some(retry_key),
+            valid_until: None,
+        };
+        let create = crate::lifecycle::materialize::build_signed_request(
+            spec,
+            crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+        )
+        .await
+        .expect("sign redrive request");
 
         let fields = create.graphql_input_fields().expect("graphql_input_fields");
         assert_eq!(

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -11,8 +11,7 @@ use crate::lifecycle::materialize::{
     build_signed_request, RequestIdentity, RequestSigner, RequestSpec, RetryLink,
     SamplingCarryover, SubagentLink,
 };
-use crate::lifecycle::{ExecutionOrigin, TriggerLineage};
-use gents_protocol::request_lifecycle::RequestLifecycleState;
+use crate::lifecycle::ExecutionOrigin;
 
 use super::queue::{parse_queue_hints, QueuePolicy, QueueSource};
 use super::{BackgroundWakeRedriveReport, RequestLifecycle};
@@ -405,32 +404,24 @@ async fn redrive_mutation(
             &candidate.agent_did,
             &candidate.request_id,
         );
-    // Reused for both subagent_depth/parent linkage: a redrive successor is
-    // not a subagent, but it carries the same "linked to one parent request,
-    // at some depth" shape `SubagentLink` was built for.
+    // Not a subagent, but the same "one parent request, at some depth" shape.
     let parent_link = SubagentLink {
         depth: candidate.subagent_depth.unwrap_or_default(),
         parent_request_id: candidate.request_id.clone(),
         parent_request_doc_id: candidate.doc_id.clone(),
-        parent_tool_call_id: None,
-        parent_tool_call_doc_id: None,
+        ..Default::default()
+    };
+    let identity = RequestIdentity {
+        request_id: request_id.to_string(),
+        agent_did: candidate.agent_did.clone(),
+        requester_did: None,
+        behavior_id: candidate.behavior_id.clone(),
+        session_id: candidate.session_id.clone(),
+        content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
+        execution_origin: ExecutionOrigin::Scheduled,
+        created_at: now.clone(),
     };
     let spec = RequestSpec {
-        identity: RequestIdentity {
-            request_id: request_id.to_string(),
-            agent_did: candidate.agent_did.clone(),
-            requester_did: None,
-            behavior_id: candidate.behavior_id.clone(),
-            session_id: candidate.session_id.clone(),
-            content: BACKGROUND_COMPLETION_WAKE_PROMPT.to_string(),
-            execution_origin: ExecutionOrigin::Scheduled,
-            created_at: now.clone(),
-        },
-        admission,
-        initial_lifecycle_state: RequestLifecycleState::Pending,
-        trigger_lineage: TriggerLineage::default(),
-        trigger_doc_id: None,
-        workspace: None,
         subagent: Some(parent_link),
         retry: Some(RetryLink {
             parent_request_id: candidate.request_id.clone(),
@@ -446,11 +437,8 @@ async fn redrive_mutation(
             seed: candidate.seed,
             max_tokens: candidate.max_tokens,
             max_total_tokens: candidate.max_total_tokens,
-            // `backend_id` is normally never persisted as `Some("")` (the
-            // only production writer that sets it, materialize.rs's
-            // `materialize_claimed_with_execution_binding`, guards the same
-            // way), but this is a durable read of whatever is on the failed
-            // row, so normalize defensively rather than assume.
+            // Durable read of a possibly-legacy row; normalize Some("")
+            // the same way materialize.rs's writer does.
             backend_id: candidate
                 .backend_id
                 .clone()
@@ -458,7 +446,7 @@ async fn redrive_mutation(
         }),
         metadata: candidate.metadata.clone(),
         retry_key: Some(retry_key.to_string()),
-        valid_until: None,
+        ..RequestSpec::new(identity, admission)
     };
     let create = build_signed_request(spec, RequestSigner::RegisteredTarget).await?;
     let request_fields = create.graphql_input_fields().map_err(anyhow::Error::msg)?;

--- a/crates/gents/src/lifecycle/background_wake_recovery.rs
+++ b/crates/gents/src/lifecycle/background_wake_recovery.rs
@@ -447,3 +447,117 @@ async fn redrive_mutation(
         conversation_doc_id = escape_graphql_string(&conversation.doc_id),
     ))
 }
+
+/// Pins today's `AgentRequestCreate::graphql_input_fields()` output for
+/// `redrive_mutation` (#1336 Task 1), before it is switched onto
+/// `build_signed_request` (#1336 Task 2).
+///
+/// `redrive_mutation` is private and returns one combined mutation string
+/// (the successor `create_AgentRequest` plus a conversation `update`), not
+/// the `AgentRequestCreate` it builds, and it stamps `created_at` from
+/// `Utc::now()` internally. This reproduces its DTO-construction statements
+/// verbatim (see `redrive_mutation` above) with a fixed `now` in place of
+/// `Utc::now()`, so — with a deterministic signing identity — the whole
+/// output, including the signature, is stable across runs.
+#[cfg(test)]
+mod pin_tests {
+    use super::*;
+    use crate::identity::AgentIdentity;
+
+    const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
+    const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
+
+    fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
+        let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
+            .step_by(2)
+            .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
+            .collect();
+        let path = dir.join("pinning.key");
+        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
+        let identity =
+            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
+        assert_eq!(identity.did(), PIN_FIXED_DID);
+        identity
+    }
+
+    #[tokio::test]
+    async fn pin_redrive_mutation_dto_construction() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let _identity = pin_fixed_signing_identity(tempdir.path());
+
+        let candidate = FailedWakeRow {
+            doc_id: "failed-doc-1".to_string(),
+            request_id: "failed-request-1".to_string(),
+            agent_did: PIN_FIXED_DID.to_string(),
+            behavior_id: "behavior-1".to_string(),
+            session_id: "sess-redrive-1".to_string(),
+            retry_root_request: Some("root-request-1".to_string()),
+            temperature: Some(0.7),
+            top_p: Some(0.9),
+            top_k: Some(40),
+            seed: Some(7),
+            max_tokens: Some(1024),
+            max_total_tokens: Some(4096),
+            metadata: Some(r#"{"queue":{"source":"scheduled"}}"#.to_string()),
+            backend_id: Some("backend-1".to_string()),
+            subagent_depth: Some(1),
+            retry_count: 2,
+            max_retries: 5,
+            terminalized_at: Some("2029-12-31T23:59:59Z".to_string()),
+        };
+        let request_id = "redrive-request-1";
+        let retry_key = "redrive-retry-key-1";
+
+        // --- reproduces redrive_mutation's DTO construction, with a fixed
+        // `now` in place of `Utc::now()` ---
+        let now = "2030-01-01T00:00:00Z".to_string();
+        let retry_root = candidate
+            .retry_root_request
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(&candidate.request_id);
+        let admission =
+            gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
+                &candidate.agent_did,
+                &candidate.request_id,
+            );
+        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
+            request_id,
+            &candidate.agent_did,
+            &candidate.agent_did,
+            &candidate.behavior_id,
+            &candidate.session_id,
+            BACKGROUND_COMPLETION_WAKE_PROMPT,
+            "scheduled",
+            &now,
+            admission,
+        );
+        create.retry_parent_request = Some(candidate.request_id.clone());
+        create.retry_parent_request_doc_id = Some(candidate.doc_id.clone());
+        create.retry_root_request = Some(retry_root.to_string());
+        create.retry_key = Some(retry_key.to_string());
+        create.temperature = candidate.temperature;
+        create.top_p = candidate.top_p;
+        create.top_k = candidate.top_k;
+        create.seed = candidate.seed;
+        create.max_tokens = candidate.max_tokens;
+        create.max_total_tokens = candidate.max_total_tokens;
+        create.metadata = candidate.metadata.clone();
+        create.backend_id = candidate.backend_id.clone();
+        create.retry_count = candidate.retry_count + 1;
+        create.max_retries = candidate.max_retries;
+        create.subagent_depth = candidate.subagent_depth.unwrap_or_default();
+        create.caused_by_parent_request_id = Some(candidate.request_id.clone());
+        create.caused_by_parent_request_doc_id = Some(candidate.doc_id.clone());
+        crate::sign_agent_request_create_as_registered_target(&mut create)
+            .await
+            .expect("sign redrive request");
+
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        assert_eq!(
+            fields,
+            "request_id: \"redrive-request-1\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"behavior-1\", session_id: \"sess-redrive-1\", retry_parent_request: \"failed-request-1\", retry_parent_request_doc_id: \"failed-doc-1\", retry_root_request: \"root-request-1\", retry_key: \"redrive-retry-key-1\", content: \"Review the new background completion results and continue the task if needed.\", temperature: 0.7, top_p: 0.9, top_k: 40, seed: 7, max_tokens: 1024, max_total_tokens: 4096, metadata: \"{\\\"queue\\\":{\\\"source\\\":\\\"scheduled\\\"}}\", backend_id: \"backend-1\", execution_origin: \"scheduled\", created_at: \"2030-01-01T00:00:00Z\", retry_count: 3, max_retries: 5, subagent_depth: 1, caused_by_parent_request_id: \"failed-request-1\", caused_by_parent_request_doc_id: \"failed-doc-1\", admission_kind: \"runtime-internal\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"5PhWwYmgF63HgneAud3fR5z7BZiqeyDmV4K8qLffUj1SADPSGJ2JQoYKbeNZH4zTZDfF6zg4XG6vERcyeJi1jXNY\", runtime_issuer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", runtime_source_request_id: \"failed-request-1\", runtime_source_kind: \"local-control\", lifecycle_state: \"pending\", failure_reason: \"\""
+        );
+    }
+}

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -252,47 +252,40 @@ pub async fn build_signed_pending_agent_request_with_lineage_workspace_and_conve
         }
         Some(kind) => anyhow::bail!("unsupported runtime request trigger kind {kind}"),
     };
-    let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-        request_id,
-        agent_did,
-        agent_did,
-        behavior_id,
-        session_id,
-        content,
-        execution_origin.as_str(),
-        now,
-        admission,
-    );
-    create.metadata =
-        (!metadata.is_empty()).then(|| serde_json::Value::Object(metadata).to_string());
-    create.retry_key = retry_key.map(str::to_owned);
-    create.initial_lifecycle_state = initial_lifecycle_state;
-    create.caused_by_trigger_id = trigger_lineage.trigger_id.clone();
-    create.caused_by_trigger_kind = trigger_lineage.trigger_kind.clone();
-    create.caused_by_trigger_doc_id = trigger_doc_id.map(str::to_owned);
-    create.caused_by_source_doc_id = trigger_lineage.source_doc_id.clone();
-    create.caused_by_correlation = trigger_lineage.correlation.clone();
-    create.caused_by_trigger_context = trigger_lineage.trigger_context.clone();
-    create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-    if let Some(workspace) = workspace_lineage {
-        create.workspace_id = workspace.workspace_id.clone();
-        create.workspace_authority = workspace.workspace_authority.clone();
-        create.workspace_owner_deployment_id = workspace.workspace_owner_deployment_id.clone();
-        create.workspace_seal_hash = workspace.workspace_seal_hash.clone();
-    }
     if requester_did.is_some_and(|did| did.trim() != agent_did) {
         tracing::debug!(
             target_agent_did = agent_did,
             "runtime trigger requester provenance remains in signed trigger context"
         );
     }
-    crate::sign_agent_request_create_as_registered_target(&mut create).await?;
-    Ok(create)
+    let spec = RequestSpec {
+        identity: RequestIdentity {
+            request_id: request_id.to_string(),
+            agent_did: agent_did.to_string(),
+            requester_did: None,
+            behavior_id: behavior_id.to_string(),
+            session_id: session_id.to_string(),
+            content: content.to_string(),
+            execution_origin,
+            created_at: now,
+        },
+        admission,
+        initial_lifecycle_state,
+        trigger_lineage,
+        trigger_doc_id: trigger_doc_id.map(str::to_owned),
+        workspace: workspace_lineage.cloned(),
+        subagent: None,
+        retry: None,
+        sampling: None,
+        metadata: (!metadata.is_empty()).then(|| serde_json::Value::Object(metadata).to_string()),
+        retry_key: retry_key.map(str::to_owned),
+        valid_until: None,
+    };
+    build_signed_request(spec, RequestSigner::RegisteredTarget).await
 }
 
 /// The identity fields every writer decides for a fresh `AgentRequest`:
 /// who it is for, what session it belongs to, and what it says.
-#[allow(dead_code)]
 pub(crate) struct RequestIdentity {
     pub request_id: String,
     pub agent_did: String,
@@ -306,7 +299,6 @@ pub(crate) struct RequestIdentity {
 
 /// Subagent parent linkage: the logical and physical identifiers of the
 /// tool call and request that spawned this child, plus its resulting depth.
-#[allow(dead_code)]
 pub(crate) struct SubagentLink {
     pub depth: u32,
     pub parent_request_id: String,
@@ -317,7 +309,6 @@ pub(crate) struct SubagentLink {
 
 /// Retry linkage: the failed request this one supersedes, the root of the
 /// retry chain, and the counters carried forward from it.
-#[allow(dead_code)]
 pub(crate) struct RetryLink {
     pub parent_request_id: String,
     pub parent_request_doc_id: String,
@@ -328,7 +319,6 @@ pub(crate) struct RetryLink {
 
 /// Sampling parameters and backend carried over from a prior request (used
 /// by background-wake redrive; unset for a fresh request).
-#[allow(dead_code)]
 pub(crate) struct SamplingCarryover {
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
@@ -343,7 +333,6 @@ pub(crate) struct SamplingCarryover {
 /// signed. This is the single seam every production writer should build
 /// through; `build_signed_request` alone owns which of its fields become
 /// which stamped columns.
-#[allow(dead_code)]
 pub(crate) struct RequestSpec {
     pub identity: RequestIdentity,
     pub admission: gents_protocol::request_admission::AgentRequestAdmissionRecord,
@@ -368,7 +357,6 @@ pub(crate) struct RequestSpec {
 /// How the built `AgentRequestCreate` is signed: as the already-registered
 /// runtime principal named by `spec.identity.agent_did` (the common case for
 /// runtime-authored requests), or with an explicit caller-held identity.
-#[allow(dead_code)]
 pub(crate) enum RequestSigner<'a> {
     RegisteredTarget,
     Identity(&'a dyn crate::identity::AgentIdentity),
@@ -379,7 +367,6 @@ pub(crate) enum RequestSigner<'a> {
 /// stamped columns; every production writer should build through it rather
 /// than hand-rolling `AgentRequestCreate::base(...)` and stamping fields
 /// itself.
-#[allow(dead_code)]
 pub(crate) async fn build_signed_request(
     spec: RequestSpec,
     signer: RequestSigner<'_>,
@@ -614,25 +601,40 @@ impl RequestLifecycle {
         let session_id = uuid::Uuid::new_v4().to_string();
         validate_trigger_provenance(&trigger_lineage)?;
         let created_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-            request_id.clone(),
-            &agent_did,
-            &agent_did,
-            behavior_id.clone(),
-            session_id.clone(),
-            content,
-            execution_origin.as_str(),
-            created_at.clone(),
-            gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(&agent_did),
-        );
-        create.backend_id = (!backend_id.is_empty()).then(|| backend_id.clone());
-        create.caused_by_trigger_id = trigger_lineage.trigger_id.clone();
-        create.caused_by_trigger_kind = trigger_lineage.trigger_kind.clone();
-        create.caused_by_source_doc_id = trigger_lineage.source_doc_id.clone();
-        create.caused_by_correlation = trigger_lineage.correlation.clone();
-        create.caused_by_trigger_context = trigger_lineage.trigger_context.clone();
-        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-        crate::sign_agent_request_create(identity.as_ref(), &mut create).await?;
+        let admission =
+            gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(&agent_did);
+        let spec = RequestSpec {
+            identity: RequestIdentity {
+                request_id: request_id.clone(),
+                agent_did: agent_did.clone(),
+                requester_did: None,
+                behavior_id: behavior_id.clone(),
+                session_id: session_id.clone(),
+                content: content.to_string(),
+                execution_origin,
+                created_at: created_at.clone(),
+            },
+            admission,
+            initial_lifecycle_state: RequestLifecycleState::Pending,
+            trigger_lineage: trigger_lineage.clone(),
+            trigger_doc_id: None,
+            workspace: None,
+            subagent: None,
+            retry: None,
+            sampling: Some(SamplingCarryover {
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                seed: None,
+                max_tokens: None,
+                max_total_tokens: None,
+                backend_id: (!backend_id.is_empty()).then(|| backend_id.clone()),
+            }),
+            metadata: None,
+            retry_key: None,
+            valid_until: None,
+        };
+        let create = build_signed_request(spec, RequestSigner::Identity(identity.as_ref())).await?;
         let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
         let resp = crate::graphql::graphql_mutation_with_transaction_retry(
             node.as_ref(),

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -258,28 +258,24 @@ pub async fn build_signed_pending_agent_request_with_lineage_workspace_and_conve
             "runtime trigger requester provenance remains in signed trigger context"
         );
     }
+    let identity = RequestIdentity {
+        request_id: request_id.to_string(),
+        agent_did: agent_did.to_string(),
+        requester_did: None,
+        behavior_id: behavior_id.to_string(),
+        session_id: session_id.to_string(),
+        content: content.to_string(),
+        execution_origin,
+        created_at: now,
+    };
     let spec = RequestSpec {
-        identity: RequestIdentity {
-            request_id: request_id.to_string(),
-            agent_did: agent_did.to_string(),
-            requester_did: None,
-            behavior_id: behavior_id.to_string(),
-            session_id: session_id.to_string(),
-            content: content.to_string(),
-            execution_origin,
-            created_at: now,
-        },
-        admission,
         initial_lifecycle_state,
         trigger_lineage,
         trigger_doc_id: trigger_doc_id.map(str::to_owned),
         workspace: workspace_lineage.cloned(),
-        subagent: None,
-        retry: None,
-        sampling: None,
         metadata: (!metadata.is_empty()).then(|| serde_json::Value::Object(metadata).to_string()),
         retry_key: retry_key.map(str::to_owned),
-        valid_until: None,
+        ..RequestSpec::new(identity, admission)
     };
     build_signed_request(spec, RequestSigner::RegisteredTarget).await
 }
@@ -299,6 +295,7 @@ pub(crate) struct RequestIdentity {
 
 /// Subagent parent linkage: the logical and physical identifiers of the
 /// tool call and request that spawned this child, plus its resulting depth.
+#[derive(Default)]
 pub(crate) struct SubagentLink {
     pub depth: u32,
     pub parent_request_id: String,
@@ -319,6 +316,7 @@ pub(crate) struct RetryLink {
 
 /// Sampling parameters and backend carried over from a prior request (used
 /// by background-wake redrive; unset for a fresh request).
+#[derive(Default)]
 pub(crate) struct SamplingCarryover {
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
@@ -352,6 +350,34 @@ pub(crate) struct RequestSpec {
     pub metadata: Option<String>,
     pub retry_key: Option<String>,
     pub valid_until: Option<String>,
+}
+
+impl RequestSpec {
+    /// A `RequestSpec` with only identity and admission decided; every
+    /// other field takes the default a writer wants when it isn't a
+    /// trigger-lineage-carrying, workspace-bound, subagent-linked, retried,
+    /// or sampling-carried-over request. Callers set only what they need
+    /// via struct-update syntax:
+    /// `RequestSpec { retry_key: Some(key), ..RequestSpec::new(identity, admission) }`.
+    pub(crate) fn new(
+        identity: RequestIdentity,
+        admission: gents_protocol::request_admission::AgentRequestAdmissionRecord,
+    ) -> Self {
+        Self {
+            identity,
+            admission,
+            initial_lifecycle_state: RequestLifecycleState::Pending,
+            trigger_lineage: TriggerLineage::default(),
+            trigger_doc_id: None,
+            workspace: None,
+            subagent: None,
+            retry: None,
+            sampling: None,
+            metadata: None,
+            retry_key: None,
+            valid_until: None,
+        }
+    }
 }
 
 /// How the built `AgentRequestCreate` is signed: as the already-registered
@@ -629,36 +655,23 @@ impl RequestLifecycle {
         let created_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         let admission =
             gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(&agent_did);
+        let request_identity = RequestIdentity {
+            request_id: request_id.clone(),
+            agent_did: agent_did.clone(),
+            requester_did: None,
+            behavior_id: behavior_id.clone(),
+            session_id: session_id.clone(),
+            content: content.to_string(),
+            execution_origin,
+            created_at: created_at.clone(),
+        };
         let spec = RequestSpec {
-            identity: RequestIdentity {
-                request_id: request_id.clone(),
-                agent_did: agent_did.clone(),
-                requester_did: None,
-                behavior_id: behavior_id.clone(),
-                session_id: session_id.clone(),
-                content: content.to_string(),
-                execution_origin,
-                created_at: created_at.clone(),
-            },
-            admission,
-            initial_lifecycle_state: RequestLifecycleState::Pending,
             trigger_lineage,
-            trigger_doc_id: None,
-            workspace: None,
-            subagent: None,
-            retry: None,
             sampling: Some(SamplingCarryover {
-                temperature: None,
-                top_p: None,
-                top_k: None,
-                seed: None,
-                max_tokens: None,
-                max_total_tokens: None,
                 backend_id: (!backend_id.is_empty()).then(|| backend_id.clone()),
+                ..Default::default()
             }),
-            metadata: None,
-            retry_key: None,
-            valid_until: None,
+            ..RequestSpec::new(request_identity, admission)
         };
         let create = build_signed_request(spec, RequestSigner::Identity(identity.as_ref())).await?;
         let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -261,7 +261,6 @@ pub async fn build_signed_pending_agent_request_with_lineage_workspace_and_conve
     let identity = RequestIdentity {
         request_id: request_id.to_string(),
         agent_did: agent_did.to_string(),
-        requester_did: None,
         behavior_id: behavior_id.to_string(),
         session_id: session_id.to_string(),
         content: content.to_string(),
@@ -285,7 +284,6 @@ pub async fn build_signed_pending_agent_request_with_lineage_workspace_and_conve
 pub(crate) struct RequestIdentity {
     pub request_id: String,
     pub agent_did: String,
-    pub requester_did: Option<String>,
     pub behavior_id: String,
     pub session_id: String,
     pub content: String,
@@ -293,10 +291,13 @@ pub(crate) struct RequestIdentity {
     pub created_at: String,
 }
 
-/// Subagent parent linkage: the logical and physical identifiers of the
-/// tool call and request that spawned this child, plus its resulting depth.
+/// Parent-request linkage: the logical and physical identifiers of the
+/// request (and, for a subagent spawn, the tool call) that caused this one,
+/// plus its resulting depth. Used both for subagent spawns and for other
+/// requests that are simply linked to one parent at some depth (a control
+/// continuation, a background-wake redrive successor).
 #[derive(Default)]
-pub(crate) struct SubagentLink {
+pub(crate) struct ParentLink {
     pub depth: u32,
     pub parent_request_id: String,
     pub parent_request_doc_id: String,
@@ -342,7 +343,7 @@ pub(crate) struct RequestSpec {
     pub trigger_lineage: TriggerLineage,
     pub trigger_doc_id: Option<String>,
     pub workspace: Option<WorkspaceLineage>,
-    pub subagent: Option<SubagentLink>,
+    pub subagent: Option<ParentLink>,
     /// `None` means this is not a retry: `retry_root_request` defaults to
     /// this request's own id and `max_retries` to `DEFAULT_REQUEST_MAX_RETRIES`.
     pub retry: Option<RetryLink>,
@@ -392,7 +393,7 @@ pub(crate) enum RequestSigner<'a> {
 /// owner of the mapping from a writer's decisions (`RequestSpec`) to the
 /// DTO's stamped columns; every production writer should build through it
 /// (or `build_signed_request`, below) rather than hand-rolling
-/// `AgentRequestCreate::base(...)` and stamping fields itself.
+/// `AgentRequestCreate::base` (see below) and stamping fields itself.
 ///
 /// Split out from signing so a caller that needs to inspect the built DTO
 /// before deciding whether to persist it (e.g. a retry-key dedupe lookup
@@ -417,15 +418,12 @@ pub(crate) fn build_request(
     } = spec;
 
     let request_id = identity.request_id.clone();
-    let requester_did = identity
-        .requester_did
-        .clone()
-        .unwrap_or_else(|| identity.agent_did.clone());
+    let agent_did = identity.agent_did.clone();
 
     let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
         identity.request_id,
         identity.agent_did,
-        requester_did,
+        agent_did,
         identity.behavior_id,
         identity.session_id,
         identity.content,
@@ -658,7 +656,6 @@ impl RequestLifecycle {
         let request_identity = RequestIdentity {
             request_id: request_id.clone(),
             agent_did: agent_did.clone(),
-            requester_did: None,
             behavior_id: behavior_id.clone(),
             session_id: session_id.clone(),
             content: content.to_string(),
@@ -936,7 +933,8 @@ mod pin_tests {
     //! Pins today's `AgentRequestCreate::graphql_input_fields()` output for
     //! each production writer, per fixed inputs, before the writers are
     //! switched onto `build_signed_request` (#1336 Task 2). Every test here
-    //! uses a deterministic signing identity (a hardcoded raw Ed25519 key)
+    //! uses a deterministic signing identity (a hardcoded raw Ed25519 key,
+    //! shared with the other pinning modules via `lifecycle::test_support`)
     //! so the emitted `admission_signature` is stable across runs; the only
     //! other source of nondeterminism in these writers is an internally
     //! generated `created_at` (and, at the subagent site, an internally
@@ -953,29 +951,7 @@ mod pin_tests {
 
     use super::*;
     use crate::identity::AgentIdentity;
-
-    /// Raw 64-byte (seed || public key) Ed25519 identity material, captured
-    /// once so every pinning test signs with the same registered DID and
-    /// therefore produces the same signature bytes for the same payload.
-    const FIXED_TEST_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
-    const FIXED_TEST_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
-
-    fn fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
-        let key_bytes: Vec<u8> = (0..FIXED_TEST_KEY_HEX.len())
-            .step_by(2)
-            .map(|offset| u8::from_str_radix(&FIXED_TEST_KEY_HEX[offset..offset + 2], 16).unwrap())
-            .collect();
-        let path = dir.join("pinning.key");
-        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
-        let identity =
-            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
-        assert_eq!(
-            identity.did(),
-            FIXED_TEST_DID,
-            "fixed pinning key derives a stable DID"
-        );
-        identity
-    }
+    use crate::lifecycle::test_support::{pin_fixed_signing_identity, PIN_FIXED_DID};
 
     /// Replace the internally generated `created_at` and `admission_signature`
     /// field text with stable placeholders, so the rest of the field set can
@@ -1000,50 +976,35 @@ mod pin_tests {
     }
 
     // --- Site 1: materialize.rs `build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title` ---
-    // Driven through `build_signed_request` with the equivalent `RequestSpec`
-    // (the same inputs the production function would derive its stamping
-    // from); still asserts against the output pinned by directly calling the
-    // production function. `created_at`/`admission_signature` are chosen by
-    // the caller here (the writer, in production, would still generate them
-    // from `Utc::now()`), so they are normalized out for the comparison.
+    // Pure and public; called directly. `created_at`/`admission_signature`
+    // are internally generated (`Utc::now()`), so they are normalized out.
 
     #[tokio::test]
     async fn pin_materialize_pending_manual_trigger() {
         let tempdir = tempfile::tempdir().unwrap();
-        let _identity = fixed_signing_identity(tempdir.path());
+        let _identity = pin_fixed_signing_identity(tempdir.path());
 
-        let spec = RequestSpec {
-            identity: RequestIdentity {
-                request_id: "req-materialize-pending-manual".to_string(),
-                agent_did: FIXED_TEST_DID.to_string(),
-                requester_did: None,
-                behavior_id: "behavior-1".to_string(),
-                session_id: "sess-materialize-pending-manual".to_string(),
-                content: "hello agent".to_string(),
-                execution_origin: ExecutionOrigin::Interactive,
-                created_at: "2030-01-01T00:00:00Z".to_string(),
-            },
-            admission: gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(
-                FIXED_TEST_DID,
-            ),
-            initial_lifecycle_state: RequestLifecycleState::Pending,
-            trigger_lineage: TriggerLineage {
-                trigger_id: None,
-                trigger_kind: Some("manual".to_string()),
-                source_doc_id: None,
-                correlation: None,
-                trigger_context: None,
-            },
-            trigger_doc_id: None,
-            workspace: None,
-            subagent: None,
-            retry: None,
-            sampling: None,
-            metadata: Some(r#"{"conversation_title":"My Conversation"}"#.to_string()),
-            retry_key: None,
-            valid_until: None,
-        };
-        let create = build_signed_request(spec, RequestSigner::RegisteredTarget)
+        let create =
+            build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+                PIN_FIXED_DID,
+                "behavior-1",
+                "hello agent",
+                ExecutionOrigin::Interactive,
+                TriggerLineage {
+                    trigger_id: None,
+                    trigger_kind: Some("manual".to_string()),
+                    source_doc_id: None,
+                    correlation: None,
+                    trigger_context: None,
+                },
+                Some("My Conversation"),
+                None,
+                "req-materialize-pending-manual",
+                "sess-materialize-pending-manual",
+                None,
+                None,
+                None,
+            )
             .await
             .expect("build signed pending manual request");
 
@@ -1058,7 +1019,7 @@ mod pin_tests {
     #[tokio::test]
     async fn pin_materialize_pending_event_trigger_with_workspace() {
         let tempdir = tempfile::tempdir().unwrap();
-        let _identity = fixed_signing_identity(tempdir.path());
+        let _identity = pin_fixed_signing_identity(tempdir.path());
 
         let trigger_lineage = TriggerLineage {
             trigger_id: Some("trigger-1".to_string()),
@@ -1074,34 +1035,21 @@ mod pin_tests {
             workspace_seal_hash: Some("seal-1".to_string()),
         };
 
-        let spec = RequestSpec {
-            identity: RequestIdentity {
-                request_id: "req-materialize-pending-event".to_string(),
-                agent_did: FIXED_TEST_DID.to_string(),
-                requester_did: None,
-                behavior_id: "behavior-1".to_string(),
-                session_id: "sess-materialize-pending-event".to_string(),
-                content: "hello agent".to_string(),
-                execution_origin: ExecutionOrigin::Scheduled,
-                created_at: "2030-01-01T00:00:00Z".to_string(),
-            },
-            admission:
-                gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_automated_trigger(
-                    FIXED_TEST_DID,
-                    "trigger-1",
-                ),
-            initial_lifecycle_state: RequestLifecycleState::WorkspaceBindingPending,
-            trigger_lineage,
-            trigger_doc_id: Some("trigger-doc-1".to_string()),
-            workspace: Some(workspace_lineage),
-            subagent: None,
-            retry: None,
-            sampling: None,
-            metadata: Some(r#"{"conversation_title":"My Conversation"}"#.to_string()),
-            retry_key: Some("retry-key-1".to_string()),
-            valid_until: None,
-        };
-        let create = build_signed_request(spec, RequestSigner::RegisteredTarget)
+        let create =
+            build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+                PIN_FIXED_DID,
+                "behavior-1",
+                "hello agent",
+                ExecutionOrigin::Scheduled,
+                trigger_lineage,
+                Some("My Conversation"),
+                Some(&workspace_lineage),
+                "req-materialize-pending-event",
+                "sess-materialize-pending-event",
+                Some("retry-key-1"),
+                None,
+                Some("trigger-doc-1"),
+            )
             .await
             .expect("build signed pending event-triggered workspace-bound request");
 
@@ -1124,7 +1072,7 @@ mod pin_tests {
     #[tokio::test]
     async fn pin_materialize_claimed_with_execution_binding() {
         let tempdir = tempfile::tempdir().unwrap();
-        let identity = fixed_signing_identity(tempdir.path());
+        let identity = pin_fixed_signing_identity(tempdir.path());
 
         let agent_did = identity.did().to_string();
         let trigger_lineage = TriggerLineage {
@@ -1135,38 +1083,24 @@ mod pin_tests {
             trigger_context: Some(r#"{"k":"v"}"#.to_string()),
         };
 
+        let request_identity = RequestIdentity {
+            request_id: "req-materialize-claimed".to_string(),
+            agent_did: agent_did.clone(),
+            behavior_id: "agent-name-1".to_string(),
+            session_id: "sess-materialize-claimed".to_string(),
+            content: "resume the run".to_string(),
+            execution_origin: ExecutionOrigin::Scheduled,
+            created_at: "2030-01-01T00:00:00Z".to_string(),
+        };
+        let admission =
+            gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(&agent_did);
         let spec = RequestSpec {
-            identity: RequestIdentity {
-                request_id: "req-materialize-claimed".to_string(),
-                agent_did: agent_did.clone(),
-                requester_did: None,
-                behavior_id: "agent-name-1".to_string(),
-                session_id: "sess-materialize-claimed".to_string(),
-                content: "resume the run".to_string(),
-                execution_origin: ExecutionOrigin::Scheduled,
-                created_at: "2030-01-01T00:00:00Z".to_string(),
-            },
-            admission: gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(
-                &agent_did,
-            ),
-            initial_lifecycle_state: RequestLifecycleState::Pending,
             trigger_lineage,
-            trigger_doc_id: None,
-            workspace: None,
-            subagent: None,
-            retry: None,
             sampling: Some(SamplingCarryover {
-                temperature: None,
-                top_p: None,
-                top_k: None,
-                seed: None,
-                max_tokens: None,
-                max_total_tokens: None,
                 backend_id: Some("backend-1".to_string()),
+                ..Default::default()
             }),
-            metadata: None,
-            retry_key: None,
-            valid_until: None,
+            ..RequestSpec::new(request_identity, admission)
         };
         let create = build_signed_request(spec, RequestSigner::Identity(&identity))
             .await

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -290,6 +290,198 @@ pub async fn build_signed_pending_agent_request_with_lineage_workspace_and_conve
     Ok(create)
 }
 
+/// The identity fields every writer decides for a fresh `AgentRequest`:
+/// who it is for, what session it belongs to, and what it says.
+#[allow(dead_code)]
+pub(crate) struct RequestIdentity {
+    pub request_id: String,
+    pub agent_did: String,
+    pub requester_did: Option<String>,
+    pub behavior_id: String,
+    pub session_id: String,
+    pub content: String,
+    pub execution_origin: ExecutionOrigin,
+    pub created_at: String,
+}
+
+/// Subagent parent linkage: the logical and physical identifiers of the
+/// tool call and request that spawned this child, plus its resulting depth.
+#[allow(dead_code)]
+pub(crate) struct SubagentLink {
+    pub depth: u32,
+    pub parent_request_id: String,
+    pub parent_request_doc_id: String,
+    pub parent_tool_call_id: Option<String>,
+    pub parent_tool_call_doc_id: Option<String>,
+}
+
+/// Retry linkage: the failed request this one supersedes, the root of the
+/// retry chain, and the counters carried forward from it.
+#[allow(dead_code)]
+pub(crate) struct RetryLink {
+    pub parent_request_id: String,
+    pub parent_request_doc_id: String,
+    pub root_request_id: String,
+    pub retry_count: i64,
+    pub max_retries: i64,
+}
+
+/// Sampling parameters and backend carried over from a prior request (used
+/// by background-wake redrive; unset for a fresh request).
+#[allow(dead_code)]
+pub(crate) struct SamplingCarryover {
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<i64>,
+    pub seed: Option<i64>,
+    pub max_tokens: Option<i64>,
+    pub max_total_tokens: Option<i64>,
+    pub backend_id: Option<String>,
+}
+
+/// Every input a writer decides before an `AgentRequestCreate` is built and
+/// signed. This is the single seam every production writer should build
+/// through; `build_signed_request` alone owns which of its fields become
+/// which stamped columns.
+#[allow(dead_code)]
+pub(crate) struct RequestSpec {
+    pub identity: RequestIdentity,
+    pub admission: gents_protocol::request_admission::AgentRequestAdmissionRecord,
+    pub initial_lifecycle_state: RequestLifecycleState,
+    /// Correlation/context/kind/id/source-doc lineage of the trigger that
+    /// caused this request. `trigger_doc_id` is carried separately because,
+    /// unlike the rest of `TriggerLineage`, it is not part of the signed
+    /// trigger-provenance payload validated by `validate_trigger_provenance`.
+    pub trigger_lineage: TriggerLineage,
+    pub trigger_doc_id: Option<String>,
+    pub workspace: Option<WorkspaceLineage>,
+    pub subagent: Option<SubagentLink>,
+    /// `None` means this is not a retry: `retry_root_request` defaults to
+    /// this request's own id and `max_retries` to `DEFAULT_REQUEST_MAX_RETRIES`.
+    pub retry: Option<RetryLink>,
+    pub sampling: Option<SamplingCarryover>,
+    pub metadata: Option<String>,
+    pub retry_key: Option<String>,
+    pub valid_until: Option<String>,
+}
+
+/// How the built `AgentRequestCreate` is signed: as the already-registered
+/// runtime principal named by `spec.identity.agent_did` (the common case for
+/// runtime-authored requests), or with an explicit caller-held identity.
+#[allow(dead_code)]
+pub(crate) enum RequestSigner<'a> {
+    RegisteredTarget,
+    Identity(&'a dyn crate::identity::AgentIdentity),
+}
+
+/// Build, stamp, and sign one `AgentRequestCreate`. This is the sole owner
+/// of the mapping from a writer's decisions (`RequestSpec`) to the DTO's
+/// stamped columns; every production writer should build through it rather
+/// than hand-rolling `AgentRequestCreate::base(...)` and stamping fields
+/// itself.
+#[allow(dead_code)]
+pub(crate) async fn build_signed_request(
+    spec: RequestSpec,
+    signer: RequestSigner<'_>,
+) -> Result<gents_protocol::request_admission::AgentRequestCreate> {
+    let RequestSpec {
+        identity,
+        admission,
+        initial_lifecycle_state,
+        trigger_lineage,
+        trigger_doc_id,
+        workspace,
+        subagent,
+        retry,
+        sampling,
+        metadata,
+        retry_key,
+        valid_until,
+    } = spec;
+
+    let request_id = identity.request_id.clone();
+    let requester_did = identity
+        .requester_did
+        .clone()
+        .unwrap_or_else(|| identity.agent_did.clone());
+
+    let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
+        identity.request_id,
+        identity.agent_did,
+        requester_did,
+        identity.behavior_id,
+        identity.session_id,
+        identity.content,
+        identity.execution_origin.as_str(),
+        identity.created_at,
+        admission,
+    );
+
+    create.initial_lifecycle_state = initial_lifecycle_state;
+    create.metadata = metadata;
+    create.retry_key = retry_key;
+    create.valid_until = valid_until;
+
+    create.caused_by_trigger_id = trigger_lineage.trigger_id;
+    create.caused_by_trigger_kind = trigger_lineage.trigger_kind;
+    create.caused_by_trigger_doc_id = trigger_doc_id;
+    create.caused_by_source_doc_id = trigger_lineage.source_doc_id;
+    create.caused_by_correlation = trigger_lineage.correlation;
+    create.caused_by_trigger_context = trigger_lineage.trigger_context;
+
+    if let Some(workspace) = workspace {
+        create.workspace_id = workspace.workspace_id;
+        create.workspace_authority = workspace.workspace_authority;
+        create.workspace_owner_deployment_id = workspace.workspace_owner_deployment_id;
+        create.workspace_seal_hash = workspace.workspace_seal_hash;
+    }
+
+    create.subagent_depth = subagent.as_ref().map_or(0, |link| link.depth);
+    if let Some(link) = subagent {
+        create.caused_by_parent_request_id = Some(link.parent_request_id);
+        create.caused_by_parent_request_doc_id = Some(link.parent_request_doc_id);
+        create.caused_by_parent_tool_call_id = link.parent_tool_call_id;
+        create.caused_by_parent_tool_call_doc_id = link.parent_tool_call_doc_id;
+    }
+
+    create.retry_root_request = Some(
+        retry
+            .as_ref()
+            .map_or_else(|| request_id.clone(), |link| link.root_request_id.clone()),
+    );
+    create.max_retries = retry
+        .as_ref()
+        .map_or(i64::from(DEFAULT_REQUEST_MAX_RETRIES), |link| {
+            link.max_retries
+        });
+    create.retry_count = retry.as_ref().map_or(0, |link| link.retry_count);
+    if let Some(link) = retry {
+        create.retry_parent_request = Some(link.parent_request_id);
+        create.retry_parent_request_doc_id = Some(link.parent_request_doc_id);
+    }
+
+    if let Some(sampling) = sampling {
+        create.temperature = sampling.temperature;
+        create.top_p = sampling.top_p;
+        create.top_k = sampling.top_k;
+        create.seed = sampling.seed;
+        create.max_tokens = sampling.max_tokens;
+        create.max_total_tokens = sampling.max_total_tokens;
+        create.backend_id = sampling.backend_id;
+    }
+
+    match signer {
+        RequestSigner::RegisteredTarget => {
+            crate::sign_agent_request_create_as_registered_target(&mut create).await?;
+        }
+        RequestSigner::Identity(identity) => {
+            crate::sign_agent_request_create(identity, &mut create).await?;
+        }
+    }
+
+    Ok(create)
+}
+
 pub async fn activate_workspace_bound_request(
     node: &EmbeddedNode,
     request_doc_id: &str,
@@ -767,35 +959,50 @@ mod pin_tests {
     }
 
     // --- Site 1: materialize.rs `build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title` ---
-    // Pure and public; called directly. `created_at`/`admission_signature`
-    // are internally generated (`Utc::now()`), so they are normalized out.
+    // Driven through `build_signed_request` with the equivalent `RequestSpec`
+    // (the same inputs the production function would derive its stamping
+    // from); still asserts against the output pinned by directly calling the
+    // production function. `created_at`/`admission_signature` are chosen by
+    // the caller here (the writer, in production, would still generate them
+    // from `Utc::now()`), so they are normalized out for the comparison.
 
     #[tokio::test]
     async fn pin_materialize_pending_manual_trigger() {
         let tempdir = tempfile::tempdir().unwrap();
         let _identity = fixed_signing_identity(tempdir.path());
 
-        let create =
-            build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+        let spec = RequestSpec {
+            identity: RequestIdentity {
+                request_id: "req-materialize-pending-manual".to_string(),
+                agent_did: FIXED_TEST_DID.to_string(),
+                requester_did: None,
+                behavior_id: "behavior-1".to_string(),
+                session_id: "sess-materialize-pending-manual".to_string(),
+                content: "hello agent".to_string(),
+                execution_origin: ExecutionOrigin::Interactive,
+                created_at: "2030-01-01T00:00:00Z".to_string(),
+            },
+            admission: gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(
                 FIXED_TEST_DID,
-                "behavior-1",
-                "hello agent",
-                ExecutionOrigin::Interactive,
-                TriggerLineage {
-                    trigger_id: None,
-                    trigger_kind: Some("manual".to_string()),
-                    source_doc_id: None,
-                    correlation: None,
-                    trigger_context: None,
-                },
-                Some("My Conversation"),
-                None,
-                "req-materialize-pending-manual",
-                "sess-materialize-pending-manual",
-                None,
-                None,
-                None,
-            )
+            ),
+            initial_lifecycle_state: RequestLifecycleState::Pending,
+            trigger_lineage: TriggerLineage {
+                trigger_id: None,
+                trigger_kind: Some("manual".to_string()),
+                source_doc_id: None,
+                correlation: None,
+                trigger_context: None,
+            },
+            trigger_doc_id: None,
+            workspace: None,
+            subagent: None,
+            retry: None,
+            sampling: None,
+            metadata: Some(r#"{"conversation_title":"My Conversation"}"#.to_string()),
+            retry_key: None,
+            valid_until: None,
+        };
+        let create = build_signed_request(spec, RequestSigner::RegisteredTarget)
             .await
             .expect("build signed pending manual request");
 
@@ -826,21 +1033,34 @@ mod pin_tests {
             workspace_seal_hash: Some("seal-1".to_string()),
         };
 
-        let create =
-            build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
-                FIXED_TEST_DID,
-                "behavior-1",
-                "hello agent",
-                ExecutionOrigin::Scheduled,
-                trigger_lineage,
-                Some("My Conversation"),
-                Some(&workspace_lineage),
-                "req-materialize-pending-event",
-                "sess-materialize-pending-event",
-                Some("retry-key-1"),
-                None,
-                Some("trigger-doc-1"),
-            )
+        let spec = RequestSpec {
+            identity: RequestIdentity {
+                request_id: "req-materialize-pending-event".to_string(),
+                agent_did: FIXED_TEST_DID.to_string(),
+                requester_did: None,
+                behavior_id: "behavior-1".to_string(),
+                session_id: "sess-materialize-pending-event".to_string(),
+                content: "hello agent".to_string(),
+                execution_origin: ExecutionOrigin::Scheduled,
+                created_at: "2030-01-01T00:00:00Z".to_string(),
+            },
+            admission:
+                gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_automated_trigger(
+                    FIXED_TEST_DID,
+                    "trigger-1",
+                ),
+            initial_lifecycle_state: RequestLifecycleState::WorkspaceBindingPending,
+            trigger_lineage,
+            trigger_doc_id: Some("trigger-doc-1".to_string()),
+            workspace: Some(workspace_lineage),
+            subagent: None,
+            retry: None,
+            sampling: None,
+            metadata: Some(r#"{"conversation_title":"My Conversation"}"#.to_string()),
+            retry_key: Some("retry-key-1".to_string()),
+            valid_until: None,
+        };
+        let create = build_signed_request(spec, RequestSigner::RegisteredTarget)
             .await
             .expect("build signed pending event-triggered workspace-bound request");
 
@@ -855,10 +1075,10 @@ mod pin_tests {
     // --- Site 2: materialize.rs `RequestLifecycle::materialize_claimed_with_execution_binding` ---
     // This associate function claims the request against a live node in the
     // same call, so it cannot be driven directly in a field-stamping test.
-    // The block below reproduces its DTO-construction statements verbatim
-    // (see the production function above), substituting a fixed
-    // `created_at` for `Utc::now()` so the whole output — including the
-    // signature — is stable.
+    // Driven through `build_signed_request` with the equivalent `RequestSpec`
+    // and `RequestSigner::Identity` (matching the production function's
+    // `sign_agent_request_create(identity.as_ref(), ...)`), asserting against
+    // the output pinned by reproducing the production statements directly.
 
     #[tokio::test]
     async fn pin_materialize_claimed_with_execution_binding() {
@@ -866,10 +1086,6 @@ mod pin_tests {
         let identity = fixed_signing_identity(tempdir.path());
 
         let agent_did = identity.did().to_string();
-        let backend_id = "backend-1".to_string();
-        let behavior_id = "agent-name-1".to_string();
-        let request_id = "req-materialize-claimed".to_string();
-        let session_id = "sess-materialize-claimed".to_string();
         let trigger_lineage = TriggerLineage {
             trigger_id: Some("trigger-1".to_string()),
             trigger_kind: Some("event".to_string()),
@@ -877,29 +1093,41 @@ mod pin_tests {
             correlation: Some("corr-1".to_string()),
             trigger_context: Some(r#"{"k":"v"}"#.to_string()),
         };
-        let content = "resume the run";
-        let execution_origin = ExecutionOrigin::Scheduled;
-        let created_at = "2030-01-01T00:00:00Z".to_string();
 
-        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-            request_id.clone(),
-            &agent_did,
-            &agent_did,
-            behavior_id.clone(),
-            session_id.clone(),
-            content,
-            execution_origin.as_str(),
-            created_at.clone(),
-            gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(&agent_did),
-        );
-        create.backend_id = (!backend_id.is_empty()).then(|| backend_id.clone());
-        create.caused_by_trigger_id = trigger_lineage.trigger_id.clone();
-        create.caused_by_trigger_kind = trigger_lineage.trigger_kind.clone();
-        create.caused_by_source_doc_id = trigger_lineage.source_doc_id.clone();
-        create.caused_by_correlation = trigger_lineage.correlation.clone();
-        create.caused_by_trigger_context = trigger_lineage.trigger_context.clone();
-        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-        crate::sign_agent_request_create(&identity, &mut create)
+        let spec = RequestSpec {
+            identity: RequestIdentity {
+                request_id: "req-materialize-claimed".to_string(),
+                agent_did: agent_did.clone(),
+                requester_did: None,
+                behavior_id: "agent-name-1".to_string(),
+                session_id: "sess-materialize-claimed".to_string(),
+                content: "resume the run".to_string(),
+                execution_origin: ExecutionOrigin::Scheduled,
+                created_at: "2030-01-01T00:00:00Z".to_string(),
+            },
+            admission: gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(
+                &agent_did,
+            ),
+            initial_lifecycle_state: RequestLifecycleState::Pending,
+            trigger_lineage,
+            trigger_doc_id: None,
+            workspace: None,
+            subagent: None,
+            retry: None,
+            sampling: Some(SamplingCarryover {
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                seed: None,
+                max_tokens: None,
+                max_total_tokens: None,
+                backend_id: Some("backend-1".to_string()),
+            }),
+            metadata: None,
+            retry_key: None,
+            valid_until: None,
+        };
+        let create = build_signed_request(spec, RequestSigner::Identity(&identity))
             .await
             .expect("sign claimed request");
 

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -362,14 +362,18 @@ pub(crate) enum RequestSigner<'a> {
     Identity(&'a dyn crate::identity::AgentIdentity),
 }
 
-/// Build, stamp, and sign one `AgentRequestCreate`. This is the sole owner
-/// of the mapping from a writer's decisions (`RequestSpec`) to the DTO's
-/// stamped columns; every production writer should build through it rather
-/// than hand-rolling `AgentRequestCreate::base(...)` and stamping fields
-/// itself.
-pub(crate) async fn build_signed_request(
+/// Build and stamp one `AgentRequestCreate`, unsigned. This is the sole
+/// owner of the mapping from a writer's decisions (`RequestSpec`) to the
+/// DTO's stamped columns; every production writer should build through it
+/// (or `build_signed_request`, below) rather than hand-rolling
+/// `AgentRequestCreate::base(...)` and stamping fields itself.
+///
+/// Split out from signing so a caller that needs to inspect the built DTO
+/// before deciding whether to persist it (e.g. a retry-key dedupe lookup
+/// keyed on a fingerprint of the pre-signature fields) does not pay for a
+/// signature it may discard.
+pub(crate) fn build_request(
     spec: RequestSpec,
-    signer: RequestSigner<'_>,
 ) -> Result<gents_protocol::request_admission::AgentRequestCreate> {
     let RequestSpec {
         identity,
@@ -457,15 +461,37 @@ pub(crate) async fn build_signed_request(
         create.backend_id = sampling.backend_id;
     }
 
+    Ok(create)
+}
+
+/// Sign an `AgentRequestCreate` built by `build_request`, either as the
+/// already-registered runtime principal named by `create.agent_did` or with
+/// an explicit caller-held identity.
+pub(crate) async fn sign_request(
+    create: &mut gents_protocol::request_admission::AgentRequestCreate,
+    signer: RequestSigner<'_>,
+) -> Result<()> {
     match signer {
         RequestSigner::RegisteredTarget => {
-            crate::sign_agent_request_create_as_registered_target(&mut create).await?;
+            crate::sign_agent_request_create_as_registered_target(create).await?;
         }
         RequestSigner::Identity(identity) => {
-            crate::sign_agent_request_create(identity, &mut create).await?;
+            crate::sign_agent_request_create(identity, create).await?;
         }
     }
+    Ok(())
+}
 
+/// Build, stamp, and sign one `AgentRequestCreate` in one call. Equivalent
+/// to `build_request` followed by `sign_request`; use the two-step form
+/// directly when the built DTO must be inspected (e.g. fingerprinted for a
+/// dedupe lookup) before a signature is worth computing.
+pub(crate) async fn build_signed_request(
+    spec: RequestSpec,
+    signer: RequestSigner<'_>,
+) -> Result<gents_protocol::request_admission::AgentRequestCreate> {
+    let mut create = build_request(spec)?;
+    sign_request(&mut create, signer).await?;
     Ok(create)
 }
 
@@ -616,7 +642,7 @@ impl RequestLifecycle {
             },
             admission,
             initial_lifecycle_state: RequestLifecycleState::Pending,
-            trigger_lineage: trigger_lineage.clone(),
+            trigger_lineage,
             trigger_doc_id: None,
             workspace: None,
             subagent: None,
@@ -675,11 +701,11 @@ impl RequestLifecycle {
             caused_by_parent_request_doc_id: None,
             caused_by_parent_tool_call_id: None,
             caused_by_parent_tool_call_doc_id: None,
-            caused_by_trigger_id: trigger_lineage.trigger_id,
-            caused_by_trigger_kind: trigger_lineage.trigger_kind,
-            caused_by_source_doc_id: trigger_lineage.source_doc_id,
-            caused_by_correlation: trigger_lineage.correlation,
-            caused_by_trigger_context: trigger_lineage.trigger_context,
+            caused_by_trigger_id: create.caused_by_trigger_id,
+            caused_by_trigger_kind: create.caused_by_trigger_kind,
+            caused_by_source_doc_id: create.caused_by_source_doc_id,
+            caused_by_correlation: create.caused_by_correlation,
+            caused_by_trigger_context: create.caused_by_trigger_context,
             workspace_id: None,
             workspace_authority: None,
             workspace_owner_deployment_id: None,

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -697,3 +697,216 @@ pub(super) async fn apply_request_session_projection(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod pin_tests {
+    //! Pins today's `AgentRequestCreate::graphql_input_fields()` output for
+    //! each production writer, per fixed inputs, before the writers are
+    //! switched onto `build_signed_request` (#1336 Task 2). Every test here
+    //! uses a deterministic signing identity (a hardcoded raw Ed25519 key)
+    //! so the emitted `admission_signature` is stable across runs; the only
+    //! other source of nondeterminism in these writers is an internally
+    //! generated `created_at` (and, at the subagent site, an internally
+    //! generated `session_id`), which each test either normalizes out of
+    //! the comparison or avoids by reproducing the writer's pure
+    //! DTO-construction statements with a fixed timestamp in place of
+    //! `Utc::now()`.
+    //!
+    //! Sites that require a live node beyond signing (parent/tool-call
+    //! lookups, retry-key dedupe queries, claim) are exercised by
+    //! reproducing their DTO-construction statements verbatim rather than
+    //! by invoking the full function, since the field-stamping logic itself
+    //! has no node dependency; see the per-site comment at each test.
+
+    use super::*;
+    use crate::identity::AgentIdentity;
+
+    /// Raw 64-byte (seed || public key) Ed25519 identity material, captured
+    /// once so every pinning test signs with the same registered DID and
+    /// therefore produces the same signature bytes for the same payload.
+    const FIXED_TEST_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
+    const FIXED_TEST_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
+
+    fn fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
+        let key_bytes: Vec<u8> = (0..FIXED_TEST_KEY_HEX.len())
+            .step_by(2)
+            .map(|offset| u8::from_str_radix(&FIXED_TEST_KEY_HEX[offset..offset + 2], 16).unwrap())
+            .collect();
+        let path = dir.join("pinning.key");
+        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
+        let identity =
+            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
+        assert_eq!(
+            identity.did(),
+            FIXED_TEST_DID,
+            "fixed pinning key derives a stable DID"
+        );
+        identity
+    }
+
+    /// Replace the internally generated `created_at` and `admission_signature`
+    /// field text with stable placeholders, so the rest of the field set can
+    /// still be pinned with a literal `assert_eq!` even though the writer
+    /// calls `Utc::now()` (and therefore signs a different payload) on every
+    /// invocation.
+    fn normalize_dynamic_fields(
+        create: &gents_protocol::request_admission::AgentRequestCreate,
+        fields: &str,
+    ) -> String {
+        let created_at_field = format!(
+            "created_at: \"{}\"",
+            escape_graphql_string(&create.created_at)
+        );
+        let signature_field = format!(
+            "admission_signature: \"{}\"",
+            bs58::encode(&create.admission.signature).into_string()
+        );
+        fields
+            .replacen(&created_at_field, "created_at: \"<CREATED_AT>\"", 1)
+            .replacen(&signature_field, "admission_signature: \"<SIGNATURE>\"", 1)
+    }
+
+    // --- Site 1: materialize.rs `build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title` ---
+    // Pure and public; called directly. `created_at`/`admission_signature`
+    // are internally generated (`Utc::now()`), so they are normalized out.
+
+    #[tokio::test]
+    async fn pin_materialize_pending_manual_trigger() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let _identity = fixed_signing_identity(tempdir.path());
+
+        let create =
+            build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+                FIXED_TEST_DID,
+                "behavior-1",
+                "hello agent",
+                ExecutionOrigin::Interactive,
+                TriggerLineage {
+                    trigger_id: None,
+                    trigger_kind: Some("manual".to_string()),
+                    source_doc_id: None,
+                    correlation: None,
+                    trigger_context: None,
+                },
+                Some("My Conversation"),
+                None,
+                "req-materialize-pending-manual",
+                "sess-materialize-pending-manual",
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("build signed pending manual request");
+
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        let normalized = normalize_dynamic_fields(&create, &fields);
+        assert_eq!(
+            normalized,
+            "request_id: \"req-materialize-pending-manual\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"behavior-1\", session_id: \"sess-materialize-pending-manual\", retry_root_request: \"req-materialize-pending-manual\", content: \"hello agent\", metadata: \"{\\\"conversation_title\\\":\\\"My Conversation\\\"}\", execution_origin: \"interactive\", caused_by_trigger_kind: \"manual\", created_at: \"<CREATED_AT>\", retry_count: 0, max_retries: 3, subagent_depth: 0, admission_kind: \"local-self\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"<SIGNATURE>\", lifecycle_state: \"pending\", failure_reason: \"\""
+        );
+    }
+
+    #[tokio::test]
+    async fn pin_materialize_pending_event_trigger_with_workspace() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let _identity = fixed_signing_identity(tempdir.path());
+
+        let trigger_lineage = TriggerLineage {
+            trigger_id: Some("trigger-1".to_string()),
+            trigger_kind: Some("event".to_string()),
+            source_doc_id: Some("source-doc-1".to_string()),
+            correlation: Some("corr-1".to_string()),
+            trigger_context: Some(r#"{"k":"v"}"#.to_string()),
+        };
+        let workspace_lineage = WorkspaceLineage {
+            workspace_id: Some("ws-1".to_string()),
+            workspace_authority: Some("readWrite".to_string()),
+            workspace_owner_deployment_id: Some("dep-1".to_string()),
+            workspace_seal_hash: Some("seal-1".to_string()),
+        };
+
+        let create =
+            build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+                FIXED_TEST_DID,
+                "behavior-1",
+                "hello agent",
+                ExecutionOrigin::Scheduled,
+                trigger_lineage,
+                Some("My Conversation"),
+                Some(&workspace_lineage),
+                "req-materialize-pending-event",
+                "sess-materialize-pending-event",
+                Some("retry-key-1"),
+                None,
+                Some("trigger-doc-1"),
+            )
+            .await
+            .expect("build signed pending event-triggered workspace-bound request");
+
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        let normalized = normalize_dynamic_fields(&create, &fields);
+        assert_eq!(
+            normalized,
+            "request_id: \"req-materialize-pending-event\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"behavior-1\", session_id: \"sess-materialize-pending-event\", retry_root_request: \"req-materialize-pending-event\", retry_key: \"retry-key-1\", content: \"hello agent\", metadata: \"{\\\"conversation_title\\\":\\\"My Conversation\\\"}\", execution_origin: \"scheduled\", caused_by_trigger_id: \"trigger-1\", caused_by_trigger_doc_id: \"trigger-doc-1\", caused_by_trigger_kind: \"event\", caused_by_correlation: \"corr-1\", caused_by_trigger_context: \"{\\\"k\\\":\\\"v\\\"}\", caused_by_source_doc_id: \"source-doc-1\", created_at: \"<CREATED_AT>\", retry_count: 0, max_retries: 3, subagent_depth: 0, workspace_id: \"ws-1\", workspace_authority: \"readWrite\", workspace_owner_deployment_id: \"dep-1\", workspace_seal_hash: \"seal-1\", admission_kind: \"runtime-internal\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"<SIGNATURE>\", runtime_issuer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", runtime_source_request_id: \"trigger-1\", runtime_source_kind: \"automated-trigger\", lifecycle_state: \"workspaceBindingPending\", failure_reason: \"\""
+        );
+    }
+
+    // --- Site 2: materialize.rs `RequestLifecycle::materialize_claimed_with_execution_binding` ---
+    // This associate function claims the request against a live node in the
+    // same call, so it cannot be driven directly in a field-stamping test.
+    // The block below reproduces its DTO-construction statements verbatim
+    // (see the production function above), substituting a fixed
+    // `created_at` for `Utc::now()` so the whole output — including the
+    // signature — is stable.
+
+    #[tokio::test]
+    async fn pin_materialize_claimed_with_execution_binding() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let identity = fixed_signing_identity(tempdir.path());
+
+        let agent_did = identity.did().to_string();
+        let backend_id = "backend-1".to_string();
+        let behavior_id = "agent-name-1".to_string();
+        let request_id = "req-materialize-claimed".to_string();
+        let session_id = "sess-materialize-claimed".to_string();
+        let trigger_lineage = TriggerLineage {
+            trigger_id: Some("trigger-1".to_string()),
+            trigger_kind: Some("event".to_string()),
+            source_doc_id: Some("source-doc-1".to_string()),
+            correlation: Some("corr-1".to_string()),
+            trigger_context: Some(r#"{"k":"v"}"#.to_string()),
+        };
+        let content = "resume the run";
+        let execution_origin = ExecutionOrigin::Scheduled;
+        let created_at = "2030-01-01T00:00:00Z".to_string();
+
+        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
+            request_id.clone(),
+            &agent_did,
+            &agent_did,
+            behavior_id.clone(),
+            session_id.clone(),
+            content,
+            execution_origin.as_str(),
+            created_at.clone(),
+            gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(&agent_did),
+        );
+        create.backend_id = (!backend_id.is_empty()).then(|| backend_id.clone());
+        create.caused_by_trigger_id = trigger_lineage.trigger_id.clone();
+        create.caused_by_trigger_kind = trigger_lineage.trigger_kind.clone();
+        create.caused_by_source_doc_id = trigger_lineage.source_doc_id.clone();
+        create.caused_by_correlation = trigger_lineage.correlation.clone();
+        create.caused_by_trigger_context = trigger_lineage.trigger_context.clone();
+        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
+        crate::sign_agent_request_create(&identity, &mut create)
+            .await
+            .expect("sign claimed request");
+
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        assert_eq!(
+            fields,
+            "request_id: \"req-materialize-claimed\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"agent-name-1\", session_id: \"sess-materialize-claimed\", retry_root_request: \"req-materialize-claimed\", content: \"resume the run\", backend_id: \"backend-1\", execution_origin: \"scheduled\", caused_by_trigger_id: \"trigger-1\", caused_by_trigger_kind: \"event\", caused_by_correlation: \"corr-1\", caused_by_trigger_context: \"{\\\"k\\\":\\\"v\\\"}\", caused_by_source_doc_id: \"source-doc-1\", created_at: \"2030-01-01T00:00:00Z\", retry_count: 0, max_retries: 3, subagent_depth: 0, admission_kind: \"local-self\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"4DPGJDS77o4K6koAPWqJP5iQU55UV919NvMny273iJRN5uQYZZh3Tr76Jwh7FKQ2GDTirX8wWw5sZbHr9gd8QiqY\", lifecycle_state: \"pending\", failure_reason: \"\""
+        );
+    }
+}

--- a/crates/gents/src/lifecycle/queue.rs
+++ b/crates/gents/src/lifecycle/queue.rs
@@ -14,7 +14,7 @@ use crate::session;
 use crate::watcher::AgentRequest;
 
 use super::materialize::EnqueuedAgentRequest;
-use super::{extract_single_doc_id, ExecutionOrigin, DEFAULT_REQUEST_MAX_RETRIES};
+use super::{extract_single_doc_id, ExecutionOrigin};
 
 mod atomic_inputs;
 mod coalescing;

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::lifecycle::materialize::{
-    build_request, sign_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
+    build_request, sign_request, ParentLink, RequestIdentity, RequestSigner, RequestSpec,
 };
 use crate::lifecycle::{ExecutionOrigin, TriggerLineage, WorkspaceLineage};
 
@@ -53,7 +53,6 @@ pub(crate) async fn enqueue_goal_continuation(
     let identity = RequestIdentity {
         request_id: request_id.clone(),
         agent_did: parent.agent_did.clone(),
-        requester_did: None,
         behavior_id,
         session_id: parent.session_id.clone(),
         content: content.to_string(),
@@ -74,7 +73,7 @@ pub(crate) async fn enqueue_goal_continuation(
             workspace_owner_deployment_id: parent.workspace_owner_deployment_id.clone(),
             workspace_seal_hash: parent.workspace_seal_hash.clone(),
         }),
-        subagent: Some(SubagentLink {
+        subagent: Some(ParentLink {
             depth: parent.subagent_depth,
             parent_request_id: parent.request_id.clone(),
             parent_request_doc_id: parent.doc_id.clone(),

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -45,31 +45,58 @@ pub(crate) async fn enqueue_goal_continuation(
             &parent.agent_did,
             &parent.request_id,
         );
-    let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-        request_id.clone(),
-        &parent.agent_did,
-        &parent.agent_did,
-        behavior_id,
-        &parent.session_id,
-        content,
-        "scheduled",
-        now,
+    let spec = crate::lifecycle::materialize::RequestSpec {
+        identity: crate::lifecycle::materialize::RequestIdentity {
+            request_id: request_id.clone(),
+            agent_did: parent.agent_did.clone(),
+            requester_did: None,
+            behavior_id,
+            session_id: parent.session_id.clone(),
+            content: content.to_string(),
+            execution_origin: ExecutionOrigin::Scheduled,
+            created_at: now,
+        },
         admission,
-    );
-    create.metadata = Some(metadata);
-    create.retry_key = Some(retry_key.clone());
-    create.caused_by_trigger_id = Some(goal_id.to_string());
-    create.caused_by_trigger_kind = Some("goal".to_string());
-    create.caused_by_correlation = parent.caused_by_correlation.clone();
-    create.caused_by_trigger_context = parent.caused_by_trigger_context.clone();
-    create.caused_by_parent_request_id = Some(parent.request_id.clone());
-    create.caused_by_parent_request_doc_id = Some(parent.doc_id.clone());
-    create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-    create.subagent_depth = parent.subagent_depth;
-    create.workspace_id = parent.workspace_id.clone();
-    create.workspace_authority = parent.workspace_authority.clone();
-    create.workspace_owner_deployment_id = parent.workspace_owner_deployment_id.clone();
-    create.workspace_seal_hash = parent.workspace_seal_hash.clone();
+        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
+        trigger_lineage: crate::lifecycle::TriggerLineage {
+            trigger_id: Some(goal_id.to_string()),
+            trigger_kind: Some("goal".to_string()),
+            source_doc_id: None,
+            correlation: parent.caused_by_correlation.clone(),
+            trigger_context: parent.caused_by_trigger_context.clone(),
+        },
+        trigger_doc_id: None,
+        workspace: Some(crate::lifecycle::WorkspaceLineage {
+            workspace_id: parent.workspace_id.clone(),
+            workspace_authority: parent.workspace_authority.clone(),
+            workspace_owner_deployment_id: parent.workspace_owner_deployment_id.clone(),
+            workspace_seal_hash: parent.workspace_seal_hash.clone(),
+        }),
+        subagent: Some(crate::lifecycle::materialize::SubagentLink {
+            depth: parent.subagent_depth,
+            parent_request_id: parent.request_id.clone(),
+            parent_request_doc_id: parent.doc_id.clone(),
+            parent_tool_call_id: None,
+            parent_tool_call_doc_id: None,
+        }),
+        retry: None,
+        sampling: None,
+        metadata: Some(metadata),
+        retry_key: Some(retry_key.clone()),
+        valid_until: None,
+    };
+    // Signing happens before the dedupe lookup below (unlike the prior
+    // hand-rolled version, which peeked at the unsigned DTO first): the
+    // fingerprint compares only pre-signature fields
+    // (`GoalBackedRequestFingerprint` explicitly excludes
+    // `admission_signature` and `created_at`), so this costs one extra local
+    // Ed25519 signature on the redundant-continuation path in exchange for
+    // going through the single signed-request constructor.
+    let create = crate::lifecycle::materialize::build_signed_request(
+        spec,
+        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+    )
+    .await?;
     let expected = crate::goal::GoalBackedRequestFingerprint::from_create(&create)?;
     if let Some(doc_id) = lookup_goal_continuation_by_retry_key(node, &retry_key, &expected).await?
     {
@@ -79,7 +106,6 @@ pub(crate) async fn enqueue_goal_continuation(
             session_id: parent.session_id.clone(),
         });
     }
-    crate::sign_agent_request_create_as_registered_target(&mut create).await?;
     let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
     let response =
         session::execute_mutation_with_retry(node, &mutation, "enqueue_goal_continuation").await;

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -3,8 +3,7 @@ use super::*;
 use crate::lifecycle::materialize::{
     build_request, sign_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
 };
-use crate::lifecycle::{TriggerLineage, WorkspaceLineage};
-use gents_protocol::request_lifecycle::RequestLifecycleState;
+use crate::lifecycle::{ExecutionOrigin, TriggerLineage, WorkspaceLineage};
 
 pub(crate) async fn enqueue_goal_continuation(
     node: &EmbeddedNode,
@@ -51,27 +50,24 @@ pub(crate) async fn enqueue_goal_continuation(
             &parent.agent_did,
             &parent.request_id,
         );
+    let identity = RequestIdentity {
+        request_id: request_id.clone(),
+        agent_did: parent.agent_did.clone(),
+        requester_did: None,
+        behavior_id,
+        session_id: parent.session_id.clone(),
+        content: content.to_string(),
+        execution_origin: ExecutionOrigin::Scheduled,
+        created_at: now,
+    };
     let spec = RequestSpec {
-        identity: RequestIdentity {
-            request_id: request_id.clone(),
-            agent_did: parent.agent_did.clone(),
-            requester_did: None,
-            behavior_id,
-            session_id: parent.session_id.clone(),
-            content: content.to_string(),
-            execution_origin: ExecutionOrigin::Scheduled,
-            created_at: now,
-        },
-        admission,
-        initial_lifecycle_state: RequestLifecycleState::Pending,
         trigger_lineage: TriggerLineage {
             trigger_id: Some(goal_id.to_string()),
             trigger_kind: Some("goal".to_string()),
-            source_doc_id: None,
             correlation: parent.caused_by_correlation.clone(),
             trigger_context: parent.caused_by_trigger_context.clone(),
+            ..Default::default()
         },
-        trigger_doc_id: None,
         workspace: Some(WorkspaceLineage {
             workspace_id: parent.workspace_id.clone(),
             workspace_authority: parent.workspace_authority.clone(),
@@ -82,14 +78,11 @@ pub(crate) async fn enqueue_goal_continuation(
             depth: parent.subagent_depth,
             parent_request_id: parent.request_id.clone(),
             parent_request_doc_id: parent.doc_id.clone(),
-            parent_tool_call_id: None,
-            parent_tool_call_doc_id: None,
+            ..Default::default()
         }),
-        retry: None,
-        sampling: None,
         metadata: Some(metadata),
         retry_key: Some(retry_key.clone()),
-        valid_until: None,
+        ..RequestSpec::new(identity, admission)
     };
     // Peek at the unsigned DTO before paying for a signature: the dedupe
     // lookup below only needs a fingerprint of the pre-signature fields.

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -88,7 +88,8 @@ pub(crate) async fn enqueue_goal_continuation(
     // lookup below only needs a fingerprint of the pre-signature fields.
     let mut create = build_request(spec)?;
     let expected = crate::goal::GoalBackedRequestFingerprint::from_create(&create)?;
-    if let Some(doc_id) = lookup_goal_continuation_by_retry_key(node, &retry_key, &expected).await?
+    if let Some(doc_id) =
+        crate::goal::load_agent_request_by_retry_key(node, &retry_key, &expected).await?
     {
         return Ok(EnqueuedAgentRequest {
             doc_id,
@@ -103,13 +104,15 @@ pub(crate) async fn enqueue_goal_continuation(
     let doc_id = match response {
         Ok(response) => match extract_single_doc_id(&response, "create_AgentRequest") {
             Some(doc_id) => Some(doc_id),
-            None => lookup_goal_continuation_by_retry_key(node, &retry_key, &expected).await?,
+            None => {
+                crate::goal::load_agent_request_by_retry_key(node, &retry_key, &expected).await?
+            }
         },
         Err(create_error) => {
             // `retry_key` is unique. A concurrent reconciler or a lost create
             // acknowledgement therefore resolves to the same durable child.
             // Only surface the original error when no such child exists.
-            match lookup_goal_continuation_by_retry_key(node, &retry_key, &expected).await? {
+            match crate::goal::load_agent_request_by_retry_key(node, &retry_key, &expected).await? {
                 Some(doc_id) => Some(doc_id),
                 None => return Err(create_error),
             }
@@ -122,50 +125,6 @@ pub(crate) async fn enqueue_goal_continuation(
         request_id,
         session_id: parent.session_id.clone(),
     })
-}
-
-async fn lookup_goal_continuation_by_retry_key(
-    node: &EmbeddedNode,
-    retry_key: &str,
-    expected: &crate::goal::GoalBackedRequestFingerprint,
-) -> Result<Option<String>> {
-    let retry_key = crate::graphql::escape_graphql_string(retry_key);
-    let query = format!(
-        r#"{{ AgentRequest(filter: {{ retry_key: {{ _eq: "{retry_key}" }} }}, limit: 2) {{
-            _docID {}
-        }} }}"#,
-        crate::goal::GOAL_BACKED_REQUEST_FINGERPRINT_FIELDS,
-    );
-    let response = node.execute(&query).await;
-    if response.has_errors() {
-        anyhow::bail!(
-            "lookup goal continuation by retry key failed: {:?}",
-            response.errors
-        );
-    }
-    let rows = response
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentRequest"))
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    anyhow::ensure!(rows.len() <= 1, "goal continuation retry key is not unique");
-    let Some(row) = rows.first() else {
-        return Ok(None);
-    };
-    let persisted: crate::goal::GoalBackedRequestFingerprint = serde_json::from_value(row.clone())
-        .context("decoding existing goal continuation fingerprint")?;
-    anyhow::ensure!(
-        persisted == *expected,
-        "goal continuation retry key conflicts with different immutable lineage"
-    );
-    Ok(Some(
-        row.get("_docID")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string)
-            .context("goal continuation has no document ID")?,
-    ))
 }
 
 // SAFETY (#664): `agent_did` scopes the candidate query AND the supersede

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+use crate::lifecycle::materialize::{
+    build_request, sign_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
+};
+use crate::lifecycle::{TriggerLineage, WorkspaceLineage};
+use gents_protocol::request_lifecycle::RequestLifecycleState;
+
 pub(crate) async fn enqueue_goal_continuation(
     node: &EmbeddedNode,
     parent: &AgentRequest,
@@ -45,8 +51,8 @@ pub(crate) async fn enqueue_goal_continuation(
             &parent.agent_did,
             &parent.request_id,
         );
-    let spec = crate::lifecycle::materialize::RequestSpec {
-        identity: crate::lifecycle::materialize::RequestIdentity {
+    let spec = RequestSpec {
+        identity: RequestIdentity {
             request_id: request_id.clone(),
             agent_did: parent.agent_did.clone(),
             requester_did: None,
@@ -57,8 +63,8 @@ pub(crate) async fn enqueue_goal_continuation(
             created_at: now,
         },
         admission,
-        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
-        trigger_lineage: crate::lifecycle::TriggerLineage {
+        initial_lifecycle_state: RequestLifecycleState::Pending,
+        trigger_lineage: TriggerLineage {
             trigger_id: Some(goal_id.to_string()),
             trigger_kind: Some("goal".to_string()),
             source_doc_id: None,
@@ -66,13 +72,13 @@ pub(crate) async fn enqueue_goal_continuation(
             trigger_context: parent.caused_by_trigger_context.clone(),
         },
         trigger_doc_id: None,
-        workspace: Some(crate::lifecycle::WorkspaceLineage {
+        workspace: Some(WorkspaceLineage {
             workspace_id: parent.workspace_id.clone(),
             workspace_authority: parent.workspace_authority.clone(),
             workspace_owner_deployment_id: parent.workspace_owner_deployment_id.clone(),
             workspace_seal_hash: parent.workspace_seal_hash.clone(),
         }),
-        subagent: Some(crate::lifecycle::materialize::SubagentLink {
+        subagent: Some(SubagentLink {
             depth: parent.subagent_depth,
             parent_request_id: parent.request_id.clone(),
             parent_request_doc_id: parent.doc_id.clone(),
@@ -85,18 +91,9 @@ pub(crate) async fn enqueue_goal_continuation(
         retry_key: Some(retry_key.clone()),
         valid_until: None,
     };
-    // Signing happens before the dedupe lookup below (unlike the prior
-    // hand-rolled version, which peeked at the unsigned DTO first): the
-    // fingerprint compares only pre-signature fields
-    // (`GoalBackedRequestFingerprint` explicitly excludes
-    // `admission_signature` and `created_at`), so this costs one extra local
-    // Ed25519 signature on the redundant-continuation path in exchange for
-    // going through the single signed-request constructor.
-    let create = crate::lifecycle::materialize::build_signed_request(
-        spec,
-        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
-    )
-    .await?;
+    // Peek at the unsigned DTO before paying for a signature: the dedupe
+    // lookup below only needs a fingerprint of the pre-signature fields.
+    let mut create = build_request(spec)?;
     let expected = crate::goal::GoalBackedRequestFingerprint::from_create(&create)?;
     if let Some(doc_id) = lookup_goal_continuation_by_retry_key(node, &retry_key, &expected).await?
     {
@@ -106,6 +103,7 @@ pub(crate) async fn enqueue_goal_continuation(
             session_id: parent.session_id.clone(),
         });
     }
+    sign_request(&mut create, RequestSigner::RegisteredTarget).await?;
     let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
     let response =
         session::execute_mutation_with_retry(node, &mutation, "enqueue_goal_continuation").await;

--- a/crates/gents/src/lifecycle/queue/mutation.rs
+++ b/crates/gents/src/lifecycle/queue/mutation.rs
@@ -4,7 +4,6 @@ use crate::lifecycle::materialize::{
     build_signed_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
 };
 use crate::lifecycle::TriggerLineage;
-use gents_protocol::request_lifecycle::RequestLifecycleState;
 
 pub(super) async fn session_request_create_mutation(
     parent: &AgentRequest,
@@ -25,40 +24,31 @@ pub(super) async fn session_request_create_mutation(
             &parent.agent_did,
             &parent.request_id,
         );
+    let identity = RequestIdentity {
+        request_id: request_id.to_string(),
+        agent_did: parent.agent_did.clone(),
+        requester_did: None,
+        behavior_id: behavior_id.to_string(),
+        session_id: parent.session_id.clone(),
+        content: content.to_string(),
+        execution_origin,
+        created_at: created_at.to_string(),
+    };
     let spec = RequestSpec {
-        identity: RequestIdentity {
-            request_id: request_id.to_string(),
-            agent_did: parent.agent_did.clone(),
-            requester_did: None,
-            behavior_id: behavior_id.to_string(),
-            session_id: parent.session_id.clone(),
-            content: content.to_string(),
-            execution_origin,
-            created_at: created_at.to_string(),
-        },
-        admission,
-        initial_lifecycle_state: RequestLifecycleState::Pending,
         trigger_lineage: TriggerLineage {
-            trigger_id: None,
-            trigger_kind: None,
-            source_doc_id: None,
             correlation: parent.caused_by_correlation.clone(),
             trigger_context: parent.caused_by_trigger_context.clone(),
+            ..Default::default()
         },
-        trigger_doc_id: None,
-        workspace: None,
         subagent: Some(SubagentLink {
             depth: parent.subagent_depth,
             parent_request_id: parent.request_id.clone(),
             parent_request_doc_id: parent.doc_id.clone(),
-            parent_tool_call_id: None,
-            parent_tool_call_doc_id: None,
+            ..Default::default()
         }),
-        retry: None,
-        sampling: None,
         metadata: Some(metadata.to_string()),
         retry_key: retry_key.map(ToOwned::to_owned),
-        valid_until: None,
+        ..RequestSpec::new(identity, admission)
     };
     let create = build_signed_request(spec, RequestSigner::RegisteredTarget).await?;
     create.graphql_mutation().map_err(anyhow::Error::msg)

--- a/crates/gents/src/lifecycle/queue/mutation.rs
+++ b/crates/gents/src/lifecycle/queue/mutation.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+use crate::lifecycle::materialize::{
+    build_signed_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
+};
+use crate::lifecycle::TriggerLineage;
+use gents_protocol::request_lifecycle::RequestLifecycleState;
+
 pub(super) async fn session_request_create_mutation(
     parent: &AgentRequest,
     behavior_id: &str,
@@ -19,8 +25,8 @@ pub(super) async fn session_request_create_mutation(
             &parent.agent_did,
             &parent.request_id,
         );
-    let spec = crate::lifecycle::materialize::RequestSpec {
-        identity: crate::lifecycle::materialize::RequestIdentity {
+    let spec = RequestSpec {
+        identity: RequestIdentity {
             request_id: request_id.to_string(),
             agent_did: parent.agent_did.clone(),
             requester_did: None,
@@ -31,8 +37,8 @@ pub(super) async fn session_request_create_mutation(
             created_at: created_at.to_string(),
         },
         admission,
-        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
-        trigger_lineage: crate::lifecycle::TriggerLineage {
+        initial_lifecycle_state: RequestLifecycleState::Pending,
+        trigger_lineage: TriggerLineage {
             trigger_id: None,
             trigger_kind: None,
             source_doc_id: None,
@@ -41,7 +47,7 @@ pub(super) async fn session_request_create_mutation(
         },
         trigger_doc_id: None,
         workspace: None,
-        subagent: Some(crate::lifecycle::materialize::SubagentLink {
+        subagent: Some(SubagentLink {
             depth: parent.subagent_depth,
             parent_request_id: parent.request_id.clone(),
             parent_request_doc_id: parent.doc_id.clone(),
@@ -54,10 +60,6 @@ pub(super) async fn session_request_create_mutation(
         retry_key: retry_key.map(ToOwned::to_owned),
         valid_until: None,
     };
-    let create = crate::lifecycle::materialize::build_signed_request(
-        spec,
-        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
-    )
-    .await?;
+    let create = build_signed_request(spec, RequestSigner::RegisteredTarget).await?;
     create.graphql_mutation().map_err(anyhow::Error::msg)
 }

--- a/crates/gents/src/lifecycle/queue/mutation.rs
+++ b/crates/gents/src/lifecycle/queue/mutation.rs
@@ -19,27 +19,45 @@ pub(super) async fn session_request_create_mutation(
             &parent.agent_did,
             &parent.request_id,
         );
-    let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-        request_id,
-        &parent.agent_did,
-        &parent.agent_did,
-        behavior_id,
-        &parent.session_id,
-        content,
-        execution_origin.as_str(),
-        created_at,
+    let spec = crate::lifecycle::materialize::RequestSpec {
+        identity: crate::lifecycle::materialize::RequestIdentity {
+            request_id: request_id.to_string(),
+            agent_did: parent.agent_did.clone(),
+            requester_did: None,
+            behavior_id: behavior_id.to_string(),
+            session_id: parent.session_id.clone(),
+            content: content.to_string(),
+            execution_origin,
+            created_at: created_at.to_string(),
+        },
         admission,
-    );
-    create.metadata = Some(metadata.to_string());
-    create.retry_key = retry_key.map(ToOwned::to_owned);
-    create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-    create.subagent_depth = parent.subagent_depth;
-    create.caused_by_parent_request_id = Some(parent.request_id.clone());
-    create.caused_by_parent_request_doc_id = Some(parent.doc_id.clone());
-    create.caused_by_parent_tool_call_id = None;
-    create.caused_by_parent_tool_call_doc_id = None;
-    create.caused_by_correlation = parent.caused_by_correlation.clone();
-    create.caused_by_trigger_context = parent.caused_by_trigger_context.clone();
-    crate::sign_agent_request_create_as_registered_target(&mut create).await?;
+        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
+        trigger_lineage: crate::lifecycle::TriggerLineage {
+            trigger_id: None,
+            trigger_kind: None,
+            source_doc_id: None,
+            correlation: parent.caused_by_correlation.clone(),
+            trigger_context: parent.caused_by_trigger_context.clone(),
+        },
+        trigger_doc_id: None,
+        workspace: None,
+        subagent: Some(crate::lifecycle::materialize::SubagentLink {
+            depth: parent.subagent_depth,
+            parent_request_id: parent.request_id.clone(),
+            parent_request_doc_id: parent.doc_id.clone(),
+            parent_tool_call_id: None,
+            parent_tool_call_doc_id: None,
+        }),
+        retry: None,
+        sampling: None,
+        metadata: Some(metadata.to_string()),
+        retry_key: retry_key.map(ToOwned::to_owned),
+        valid_until: None,
+    };
+    let create = crate::lifecycle::materialize::build_signed_request(
+        spec,
+        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+    )
+    .await?;
     create.graphql_mutation().map_err(anyhow::Error::msg)
 }

--- a/crates/gents/src/lifecycle/queue/mutation.rs
+++ b/crates/gents/src/lifecycle/queue/mutation.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::lifecycle::materialize::{
-    build_signed_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
+    build_signed_request, ParentLink, RequestIdentity, RequestSigner, RequestSpec,
 };
 use crate::lifecycle::TriggerLineage;
 
@@ -27,7 +27,6 @@ pub(super) async fn session_request_create_mutation(
     let identity = RequestIdentity {
         request_id: request_id.to_string(),
         agent_did: parent.agent_did.clone(),
-        requester_did: None,
         behavior_id: behavior_id.to_string(),
         session_id: parent.session_id.clone(),
         content: content.to_string(),
@@ -40,7 +39,7 @@ pub(super) async fn session_request_create_mutation(
             trigger_context: parent.caused_by_trigger_context.clone(),
             ..Default::default()
         },
-        subagent: Some(SubagentLink {
+        subagent: Some(ParentLink {
             depth: parent.subagent_depth,
             parent_request_id: parent.request_id.clone(),
             parent_request_doc_id: parent.doc_id.clone(),

--- a/crates/gents/src/lifecycle/queue/tests.rs
+++ b/crates/gents/src/lifecycle/queue/tests.rs
@@ -252,6 +252,8 @@ mod metadata;
 mod pin_tests {
     use super::*;
     use crate::identity::AgentIdentity;
+    use crate::lifecycle::{TriggerLineage, WorkspaceLineage};
+    use gents_protocol::request_lifecycle::RequestLifecycleState;
 
     /// Same fixed Ed25519 identity material as
     /// `lifecycle::materialize::pin_tests`, duplicated here rather than
@@ -284,9 +286,10 @@ mod pin_tests {
     }
 
     // --- Site 3: `lifecycle::queue::mutation::session_request_create_mutation` ---
-    // Pure (no node) and already returns the full mutation string built
-    // from `create.graphql_mutation()`; the input fields are extracted from
-    // that known wrapper.
+    // Driven through `build_signed_request` with the equivalent `RequestSpec`,
+    // asserting against the output pinned by calling the production function
+    // directly (which is pure and returns the full mutation string built
+    // from `create.graphql_mutation()`).
 
     #[tokio::test]
     async fn pin_session_request_create_mutation() {
@@ -294,23 +297,53 @@ mod pin_tests {
         let _identity = pin_fixed_signing_identity(tempdir.path());
 
         let parent = pin_parent_request();
-        let mutation = session_request_create_mutation(
-            &parent,
-            "behavior-1",
-            "steering content",
-            ExecutionOrigin::Interactive,
-            r#"{"queue":{"source":"steering"}}"#,
-            "req-session-mutation-1",
-            "2030-01-01T00:00:00Z",
-            Some("retry-key-session-1"),
+        let spec = crate::lifecycle::materialize::RequestSpec {
+            identity: crate::lifecycle::materialize::RequestIdentity {
+                request_id: "req-session-mutation-1".to_string(),
+                agent_did: parent.agent_did.clone(),
+                requester_did: None,
+                behavior_id: "behavior-1".to_string(),
+                session_id: parent.session_id.clone(),
+                content: "steering content".to_string(),
+                execution_origin: ExecutionOrigin::Interactive,
+                created_at: "2030-01-01T00:00:00Z".to_string(),
+            },
+            admission:
+                gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
+                    &parent.agent_did,
+                    &parent.request_id,
+                ),
+            initial_lifecycle_state: RequestLifecycleState::Pending,
+            trigger_lineage: TriggerLineage {
+                trigger_id: None,
+                trigger_kind: None,
+                source_doc_id: None,
+                correlation: parent.caused_by_correlation.clone(),
+                trigger_context: parent.caused_by_trigger_context.clone(),
+            },
+            trigger_doc_id: None,
+            workspace: None,
+            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+                depth: parent.subagent_depth,
+                parent_request_id: parent.request_id.clone(),
+                parent_request_doc_id: parent.doc_id.clone(),
+                parent_tool_call_id: None,
+                parent_tool_call_doc_id: None,
+            }),
+            retry: None,
+            sampling: None,
+            metadata: Some(r#"{"queue":{"source":"steering"}}"#.to_string()),
+            retry_key: Some("retry-key-session-1".to_string()),
+            valid_until: None,
+        };
+        let create = crate::lifecycle::materialize::build_signed_request(
+            spec,
+            crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
         )
         .await
-        .expect("build session request create mutation");
+        .expect("build session request create");
 
-        let fields = mutation
-            .strip_prefix("mutation { create_AgentRequest(input: { ")
-            .and_then(|rest| rest.strip_suffix(" }) { _docID } }"))
-            .expect("mutation wraps create_AgentRequest input fields");
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
 
         assert_eq!(
             fields,
@@ -375,34 +408,52 @@ mod pin_tests {
                 &parent.agent_did,
                 &parent.request_id,
             );
-        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-            request_id.clone(),
-            &parent.agent_did,
-            &parent.agent_did,
-            behavior_id,
-            &parent.session_id,
-            content,
-            "scheduled",
-            now,
+        let spec = crate::lifecycle::materialize::RequestSpec {
+            identity: crate::lifecycle::materialize::RequestIdentity {
+                request_id: request_id.clone(),
+                agent_did: parent.agent_did.clone(),
+                requester_did: None,
+                behavior_id,
+                session_id: parent.session_id.clone(),
+                content: content.to_string(),
+                execution_origin: ExecutionOrigin::Scheduled,
+                created_at: now,
+            },
             admission,
-        );
-        create.metadata = Some(metadata);
-        create.retry_key = Some(retry_key.clone());
-        create.caused_by_trigger_id = Some(goal_id.to_string());
-        create.caused_by_trigger_kind = Some("goal".to_string());
-        create.caused_by_correlation = parent.caused_by_correlation.clone();
-        create.caused_by_trigger_context = parent.caused_by_trigger_context.clone();
-        create.caused_by_parent_request_id = Some(parent.request_id.clone());
-        create.caused_by_parent_request_doc_id = Some(parent.doc_id.clone());
-        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-        create.subagent_depth = parent.subagent_depth;
-        create.workspace_id = parent.workspace_id.clone();
-        create.workspace_authority = parent.workspace_authority.clone();
-        create.workspace_owner_deployment_id = parent.workspace_owner_deployment_id.clone();
-        create.workspace_seal_hash = parent.workspace_seal_hash.clone();
-        crate::sign_agent_request_create_as_registered_target(&mut create)
-            .await
-            .expect("sign goal continuation request");
+            initial_lifecycle_state: RequestLifecycleState::Pending,
+            trigger_lineage: TriggerLineage {
+                trigger_id: Some(goal_id.to_string()),
+                trigger_kind: Some("goal".to_string()),
+                source_doc_id: None,
+                correlation: parent.caused_by_correlation.clone(),
+                trigger_context: parent.caused_by_trigger_context.clone(),
+            },
+            trigger_doc_id: None,
+            workspace: Some(WorkspaceLineage {
+                workspace_id: parent.workspace_id.clone(),
+                workspace_authority: parent.workspace_authority.clone(),
+                workspace_owner_deployment_id: parent.workspace_owner_deployment_id.clone(),
+                workspace_seal_hash: parent.workspace_seal_hash.clone(),
+            }),
+            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+                depth: parent.subagent_depth,
+                parent_request_id: parent.request_id.clone(),
+                parent_request_doc_id: parent.doc_id.clone(),
+                parent_tool_call_id: None,
+                parent_tool_call_doc_id: None,
+            }),
+            retry: None,
+            sampling: None,
+            metadata: Some(metadata),
+            retry_key: Some(retry_key.clone()),
+            valid_until: None,
+        };
+        let create = crate::lifecycle::materialize::build_signed_request(
+            spec,
+            crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+        )
+        .await
+        .expect("sign goal continuation request");
 
         let fields = create.graphql_input_fields().expect("graphql_input_fields");
         assert_eq!(

--- a/crates/gents/src/lifecycle/queue/tests.rs
+++ b/crates/gents/src/lifecycle/queue/tests.rs
@@ -252,29 +252,9 @@ mod metadata;
 /// where `created_at` is generated internally).
 mod pin_tests {
     use super::*;
-    use crate::identity::AgentIdentity;
+    use crate::lifecycle::test_support::{pin_fixed_signing_identity, PIN_FIXED_DID};
     use crate::lifecycle::{TriggerLineage, WorkspaceLineage};
     use gents_protocol::request_lifecycle::RequestLifecycleState;
-
-    /// Same fixed Ed25519 identity material as
-    /// `lifecycle::materialize::pin_tests`, duplicated here rather than
-    /// shared so each pinning module stays a self-contained fixture (this
-    /// crate's existing convention: see `test_db` above).
-    const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
-    const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
-
-    fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
-        let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
-            .step_by(2)
-            .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
-            .collect();
-        let path = dir.join("pinning.key");
-        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
-        let identity =
-            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
-        assert_eq!(identity.did(), PIN_FIXED_DID);
-        identity
-    }
 
     fn pin_parent_request() -> AgentRequest {
         let mut parent = parent_request(PIN_FIXED_DID, "sess-pin-parent");
@@ -287,10 +267,9 @@ mod pin_tests {
     }
 
     // --- Site 3: `lifecycle::queue::mutation::session_request_create_mutation` ---
-    // Driven through `build_signed_request` with the equivalent `RequestSpec`,
-    // asserting against the output pinned by calling the production function
-    // directly (which is pure and returns the full mutation string built
-    // from `create.graphql_mutation()`).
+    // Pure (no node) and already returns the full mutation string built
+    // from `create.graphql_mutation()`; the input fields are extracted from
+    // that known wrapper.
 
     #[tokio::test]
     async fn pin_session_request_create_mutation() {
@@ -298,53 +277,23 @@ mod pin_tests {
         let _identity = pin_fixed_signing_identity(tempdir.path());
 
         let parent = pin_parent_request();
-        let spec = crate::lifecycle::materialize::RequestSpec {
-            identity: crate::lifecycle::materialize::RequestIdentity {
-                request_id: "req-session-mutation-1".to_string(),
-                agent_did: parent.agent_did.clone(),
-                requester_did: None,
-                behavior_id: "behavior-1".to_string(),
-                session_id: parent.session_id.clone(),
-                content: "steering content".to_string(),
-                execution_origin: ExecutionOrigin::Interactive,
-                created_at: "2030-01-01T00:00:00Z".to_string(),
-            },
-            admission:
-                gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
-                    &parent.agent_did,
-                    &parent.request_id,
-                ),
-            initial_lifecycle_state: RequestLifecycleState::Pending,
-            trigger_lineage: TriggerLineage {
-                trigger_id: None,
-                trigger_kind: None,
-                source_doc_id: None,
-                correlation: parent.caused_by_correlation.clone(),
-                trigger_context: parent.caused_by_trigger_context.clone(),
-            },
-            trigger_doc_id: None,
-            workspace: None,
-            subagent: Some(crate::lifecycle::materialize::SubagentLink {
-                depth: parent.subagent_depth,
-                parent_request_id: parent.request_id.clone(),
-                parent_request_doc_id: parent.doc_id.clone(),
-                parent_tool_call_id: None,
-                parent_tool_call_doc_id: None,
-            }),
-            retry: None,
-            sampling: None,
-            metadata: Some(r#"{"queue":{"source":"steering"}}"#.to_string()),
-            retry_key: Some("retry-key-session-1".to_string()),
-            valid_until: None,
-        };
-        let create = crate::lifecycle::materialize::build_signed_request(
-            spec,
-            crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+        let mutation = session_request_create_mutation(
+            &parent,
+            "behavior-1",
+            "steering content",
+            ExecutionOrigin::Interactive,
+            r#"{"queue":{"source":"steering"}}"#,
+            "req-session-mutation-1",
+            "2030-01-01T00:00:00Z",
+            Some("retry-key-session-1"),
         )
         .await
-        .expect("build session request create");
+        .expect("build session request create mutation");
 
-        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        let fields = mutation
+            .strip_prefix("mutation { create_AgentRequest(input: { ")
+            .and_then(|rest| rest.strip_suffix(" }) { _docID } }"))
+            .expect("mutation wraps create_AgentRequest input fields");
 
         assert_eq!(
             fields,
@@ -413,7 +362,6 @@ mod pin_tests {
             identity: crate::lifecycle::materialize::RequestIdentity {
                 request_id: request_id.clone(),
                 agent_did: parent.agent_did.clone(),
-                requester_did: None,
                 behavior_id,
                 session_id: parent.session_id.clone(),
                 content: content.to_string(),
@@ -436,7 +384,7 @@ mod pin_tests {
                 workspace_owner_deployment_id: parent.workspace_owner_deployment_id.clone(),
                 workspace_seal_hash: parent.workspace_seal_hash.clone(),
             }),
-            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+            subagent: Some(crate::lifecycle::materialize::ParentLink {
                 depth: parent.subagent_depth,
                 parent_request_id: parent.request_id.clone(),
                 parent_request_doc_id: parent.doc_id.clone(),

--- a/crates/gents/src/lifecycle/queue/tests.rs
+++ b/crates/gents/src/lifecycle/queue/tests.rs
@@ -240,3 +240,174 @@ async fn request_doc_lookup_rejects_duplicate_logical_request_ids() {
 mod background_completion;
 mod coalescing;
 mod metadata;
+
+/// Pins today's `AgentRequestCreate::graphql_input_fields()` output for the
+/// `lifecycle::queue` production writers (#1336 Task 1), before they are
+/// switched onto `build_signed_request` (#1336 Task 2). Both writers take
+/// `created_at` (and, for the session-mutation site, `request_id` and
+/// `retry_key`) as caller-supplied parameters, so — with a deterministic
+/// signing identity — their output is fully stable across runs; no
+/// normalization is needed here (contrast `lifecycle::materialize::pin_tests`,
+/// where `created_at` is generated internally).
+mod pin_tests {
+    use super::*;
+    use crate::identity::AgentIdentity;
+
+    /// Same fixed Ed25519 identity material as
+    /// `lifecycle::materialize::pin_tests`, duplicated here rather than
+    /// shared so each pinning module stays a self-contained fixture (this
+    /// crate's existing convention: see `test_db` above).
+    const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
+    const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
+
+    fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
+        let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
+            .step_by(2)
+            .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
+            .collect();
+        let path = dir.join("pinning.key");
+        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
+        let identity =
+            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
+        assert_eq!(identity.did(), PIN_FIXED_DID);
+        identity
+    }
+
+    fn pin_parent_request() -> AgentRequest {
+        let mut parent = parent_request(PIN_FIXED_DID, "sess-pin-parent");
+        parent.request_id = "pin-parent-request".to_string();
+        parent.doc_id = "pin-parent-doc".to_string();
+        parent.subagent_depth = 2;
+        parent.caused_by_correlation = Some("corr-parent".to_string());
+        parent.caused_by_trigger_context = Some(r#"{"a":"b"}"#.to_string());
+        parent
+    }
+
+    // --- Site 3: `lifecycle::queue::mutation::session_request_create_mutation` ---
+    // Pure (no node) and already returns the full mutation string built
+    // from `create.graphql_mutation()`; the input fields are extracted from
+    // that known wrapper.
+
+    #[tokio::test]
+    async fn pin_session_request_create_mutation() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let _identity = pin_fixed_signing_identity(tempdir.path());
+
+        let parent = pin_parent_request();
+        let mutation = session_request_create_mutation(
+            &parent,
+            "behavior-1",
+            "steering content",
+            ExecutionOrigin::Interactive,
+            r#"{"queue":{"source":"steering"}}"#,
+            "req-session-mutation-1",
+            "2030-01-01T00:00:00Z",
+            Some("retry-key-session-1"),
+        )
+        .await
+        .expect("build session request create mutation");
+
+        let fields = mutation
+            .strip_prefix("mutation { create_AgentRequest(input: { ")
+            .and_then(|rest| rest.strip_suffix(" }) { _docID } }"))
+            .expect("mutation wraps create_AgentRequest input fields");
+
+        assert_eq!(
+            fields,
+            "request_id: \"req-session-mutation-1\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"behavior-1\", session_id: \"sess-pin-parent\", retry_root_request: \"req-session-mutation-1\", retry_key: \"retry-key-session-1\", content: \"steering content\", metadata: \"{\\\"queue\\\":{\\\"source\\\":\\\"steering\\\"}}\", execution_origin: \"interactive\", caused_by_correlation: \"corr-parent\", caused_by_trigger_context: \"{\\\"a\\\":\\\"b\\\"}\", created_at: \"2030-01-01T00:00:00Z\", retry_count: 0, max_retries: 3, subagent_depth: 2, caused_by_parent_request_id: \"pin-parent-request\", caused_by_parent_request_doc_id: \"pin-parent-doc\", admission_kind: \"runtime-internal\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"5Tvz6LV31BdgtSqE22FqJHXnatDd6BkkvuVtKmEGJPai2Md5ooHQWKb4UZ4vc2q7oyh2cXh3UhkeqjFp9oqsUgjh\", runtime_issuer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", runtime_source_request_id: \"pin-parent-request\", runtime_source_kind: \"local-control\", lifecycle_state: \"pending\", failure_reason: \"\""
+        );
+    }
+
+    // --- Site 4: `lifecycle::queue::goal_continuation::enqueue_goal_continuation` ---
+    // This persists to a live node and returns only the doc/request/session
+    // ids, not the `AgentRequestCreate` it built, and its retry-key dedupe
+    // lookup also requires a node. The block below reproduces its
+    // DTO-construction statements verbatim (see the production function),
+    // substituting a fixed `now` for `Utc::now()` and inlining
+    // `parent_behavior_id`'s no-node-needed fast path (returning
+    // `parent.behavior_id` directly, since it is set here).
+
+    #[tokio::test]
+    async fn pin_enqueue_goal_continuation_dto_construction() {
+        use sha2::{Digest, Sha256};
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let _identity = pin_fixed_signing_identity(tempdir.path());
+
+        let mut parent = pin_parent_request();
+        parent.workspace_id = Some("ws-goal-1".to_string());
+        parent.workspace_authority = Some("readWrite".to_string());
+        parent.workspace_owner_deployment_id = Some("dep-goal-1".to_string());
+        parent.workspace_seal_hash = Some("seal-goal-1".to_string());
+
+        let goal_id = "goal-1";
+        let continuation_sequence: i64 = 3;
+        let content = "continue the goal";
+        let behavior_id = parent.behavior_id.clone().unwrap();
+
+        let digest = Sha256::digest(format!("{goal_id}\0{}", parent.request_id).as_bytes());
+        let digest_hex = digest[..16]
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        let request_id = format!("goal-cont-{continuation_sequence:020}-{digest_hex}");
+        let retry_key = format!("goal-continuation:{digest_hex}");
+        let now = "2030-01-01T00:00:00Z".to_string();
+        let queue_hints = QueueHints {
+            source: QueueSource::Goal,
+            policy: QueuePolicy::Coalesce,
+            key: Some(format!("goal:{digest_hex}")),
+            queued_after_request_id: Some(parent.request_id.clone()),
+            interrupted_request_id: None,
+        };
+        let metadata = serde_json::json!({
+            "queue": queue_hints,
+            "goal": {
+                "goal_id": goal_id,
+                "parent_request_id": parent.request_id,
+                "continuation_sequence": continuation_sequence,
+                "wrapup": false,
+            }
+        })
+        .to_string();
+        let admission =
+            gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
+                &parent.agent_did,
+                &parent.request_id,
+            );
+        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
+            request_id.clone(),
+            &parent.agent_did,
+            &parent.agent_did,
+            behavior_id,
+            &parent.session_id,
+            content,
+            "scheduled",
+            now,
+            admission,
+        );
+        create.metadata = Some(metadata);
+        create.retry_key = Some(retry_key.clone());
+        create.caused_by_trigger_id = Some(goal_id.to_string());
+        create.caused_by_trigger_kind = Some("goal".to_string());
+        create.caused_by_correlation = parent.caused_by_correlation.clone();
+        create.caused_by_trigger_context = parent.caused_by_trigger_context.clone();
+        create.caused_by_parent_request_id = Some(parent.request_id.clone());
+        create.caused_by_parent_request_doc_id = Some(parent.doc_id.clone());
+        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
+        create.subagent_depth = parent.subagent_depth;
+        create.workspace_id = parent.workspace_id.clone();
+        create.workspace_authority = parent.workspace_authority.clone();
+        create.workspace_owner_deployment_id = parent.workspace_owner_deployment_id.clone();
+        create.workspace_seal_hash = parent.workspace_seal_hash.clone();
+        crate::sign_agent_request_create_as_registered_target(&mut create)
+            .await
+            .expect("sign goal continuation request");
+
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        assert_eq!(
+            fields,
+            "request_id: \"goal-cont-00000000000000000003-355ac0cefea9f3d0afab06ffb90fd1ec\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"general\", session_id: \"sess-pin-parent\", retry_root_request: \"goal-cont-00000000000000000003-355ac0cefea9f3d0afab06ffb90fd1ec\", retry_key: \"goal-continuation:355ac0cefea9f3d0afab06ffb90fd1ec\", content: \"continue the goal\", metadata: \"{\\\"goal\\\":{\\\"continuation_sequence\\\":3,\\\"goal_id\\\":\\\"goal-1\\\",\\\"parent_request_id\\\":\\\"pin-parent-request\\\",\\\"wrapup\\\":false},\\\"queue\\\":{\\\"key\\\":\\\"goal:355ac0cefea9f3d0afab06ffb90fd1ec\\\",\\\"policy\\\":\\\"coalesce\\\",\\\"queued_after_request_id\\\":\\\"pin-parent-request\\\",\\\"source\\\":\\\"goal\\\"}}\", execution_origin: \"scheduled\", caused_by_trigger_id: \"goal-1\", caused_by_trigger_kind: \"goal\", caused_by_correlation: \"corr-parent\", caused_by_trigger_context: \"{\\\"a\\\":\\\"b\\\"}\", created_at: \"2030-01-01T00:00:00Z\", retry_count: 0, max_retries: 3, subagent_depth: 2, caused_by_parent_request_id: \"pin-parent-request\", caused_by_parent_request_doc_id: \"pin-parent-doc\", workspace_id: \"ws-goal-1\", workspace_authority: \"readWrite\", workspace_owner_deployment_id: \"dep-goal-1\", workspace_seal_hash: \"seal-goal-1\", admission_kind: \"runtime-internal\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"2eoh9K96ztMwPRNFSEiQuJAqNSxY92o9UamCjFePL3YFFpmKmAUnvT5ccGjq49RpmxskKT215bnirUwsXz9SHgUP\", runtime_issuer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", runtime_source_request_id: \"pin-parent-request\", runtime_source_kind: \"local-control\", lifecycle_state: \"pending\", failure_reason: \"\""
+        );
+    }
+}

--- a/crates/gents/src/lifecycle/queue/tests.rs
+++ b/crates/gents/src/lifecycle/queue/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::identity::AgentIdentity;
+use crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES;
 use std::sync::Arc;
 use tempfile::TempDir;
 

--- a/crates/gents/src/lifecycle/test_support.rs
+++ b/crates/gents/src/lifecycle/test_support.rs
@@ -1,0 +1,29 @@
+//! Shared fixture for the `#[1336]` pinning tests (`lifecycle::materialize`,
+//! `lifecycle::queue`, `lifecycle::background_wake_recovery`,
+//! `tool_call_lifecycle::subagent_request`): one fixed Ed25519 identity so
+//! every pinning test signs with the same registered DID and therefore
+//! produces the same signature bytes for the same payload.
+
+use crate::identity::AgentIdentity;
+
+/// Raw 64-byte (seed || public key) Ed25519 identity material, captured
+/// once so every pinning test signs with the same registered DID.
+pub(crate) const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
+pub(crate) const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
+
+pub(crate) fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
+    let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
+        .step_by(2)
+        .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
+        .collect();
+    let path = dir.join("pinning.key");
+    std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
+    let identity =
+        crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
+    assert_eq!(
+        identity.did(),
+        PIN_FIXED_DID,
+        "fixed pinning key derives a stable DID"
+    );
+    identity
+}

--- a/crates/gents/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/gents/src/tool_call_lifecycle/subagent_request.rs
@@ -12,7 +12,7 @@ use defra_node::EmbeddedNode;
 use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
-use crate::lifecycle::{WorkspaceLineage, DEFAULT_REQUEST_MAX_RETRIES};
+use crate::lifecycle::WorkspaceLineage;
 use crate::session::execute_mutation_with_retry;
 
 use super::IllegalToolCallTransition;
@@ -332,39 +332,48 @@ async fn create_subagent_request_inner(
             )
         }
     };
-    let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-        request_id.clone(),
-        agent_did.clone(),
-        agent_did.clone(),
-        behavior_id,
-        new_session_id,
-        prompt,
-        "interactive",
-        now,
+    let spec = crate::lifecycle::materialize::RequestSpec {
+        identity: crate::lifecycle::materialize::RequestIdentity {
+            request_id: request_id.clone(),
+            agent_did: agent_did.clone(),
+            requester_did: None,
+            behavior_id,
+            session_id: new_session_id,
+            content: prompt,
+            execution_origin: crate::lifecycle::ExecutionOrigin::Interactive,
+            created_at: now,
+        },
         admission,
-    );
-    create.metadata = metadata;
-    create.valid_until =
-        deadline.map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
-    create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-    create.subagent_depth = new_subagent_depth;
-    create.caused_by_parent_request_id = Some(parent_request_id);
-    create.caused_by_parent_request_doc_id = Some(parent_doc_ids.0);
-    create.caused_by_parent_tool_call_id = Some(parent_tool_call_id.clone());
-    create.caused_by_parent_tool_call_doc_id = Some(parent_doc_ids.1);
-    create.caused_by_trigger_id = Some(parent_tool_call_id);
-    create.caused_by_trigger_kind = Some("subagent".to_string());
-    create.caused_by_correlation = runtime_context
-        .as_ref()
-        .and_then(|context| context.correlation.clone());
-    create.caused_by_trigger_context = inherited_context_json;
-    if let Some(workspace) = workspace {
-        create.workspace_id = workspace.workspace_id;
-        create.workspace_authority = workspace.workspace_authority;
-        create.workspace_owner_deployment_id = workspace.workspace_owner_deployment_id;
-        create.workspace_seal_hash = workspace.workspace_seal_hash;
-    }
-    crate::sign_agent_request_create_as_registered_target(&mut create).await?;
+        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
+        trigger_lineage: crate::lifecycle::TriggerLineage {
+            trigger_id: Some(parent_tool_call_id.clone()),
+            trigger_kind: Some("subagent".to_string()),
+            source_doc_id: None,
+            correlation: runtime_context
+                .as_ref()
+                .and_then(|context| context.correlation.clone()),
+            trigger_context: inherited_context_json,
+        },
+        trigger_doc_id: None,
+        workspace,
+        subagent: Some(crate::lifecycle::materialize::SubagentLink {
+            depth: new_subagent_depth,
+            parent_request_id: parent_request_id.clone(),
+            parent_request_doc_id: parent_doc_ids.0.clone(),
+            parent_tool_call_id: Some(parent_tool_call_id.clone()),
+            parent_tool_call_doc_id: Some(parent_doc_ids.1.clone()),
+        }),
+        retry: None,
+        sampling: None,
+        metadata,
+        retry_key: None,
+        valid_until: deadline.map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+    };
+    let create = crate::lifecycle::materialize::build_signed_request(
+        spec,
+        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+    )
+    .await?;
     let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
 
     execute_mutation_with_retry(node, &mutation, "create_subagent_request").await?;

--- a/crates/gents/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/gents/src/tool_call_lifecycle/subagent_request.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
 use crate::lifecycle::materialize::{
-    build_signed_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
+    build_signed_request, ParentLink, RequestIdentity, RequestSigner, RequestSpec,
 };
 use crate::lifecycle::{ExecutionOrigin, TriggerLineage, WorkspaceLineage};
 use crate::session::execute_mutation_with_retry;
@@ -338,7 +338,6 @@ async fn create_subagent_request_inner(
     let identity = RequestIdentity {
         request_id: request_id.clone(),
         agent_did: agent_did.clone(),
-        requester_did: None,
         behavior_id,
         session_id: new_session_id,
         content: prompt,
@@ -356,7 +355,7 @@ async fn create_subagent_request_inner(
             ..Default::default()
         },
         workspace,
-        subagent: Some(SubagentLink {
+        subagent: Some(ParentLink {
             depth: new_subagent_depth,
             parent_request_id: parent_request_id.clone(),
             parent_request_doc_id: parent_doc_ids.0.clone(),
@@ -508,23 +507,7 @@ mod tests {
 #[cfg(test)]
 mod pin_tests {
     use super::*;
-    use crate::identity::AgentIdentity;
-
-    const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
-    const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
-
-    fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
-        let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
-            .step_by(2)
-            .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
-            .collect();
-        let path = dir.join("pinning.key");
-        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
-        let identity =
-            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
-        assert_eq!(identity.did(), PIN_FIXED_DID);
-        identity
-    }
+    use crate::lifecycle::test_support::{pin_fixed_signing_identity, PIN_FIXED_DID};
 
     #[tokio::test]
     async fn pin_create_subagent_request_inner_dto_construction() {
@@ -593,7 +576,6 @@ mod pin_tests {
             identity: crate::lifecycle::materialize::RequestIdentity {
                 request_id: request_id.clone(),
                 agent_did: agent_did.clone(),
-                requester_did: None,
                 behavior_id,
                 session_id: new_session_id,
                 content: prompt,
@@ -614,7 +596,7 @@ mod pin_tests {
             },
             trigger_doc_id: None,
             workspace,
-            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+            subagent: Some(crate::lifecycle::materialize::ParentLink {
                 depth: new_subagent_depth,
                 parent_request_id: parent_request_id.clone(),
                 parent_request_doc_id: parent_doc_ids.0.clone(),

--- a/crates/gents/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/gents/src/tool_call_lifecycle/subagent_request.rs
@@ -12,8 +12,12 @@ use defra_node::EmbeddedNode;
 use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
-use crate::lifecycle::WorkspaceLineage;
+use crate::lifecycle::materialize::{
+    build_signed_request, RequestIdentity, RequestSigner, RequestSpec, SubagentLink,
+};
+use crate::lifecycle::{ExecutionOrigin, TriggerLineage, WorkspaceLineage};
 use crate::session::execute_mutation_with_retry;
+use gents_protocol::request_lifecycle::RequestLifecycleState;
 
 use super::IllegalToolCallTransition;
 
@@ -332,20 +336,20 @@ async fn create_subagent_request_inner(
             )
         }
     };
-    let spec = crate::lifecycle::materialize::RequestSpec {
-        identity: crate::lifecycle::materialize::RequestIdentity {
+    let spec = RequestSpec {
+        identity: RequestIdentity {
             request_id: request_id.clone(),
             agent_did: agent_did.clone(),
             requester_did: None,
             behavior_id,
             session_id: new_session_id,
             content: prompt,
-            execution_origin: crate::lifecycle::ExecutionOrigin::Interactive,
+            execution_origin: ExecutionOrigin::Interactive,
             created_at: now,
         },
         admission,
-        initial_lifecycle_state: gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
-        trigger_lineage: crate::lifecycle::TriggerLineage {
+        initial_lifecycle_state: RequestLifecycleState::Pending,
+        trigger_lineage: TriggerLineage {
             trigger_id: Some(parent_tool_call_id.clone()),
             trigger_kind: Some("subagent".to_string()),
             source_doc_id: None,
@@ -356,7 +360,7 @@ async fn create_subagent_request_inner(
         },
         trigger_doc_id: None,
         workspace,
-        subagent: Some(crate::lifecycle::materialize::SubagentLink {
+        subagent: Some(SubagentLink {
             depth: new_subagent_depth,
             parent_request_id: parent_request_id.clone(),
             parent_request_doc_id: parent_doc_ids.0.clone(),
@@ -369,11 +373,7 @@ async fn create_subagent_request_inner(
         retry_key: None,
         valid_until: deadline.map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
     };
-    let create = crate::lifecycle::materialize::build_signed_request(
-        spec,
-        crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
-    )
-    .await?;
+    let create = build_signed_request(spec, RequestSigner::RegisteredTarget).await?;
     let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
 
     execute_mutation_with_retry(node, &mutation, "create_subagent_request").await?;

--- a/crates/gents/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/gents/src/tool_call_lifecycle/subagent_request.rs
@@ -487,3 +487,141 @@ mod tests {
         }
     }
 }
+
+/// Pins today's `AgentRequestCreate::graphql_input_fields()` output for
+/// `create_subagent_request_inner` (#1336 Task 1), before it is switched
+/// onto `build_signed_request` (#1336 Task 2).
+///
+/// `create_subagent_request_inner` validates the parent request/tool-call
+/// against a live node before it builds `create` at all, persists via
+/// `execute_mutation_with_retry`, and returns only the child `request_id` —
+/// never the `AgentRequestCreate` it built. It also generates both
+/// `new_session_id` (`Uuid::new_v4()`) and `now` (`Utc::now()`) internally.
+/// This reproduces its DTO-construction statements verbatim (see
+/// `create_subagent_request_inner` above, from "Generate fresh session
+/// identifier" through the `workspace` field assignments), substituting
+/// fixed values for both and skipping the node-dependent parent/tool-call
+/// validation, which the DTO-construction logic itself does not consult.
+#[cfg(test)]
+mod pin_tests {
+    use super::*;
+    use crate::identity::AgentIdentity;
+
+    const PIN_FIXED_KEY_HEX: &str = "4cbf8c1186d2fcb70559342fd142650a5ec5938d26a187d87e2c061b530d7be46edb79d5f548207182f7911b55709c9e4b9961c709486e5ce920e306470fe6d6";
+    const PIN_FIXED_DID: &str = "did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7";
+
+    fn pin_fixed_signing_identity(dir: &std::path::Path) -> crate::identity::KeyIdentity {
+        let key_bytes: Vec<u8> = (0..PIN_FIXED_KEY_HEX.len())
+            .step_by(2)
+            .map(|offset| u8::from_str_radix(&PIN_FIXED_KEY_HEX[offset..offset + 2], 16).unwrap())
+            .collect();
+        let path = dir.join("pinning.key");
+        std::fs::write(&path, &key_bytes).expect("write fixed pinning key");
+        let identity =
+            crate::identity::KeyIdentity::load_or_create(&path, None).expect("load fixed identity");
+        assert_eq!(identity.did(), PIN_FIXED_DID);
+        identity
+    }
+
+    #[tokio::test]
+    async fn pin_create_subagent_request_inner_dto_construction() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let _identity = pin_fixed_signing_identity(tempdir.path());
+
+        let request_id = "subagent-request-1".to_string();
+        let parent_request_id = "subagent-parent-request-1".to_string();
+        let parent_tool_call_id = "subagent-parent-tool-call-1".to_string();
+        let parent_subagent_depth: u32 = 1;
+        let agent_did = PIN_FIXED_DID.to_string();
+        let behavior_id = "behavior-1".to_string();
+        let prompt = "spawn a subagent to help".to_string();
+        let deadline: Option<DateTime<Utc>> =
+            Some("2030-06-01T00:00:00Z".parse().expect("valid deadline"));
+        let parent_doc_ids = (
+            "subagent-parent-request-doc-1".to_string(),
+            "subagent-parent-tool-call-doc-1".to_string(),
+        );
+        let workspace = Some(WorkspaceLineage {
+            workspace_id: Some("ws-subagent-1".to_string()),
+            workspace_authority: Some("readWrite".to_string()),
+            workspace_owner_deployment_id: Some("dep-subagent-1".to_string()),
+            workspace_seal_hash: Some("seal-subagent-1".to_string()),
+        });
+
+        // --- reproduces create_subagent_request_inner's DTO construction,
+        // with fixed values for new_session_id and now ---
+        let new_session_id = "sess-subagent-1".to_string();
+        let new_subagent_depth = parent_subagent_depth + 1;
+        let now = "2030-01-01T00:00:00Z".to_string();
+
+        let prompt_selection = crate::skills::prompt_slash_skill_selection(&prompt);
+        let prompt = prompt_selection.prompt;
+        let metadata = (!prompt_selection.selected_skill_ids.is_empty()).then(|| {
+            serde_json::json!({ "selected_skill_ids": prompt_selection.selected_skill_ids })
+                .to_string()
+        });
+        let runtime_context = crate::tool_call_lifecycle::runtime::current_tool_runtime_context();
+        let inherited_context_json = runtime_context
+            .as_ref()
+            .filter(|context| !context.source_fields.is_empty())
+            .map(|context| {
+                serde_json::to_string(&crate::lifecycle::TriggerExecutionContext {
+                    version: 1,
+                    source_fields: context.source_fields.clone(),
+                })
+            })
+            .transpose()
+            .expect("serialize inherited trigger context");
+        if let Some(workspace) = workspace.as_ref() {
+            workspace
+                .require_authority_if_workspace_id()
+                .expect("workspace authority present");
+        }
+        let admission =
+            gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_child(
+                &agent_did,
+                &parent_request_id,
+            );
+        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
+            request_id.clone(),
+            agent_did.clone(),
+            agent_did.clone(),
+            behavior_id,
+            new_session_id,
+            prompt,
+            "interactive",
+            now,
+            admission,
+        );
+        create.metadata = metadata;
+        create.valid_until =
+            deadline.map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
+        create.subagent_depth = new_subagent_depth;
+        create.caused_by_parent_request_id = Some(parent_request_id);
+        create.caused_by_parent_request_doc_id = Some(parent_doc_ids.0);
+        create.caused_by_parent_tool_call_id = Some(parent_tool_call_id.clone());
+        create.caused_by_parent_tool_call_doc_id = Some(parent_doc_ids.1);
+        create.caused_by_trigger_id = Some(parent_tool_call_id);
+        create.caused_by_trigger_kind = Some("subagent".to_string());
+        create.caused_by_correlation = runtime_context
+            .as_ref()
+            .and_then(|context| context.correlation.clone());
+        create.caused_by_trigger_context = inherited_context_json;
+        if let Some(workspace) = workspace {
+            create.workspace_id = workspace.workspace_id;
+            create.workspace_authority = workspace.workspace_authority;
+            create.workspace_owner_deployment_id = workspace.workspace_owner_deployment_id;
+            create.workspace_seal_hash = workspace.workspace_seal_hash;
+        }
+        crate::sign_agent_request_create_as_registered_target(&mut create)
+            .await
+            .expect("sign subagent request");
+
+        let fields = create.graphql_input_fields().expect("graphql_input_fields");
+        assert_eq!(
+            fields,
+            "request_id: \"subagent-request-1\", agent_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", requester_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", behavior_id: \"behavior-1\", session_id: \"sess-subagent-1\", retry_root_request: \"subagent-request-1\", content: \"spawn a subagent to help\", execution_origin: \"interactive\", caused_by_trigger_id: \"subagent-parent-tool-call-1\", caused_by_trigger_kind: \"subagent\", created_at: \"2030-01-01T00:00:00Z\", retry_count: 0, max_retries: 3, valid_until: \"2030-06-01T00:00:00Z\", subagent_depth: 2, caused_by_parent_request_id: \"subagent-parent-request-1\", caused_by_parent_request_doc_id: \"subagent-parent-request-doc-1\", caused_by_parent_tool_call_id: \"subagent-parent-tool-call-1\", caused_by_parent_tool_call_doc_id: \"subagent-parent-tool-call-doc-1\", workspace_id: \"ws-subagent-1\", workspace_authority: \"readWrite\", workspace_owner_deployment_id: \"dep-subagent-1\", workspace_seal_hash: \"seal-subagent-1\", admission_kind: \"runtime-internal\", admission_signer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", admission_signature: \"BwhogeGeGk4MH2ovZKskcrSPjik79JvmHt4wXZoejNzYbr7d4954c6vdRSaHEBWXgsHReF4Wqth5UHncWNQ2ene\", runtime_issuer_did: \"did:key:z6Mkmuzzq2Ea9TgVB5EnaeY655fERuo15hrBtsL2oT3arco7\", runtime_source_request_id: \"subagent-parent-request-1\", runtime_source_kind: \"local-child\", lifecycle_state: \"pending\", failure_reason: \"\""
+        );
+    }
+}

--- a/crates/gents/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/gents/src/tool_call_lifecycle/subagent_request.rs
@@ -582,41 +582,55 @@ mod pin_tests {
                 &agent_did,
                 &parent_request_id,
             );
-        let mut create = gents_protocol::request_admission::AgentRequestCreate::base(
-            request_id.clone(),
-            agent_did.clone(),
-            agent_did.clone(),
-            behavior_id,
-            new_session_id,
-            prompt,
-            "interactive",
-            now,
+        // Driven through `build_signed_request` with the equivalent
+        // `RequestSpec`, asserting against the output pinned by reproducing
+        // `create_subagent_request_inner`'s DTO-construction statements
+        // directly.
+        let spec = crate::lifecycle::materialize::RequestSpec {
+            identity: crate::lifecycle::materialize::RequestIdentity {
+                request_id: request_id.clone(),
+                agent_did: agent_did.clone(),
+                requester_did: None,
+                behavior_id,
+                session_id: new_session_id,
+                content: prompt,
+                execution_origin: crate::lifecycle::ExecutionOrigin::Interactive,
+                created_at: now,
+            },
             admission,
-        );
-        create.metadata = metadata;
-        create.valid_until =
-            deadline.map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
-        create.max_retries = i64::from(DEFAULT_REQUEST_MAX_RETRIES);
-        create.subagent_depth = new_subagent_depth;
-        create.caused_by_parent_request_id = Some(parent_request_id);
-        create.caused_by_parent_request_doc_id = Some(parent_doc_ids.0);
-        create.caused_by_parent_tool_call_id = Some(parent_tool_call_id.clone());
-        create.caused_by_parent_tool_call_doc_id = Some(parent_doc_ids.1);
-        create.caused_by_trigger_id = Some(parent_tool_call_id);
-        create.caused_by_trigger_kind = Some("subagent".to_string());
-        create.caused_by_correlation = runtime_context
-            .as_ref()
-            .and_then(|context| context.correlation.clone());
-        create.caused_by_trigger_context = inherited_context_json;
-        if let Some(workspace) = workspace {
-            create.workspace_id = workspace.workspace_id;
-            create.workspace_authority = workspace.workspace_authority;
-            create.workspace_owner_deployment_id = workspace.workspace_owner_deployment_id;
-            create.workspace_seal_hash = workspace.workspace_seal_hash;
-        }
-        crate::sign_agent_request_create_as_registered_target(&mut create)
-            .await
-            .expect("sign subagent request");
+            initial_lifecycle_state:
+                gents_protocol::request_lifecycle::RequestLifecycleState::Pending,
+            trigger_lineage: crate::lifecycle::TriggerLineage {
+                trigger_id: Some(parent_tool_call_id.clone()),
+                trigger_kind: Some("subagent".to_string()),
+                source_doc_id: None,
+                correlation: runtime_context
+                    .as_ref()
+                    .and_then(|context| context.correlation.clone()),
+                trigger_context: inherited_context_json,
+            },
+            trigger_doc_id: None,
+            workspace,
+            subagent: Some(crate::lifecycle::materialize::SubagentLink {
+                depth: new_subagent_depth,
+                parent_request_id: parent_request_id.clone(),
+                parent_request_doc_id: parent_doc_ids.0.clone(),
+                parent_tool_call_id: Some(parent_tool_call_id.clone()),
+                parent_tool_call_doc_id: Some(parent_doc_ids.1.clone()),
+            }),
+            retry: None,
+            sampling: None,
+            metadata,
+            retry_key: None,
+            valid_until: deadline
+                .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        };
+        let create = crate::lifecycle::materialize::build_signed_request(
+            spec,
+            crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
+        )
+        .await
+        .expect("sign subagent request");
 
         let fields = create.graphql_input_fields().expect("graphql_input_fields");
         assert_eq!(

--- a/crates/gents/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/gents/src/tool_call_lifecycle/subagent_request.rs
@@ -17,7 +17,6 @@ use crate::lifecycle::materialize::{
 };
 use crate::lifecycle::{ExecutionOrigin, TriggerLineage, WorkspaceLineage};
 use crate::session::execute_mutation_with_retry;
-use gents_protocol::request_lifecycle::RequestLifecycleState;
 
 use super::IllegalToolCallTransition;
 
@@ -336,29 +335,26 @@ async fn create_subagent_request_inner(
             )
         }
     };
+    let identity = RequestIdentity {
+        request_id: request_id.clone(),
+        agent_did: agent_did.clone(),
+        requester_did: None,
+        behavior_id,
+        session_id: new_session_id,
+        content: prompt,
+        execution_origin: ExecutionOrigin::Interactive,
+        created_at: now,
+    };
     let spec = RequestSpec {
-        identity: RequestIdentity {
-            request_id: request_id.clone(),
-            agent_did: agent_did.clone(),
-            requester_did: None,
-            behavior_id,
-            session_id: new_session_id,
-            content: prompt,
-            execution_origin: ExecutionOrigin::Interactive,
-            created_at: now,
-        },
-        admission,
-        initial_lifecycle_state: RequestLifecycleState::Pending,
         trigger_lineage: TriggerLineage {
             trigger_id: Some(parent_tool_call_id.clone()),
             trigger_kind: Some("subagent".to_string()),
-            source_doc_id: None,
             correlation: runtime_context
                 .as_ref()
                 .and_then(|context| context.correlation.clone()),
             trigger_context: inherited_context_json,
+            ..Default::default()
         },
-        trigger_doc_id: None,
         workspace,
         subagent: Some(SubagentLink {
             depth: new_subagent_depth,
@@ -367,11 +363,9 @@ async fn create_subagent_request_inner(
             parent_tool_call_id: Some(parent_tool_call_id.clone()),
             parent_tool_call_doc_id: Some(parent_doc_ids.1.clone()),
         }),
-        retry: None,
-        sampling: None,
         metadata,
-        retry_key: None,
         valid_until: deadline.map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+        ..RequestSpec::new(identity, admission)
     };
     let create = build_signed_request(spec, RequestSigner::RegisteredTarget).await?;
     let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;

--- a/crates/gents/tests/misc/legacy_authority_absence.rs
+++ b/crates/gents/tests/misc/legacy_authority_absence.rs
@@ -158,7 +158,13 @@ fn production_pending_request_writers_use_the_signed_canonical_builder() {
             "a production Pending writer bypassed AgentRequestCreate"
         );
         assert!(
-            source.contains("AgentRequestCreate") || source.contains("write_pending_agent_request"),
+            source.contains("AgentRequestCreate")
+                || source.contains("write_pending_agent_request")
+                // #1336: queue/mutation.rs and queue/goal_continuation.rs no
+                // longer spell "AgentRequestCreate" at all — they build a
+                // RequestSpec and construct through
+                // build_request/build_signed_request/sign_request instead.
+                || source.contains("RequestSpec"),
             "a production Pending writer lost its canonical signed authoring seam"
         );
     }
@@ -179,11 +185,46 @@ fn production_pending_request_writers_use_the_signed_canonical_builder() {
     assert!(!signed_direct_materializer.contains("add_AgentRequest(input:"));
     assert!(!signed_direct_materializer.contains("status: \"processing\""));
     assert!(signed_direct_materializer.contains("Arc<dyn crate::identity::AgentIdentity>"));
-    assert!(signed_direct_materializer.contains("AgentRequestCreate::base"));
+    // #1336: this site now builds and signs its AgentRequestCreate through
+    // the shared constructor rather than hand-rolling
+    // AgentRequestCreate::base(...) itself.
+    assert!(signed_direct_materializer.contains("build_signed_request"));
     assert!(signed_direct_materializer.contains("verify_fresh_local_self_request"));
     assert!(signed_direct_materializer.contains("claim_with_identity"));
     assert!(!oneshot.contains("add_AgentRequest(input:"));
     assert!(oneshot.contains("behavior.principal_identity().clone()"));
+
+    // #1336: materialize.rs's build_request is the sole owner of
+    // AgentRequestCreate::base construction in this crate; every other
+    // in-crate writer builds through build_request/build_signed_request
+    // instead of calling AgentRequestCreate::base itself. (gents-cli and
+    // gents-desktop-core author their own AgentRequestCreate values
+    // independently of this crate's constructor and are out of #1336's
+    // scope, so they are not checked here.)
+    assert_eq!(
+        materialize.matches("AgentRequestCreate::base(").count(),
+        1,
+        "materialize.rs's build_request must be this crate's only direct AgentRequestCreate::base call"
+    );
+    for (name, source) in [
+        (
+            "lifecycle/queue/mutation.rs",
+            include_str!("../../src/lifecycle/queue/mutation.rs"),
+        ),
+        (
+            "lifecycle/queue/goal_continuation.rs",
+            include_str!("../../src/lifecycle/queue/goal_continuation.rs"),
+        ),
+        (
+            "tool_call_lifecycle/subagent_request.rs",
+            include_str!("../../src/tool_call_lifecycle/subagent_request.rs"),
+        ),
+    ] {
+        assert!(
+            !source.contains("AgentRequestCreate::base("),
+            "{name} bypassed the shared build_request/build_signed_request constructor"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #1336 for the runtime crate. Stacked on #1348 (base branch `so/1337-cli-tool-managed-exec`). At this PR boundary, four client writer sites remain in `gents-cli` and `gents-desktop-core`; [#1373](https://github.com/gents-ai/gents/pull/1373) completes #1350 by routing those sites through the public constructor.

## What changed

One shared constructor builds and stamps every runtime-authored production `AgentRequestCreate`, with signing routed through the same module.

- `lifecycle::materialize::RequestSpec` (identity, admission, initial state, trigger/workspace/parent lineage, retry link, sampling carry-over, metadata, retry key, validity) with `RequestSpec::new(identity, admission)` supplying every default; `build_request` stamps, `sign_request` signs, `build_signed_request` does both.
- The six hand-rolled `AgentRequestCreate::base(..)` + field-stamping + sign sequences (pending materialization, claimed-with-binding, session/steering wake, goal continuation, background-wake redrive, subagent child) now build a `RequestSpec` and name only the fields they set. Workspace lineage, `max_retries`, `subagent_depth`, and the six `caused_by_trigger_*` columns are stamped in one place instead of being copied by hand at some sites and forgotten at others.
- Goal continuation keeps its original order: build, dedupe by retry-key fingerprint, then sign.
- The retry-key fingerprint lookup shared by goal creation and goal continuation is one function in `goal.rs`.

## Net code

This PR grows non-test code: one constructor with its spec types replaces six shorter hand-rolled sequences. That is the deliberate trade for this issue (one owner of what a request row carries); the milestone's net-deletion criterion is judged per fact, and the follow-up #1342 (typed rows) removes more of the per-site plumbing.

## Byte-identical outputs

Seven pinning tests capture each writer's `graphql_input_fields()` output against the old code paths (first commit), then drive the same expectations through the new constructor (second commit). They stay as the regression fence for the seam.

## Verification

`cargo test -p gents --lib lifecycle::` (116), `--test conformance request_lifecycle` (20, the production-writers fence), `--test e2e_subagent` (107), `--test e2e_triggers` (8), `--test misc goal_controller` (24); `cargo check --workspace --all-targets`; `cargo fmt --all --check`. Runtime-crate grep gate: `AgentRequestCreate::base(` appears in production code only inside `build_request`; client sites are completed by #1373 (#1350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eatk66c9sS6vPq2nasHJVd

