### PR TITLE
Goal tokens and /self utilization use the budget owners (#1335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
   `RequestShowHeader.status`, `ChildRequestView.status`,
   `GraphRunRequestView.status`); read `lifecycle_state` instead.
 
+### Fixed
+
+- `Goal.tokens_used` now reports the charged total (input incl. cached +
+  output), matching the request ledger; `/self` utilization is measured
+  against the effective input budget.
+
 ## 0.15.0 - 2026-09-01
 
 ### Breaking changes

--- a/crates/gents-cli/src/http/router.rs
+++ b/crates/gents-cli/src/http/router.rs
@@ -610,6 +610,7 @@ mod tests {
             endpoint: "https://api.example.test/v1".to_string(),
             inference_profile_id: format!("{id}-profile"),
             context_window: Some(128_000),
+            compaction_threshold: gents::config::DEFAULT_COMPACTION_THRESHOLD,
         }
     }
 

--- a/crates/gents-cli/src/http/self_view.rs
+++ b/crates/gents-cli/src/http/self_view.rs
@@ -9,7 +9,7 @@ use crate::post_graphql;
 
 const RECENT_REQUEST_SCAN: usize = 200;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct SelfBehavior {
     pub(crate) behavior_id: String,
     pub(crate) display_name: String,
@@ -20,6 +20,10 @@ pub(crate) struct SelfBehavior {
     pub(crate) endpoint: String,
     pub(crate) inference_profile_id: String,
     pub(crate) context_window: Option<i64>,
+    /// Compaction threshold fraction (0.0-1.0) sourced from the behavior row,
+    /// falling back to `gents::config::DEFAULT_COMPACTION_THRESHOLD` when the
+    /// row leaves it unset.
+    pub(crate) compaction_threshold: f64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -34,6 +38,8 @@ pub(crate) struct ContextBudget {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub(crate) struct ContextIndicator {
+    /// The effective input budget (context window scaled by the compaction
+    /// threshold) of the primary behavior, not the raw context window.
     pub(crate) max_tokens: Option<i64>,
     pub(crate) current_estimate: Option<i64>,
     pub(crate) utilization_percent: Option<f64>,
@@ -73,6 +79,8 @@ struct BehaviorRow {
     inference_profile_id: Option<String>,
     #[serde(default)]
     enabled: Option<bool>,
+    #[serde(default)]
+    compaction_threshold: Option<f64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -144,6 +152,7 @@ fn self_view_query(agent_did: &str) -> String {
             backend_id
             inference_profile_id
             enabled
+            compaction_threshold
         }}
         InferenceBackend(order: {{ backend_id: ASC }}) {{
             backend_id
@@ -238,6 +247,9 @@ fn build_behaviors(
                     .unwrap_or_default(),
                 inference_profile_id,
                 context_window: profile.and_then(|profile| profile.context_window),
+                compaction_threshold: behavior
+                    .compaction_threshold
+                    .unwrap_or(gents::config::DEFAULT_COMPACTION_THRESHOLD),
             })
         })
         .collect()
@@ -273,12 +285,23 @@ fn build_context_indicator(
     behaviors: &[SelfBehavior],
     context_budget: &ContextBudget,
 ) -> ContextIndicator {
+    // max_tokens is the effective input budget (context window scaled by the
+    // compaction threshold) of the enabled behavior with the largest window,
+    // not the raw context window: utilization is measured against the same
+    // budget the runtime dispatches against.
     let max_tokens = behaviors
         .iter()
         .filter(|behavior| behavior.enabled)
-        .filter_map(|behavior| behavior.context_window)
-        .filter(|value| *value > 0)
-        .max();
+        .filter(|behavior| behavior.context_window.is_some_and(|value| value > 0))
+        .max_by_key(|behavior| behavior.context_window.unwrap_or_default())
+        .map(|behavior| {
+            let context_window = behavior.context_window.unwrap_or_default().max(0) as usize;
+            let budget = gents::provider_budget::effective_input_budget(
+                context_window,
+                behavior.compaction_threshold,
+            );
+            i64::try_from(budget).unwrap_or(i64::MAX)
+        });
     let current_estimate = context_budget
         .latest_compacted_tokens
         .or(context_budget.latest_original_tokens);
@@ -330,6 +353,10 @@ mod tests {
         assert_eq!(b.provider_kind, "OpenAiCompatible");
         assert_eq!(b.endpoint, "http://host/v1");
         assert_eq!(b.context_window, Some(128000));
+        assert_eq!(
+            b.compaction_threshold,
+            gents::config::DEFAULT_COMPACTION_THRESHOLD
+        );
     }
 
     #[test]
@@ -344,6 +371,10 @@ mod tests {
         assert_eq!(behaviors[0].endpoint, "");
         assert_eq!(behaviors[0].context_window, None);
         assert!(behaviors[0].enabled);
+        assert_eq!(
+            behaviors[0].compaction_threshold,
+            gents::config::DEFAULT_COMPACTION_THRESHOLD
+        );
     }
 
     #[test]
@@ -393,6 +424,7 @@ mod tests {
                 endpoint: String::new(),
                 inference_profile_id: String::new(),
                 context_window: Some(2000),
+                compaction_threshold: 0.75,
             },
             SelfBehavior {
                 behavior_id: "enabled".to_string(),
@@ -404,6 +436,7 @@ mod tests {
                 endpoint: String::new(),
                 inference_profile_id: String::new(),
                 context_window: Some(1000),
+                compaction_threshold: 0.8,
             },
         ];
         let budget = ContextBudget {
@@ -417,13 +450,47 @@ mod tests {
 
         let context = build_context_indicator(&behaviors, &budget);
 
-        assert_eq!(context.max_tokens, Some(1000));
+        // max_tokens is the effective input budget of the enabled behavior
+        // with the largest window (1000 * 0.8 == 800), not the raw window.
+        assert_eq!(context.max_tokens, Some(800));
         assert_eq!(context.current_estimate, Some(400));
-        assert_eq!(context.utilization_percent, Some(40.0));
+        assert_eq!(context.utilization_percent, Some(50.0));
         assert_eq!(context.compaction_count, 2);
         assert_eq!(
             context.last_compacted_at.as_deref(),
             Some("2026-06-03T10:30:00Z")
         );
+    }
+
+    #[test]
+    fn context_indicator_utilization_is_measured_against_the_effective_input_budget() {
+        let behaviors = vec![SelfBehavior {
+            behavior_id: "enabled".to_string(),
+            display_name: String::new(),
+            model_name: String::new(),
+            enabled: true,
+            backend_id: String::new(),
+            provider_kind: String::new(),
+            endpoint: String::new(),
+            inference_profile_id: String::new(),
+            context_window: Some(100_000),
+            compaction_threshold: 0.75,
+        }];
+        let budget = ContextBudget {
+            compaction_count: 0,
+            latest_compaction_at: None,
+            latest_original_tokens: Some(60_000),
+            latest_compacted_tokens: None,
+            sessions_considered: 1,
+            request_scan_limit: RECENT_REQUEST_SCAN as i64,
+        };
+
+        let context = build_context_indicator(&behaviors, &budget);
+
+        // Budget is 100_000 * 0.75 == 75_000, so 60_000 current tokens is
+        // 80% utilized, not 60% of the raw 100_000 window.
+        assert_eq!(context.max_tokens, Some(75_000));
+        assert_eq!(context.current_estimate, Some(60_000));
+        assert_eq!(context.utilization_percent, Some(80.0));
     }
 }

--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -2248,6 +2248,8 @@ pub async fn claim_retry_continuation(
         .is_some_and(mutation_returned_rows))
 }
 
+/// Sum of tokens charged against the session's budget: the charged total,
+/// same as the request ledger (`crate::provider_usage::charged_usage_total`).
 pub async fn session_token_usage(
     node: &EmbeddedNode,
     agent_did: &str,
@@ -2283,8 +2285,8 @@ pub async fn session_token_usage(
     let query = format!(
         r#"{{
             InferenceCall(
-                filter: {{ agent_did: {{ _eq: "{agent_did}" }}, request_id: {{ _in: [{request_ids}] }}, call_state: {{ _eq: "completed" }} }}
-            ) {{ prompt_tokens completion_tokens cached_input_tokens }}
+                filter: {{ agent_did: {{ _eq: "{agent_did}" }}, request_id: {{ _in: [{request_ids}] }} }}
+            ) {{ prompt_tokens completion_tokens }}
         }}"#
     );
     #[derive(Deserialize)]
@@ -2293,23 +2295,18 @@ pub async fn session_token_usage(
         prompt_tokens: Option<i64>,
         #[serde(default)]
         completion_tokens: Option<i64>,
-        #[serde(default)]
-        cached_input_tokens: Option<i64>,
     }
     let response =
         graphql_with_transaction_retry(node, &query, "query goal inference usage").await?;
     let usage_rows: Vec<UsageRow> =
         rows(&response, "InferenceCall").context("decoding goal inference usage")?;
-    Ok(usage_rows.into_iter().fold(0_i64, |total, row| {
-        let fresh_input = row
-            .prompt_tokens
-            .unwrap_or_default()
-            .saturating_sub(row.cached_input_tokens.unwrap_or_default())
-            .max(0);
-        total.saturating_add(
-            fresh_input.saturating_add(row.completion_tokens.unwrap_or_default().max(0)),
-        )
-    }))
+    let charged = crate::provider_usage::sum_charged_from_persisted_parts(
+        usage_rows
+            .into_iter()
+            .map(|row| (row.prompt_tokens, row.completion_tokens)),
+    )
+    .context("summing goal inference usage")?;
+    Ok(i64::try_from(charged).unwrap_or(i64::MAX))
 }
 
 pub async fn refresh_goal_usage(node: &EmbeddedNode, goal: &GoalDocument) -> Result<i64> {

--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -2249,7 +2249,7 @@ pub async fn claim_retry_continuation(
 }
 
 /// Sum of tokens charged against the session's budget: the charged total,
-/// same as the request ledger (`crate::provider_usage::charged_usage_total`).
+/// same as the request ledger (`crate::provider_usage::sum_charged_from_persisted_parts`).
 pub async fn session_token_usage(
     node: &EmbeddedNode,
     agent_did: &str,

--- a/crates/gents/tests/misc/goal_controller.rs
+++ b/crates/gents/tests/misc/goal_controller.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use gents::goal::{
     claim_continuation, claim_retry_continuation, create_goal_for_session,
-    delete_goals_for_session, load_canonical_goal, load_goals_for_session, set_goal,
-    update_goal_fields, update_goal_fields_if_status, CreateGoalForSessionError,
+    delete_goals_for_session, load_canonical_goal, load_goals_for_session, session_token_usage,
+    set_goal, update_goal_fields, update_goal_fields_if_status, CreateGoalForSessionError,
     CreateGoalForSessionOutcome, GoalStatus,
 };
 use gents::{
@@ -1172,10 +1172,55 @@ async fn token_budget_materializes_one_wrapup_and_never_repeats_it() {
         .expect("load goal")
         .expect("goal exists");
     assert_eq!(goal.parsed_status(), Some(GoalStatus::BudgetLimited));
-    assert_eq!(goal.tokens_used, Some(15));
+    // Charged total: prompt_tokens (100, cached input included by design) +
+    // completion_tokens (5) == 105, matching the request ledger's formula.
+    assert_eq!(goal.tokens_used, Some(105));
     assert_eq!(goal.wrapup_requested, Some(true));
     assert_eq!(goal.wrapup_completed, Some(true));
     assert_eq!(goal_children(&db).await.len(), 1);
+}
+
+#[tokio::test]
+async fn session_token_usage_charges_cached_input_as_part_of_the_total() {
+    let db = test_db("goal-cached-input").await;
+    seed_completed_request(&db, "parent-cached").await;
+    let usage = format!(
+        r#"mutation {{
+        add_InferenceCall(input: {{
+            call_id: "goal-cached-call",
+            runtime_instance_id: "goal-test",
+            request_id: "parent-cached",
+            call_seq: 1,
+            backend_id: "backend-test",
+            behavior_id: "test",
+            agent_did: "{}",
+            call_kind: "inference",
+            attempt: 1,
+            call_state: "completed",
+            queued_at: "2026-07-15T00:00:00Z",
+            started_at: "2026-07-15T00:00:00Z",
+            ended_at: "2026-07-15T00:00:01Z",
+            priority: 0,
+            queue_depth_at_enqueue: 0,
+            controller_generation: 1,
+            backend_config_fingerprint: "goal-test",
+            prompt_tokens: 1000,
+            completion_tokens: 50,
+            cached_input_tokens: 800
+        }}) {{ _docID }}
+    }}"#,
+        db.node_identity.did()
+    );
+    let response = db.node.execute(&usage).await;
+    assert!(!response.has_errors(), "seed usage: {:?}", response.errors);
+
+    let tokens = session_token_usage(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .expect("session token usage");
+    // Charged total is prompt_tokens (1000, cached input included) +
+    // completion_tokens (50) == 1050, not the old "fresh input" formula
+    // ((1000 - 800) + 50 == 250).
+    assert_eq!(tokens, 1050);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1335. Stacked on #1351 (base branch `so/1336-request-create`).

## What changed

- `Goal.tokens_used` is the charged usage total (`input + output`, input including cached) summed by `provider_usage::sum_charged_from_persisted_parts` over the same `InferenceCall` rows the request ledger rehydrates from. The goal-only "fresh input" formula and its `call_state == completed` filter are deleted. Cache-heavy sessions previously under-counted goal budgets by up to 4x.
- The CLI `/self` context indicator measures utilization against the effective input budget (`effective_input_budget(context_window, compaction_threshold)`), exported from `gents`, instead of the raw context window. `max_tokens` on the indicator is the budget; field names unchanged.

## Verification

Failing tests first (cached-input goal case; 100k window at 0.75 threshold with 60k current reports 80%), then `cargo test -p gents --test misc goal_controller`, `--test conformance goals`, `cargo test -p gents-cli --lib http::self_view`, `cargo check --workspace --all-targets`, `cargo fmt --all --check`. CHANGELOG Unreleased carries the fix line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eatk66c9sS6vPq2nasHJVd
