### PR TITLE
One backend availability predicate; CLI readers consume readiness (#1332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ### Fixed
 
+- `/healthz` and `gents fleet-slots` now report backends the local prober has
+  vetoed as degraded/not accepting, matching admission.
 - `Goal.tokens_used` now reports the charged total (input incl. cached +
   output), matching the request ledger; `/self` utilization is measured
   against the effective input budget.

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use anyhow::{Context, Result};
 use gents::{
     backend_registry::list_enabled_backends, list_agent_behaviors, load_agent_behavior,
@@ -7,7 +5,8 @@ use gents::{
 };
 use gents_codex_protocol as codex;
 use gents_protocol::row::{
-    project_behavior_readiness_summary, BehaviorReadinessState, ProjectedBehaviorReadinessSummary,
+    project_behavior_readiness_summary, BehaviorReadinessUnavailableReason,
+    ProjectedBehaviorReadinessSummary,
 };
 use serde_json::{json, Value};
 
@@ -81,22 +80,15 @@ pub(super) async fn load_bound_behavior(state: &ShimState) -> Result<AgentBehavi
 }
 
 pub(super) async fn available_model_backends(state: &ShimState) -> Result<Vec<InferenceBackend>> {
+    // The model list is a *configuration* surface — pick a backend to bind a
+    // behavior to — not an admission decision, so it starts from the
+    // document's configured intent (`enabled` backends, as before #1332)
+    // and must keep working before this runtime has published any
+    // readiness at all (fresh stores, config-only sessions, a backend that
+    // has no behavior bound to it yet). It only drops a backend on an
+    // *explicit* readiness veto; `fleet_slots.rs`/`healthz` are the
+    // admission-reporting surfaces and keep their fail-closed behavior.
     let mut backends = list_enabled_backends(state.node.as_ref()).await?;
-    let accepting = backend_admission_from_local_readiness(state).await?;
-    backends.retain(|backend| accepting.get(&backend.backend_id).copied().unwrap_or(false));
-    backends.sort_by(|left, right| left.backend_id.cmp(&right.backend_id));
-    Ok(backends)
-}
-
-/// Per-backend "accepting admission" from this agent's own behavior
-/// readiness projection — never from `InferenceBackend`'s
-/// `enabled`/`probe_status` (measured health stays unpersisted; #640, see
-/// `backend_health.rs`). Mirrors `fleet_slots.rs::backend_admission_from_readiness`:
-/// a backend accepts once any locally bound behavior is reported `Ready`;
-/// with no such signal it fails closed to not-accepting.
-async fn backend_admission_from_local_readiness(
-    state: &ShimState,
-) -> Result<BTreeMap<String, bool>> {
     let behaviors = list_agent_behaviors(state.node.as_ref(), state.agent_did.as_ref())
         .await
         .context("listing agent behaviors for model selection")?;
@@ -106,45 +98,69 @@ async fn backend_admission_from_local_readiness(
     )
     .await
     .context("loading behavior readiness for model selection")?;
-    Ok(backend_admission_from_readiness_row(
-        &behaviors,
-        readiness_row.as_ref(),
-        state.agent_did.as_ref(),
-        chrono::Utc::now(),
-    ))
+    let observed_at = chrono::Utc::now();
+    backends.retain(|backend| {
+        !backend_vetoed_by_readiness(
+            &backend.backend_id,
+            &behaviors,
+            readiness_row.as_ref(),
+            state.agent_did.as_ref(),
+            observed_at,
+        )
+    });
+    backends.sort_by(|left, right| left.backend_id.cmp(&right.backend_id));
+    Ok(backends)
 }
 
-/// Pure core of `backend_admission_from_local_readiness`, split out so it is
-/// testable without a live `EmbeddedNode`/`ShimState`.
-fn backend_admission_from_readiness_row(
+/// Whether the readiness projection *explicitly* vetoes `backend_id` — never
+/// a "we don't know" signal. True only when a readiness row exists for this
+/// agent and every behavior currently bound to `backend_id` is reported
+/// `Unavailable` with a backend-related reason (`BackendDisabled` or
+/// `BackendTemporarilyUnavailable`). No readiness row, no behaviors bound
+/// yet, or at least one bound behavior that's `Ready` or unavailable for an
+/// unrelated reason — all read as "not vetoed."
+fn backend_vetoed_by_readiness(
+    backend_id: &str,
     behaviors: &[AgentBehaviorDocument],
     readiness_row: Option<&gents_protocol::row::AgentBehaviorReadinessRow>,
     agent_did: &str,
     observed_at: chrono::DateTime<chrono::Utc>,
-) -> BTreeMap<String, bool> {
-    let projected = project_behavior_readiness_summary(readiness_row, agent_did, observed_at);
-    let mut accepting = BTreeMap::<String, bool>::new();
-    for behavior in behaviors {
-        let Some(backend_id) = behavior
-            .backend_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        else {
-            continue;
+) -> bool {
+    let Some(readiness_row) = readiness_row else {
+        return false;
+    };
+    let summary =
+        match project_behavior_readiness_summary(Some(readiness_row), agent_did, observed_at) {
+            ProjectedBehaviorReadinessSummary::Observed(summary) => summary,
+            ProjectedBehaviorReadinessSummary::Unknown(_) => return false,
         };
-        let ready = matches!(
-            &projected,
-            ProjectedBehaviorReadinessSummary::Observed(summary)
-                if summary.snapshot.behaviors.iter().any(|entry| {
-                    entry.behavior_id == behavior.behavior_id
-                        && entry.state == BehaviorReadinessState::Ready
-                })
-        );
-        let entry = accepting.entry(backend_id.to_string()).or_insert(false);
-        *entry = *entry || ready;
+
+    let bound_behavior_ids = behaviors
+        .iter()
+        .filter(|behavior| {
+            behavior
+                .backend_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                == Some(backend_id)
+        })
+        .map(|behavior| behavior.behavior_id.as_str())
+        .collect::<Vec<_>>();
+
+    if bound_behavior_ids.is_empty() {
+        return false;
     }
-    accepting
+
+    bound_behavior_ids.into_iter().all(|behavior_id| {
+        matches!(
+            summary.unavailable_behaviors.get(behavior_id),
+            Some(
+                BehaviorReadinessUnavailableReason::BackendDisabled
+                    | BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable
+            )
+        )
+    })
 }
 
 pub(super) fn model_list_entries(
@@ -272,7 +288,7 @@ mod tests {
     use super::*;
     use gents_protocol::row::{
         AgentBehaviorReadinessRow, BehaviorReadinessEntry, BehaviorReadinessProcessState,
-        BehaviorReadinessSnapshot, BehaviorReadinessUnavailableReason,
+        BehaviorReadinessSnapshot, BehaviorReadinessState, BehaviorReadinessUnavailableReason,
         BEHAVIOR_READINESS_FORMAT_VERSION,
     };
 
@@ -335,7 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn backend_vetoed_by_readiness_is_not_offered_even_though_document_is_healthy() {
+    fn backend_vetoed_when_every_bound_behavior_is_explicitly_vetoed() {
         // `available_model_backends` starts from `list_enabled_backends`, so
         // this exercises the case that matters: the `InferenceBackend`
         // document itself would read enabled+healthy, but this runtime's
@@ -352,19 +368,21 @@ mod tests {
         );
         let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
 
-        let accepting =
-            backend_admission_from_readiness_row(&behaviors, Some(&row), agent_did, observed_at);
-
-        assert_eq!(
-            accepting.get("backend-a").copied(),
-            Some(false),
+        assert!(
+            backend_vetoed_by_readiness(
+                "backend-a",
+                &behaviors,
+                Some(&row),
+                agent_did,
+                observed_at
+            ),
             "a backend the local prober vetoed via readiness must not be offered for \
              selection even though the InferenceBackend document itself would read healthy"
         );
     }
 
     #[test]
-    fn ready_behavior_offers_its_backend() {
+    fn backend_not_vetoed_when_bound_behavior_is_ready() {
         let agent_did = "did:test:codex-shim";
         let behaviors = vec![behavior("default", "backend-a")];
         let row = readiness_row(
@@ -375,21 +393,55 @@ mod tests {
         );
         let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
 
-        let accepting =
-            backend_admission_from_readiness_row(&behaviors, Some(&row), agent_did, observed_at);
-
-        assert_eq!(accepting.get("backend-a").copied(), Some(true));
+        assert!(!backend_vetoed_by_readiness(
+            "backend-a",
+            &behaviors,
+            Some(&row),
+            agent_did,
+            observed_at
+        ));
     }
 
     #[test]
-    fn missing_readiness_row_fails_closed() {
+    fn missing_readiness_row_leaves_configured_backend_offered() {
+        // The model list is a configuration surface (choose a backend to
+        // configure a behavior with) and must work before this runtime has
+        // published any readiness at all — a fresh store, a config-only
+        // session. Absence of a readiness row is not a veto.
         let agent_did = "did:test:codex-shim";
         let behaviors = vec![behavior("default", "backend-a")];
         let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
 
-        let accepting =
-            backend_admission_from_readiness_row(&behaviors, None, agent_did, observed_at);
+        assert!(!backend_vetoed_by_readiness(
+            "backend-a",
+            &behaviors,
+            None,
+            agent_did,
+            observed_at
+        ));
+    }
 
-        assert_eq!(accepting.get("backend-a").copied(), Some(false));
+    #[test]
+    fn backend_with_no_bound_behaviors_is_not_vetoed() {
+        // A brand-new backend with no `AgentBehavior` bound to it yet (the
+        // exact shape of a backend just created for configuration) has
+        // nothing in the readiness projection to veto it with.
+        let agent_did = "did:test:codex-shim";
+        let behaviors = vec![behavior("default", "backend-a")];
+        let row = readiness_row(
+            agent_did,
+            "default",
+            vec![("default", true)],
+            "2026-09-03T11:59:50Z",
+        );
+        let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
+
+        assert!(!backend_vetoed_by_readiness(
+            "backend-b",
+            &behaviors,
+            Some(&row),
+            agent_did,
+            observed_at
+        ));
     }
 }

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use gents::{
-    backend_registry::list_enabled_backends, load_agent_behavior, AgentBehaviorDocument,
-    InferenceBackend,
+    backend_registry::list_enabled_backends, document_configured_available, load_agent_behavior,
+    AgentBehaviorDocument, InferenceBackend,
 };
 use gents_codex_protocol as codex;
 use serde_json::{json, Value};
@@ -77,7 +77,7 @@ pub(super) async fn load_bound_behavior(state: &ShimState) -> Result<AgentBehavi
 
 pub(super) async fn available_model_backends(state: &ShimState) -> Result<Vec<InferenceBackend>> {
     let mut backends = list_enabled_backends(state.node.as_ref()).await?;
-    backends.retain(|backend| backend.is_available());
+    backends.retain(document_configured_available);
     backends.sort_by(|left, right| left.backend_id.cmp(&right.backend_id));
     Ok(backends)
 }

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -1,9 +1,14 @@
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result};
 use gents::{
-    backend_registry::list_enabled_backends, document_configured_available, load_agent_behavior,
+    backend_registry::list_enabled_backends, list_agent_behaviors, load_agent_behavior,
     AgentBehaviorDocument, InferenceBackend,
 };
 use gents_codex_protocol as codex;
+use gents_protocol::row::{
+    project_behavior_readiness_summary, BehaviorReadinessState, ProjectedBehaviorReadinessSummary,
+};
 use serde_json::{json, Value};
 
 use super::super::bound_behavior::{model_selection_id, parse_model_selection_id};
@@ -77,9 +82,69 @@ pub(super) async fn load_bound_behavior(state: &ShimState) -> Result<AgentBehavi
 
 pub(super) async fn available_model_backends(state: &ShimState) -> Result<Vec<InferenceBackend>> {
     let mut backends = list_enabled_backends(state.node.as_ref()).await?;
-    backends.retain(document_configured_available);
+    let accepting = backend_admission_from_local_readiness(state).await?;
+    backends.retain(|backend| accepting.get(&backend.backend_id).copied().unwrap_or(false));
     backends.sort_by(|left, right| left.backend_id.cmp(&right.backend_id));
     Ok(backends)
+}
+
+/// Per-backend "accepting admission" from this agent's own behavior
+/// readiness projection — never from `InferenceBackend`'s
+/// `enabled`/`probe_status` (measured health stays unpersisted; #640, see
+/// `backend_health.rs`). Mirrors `fleet_slots.rs::backend_admission_from_readiness`:
+/// a backend accepts once any locally bound behavior is reported `Ready`;
+/// with no such signal it fails closed to not-accepting.
+async fn backend_admission_from_local_readiness(
+    state: &ShimState,
+) -> Result<BTreeMap<String, bool>> {
+    let behaviors = list_agent_behaviors(state.node.as_ref(), state.agent_did.as_ref())
+        .await
+        .context("listing agent behaviors for model selection")?;
+    let readiness_row = crate::commands::status::load_behavior_readiness(
+        &ConfigAccess::Local(state.node.clone()),
+        state.agent_did.as_ref(),
+    )
+    .await
+    .context("loading behavior readiness for model selection")?;
+    Ok(backend_admission_from_readiness_row(
+        &behaviors,
+        readiness_row.as_ref(),
+        state.agent_did.as_ref(),
+        chrono::Utc::now(),
+    ))
+}
+
+/// Pure core of `backend_admission_from_local_readiness`, split out so it is
+/// testable without a live `EmbeddedNode`/`ShimState`.
+fn backend_admission_from_readiness_row(
+    behaviors: &[AgentBehaviorDocument],
+    readiness_row: Option<&gents_protocol::row::AgentBehaviorReadinessRow>,
+    agent_did: &str,
+    observed_at: chrono::DateTime<chrono::Utc>,
+) -> BTreeMap<String, bool> {
+    let projected = project_behavior_readiness_summary(readiness_row, agent_did, observed_at);
+    let mut accepting = BTreeMap::<String, bool>::new();
+    for behavior in behaviors {
+        let Some(backend_id) = behavior
+            .backend_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let ready = matches!(
+            &projected,
+            ProjectedBehaviorReadinessSummary::Observed(summary)
+                if summary.snapshot.behaviors.iter().any(|entry| {
+                    entry.behavior_id == behavior.behavior_id
+                        && entry.state == BehaviorReadinessState::Ready
+                })
+        );
+        let entry = accepting.entry(backend_id.to_string()).or_insert(false);
+        *entry = *entry || ready;
+    }
+    accepting
 }
 
 pub(super) fn model_list_entries(
@@ -200,4 +265,131 @@ async fn apply_model_to_bound_behavior(
         .await
         .context("writing AgentBehavior with selected backend model")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gents_protocol::row::{
+        AgentBehaviorReadinessRow, BehaviorReadinessEntry, BehaviorReadinessProcessState,
+        BehaviorReadinessSnapshot, BehaviorReadinessUnavailableReason,
+        BEHAVIOR_READINESS_FORMAT_VERSION,
+    };
+
+    fn behavior(behavior_id: &str, backend_id: &str) -> AgentBehaviorDocument {
+        AgentBehaviorDocument {
+            behavior_id: behavior_id.to_string(),
+            agent_did: "did:test:codex-shim".to_string(),
+            display_name: None,
+            description: None,
+            summary: None,
+            system_prompt: None,
+            request_context_template: None,
+            backend_id: Some(backend_id.to_string()),
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            skill_refs: Vec::new(),
+            skill_excludes: Vec::new(),
+            created_at: None,
+        }
+    }
+
+    fn readiness_row(
+        agent_did: &str,
+        default_behavior_id: &str,
+        entries: Vec<(&str, bool)>,
+        updated_at: &str,
+    ) -> AgentBehaviorReadinessRow {
+        AgentBehaviorReadinessRow {
+            agent_did: agent_did.to_string(),
+            snapshot_json: serde_json::to_string(&BehaviorReadinessSnapshot {
+                format_version: BEHAVIOR_READINESS_FORMAT_VERSION,
+                process_state: BehaviorReadinessProcessState::Ready,
+                active_generation: 1,
+                router_generation: 1,
+                default_behavior_id: default_behavior_id.to_string(),
+                behaviors: entries
+                    .into_iter()
+                    .map(|(behavior_id, ready)| BehaviorReadinessEntry {
+                        behavior_id: behavior_id.to_string(),
+                        state: if ready {
+                            BehaviorReadinessState::Ready
+                        } else {
+                            BehaviorReadinessState::Unavailable
+                        },
+                        reason: if ready {
+                            None
+                        } else {
+                            Some(BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable)
+                        },
+                    })
+                    .collect(),
+            })
+            .unwrap(),
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn backend_vetoed_by_readiness_is_not_offered_even_though_document_is_healthy() {
+        // `available_model_backends` starts from `list_enabled_backends`, so
+        // this exercises the case that matters: the `InferenceBackend`
+        // document itself would read enabled+healthy, but this runtime's
+        // local prober vetoed it — that veto only ever reaches the readiness
+        // projection (#640; measured health is never persisted to the
+        // document).
+        let agent_did = "did:test:codex-shim";
+        let behaviors = vec![behavior("default", "backend-a")];
+        let row = readiness_row(
+            agent_did,
+            "default",
+            vec![("default", false)],
+            "2026-09-03T11:59:50Z",
+        );
+        let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
+
+        let accepting =
+            backend_admission_from_readiness_row(&behaviors, Some(&row), agent_did, observed_at);
+
+        assert_eq!(
+            accepting.get("backend-a").copied(),
+            Some(false),
+            "a backend the local prober vetoed via readiness must not be offered for \
+             selection even though the InferenceBackend document itself would read healthy"
+        );
+    }
+
+    #[test]
+    fn ready_behavior_offers_its_backend() {
+        let agent_did = "did:test:codex-shim";
+        let behaviors = vec![behavior("default", "backend-a")];
+        let row = readiness_row(
+            agent_did,
+            "default",
+            vec![("default", true)],
+            "2026-09-03T11:59:50Z",
+        );
+        let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
+
+        let accepting =
+            backend_admission_from_readiness_row(&behaviors, Some(&row), agent_did, observed_at);
+
+        assert_eq!(accepting.get("backend-a").copied(), Some(true));
+    }
+
+    #[test]
+    fn missing_readiness_row_fails_closed() {
+        let agent_did = "did:test:codex-shim";
+        let behaviors = vec![behavior("default", "backend-a")];
+        let observed_at = "2026-09-03T12:00:00Z".parse().unwrap();
+
+        let accepting =
+            backend_admission_from_readiness_row(&behaviors, None, agent_did, observed_at);
+
+        assert_eq!(accepting.get("backend-a").copied(), Some(false));
+    }
 }

--- a/crates/gents-cli/src/commands/diagnose/backends.rs
+++ b/crates/gents-cli/src/commands/diagnose/backends.rs
@@ -120,7 +120,7 @@ async fn diagnose_backend(backend: &Value, required_models: Vec<String>) -> Valu
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let mut ok = enabled && probe_status == "healthy";
+    let mut ok = gents::document_available_from_fields(enabled, &probe_status);
     let mut error = None::<String>;
     let mut discovered_models = Vec::<String>::new();
 

--- a/crates/gents-cli/src/commands/diagnose/backends.rs
+++ b/crates/gents-cli/src/commands/diagnose/backends.rs
@@ -120,7 +120,7 @@ async fn diagnose_backend(backend: &Value, required_models: Vec<String>) -> Valu
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    let mut ok = gents::document_available_from_fields(enabled, &probe_status);
+    let mut ok = gents::document_configured_from_fields(enabled, &probe_status);
     let mut error = None::<String>;
     let mut discovered_models = Vec::<String>::new();
 

--- a/crates/gents-cli/src/http/fleet_slots.rs
+++ b/crates/gents-cli/src/http/fleet_slots.rs
@@ -2,7 +2,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use gents::{HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS};
+use gents::{call_state_holds_backend_slot, UNKNOWN_PROBE_STATUS};
+use gents_protocol::row::{
+    project_behavior_readiness_summary, AgentBehaviorReadinessRow, BehaviorReadinessState,
+    ProjectedBehaviorReadinessSummary,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -72,6 +76,8 @@ struct FleetSlotQueryEnvelope {
     calls: Vec<InferenceCallRow>,
     #[serde(rename = "AgentRequest", default)]
     requests: Vec<RequestRow>,
+    #[serde(rename = "AgentBehaviorReadiness", default)]
+    behavior_readiness: Vec<AgentBehaviorReadinessRow>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -123,17 +129,16 @@ impl BackendRow {
         self.enabled.unwrap_or(false)
     }
 
-    fn normalized_probe_status(&self) -> String {
+    /// Raw operator-intent `probe_status` for display only — never a truth
+    /// source for admission (that's the readiness projection; see
+    /// `backend_admission_from_readiness`).
+    fn display_probe_status(&self) -> String {
         let probe_status = clean_optional_string(self.probe_status.as_deref());
         if probe_status.is_empty() {
             UNKNOWN_PROBE_STATUS.to_string()
         } else {
             probe_status
         }
-    }
-
-    fn accepting_admission(&self) -> bool {
-        self.is_enabled() && self.normalized_probe_status() == HEALTHY_PROBE_STATUS
     }
 
     fn max_concurrent(&self) -> i64 {
@@ -217,6 +222,11 @@ fn fleet_slot_snapshot_query() -> &'static str {
             behavior_id
             deadline
         }
+        AgentBehaviorReadiness(order: { agent_did: ASC }) {
+            agent_did
+            snapshot_json
+            updated_at
+        }
     }"#
 }
 
@@ -241,6 +251,22 @@ fn build_fleet_slot_snapshot(
             (!behavior_id.is_empty()).then_some((behavior_id, behavior))
         })
         .collect::<BTreeMap<_, _>>();
+
+    let readiness_by_agent = envelope
+        .behavior_readiness
+        .into_iter()
+        .map(|row| (row.agent_did.clone(), row))
+        .collect::<BTreeMap<_, _>>();
+
+    // Measured backend health is never persisted to `InferenceBackend`
+    // (#640), so out-of-process readers like this one cannot compute
+    // admission from that document's `enabled`/`probe_status` fields —
+    // only the runtime that owns the live `BackendHealthMap` can. The
+    // per-backend "accepting" flag instead comes from the readiness rows
+    // for behaviors bound to that backend, published by each behavior's
+    // own runtime.
+    let backend_accepting =
+        backend_admission_from_readiness(&behaviors, &readiness_by_agent, generated_at);
 
     let mut backend_counts = BTreeMap::<String, SlotCounts>::new();
     let mut behavior_counts = BTreeMap::<String, SlotCounts>::new();
@@ -289,15 +315,13 @@ fn build_fleet_slot_snapshot(
         let max_concurrent = configured
             .map(BackendRow::max_concurrent)
             .unwrap_or_default();
-        let accepting_admission = configured
-            .map(BackendRow::accepting_admission)
-            .unwrap_or(false);
+        let accepting_admission = backend_accepting.get(&backend_id).copied().unwrap_or(false);
         backend_snapshots.push(FleetBackendAdmissionCounters {
             backend_id,
             configured: configured.is_some(),
             enabled: configured.map(BackendRow::is_enabled).unwrap_or(false),
             probe_status: configured
-                .map(BackendRow::normalized_probe_status)
+                .map(BackendRow::display_probe_status)
                 .unwrap_or_else(|| UNKNOWN_PROBE_STATUS.to_string()),
             accepting_admission,
             running: counts.assigned,
@@ -330,9 +354,7 @@ fn build_fleet_slot_snapshot(
             .unwrap_or_default();
         let backend = backends.get(&backend_id);
         let max = backend.map(BackendRow::max_concurrent).unwrap_or_default();
-        let backend_available = backend
-            .map(BackendRow::accepting_admission)
-            .unwrap_or(false);
+        let backend_available = backend_accepting.get(&backend_id).copied().unwrap_or(false);
         let enabled = configured.map(BehaviorRow::is_enabled).unwrap_or(false);
         let backend_running = backend_counts
             .get(&backend_id)
@@ -386,11 +408,46 @@ fn build_fleet_slot_snapshot(
     }
 }
 
+/// Per-backend "accepting admission" from the readiness rows of the
+/// behaviors currently bound to it — never from `InferenceBackend`'s
+/// `enabled`/`probe_status` (measured health stays unpersisted; see
+/// `backend_health.rs`). A backend accepts once any bound behavior's own
+/// runtime reports it `Ready`; with no such signal it fails closed to
+/// not-accepting, matching every other unconfigured/stale edge in this
+/// snapshot.
+fn backend_admission_from_readiness(
+    behaviors: &BTreeMap<String, BehaviorRow>,
+    readiness_by_agent: &BTreeMap<String, AgentBehaviorReadinessRow>,
+    observed_at: DateTime<Utc>,
+) -> BTreeMap<String, bool> {
+    let mut accepting = BTreeMap::<String, bool>::new();
+    for (behavior_id, behavior) in behaviors {
+        let backend_id = behavior.normalized_backend_id();
+        if backend_id.is_empty() {
+            continue;
+        }
+        let agent_did = clean_string(&behavior.agent_did);
+        let readiness_row = readiness_by_agent.get(&agent_did);
+        let projected = project_behavior_readiness_summary(readiness_row, &agent_did, observed_at);
+        let ready = matches!(
+            &projected,
+            ProjectedBehaviorReadinessSummary::Observed(summary)
+                if summary.snapshot.behaviors.iter().any(|entry| {
+                    &entry.behavior_id == behavior_id
+                        && entry.state == BehaviorReadinessState::Ready
+                })
+        );
+        let entry = accepting.entry(backend_id).or_insert(false);
+        *entry = *entry || ready;
+    }
+    accepting
+}
+
 fn apply_call_state(call_state: &str, counts: &mut SlotCounts) {
-    match call_state {
-        "running" => counts.assigned += 1,
-        "queued" => counts.queued += 1,
-        _ => {}
+    if call_state_holds_backend_slot(call_state) {
+        counts.assigned += 1;
+    } else if call_state == "queued" {
+        counts.queued += 1;
     }
 }
 
@@ -414,7 +471,39 @@ fn clean_string(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gents_protocol::row::{
+        BehaviorReadinessEntry, BehaviorReadinessProcessState, BehaviorReadinessSnapshot,
+        BEHAVIOR_READINESS_FORMAT_VERSION,
+    };
     use serde_json::json;
+
+    fn readiness_row(
+        agent_did: &str,
+        default_behavior_id: &str,
+        ready_behavior_ids: &[&str],
+        updated_at: &str,
+    ) -> AgentBehaviorReadinessRow {
+        AgentBehaviorReadinessRow {
+            agent_did: agent_did.to_string(),
+            snapshot_json: serde_json::to_string(&BehaviorReadinessSnapshot {
+                format_version: BEHAVIOR_READINESS_FORMAT_VERSION,
+                process_state: BehaviorReadinessProcessState::Ready,
+                active_generation: 1,
+                router_generation: 1,
+                default_behavior_id: default_behavior_id.to_string(),
+                behaviors: ready_behavior_ids
+                    .iter()
+                    .map(|behavior_id| BehaviorReadinessEntry {
+                        behavior_id: behavior_id.to_string(),
+                        state: BehaviorReadinessState::Ready,
+                        reason: None,
+                    })
+                    .collect(),
+            })
+            .unwrap(),
+            updated_at: updated_at.to_string(),
+        }
+    }
 
     fn find_backend<'a>(
         snapshot: &'a FleetSlotSnapshot,
@@ -485,6 +574,12 @@ mod tests {
                     behavior_id: Some("behavior-a".to_string()),
                     deadline: Some("2026-05-20T11:59:00Z".to_string()),
                 }],
+                behavior_readiness: vec![readiness_row(
+                    "did:test:test",
+                    "behavior-a",
+                    &["behavior-a", "behavior-b"],
+                    "2026-05-20T11:59:50Z",
+                )],
             },
         );
 
@@ -581,6 +676,7 @@ mod tests {
                         deadline: None,
                     },
                 ],
+                behavior_readiness: Vec::new(),
             },
         );
 

--- a/crates/gents-cli/src/http/healthz.rs
+++ b/crates/gents-cli/src/http/healthz.rs
@@ -1,4 +1,7 @@
-use gents_protocol::row::{project_behavior_readiness_summary, ProjectedBehaviorReadinessSummary};
+use gents_protocol::row::{
+    project_behavior_readiness_summary, BehaviorReadinessUnavailableReason,
+    ProjectedBehaviorReadinessSummary,
+};
 use serde_json::{json, Value};
 
 use crate::http::prometheus::MetricsQueryData;
@@ -47,10 +50,23 @@ fn render_healthz_payload_at(
                 }
                 ProjectedBehaviorReadinessSummary::Unknown(_) => true,
             };
-            let backend_degraded = data
-                .inference_backends
-                .iter()
-                .any(|backend| backend.enabled && backend.probe_status != "healthy");
+            // Measured backend health is never persisted to
+            // `InferenceBackend` (#640; see `backend_health.rs`), so this
+            // out-of-process reader can't compute degradation from that
+            // document's `enabled`/`probe_status` fields — only from the
+            // readiness projection this runtime already published above.
+            let backend_degraded = match &readiness {
+                ProjectedBehaviorReadinessSummary::Observed(summary) => {
+                    summary.unavailable_behaviors.values().any(|reason| {
+                        matches!(
+                            reason,
+                            BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable
+                                | BehaviorReadinessUnavailableReason::BackendDisabled
+                        )
+                    })
+                }
+                ProjectedBehaviorReadinessSummary::Unknown(_) => false,
+            };
             let liveness_degraded = data.liveness.expired_processing_count > 0;
             let codex_shim = state
                 .codex_shim_health
@@ -298,6 +314,54 @@ mod tests {
                 .get("expired_processing_count")
                 .and_then(|v| v.as_i64()),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn healthz_reports_backend_degraded_from_readiness_not_backend_document() {
+        // The `InferenceBackend` row itself is healthy — this runtime's
+        // *measured* health (#640, never persisted to that document) is
+        // what vetoed the behavior, and only the readiness projection
+        // carries that signal.
+        let vetoed_readiness = AgentBehaviorReadinessRow {
+            agent_did: "did:test:test".to_string(),
+            snapshot_json: serde_json::to_string(&BehaviorReadinessSnapshot {
+                format_version: BEHAVIOR_READINESS_FORMAT_VERSION,
+                process_state: BehaviorReadinessProcessState::Ready,
+                active_generation: 1,
+                router_generation: 1,
+                default_behavior_id: "default".to_string(),
+                behaviors: vec![BehaviorReadinessEntry {
+                    behavior_id: "default".to_string(),
+                    state: BehaviorReadinessState::Unavailable,
+                    reason: Some(
+                        gents_protocol::row::BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable,
+                    ),
+                }],
+            })
+            .unwrap(),
+            updated_at: "2026-05-13T11:59:30Z".to_string(),
+        };
+        let data = MetricsQueryData {
+            agent_runtimes: vec![ready_runtime()],
+            behavior_readiness: vec![vetoed_readiness],
+            inference_backends: vec![healthy_backend()],
+            liveness: RuntimeLivenessSnapshot::default(),
+        };
+
+        let payload = render_healthz_payload_at(&state(), Some(&data), None, observed_at());
+
+        assert_eq!(
+            payload
+                .pointer("/checks/backends/status")
+                .and_then(Value::as_str),
+            Some("degraded"),
+            "a readiness-reported backend veto must degrade the backends check even though \
+             the InferenceBackend document itself reports healthy: {payload}"
+        );
+        assert_eq!(
+            payload.get("status").and_then(Value::as_str),
+            Some("degraded")
         );
     }
 

--- a/crates/gents/src/admission/config.rs
+++ b/crates/gents/src/admission/config.rs
@@ -87,14 +87,16 @@ pub(crate) enum BackendAvailability {
     MeasuredUnhealthy,
 }
 
-/// Document-only availability from raw `(enabled, probe_status)` fields —
-/// `BackendAdmissionConfig::availability` without a `measured_unhealthy`
-/// term, for the few callers outside the `gents` crate that only ever see a
-/// document (never this runtime's live `BackendHealthMap`): the codex
-/// shim's model list and `gents diagnose`, which work from a partially
-/// parsed config blob rather than a full `InferenceBackend`. This file
+/// Whether the *document* declares this backend enabled and healthy —
+/// operator/bootstrap intent from raw `(enabled, probe_status)` fields, not
+/// a live availability verdict: it has no `measured_unhealthy` term, so it
+/// says nothing about this runtime's `BackendHealthMap` (#640). The one
+/// caller is `gents diagnose`, which uses it to gate whether to even attempt
+/// its own live reachability probe against an offline-exported config
+/// blob (not a full `InferenceBackend`). Named "configured", not
+/// "available", so it isn't mistaken for an admission decision; this file
 /// stays the single owner of the `enabled`/`probe_status` comparison.
-pub fn document_available_from_fields(enabled: bool, probe_status: &str) -> bool {
+pub fn document_configured_from_fields(enabled: bool, probe_status: &str) -> bool {
     enabled && probe_status == HEALTHY_PROBE_STATUS
 }
 

--- a/crates/gents/src/admission/config.rs
+++ b/crates/gents/src/admission/config.rs
@@ -56,10 +56,46 @@ impl BackendAdmissionConfig {
 
     /// Effective availability: operator/bootstrap intent from the shared
     /// document AND the local measurement not vetoing — mirrors
-    /// `Proofs.BackendHealth.effectiveAvailable` (B6).
-    pub(crate) fn is_available(&self) -> bool {
-        self.enabled && self.probe_status == HEALTHY_PROBE_STATUS && !self.measured_unhealthy
+    /// `Proofs.BackendHealth.effectiveAvailable` (B6). Names the failing
+    /// term so callers can report *why* without recomputing the comparison
+    /// — this is the single owner of that comparison in the codebase.
+    pub(crate) fn availability(&self) -> BackendAvailability {
+        if !self.enabled {
+            BackendAvailability::Disabled
+        } else if self.probe_status != HEALTHY_PROBE_STATUS {
+            BackendAvailability::ProbeNotHealthy
+        } else if self.measured_unhealthy {
+            BackendAvailability::MeasuredUnhealthy
+        } else {
+            BackendAvailability::Available
+        }
     }
+
+    pub(crate) fn is_available(&self) -> bool {
+        self.availability() == BackendAvailability::Available
+    }
+}
+
+/// The term of [`BackendAdmissionConfig::availability`] that failed, so
+/// callers that need to explain *why* a backend is unavailable don't
+/// recompute `enabled`/`probe_status`/`measured_unhealthy` themselves.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BackendAvailability {
+    Available,
+    Disabled,
+    ProbeNotHealthy,
+    MeasuredUnhealthy,
+}
+
+/// Document-only availability from raw `(enabled, probe_status)` fields —
+/// `BackendAdmissionConfig::availability` without a `measured_unhealthy`
+/// term, for the few callers outside the `gents` crate that only ever see a
+/// document (never this runtime's live `BackendHealthMap`): the codex
+/// shim's model list and `gents diagnose`, which work from a partially
+/// parsed config blob rather than a full `InferenceBackend`. This file
+/// stays the single owner of the `enabled`/`probe_status` comparison.
+pub fn document_available_from_fields(enabled: bool, probe_status: &str) -> bool {
+    enabled && probe_status == HEALTHY_PROBE_STATUS
 }
 
 pub(crate) fn backend_admission_configs_from_backends<'a>(
@@ -75,4 +111,59 @@ pub(crate) fn backend_admission_configs_from_backends<'a>(
         );
     }
     Ok(configs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(
+        enabled: bool,
+        probe_status: &str,
+        measured_unhealthy: bool,
+    ) -> BackendAdmissionConfig {
+        BackendAdmissionConfig {
+            backend_id: "test".to_string(),
+            max_concurrent: 1,
+            max_queue_depth: 0,
+            enabled,
+            probe_status: probe_status.to_string(),
+            measured_unhealthy,
+            config_fingerprint: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn availability_requires_enabled_healthy_and_unvetoed() {
+        assert_eq!(
+            config(true, HEALTHY_PROBE_STATUS, false).availability(),
+            BackendAvailability::Available
+        );
+        assert!(config(true, HEALTHY_PROBE_STATUS, false).is_available());
+
+        assert_eq!(
+            config(false, HEALTHY_PROBE_STATUS, false).availability(),
+            BackendAvailability::Disabled
+        );
+        assert!(!config(false, HEALTHY_PROBE_STATUS, false).is_available());
+
+        assert_eq!(
+            config(true, "unhealthy", false).availability(),
+            BackendAvailability::ProbeNotHealthy
+        );
+        assert!(!config(true, "unhealthy", false).is_available());
+
+        assert_eq!(
+            config(true, HEALTHY_PROBE_STATUS, true).availability(),
+            BackendAvailability::MeasuredUnhealthy
+        );
+        assert!(!config(true, HEALTHY_PROBE_STATUS, true).is_available());
+
+        // enabled=false wins over a bad probe_status: the disabled term is
+        // checked first.
+        assert_eq!(
+            config(false, "unhealthy", true).availability(),
+            BackendAvailability::Disabled
+        );
+    }
 }

--- a/crates/gents/src/admission/mod.rs
+++ b/crates/gents/src/admission/mod.rs
@@ -5,7 +5,6 @@ mod permit;
 mod persistence;
 mod recovery;
 mod registry;
-#[cfg(test)]
 mod slot_accounting;
 pub(crate) mod stream_guard;
 
@@ -19,6 +18,9 @@ pub(crate) use config::BackendAvailability;
 pub use config::{document_available_from_fields, BackendAdmissionConfig};
 pub use recovery::{InferenceCall, InferenceCallRecoveryReport};
 pub(crate) use registry::AdmissionRegistry;
+pub use slot_accounting::{
+    call_state_holds_backend_slot, reconstructed_running_slot_count, InferenceCallSlotRow,
+};
 
 #[cfg(test)]
 mod tests;

--- a/crates/gents/src/admission/mod.rs
+++ b/crates/gents/src/admission/mod.rs
@@ -15,12 +15,10 @@ pub(crate) use client::{
 };
 pub(crate) use config::backend_admission_configs_from_backends;
 pub(crate) use config::BackendAvailability;
-pub use config::{document_available_from_fields, BackendAdmissionConfig};
+pub use config::{document_configured_from_fields, BackendAdmissionConfig};
 pub use recovery::{InferenceCall, InferenceCallRecoveryReport};
 pub(crate) use registry::AdmissionRegistry;
-pub use slot_accounting::{
-    call_state_holds_backend_slot, reconstructed_running_slot_count, InferenceCallSlotRow,
-};
+pub use slot_accounting::call_state_holds_backend_slot;
 
 #[cfg(test)]
 mod tests;

--- a/crates/gents/src/admission/mod.rs
+++ b/crates/gents/src/admission/mod.rs
@@ -15,7 +15,8 @@ pub(crate) use client::{
     terminal_failure_reason_observer, AdmissionCallContext, AdmittedCompletionClient, CallKind,
 };
 pub(crate) use config::backend_admission_configs_from_backends;
-pub use config::BackendAdmissionConfig;
+pub(crate) use config::BackendAvailability;
+pub use config::{document_available_from_fields, BackendAdmissionConfig};
 pub use recovery::{InferenceCall, InferenceCallRecoveryReport};
 pub(crate) use registry::AdmissionRegistry;
 

--- a/crates/gents/src/admission/slot_accounting.rs
+++ b/crates/gents/src/admission/slot_accounting.rs
@@ -1,11 +1,11 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct InferenceCallSlotRow<'a> {
+pub struct InferenceCallSlotRow<'a> {
     pub(crate) backend_id: &'a str,
     pub(crate) call_state: &'a str,
 }
 
 impl<'a> InferenceCallSlotRow<'a> {
-    pub(crate) fn new(backend_id: &'a str, call_state: &'a str) -> Self {
+    pub fn new(backend_id: &'a str, call_state: &'a str) -> Self {
         Self {
             backend_id,
             call_state,
@@ -13,7 +13,11 @@ impl<'a> InferenceCallSlotRow<'a> {
     }
 }
 
-fn call_state_holds_backend_slot(call_state: &str) -> bool {
+/// Whether an `InferenceCall` in this `call_state` currently holds a backend
+/// concurrency slot. The single owner of that definition — reused by the
+/// admission runtime's own reconstruction and by out-of-process readers
+/// (`gents fleet-slots`) so neither re-derives it from the raw string.
+pub fn call_state_holds_backend_slot(call_state: &str) -> bool {
     call_state == "running"
 }
 
@@ -25,7 +29,7 @@ pub(crate) fn slot_contribution(row: InferenceCallSlotRow<'_>, backend_id: &str)
     }
 }
 
-pub(crate) fn reconstructed_running_slot_count<'a>(
+pub fn reconstructed_running_slot_count<'a>(
     rows: impl IntoIterator<Item = InferenceCallSlotRow<'a>>,
     backend_id: &str,
 ) -> usize {

--- a/crates/gents/src/admission/slot_accounting.rs
+++ b/crates/gents/src/admission/slot_accounting.rs
@@ -1,11 +1,13 @@
+#[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct InferenceCallSlotRow<'a> {
+pub(crate) struct InferenceCallSlotRow<'a> {
     pub(crate) backend_id: &'a str,
     pub(crate) call_state: &'a str,
 }
 
+#[cfg(test)]
 impl<'a> InferenceCallSlotRow<'a> {
-    pub fn new(backend_id: &'a str, call_state: &'a str) -> Self {
+    pub(crate) fn new(backend_id: &'a str, call_state: &'a str) -> Self {
         Self {
             backend_id,
             call_state,
@@ -15,12 +17,14 @@ impl<'a> InferenceCallSlotRow<'a> {
 
 /// Whether an `InferenceCall` in this `call_state` currently holds a backend
 /// concurrency slot. The single owner of that definition — reused by the
-/// admission runtime's own reconstruction and by out-of-process readers
-/// (`gents fleet-slots`) so neither re-derives it from the raw string.
+/// admission runtime's own reconstruction (in tests, below) and by
+/// out-of-process readers (`gents fleet-slots`) so neither re-derives it
+/// from the raw string.
 pub fn call_state_holds_backend_slot(call_state: &str) -> bool {
     call_state == "running"
 }
 
+#[cfg(test)]
 pub(crate) fn slot_contribution(row: InferenceCallSlotRow<'_>, backend_id: &str) -> usize {
     if row.backend_id == backend_id && call_state_holds_backend_slot(row.call_state) {
         1
@@ -29,7 +33,8 @@ pub(crate) fn slot_contribution(row: InferenceCallSlotRow<'_>, backend_id: &str)
     }
 }
 
-pub fn reconstructed_running_slot_count<'a>(
+#[cfg(test)]
+pub(crate) fn reconstructed_running_slot_count<'a>(
     rows: impl IntoIterator<Item = InferenceCallSlotRow<'a>>,
     backend_id: &str,
 ) -> usize {

--- a/crates/gents/src/agent/builder.rs
+++ b/crates/gents/src/agent/builder.rs
@@ -47,6 +47,12 @@ pub struct GentsBuilder {
     rendered_request_capture_factory:
         Option<crate::rendered_request::RenderedRequestCaptureFactory>,
     behaviors: Vec<PendingAgentBehavior>,
+    /// This runtime's measured probe health (#640), consulted alongside the
+    /// document when admitting a behavior's backend. Empty by default —
+    /// build paths that run before the prober has an opinion (startup,
+    /// tests) never veto on measured health, matching
+    /// `BackendAdmissionConfig::measured_unhealthy`'s own default.
+    backend_health: crate::backend_health::BackendHealthMap,
 }
 
 impl GentsBuilder {
@@ -61,6 +67,18 @@ impl GentsBuilder {
 
     pub fn identity(mut self, identity: Arc<dyn AgentIdentity>) -> Self {
         self.identity = Some(identity);
+        self
+    }
+
+    /// Test-only: seed the measured probe health this build should veto on,
+    /// exercising the same `BackendAdmissionConfig` path the runtime
+    /// consults after startup.
+    #[cfg(test)]
+    pub(crate) fn backend_health(
+        mut self,
+        backend_health: crate::backend_health::BackendHealthMap,
+    ) -> Self {
+        self.backend_health = backend_health;
         self
     }
 
@@ -187,7 +205,7 @@ impl GentsBuilder {
         > = Vec::with_capacity(self.behaviors.len());
         for behavior in self.behaviors {
             let factory = behavior
-                .into_factory(node.as_ref(), &self.tool_ceiling)
+                .into_factory(node.as_ref(), &self.tool_ceiling, &self.backend_health)
                 .await?;
             behavior_factories.push(factory);
         }
@@ -236,7 +254,7 @@ impl GentsBuilder {
             background_execution_registry: BackgroundExecutionRegistry::default(),
             health_checker_options: self.health_checker_options,
             backend_prober_options: crate::backend_health::BackendProberOptions::default(),
-            backend_health: crate::backend_health::BackendHealthMap::new(),
+            backend_health: self.backend_health,
             process_state_observer: self.process_state_observer,
             runtime_snapshot_observer: None,
             startup_build_failure_observer: None,
@@ -499,6 +517,7 @@ impl PendingAgentBehavior {
         self,
         node: &EmbeddedNode,
         tool_ceiling: &ToolCeiling,
+        backend_health: &crate::backend_health::BackendHealthMap,
     ) -> Result<
         Box<
             dyn FnOnce(
@@ -519,16 +538,22 @@ impl PendingAgentBehavior {
                 backend_id
             )
         })?;
-        if !backend.is_available() {
+        // `BackendAdmissionConfig::is_available` is the single owner of the
+        // enabled/probe_status/measured_unhealthy comparison (#1332); apply
+        // this builder's measured health the same way the reconciler does
+        // before gating on it.
+        let admission_config = BackendAdmissionConfig::from_backend(&backend)?
+            .with_measured_unhealthy(backend_health.measured_blocks_routing(&backend_id).await);
+        if !admission_config.is_available() {
             anyhow::bail!(
-                "behavior '{}' backend {} is unavailable (enabled={} probe_status={})",
+                "behavior '{}' backend {} is unavailable (enabled={} probe_status={} measured_unhealthy={})",
                 self.name,
                 backend_id,
                 backend.enabled,
-                backend.probe_status
+                backend.probe_status,
+                admission_config.measured_unhealthy,
             );
         }
-        BackendAdmissionConfig::from_backend(&backend)?;
 
         let behavior_name = self.name.clone();
         let resolved_backend_id = Some(backend.backend_id);

--- a/crates/gents/src/agent/document_view/snapshot.rs
+++ b/crates/gents/src/agent/document_view/snapshot.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use defra_node::EmbeddedNode;
 use gents_protocol::row::BehaviorReadinessUnavailableReason;
 
-use crate::admission::backend_admission_configs_from_backends;
+use crate::admission::{backend_admission_configs_from_backends, BackendAvailability};
 use crate::config::AgentBehavior;
 use crate::document_config::{
     default_behavior_id_for_agent, AgentBehavior as AgentBehaviorDocument,
@@ -69,6 +69,10 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
     };
 
     let measured_vetoed = context.backend_health.vetoed_backend_ids().await;
+    let backend_admission_configs = backend_admission_configs_from_backends(
+        view.backends.values().map(|record| &record.value),
+        &measured_vetoed,
+    )?;
 
     let mut unavailable_behaviors = HashMap::new();
     let mut behavior_factories: Vec<
@@ -120,41 +124,61 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
                         ),
                     )
                 })?;
-            if !backend.enabled {
-                return Err(BehaviorResolutionError::new(
-                    BehaviorReadinessUnavailableReason::BackendDisabled,
-                    anyhow!(
-                        "behavior {} backend {} is unavailable (enabled={} probe_status={})",
-                        behavior.behavior_id,
-                        backend.backend_id,
-                        backend.enabled,
-                        backend.probe_status
-                    ),
-                ));
-            }
-            if !backend.is_available() {
-                return Err(BehaviorResolutionError::new(
-                    BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable,
-                    anyhow!(
-                        "behavior {} backend {} is not ready (probe_status={})",
-                        behavior.behavior_id,
-                        backend.backend_id,
-                        backend.probe_status
-                    ),
-                ));
-            }
-            if measured_vetoed.contains(&backend.backend_id) {
-                return Err(BehaviorResolutionError::new(
-                    BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable,
-                    anyhow!(
-                        "behavior {} backend {} is measured unhealthy by the local prober \
-                         (document probe_status={} is operator intent; routing resumes on \
-                         the next successful probe)",
-                        behavior.behavior_id,
-                        backend.backend_id,
-                        backend.probe_status
-                    ),
-                ));
+            // `BackendAdmissionConfig::availability` is the single owner of
+            // the enabled/probe_status/measured_unhealthy comparison; built
+            // once above for every backend and reused here and for the
+            // snapshot's admission configs below.
+            let admission_config = backend_admission_configs
+                .get(&backend.backend_id)
+                .cloned()
+                .ok_or_else(|| {
+                    BehaviorResolutionError::new(
+                        BehaviorReadinessUnavailableReason::BackendNotConfigured,
+                        anyhow!(
+                            "behavior {} references missing backend {}",
+                            behavior.behavior_id,
+                            backend.backend_id
+                        ),
+                    )
+                })?;
+            match admission_config.availability() {
+                BackendAvailability::Available => {}
+                BackendAvailability::Disabled => {
+                    return Err(BehaviorResolutionError::new(
+                        BehaviorReadinessUnavailableReason::BackendDisabled,
+                        anyhow!(
+                            "behavior {} backend {} is unavailable (enabled={} probe_status={})",
+                            behavior.behavior_id,
+                            backend.backend_id,
+                            backend.enabled,
+                            backend.probe_status
+                        ),
+                    ));
+                }
+                BackendAvailability::ProbeNotHealthy => {
+                    return Err(BehaviorResolutionError::new(
+                        BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable,
+                        anyhow!(
+                            "behavior {} backend {} is not ready (probe_status={})",
+                            behavior.behavior_id,
+                            backend.backend_id,
+                            backend.probe_status
+                        ),
+                    ));
+                }
+                BackendAvailability::MeasuredUnhealthy => {
+                    return Err(BehaviorResolutionError::new(
+                        BehaviorReadinessUnavailableReason::BackendTemporarilyUnavailable,
+                        anyhow!(
+                            "behavior {} backend {} is measured unhealthy by the local prober \
+                             (document probe_status={} is operator intent; routing resumes on \
+                             the next successful probe)",
+                            behavior.behavior_id,
+                            backend.backend_id,
+                            backend.probe_status
+                        ),
+                    ));
+                }
             }
             if backend.provider_kind == crate::backend_provider::BackendProviderKind::ChatGptCodex
                 && !view.has_enabled_oauth_credential(crate::chatgpt_codex::CHATGPT_CODEX_PROVIDER)
@@ -394,11 +418,6 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
         tool_surfaces.insert(behavior.behavior_id.clone(), Arc::new(tool_surface));
         behaviors.push(behavior);
     }
-
-    let backend_admission_configs = backend_admission_configs_from_backends(
-        view.backends.values().map(|record| &record.value),
-        &measured_vetoed,
-    )?;
 
     let (active_schedules, unavailable_schedules) = resolve_schedules(view, &unavailable_behaviors);
     let (active_event_triggers, unavailable_event_triggers) =

--- a/crates/gents/src/agent/tests/builder.rs
+++ b/crates/gents/src/agent/tests/builder.rs
@@ -88,3 +88,44 @@ async fn builder_requires_resolvable_backend_documents() {
         .to_string()
         .contains("behavior 'policy-ops' references missing backend missing-backend"));
 }
+
+#[tokio::test]
+async fn builder_rejects_backend_vetoed_by_measured_health() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    insert_backend(
+        node.as_ref(),
+        "builder-vetoed-backend",
+        "http://127.0.0.1:8778/v1",
+    )
+    .await;
+    let identity = Arc::new(test_identity("builder-measured-unhealthy"));
+
+    let backend_health = crate::backend_health::BackendHealthMap::new();
+    backend_health
+        .set_for_test(
+            "builder-vetoed-backend",
+            crate::backend_health::BackendHealthState::Unhealthy,
+            3,
+        )
+        .await;
+
+    let error = match Gents::builder()
+        .node(node)
+        .identity(identity)
+        .backend_health(backend_health)
+        .behavior("policy-ops")
+        .backend_id("builder-vetoed-backend")
+        .done()
+        .build()
+        .await
+    {
+        Ok(_) => panic!("builder should reject a backend this runtime has measured unhealthy"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.to_string().contains("measured_unhealthy=true"),
+        "error should name the measured-health veto: {error}"
+    );
+}

--- a/crates/gents/src/backend_registry.rs
+++ b/crates/gents/src/backend_registry.rs
@@ -96,10 +96,6 @@ impl InferenceBackend {
         })
     }
 
-    pub fn is_available(&self) -> bool {
-        self.enabled && self.probe_status == HEALTHY_PROBE_STATUS
-    }
-
     pub fn resolved_api_key(&self) -> Option<String> {
         if let Some(key) = self.api_key.as_ref() {
             return Some(key.clone());
@@ -133,6 +129,19 @@ pub fn derive_display_state(enabled: bool, probe_status: &str) -> &'static str {
         "unknown" => "unknown",
         _ => "unknown",
     }
+}
+
+/// Document-only backend availability: `BackendAdmissionConfig`'s predicate
+/// evaluated with `measured_unhealthy = false`, since callers here only ever
+/// have a document read, never this runtime's live `BackendHealthMap` (used
+/// for #640 routing decisions). `BackendAdmissionConfig` stays the single
+/// owner of the `enabled`/`probe_status` comparison; this delegates to it
+/// rather than re-deriving the fields, for the handful of callers outside
+/// the `gents` crate (the codex shim's model list, `gents diagnose`) that
+/// aren't in-process admission and so can't consult the readiness
+/// projection either.
+pub fn document_configured_available(backend: &InferenceBackend) -> bool {
+    crate::admission::document_available_from_fields(backend.enabled, &backend.probe_status)
 }
 
 pub async fn lookup_backend(

--- a/crates/gents/src/backend_registry.rs
+++ b/crates/gents/src/backend_registry.rs
@@ -131,19 +131,6 @@ pub fn derive_display_state(enabled: bool, probe_status: &str) -> &'static str {
     }
 }
 
-/// Document-only backend availability: `BackendAdmissionConfig`'s predicate
-/// evaluated with `measured_unhealthy = false`, since callers here only ever
-/// have a document read, never this runtime's live `BackendHealthMap` (used
-/// for #640 routing decisions). `BackendAdmissionConfig` stays the single
-/// owner of the `enabled`/`probe_status` comparison; this delegates to it
-/// rather than re-deriving the fields, for the handful of callers outside
-/// the `gents` crate (the codex shim's model list, `gents diagnose`) that
-/// aren't in-process admission and so can't consult the readiness
-/// projection either.
-pub fn document_configured_available(backend: &InferenceBackend) -> bool {
-    crate::admission::document_available_from_fields(backend.enabled, &backend.probe_status)
-}
-
 pub async fn lookup_backend(
     node: &EmbeddedNode,
     backend_id: &str,

--- a/crates/gents/src/backend_registry/tests.rs
+++ b/crates/gents/src/backend_registry/tests.rs
@@ -59,37 +59,6 @@ fn inference_backend_from_value_requires_provider_kind() {
 }
 
 #[test]
-fn document_configured_available_requires_enabled_and_healthy() {
-    let healthy = InferenceBackend {
-        backend_id: "test".into(),
-        name: "Test".into(),
-        provider_kind: BackendProviderKind::OpenAiCompatible,
-        openai_wire_api: None,
-        endpoint: "http://localhost:8000/v1".into(),
-        api_key: None,
-        api_key_env_var: None,
-        max_concurrent: 1,
-        max_queue_depth: DEFAULT_MAX_QUEUE_DEPTH,
-        enabled: true,
-        models: Vec::new(),
-        probe_status: "healthy".into(),
-    };
-    assert!(document_configured_available(&healthy));
-
-    let disabled = InferenceBackend {
-        enabled: false,
-        ..healthy.clone()
-    };
-    assert!(!document_configured_available(&disabled));
-
-    let unhealthy = InferenceBackend {
-        probe_status: "unhealthy".into(),
-        ..healthy.clone()
-    };
-    assert!(!document_configured_available(&unhealthy));
-}
-
-#[test]
 fn generated_backend_health_admission_cases_match_registry_and_admission_policy() {
     let cases = lean_backend_health_admission_cases();
     assert_eq!(cases.len(), 7);
@@ -113,9 +82,12 @@ fn generated_backend_health_admission_cases_match_registry_and_admission_policy(
             BackendAdmissionConfig::from_backend(&backend).expect("valid backend config");
 
         assert_eq!(
-            document_configured_available(&backend),
+            crate::admission::document_configured_from_fields(
+                backend.enabled,
+                &backend.probe_status
+            ),
             case.expected_available,
-            "{} registry availability drifted from Lean case",
+            "{} document-configured availability drifted from Lean case",
             case.name
         );
         assert_eq!(

--- a/crates/gents/src/backend_registry/tests.rs
+++ b/crates/gents/src/backend_registry/tests.rs
@@ -59,7 +59,7 @@ fn inference_backend_from_value_requires_provider_kind() {
 }
 
 #[test]
-fn is_available_requires_enabled_and_healthy() {
+fn document_configured_available_requires_enabled_and_healthy() {
     let healthy = InferenceBackend {
         backend_id: "test".into(),
         name: "Test".into(),
@@ -74,19 +74,19 @@ fn is_available_requires_enabled_and_healthy() {
         models: Vec::new(),
         probe_status: "healthy".into(),
     };
-    assert!(healthy.is_available());
+    assert!(document_configured_available(&healthy));
 
     let disabled = InferenceBackend {
         enabled: false,
         ..healthy.clone()
     };
-    assert!(!disabled.is_available());
+    assert!(!document_configured_available(&disabled));
 
     let unhealthy = InferenceBackend {
         probe_status: "unhealthy".into(),
         ..healthy.clone()
     };
-    assert!(!unhealthy.is_available());
+    assert!(!document_configured_available(&unhealthy));
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn generated_backend_health_admission_cases_match_registry_and_admission_policy(
             BackendAdmissionConfig::from_backend(&backend).expect("valid backend config");
 
         assert_eq!(
-            backend.is_available(),
+            document_configured_available(&backend),
             case.expected_available,
             "{} registry availability drifted from Lean case",
             case.name

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -151,7 +151,7 @@ pub use adapter_projection::{
     ProjectionRedactionMode, ATIF_SCHEMA_VERSION,
 };
 pub use admission::BackendAdmissionConfig;
-pub use admission::{InferenceCall, InferenceCallRecoveryReport};
+pub use admission::{document_available_from_fields, InferenceCall, InferenceCallRecoveryReport};
 pub use agent::{
     BehaviorBuilder, DocumentRuntimeOptions, Gents, GentsBuilder, ProcessLifecycleObserver,
     ProcessLifecycleState, RuntimeSnapshotObserver,
@@ -161,7 +161,9 @@ pub use backend_health::{
     BackendHealthSnapshot, BackendHealthState, BackendProberOptions, ProbeCycleOutcome,
 };
 pub use backend_provider::{discover_models as discover_backend_models, BackendProviderKind};
-pub use backend_registry::{InferenceBackend, HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS};
+pub use backend_registry::{
+    document_configured_available, InferenceBackend, HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS,
+};
 pub use background_completion_diagnostics::{
     load_background_completion_diagnostics, BackgroundCompletionDiagnostics,
     BackgroundCompletionEpochDiagnostic,

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -150,11 +150,9 @@ pub use adapter_projection::{
     AtifStep, AtifStepSource, AtifToolCall, AtifTrajectory, ProjectionContext,
     ProjectionRedactionMode, ATIF_SCHEMA_VERSION,
 };
+pub use admission::call_state_holds_backend_slot;
 pub use admission::BackendAdmissionConfig;
-pub use admission::{
-    call_state_holds_backend_slot, reconstructed_running_slot_count, InferenceCallSlotRow,
-};
-pub use admission::{document_available_from_fields, InferenceCall, InferenceCallRecoveryReport};
+pub use admission::{document_configured_from_fields, InferenceCall, InferenceCallRecoveryReport};
 pub use agent::{
     BehaviorBuilder, DocumentRuntimeOptions, Gents, GentsBuilder, ProcessLifecycleObserver,
     ProcessLifecycleState, RuntimeSnapshotObserver,
@@ -164,9 +162,7 @@ pub use backend_health::{
     BackendHealthSnapshot, BackendHealthState, BackendProberOptions, ProbeCycleOutcome,
 };
 pub use backend_provider::{discover_models as discover_backend_models, BackendProviderKind};
-pub use backend_registry::{
-    document_configured_available, InferenceBackend, HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS,
-};
+pub use backend_registry::{InferenceBackend, HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS};
 pub use background_completion_diagnostics::{
     load_background_completion_diagnostics, BackgroundCompletionDiagnostics,
     BackgroundCompletionEpochDiagnostic,

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -151,6 +151,9 @@ pub use adapter_projection::{
     ProjectionRedactionMode, ATIF_SCHEMA_VERSION,
 };
 pub use admission::BackendAdmissionConfig;
+pub use admission::{
+    call_state_holds_backend_slot, reconstructed_running_slot_count, InferenceCallSlotRow,
+};
 pub use admission::{document_available_from_fields, InferenceCall, InferenceCallRecoveryReport};
 pub use agent::{
     BehaviorBuilder, DocumentRuntimeOptions, Gents, GentsBuilder, ProcessLifecycleObserver,


### PR DESCRIPTION
Closes #1332. Stacked on #1352 (base branch `so/1335-goal-tokens`).

## What changed

One predicate answers "is this backend available to route to": `BackendAdmissionConfig::is_available` (Lean `effectiveAvailable`, B6), which includes the local prober's veto that is deliberately never persisted.

- In-process: `document_view/snapshot.rs` and `agent/builder.rs` build the admission config once and use its verdict; the document-only `InferenceBackend::is_available` is deleted. Builder-constructed agents no longer bypass the measured-health veto.
- Out-of-process: `/healthz` `backend_degraded` and `gents fleet-slots` accepting-admission are derived from the published behavior readiness projection (`BackendDisabled` / `BackendTemporarilyUnavailable`) instead of re-reading `probe_status` from the document, so a vetoed backend now shows as degraded the way admission sees it.
- `fleet_slots.rs` calls the exported `admission::slot_accounting` predicate instead of its copy.
- The codex-shim model list derives selectable backends from the readiness projection too, so a vetoed backend is not offered.

## Net code

This PR grows the CLI: `healthz`, `fleet-slots`, and the codex shim gain a readiness-projection consumer they never had, which is the fix. The runtime side deletes the document-only predicate and the hand-recomposed checks.

## Verification

Builder veto test (failing first), readiness-row tests for healthz and fleet-slots, `cargo test -p gents --lib agent::document_view agent::builder admission`, `--test conformance backend_health`, `cargo test -p gents-cli --lib http::`, `cargo check --workspace --all-targets`, `cargo fmt --all --check`. Grep gate: no availability decision outside `admission/config.rs` compares `probe_status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eatk66c9sS6vPq2nasHJVd
