### PR TITLE
MCP service health is projected once in Rust; delete the desktop stuck heuristic (#1333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+### Added
+
+- Desktop bridge 6.2: `MCPServiceHealthView.displayState` (`healthy | stale |
+  unreachable`) is the only MCP health classification; the desktop's
+  synthetic `stuck` state is removed.
+
 ### Breaking changes
 
 - `AgentRequest.status` is removed; `lifecycle_state` is the only request

--- a/apps/gents-desktop/tests/mcp-health-panel.test.tsx
+++ b/apps/gents-desktop/tests/mcp-health-panel.test.tsx
@@ -26,14 +26,32 @@ const api = createDesktopApiAdapter(
   }),
 );
 
+// Mirrors ToolServiceHealthState::project (crates/gents-protocol/src/tool_service_health.rs)
+// so fixtures don't drift from the server's classification.
+function displayStateFor(status: string): "healthy" | "stale" | "unreachable" {
+  switch (status) {
+    case "healthy":
+      return "healthy";
+    case "degraded":
+      return "stale";
+    case "evicted":
+    case "reconnecting":
+      return "unreachable";
+    default:
+      return "unreachable";
+  }
+}
+
 function svc(
   overrides: Partial<MCPServiceHealthView> & { serviceId: string },
 ): MCPServiceHealthView {
+  const status = overrides.status ?? "healthy";
   return {
     serviceId: overrides.serviceId,
     agentDid: overrides.agentDid ?? "did:test:agent-1",
     endpoint: overrides.endpoint ?? "100.69.4.79:9201/mcp",
-    status: overrides.status ?? "healthy",
+    status,
+    displayState: overrides.displayState ?? displayStateFor(status),
     failureCount: overrides.failureCount ?? 0,
     kMax: overrides.kMax ?? 3,
     backoffUntil: overrides.backoffUntil ?? null,
@@ -70,7 +88,7 @@ describe("McpHealthPanelView", () => {
 
     expect(screen.getByTestId("mcp-health-status-ok-svc")).toHaveTextContent("healthy");
     expect(screen.getByTestId("mcp-health-status-evicted-svc")).toHaveTextContent(
-      "evicted (backoff)",
+      "unreachable",
     );
 
     fireEvent.click(screen.getByTestId("mcp-health-probe-ok-svc"));

--- a/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
+++ b/apps/gents-desktop/tests/ui-harness/desktopHarness.ts
@@ -1479,6 +1479,7 @@ export function createDesktopUiHarness(
           service.mcpPath ?? "/mcp"
         }`,
         status: "healthy",
+        displayState: "healthy",
         failureCount: 0,
         kMax: 3,
         backoffUntil: null,

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -281,7 +281,7 @@
       "permissionSet": "native-e2e"
     }
   ],
-  "contractVersion": "6.1",
+  "contractVersion": "6.2",
   "errorCodes": [
     "clientNotRunning",
     "clientStartFailed",
@@ -416,5 +416,5 @@
       "name": "full"
     }
   ],
-  "wireSchemaHash": "67594ec0a37b28e01076fc29b20bf04a87a76f51373c698a156bc0a7b9d90a02"
+  "wireSchemaHash": "df5cd8234a352627975cc23f8b8f258d7d0675a4c544d4a8f8b02b930f35010e"
 }

--- a/crates/gents-cli/src/http/mcp_pool.rs
+++ b/crates/gents-cli/src/http/mcp_pool.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use gents::graphql::escape_graphql_string;
 use gents_protocol::row::{ToolServiceHealthStateRow, ToolServiceRegistryRow};
+use gents_protocol::tool_service_health::{ToolServiceHealthProjection, ToolServiceHealthState};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -197,16 +198,18 @@ fn status_eq(value: Option<&str>, expected: &str) -> bool {
         .is_some_and(|value| value.eq_ignore_ascii_case(expected))
 }
 
+/// Buckets a persisted `ToolServiceHealthState.status` value by the owned
+/// projection (`ToolServiceHealthState::parse_opt` + `project()`) — the same
+/// classification the desktop bridge's `MCPServiceHealthView.display_state`
+/// uses. A missing or unrecognized status (including a row that somehow
+/// persisted a projection word like `"stale"`/`"unreachable"` instead of a
+/// real state) falls into `unknown`, the one fail-safe bucket.
 fn count_health_status(totals: &mut McpPoolTotals, status: Option<&str>) {
-    match status.map(|value| value.trim().to_ascii_lowercase()) {
-        Some(status) if status == "healthy" => totals.healthy += 1,
-        Some(status) if status == "degraded" || status == "stale" => totals.degraded += 1,
-        Some(status)
-            if status == "evicted" || status == "reconnecting" || status == "unreachable" =>
-        {
-            totals.unreachable += 1;
-        }
-        Some(_) | None => totals.unknown += 1,
+    match ToolServiceHealthState::parse_opt(status).map(ToolServiceHealthState::project) {
+        Some(ToolServiceHealthProjection::Healthy) => totals.healthy += 1,
+        Some(ToolServiceHealthProjection::Stale) => totals.degraded += 1,
+        Some(ToolServiceHealthProjection::Unreachable) => totals.unreachable += 1,
+        None => totals.unknown += 1,
     }
 }
 
@@ -296,5 +299,47 @@ mod tests {
         assert_eq!(obs.tool_count, Some(12));
         assert_eq!(obs.health_status.as_deref(), Some("healthy"));
         assert_eq!(obs.endpoint.as_deref(), Some("http://100.64.0.10:9201/mcp"));
+    }
+
+    #[test]
+    fn count_health_status_buckets_by_the_owned_projection() {
+        let mut totals = McpPoolTotals::default();
+        for status in ["healthy", "degraded", "evicted", "reconnecting"] {
+            count_health_status(&mut totals, Some(status));
+        }
+        assert_eq!(
+            totals,
+            McpPoolTotals {
+                registered: 0,
+                online: 0,
+                healthy: 1,
+                degraded: 1,
+                unreachable: 2,
+                unknown: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn count_health_status_falls_back_to_unknown_for_missing_or_unrecognized_status() {
+        let mut totals = McpPoolTotals::default();
+        // Projection words are not valid raw states: a row persisted with
+        // "stale" or "unreachable" (never written by health_checker, but
+        // defensively possible from a corrupt/legacy row) must not silently
+        // count as the real ToolServiceHealthState of the same name.
+        for status in [None, Some("stale"), Some("unreachable"), Some("bogus")] {
+            count_health_status(&mut totals, status);
+        }
+        assert_eq!(
+            totals,
+            McpPoolTotals {
+                registered: 0,
+                online: 0,
+                healthy: 0,
+                degraded: 0,
+                unreachable: 0,
+                unknown: 4,
+            }
+        );
     }
 }

--- a/crates/gents-desktop-bridge/src/commands/mcp_health.rs
+++ b/crates/gents-desktop-bridge/src/commands/mcp_health.rs
@@ -8,6 +8,7 @@ use gents::{
 };
 use gents_desktop_core::client::ClientCore;
 use gents_protocol::row::{ToolServiceHealthStateRow, ToolServiceRegistryRow};
+use gents_protocol::tool_service_health::ToolServiceHealthState;
 
 use super::super::types::{MCPServiceHealthView, McpServiceProbeResult};
 
@@ -74,15 +75,34 @@ pub async fn load_mcp_services_with_health(core: &ClientCore) -> Result<Vec<MCPS
         .collect::<std::result::Result<_, _>>()
         .map_err(|error| anyhow!("parsing ToolServiceHealthState rows: {error}"))?;
 
-    Ok(rows.into_iter().map(view_from_row).collect())
+    rows.into_iter().map(view_from_row).collect()
 }
 
-fn view_from_row(row: ToolServiceHealthStateRow) -> MCPServiceHealthView {
-    MCPServiceHealthView {
+/// `display_state` is the collapsed three-state projection
+/// (`ToolServiceHealthState::project`) of the persisted `status` column.
+/// A row with a missing or unrecognized `status` is a data error — this
+/// command surfaces it as `Err` rather than inventing a synthetic
+/// classification, so a corrupt/legacy row fails loudly instead of
+/// silently rendering as healthy.
+pub(crate) fn view_from_row(row: ToolServiceHealthStateRow) -> Result<MCPServiceHealthView> {
+    let display_state = ToolServiceHealthState::parse_opt(row.status.as_deref())
+        .ok_or_else(|| {
+            anyhow!(
+                "ToolServiceHealthState row for service_id={:?} has missing/unrecognized status {:?}",
+                row.service_id,
+                row.status
+            )
+        })?
+        .project()
+        .as_str()
+        .to_string();
+
+    Ok(MCPServiceHealthView {
         service_id: row.service_id,
         agent_did: row.agent_did,
         endpoint: row.endpoint,
         status: row.status,
+        display_state,
         tool_count: row.tool_count,
         failure_count: row.failure_count,
         k_max: row.k_max,
@@ -92,7 +112,7 @@ fn view_from_row(row: ToolServiceHealthStateRow) -> MCPServiceHealthView {
         last_error_class: row.last_error_class,
         last_error_message: row.last_error_message,
         updated_at: row.updated_at,
-    }
+    })
 }
 
 pub async fn probe_mcp_service(

--- a/crates/gents-desktop-bridge/src/contract.rs
+++ b/crates/gents-desktop-bridge/src/contract.rs
@@ -7,6 +7,9 @@ use ts_rs::TS;
 use crate::error::BridgeErrorCode;
 
 /// Exact `MAJOR.MINOR` contract version. The client accepts no version range.
+// 6.2: additive — MCPServiceHealthView.displayState is the projected
+//      three-state MCP health classification (ToolServiceHealthState::project);
+//      the desktop no longer re-derives a synthetic "stuck" state from status.
 // 6.1: additive — DesktopInitSummary is generated from the Rust struct
 //      (camelCase wire shape) instead of a hand-written TS mirror (#1340).
 // 6.0: breaking — exact-version matching, single-owner client state, and
@@ -45,13 +48,13 @@ use crate::error::BridgeErrorCode;
 // grantable [[set]] entries + default (core/client-lifecycle).
 // 0.3: BridgeError on command Err paths; SnapshotGrants projection; native-e2e.
 // 0.2: desktop_bridge_contract, desktop_peer_probe_address; peer_status by id.
-pub const CONTRACT_VERSION: &str = "6.1";
+pub const CONTRACT_VERSION: &str = "6.2";
 
 /// Exact digest of the committed generated TypeScript wire tree. The client
 /// checks this in addition to semantic versioning, so a DTO shape change
 /// cannot silently ship under an unchanged contract version.
 pub const WIRE_SCHEMA_HASH: &str =
-    "67594ec0a37b28e01076fc29b20bf04a87a76f51373c698a156bc0a7b9d90a02";
+    "df5cd8234a352627975cc23f8b8f258d7d0675a4c544d4a8f8b02b930f35010e";
 
 /// Package version string shared with workspace release train.
 pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/gents-desktop-bridge/src/snapshot/tests/mcp_health.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/tests/mcp_health.rs
@@ -7,7 +7,7 @@ use lean_vocab_test::lean_mcp_health_cases;
 use crate::commands::mcp_health::view_from_row;
 
 /// Translate an internal Lean `HealthState` name to the DefraDB-persisted
-/// string vocabulary used by `health_checker::HealthStateInternal::to_defradb`.
+/// string vocabulary used by `gents_protocol::tool_service_health::ToolServiceHealthState::as_str`.
 /// Identity for every internal state — the persisted vocabulary mirrors
 /// `Proofs/MCPHealth/State.lean :: HealthState.toDefraDB` exactly. The
 /// public `HealthStatus` collapse (degraded → stale, evicted+reconnecting

--- a/crates/gents-desktop-bridge/src/snapshot/tests/mcp_health.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/tests/mcp_health.rs
@@ -4,7 +4,7 @@ mod lean_vocab_test;
 use gents_protocol::row::ToolServiceHealthStateRow;
 use lean_vocab_test::lean_mcp_health_cases;
 
-use crate::types::MCPServiceHealthView;
+use crate::commands::mcp_health::view_from_row;
 
 /// Translate an internal Lean `HealthState` name to the DefraDB-persisted
 /// string vocabulary used by `health_checker::HealthStateInternal::to_defradb`.
@@ -54,24 +54,6 @@ fn row_from_lean(case_name: &str, state: &str, count: usize) -> ToolServiceHealt
     }
 }
 
-fn view_from_row(row: &ToolServiceHealthStateRow) -> MCPServiceHealthView {
-    MCPServiceHealthView {
-        service_id: row.service_id.clone(),
-        agent_did: row.agent_did.clone(),
-        endpoint: row.endpoint.clone(),
-        status: row.status.clone(),
-        tool_count: row.tool_count,
-        failure_count: row.failure_count,
-        k_max: row.k_max,
-        backoff_until: row.backoff_until.clone(),
-        last_probe_at: row.last_probe_at.clone(),
-        last_seen: row.last_seen.clone(),
-        last_error_class: row.last_error_class.clone(),
-        last_error_message: row.last_error_message.clone(),
-        updated_at: row.updated_at.clone(),
-    }
-}
-
 #[test]
 fn mcp_health_view_preserves_every_generated_lean_mcp_health_case_transition() {
     let cases = lean_mcp_health_cases();
@@ -90,7 +72,12 @@ fn mcp_health_view_preserves_every_generated_lean_mcp_health_case_transition() {
         };
 
         let row = row_from_lean(&case.name, next_state, next_count);
-        let view = view_from_row(&row);
+        let view = view_from_row(row).unwrap_or_else(|error| {
+            panic!(
+                "Lean MCP health case {} row must project to a view: {error}",
+                case.name
+            )
+        });
 
         let expected_persisted_status = lean_state_to_defradb_status(next_state);
         assert_eq!(
@@ -112,15 +99,9 @@ fn mcp_health_view_preserves_every_generated_lean_mcp_health_case_transition() {
         );
 
         if let Some(projection) = case.rust_projection.as_deref() {
-            let view_projection = match view.status.as_deref().unwrap_or("") {
-                "healthy" => "healthy",
-                "degraded" => "stale",
-                "evicted" | "reconnecting" => "unreachable",
-                other => panic!("unexpected view status {other:?}"),
-            };
             assert_eq!(
-                view_projection, projection,
-                "Lean MCP health case {} HealthStatus projection must agree with view collapse",
+                view.display_state, projection,
+                "Lean MCP health case {} HealthStatus projection must agree with the bridge's display_state",
                 case.name,
             );
         }

--- a/crates/gents-desktop-bridge/src/types/views/operations.rs
+++ b/crates/gents-desktop-bridge/src/types/views/operations.rs
@@ -268,10 +268,12 @@ pub struct InferenceCallSummaryView {
 /// desktop sees the K-model state evolve over time without needing an
 /// in-process agent runtime.
 ///
-/// `status` is the internal `HealthStateInternal` projection
-/// (`healthy` / `stale` / `evicted` / `reconnecting`) so the operator UI
-/// can distinguish back-off from in-flight retry; the public three-state
-/// `HealthStatus` collapses `evicted` and `reconnecting` to `unreachable`.
+/// `status` is the internal `ToolServiceHealthState` vocabulary
+/// (`healthy` / `degraded` / `evicted` / `reconnecting`) so the operator UI
+/// can distinguish back-off from in-flight retry; `display_state` is the
+/// collapsed three-state projection (`healthy` / `stale` / `unreachable`),
+/// projection owned by `ToolServiceHealthState::project` — the panel and
+/// table classify against `display_state` only, never `status`.
 #[derive(Debug, Clone, PartialEq, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
 pub struct MCPServiceHealthView {
@@ -279,6 +281,7 @@ pub struct MCPServiceHealthView {
     pub agent_did: Option<String>,
     pub endpoint: Option<String>,
     pub status: Option<String>,
+    pub display_state: String,
     pub tool_count: Option<i64>,
     pub failure_count: Option<i64>,
     pub k_max: Option<i64>,

--- a/crates/gents-protocol/src/lib.rs
+++ b/crates/gents-protocol/src/lib.rs
@@ -13,4 +13,5 @@ pub mod row;
 pub mod schemas;
 pub mod session_hydration;
 pub mod timeline;
+pub mod tool_service_health;
 pub mod transcript;

--- a/crates/gents-protocol/src/row.rs
+++ b/crates/gents-protocol/src/row.rs
@@ -1028,13 +1028,13 @@ pub struct ToolServiceRegistryRow {
 }
 
 /// Persisted snapshot of one MCP service's health, written by the agent's
-/// `health_checker` on every probe cycle. `status` carries the precise
-/// `HealthStateInternal` projection ("healthy" / "stale" / "evicted" /
-/// "reconnecting") so the operator UI can distinguish back-off from
-/// in-flight retry without going through the collapsed three-state
-/// `HealthStatus`. `failure_count` / `k_max` / `backoff_until` give the
-/// K-model context per the design in
-/// `Proofs/MCPHealth/{State,Transition}.lean`.
+/// `health_checker` on every probe cycle. `status` carries the raw
+/// `ToolServiceHealthState` vocabulary ("healthy" / "degraded" / "evicted" /
+/// "reconnecting"; see `tool_service_health::ToolServiceHealthState`) so the
+/// operator UI can distinguish back-off from in-flight retry without going
+/// through the collapsed three-state `ToolServiceHealthProjection`.
+/// `failure_count` / `k_max` / `backoff_until` give the K-model context per
+/// the design in `Proofs/MCPHealth/{State,Transition}.lean`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolServiceHealthStateRow {
     pub service_id: String,

--- a/crates/gents-protocol/src/tool_service_health.rs
+++ b/crates/gents-protocol/src/tool_service_health.rs
@@ -1,0 +1,174 @@
+//! `ToolServiceHealthState`: the single Rust owner of MCP health vocabulary
+//! and its projection to the collapsed operator-facing status.
+//!
+//! One column (`status` on `ToolServiceHealthState`), one enum. Source of
+//! truth: the Lean `HealthState` model in
+//! `crates/gents/proofs/Proofs/MCPHealth/State.lean` — `as_str` here must
+//! stay byte-identical to that model's `toDefraDB`, which the
+//! `lean_vocab_test` fence in `crates/gents/src/health_checker.rs` checks
+//! against this crate's `ALL`/`as_str`.
+
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+/// The full internal MCP service health state, persisted verbatim to the
+/// `ToolServiceHealthState` DefraDB collection's `status` column.
+///
+/// Distinct from [`ToolServiceHealthProjection`]: operators reading the raw
+/// row can tell the staleness flavor of degraded (heartbeat lag,
+/// `failure_count == 0`) from the failure-count flavor
+/// (`1 <= failure_count < K`), and can see `Evicted` vs. `Reconnecting`
+/// separately even though both collapse to `Unreachable` downstream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolServiceHealthState {
+    Healthy,
+    Degraded,
+    Evicted,
+    Reconnecting,
+}
+
+/// The collapsed three-state projection every consumer (CLI totals, desktop
+/// panel, `HealthStatus`) classifies against. Owned entirely by
+/// [`ToolServiceHealthState::project`] — no other layer re-derives it from
+/// raw status strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolServiceHealthProjection {
+    Healthy,
+    Stale,
+    Unreachable,
+}
+
+impl ToolServiceHealthState {
+    pub const ALL: [Self; 4] = [
+        Self::Healthy,
+        Self::Degraded,
+        Self::Evicted,
+        Self::Reconnecting,
+    ];
+
+    /// String form persisted to the `ToolServiceHealthState` DefraDB
+    /// collection. Mirrors `HealthState.toDefraDB` in
+    /// `Proofs/MCPHealth/State.lean` exactly.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Degraded => "degraded",
+            Self::Evicted => "evicted",
+            Self::Reconnecting => "reconnecting",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, InvalidToolServiceHealthState> {
+        match value {
+            "healthy" => Ok(Self::Healthy),
+            "degraded" => Ok(Self::Degraded),
+            "evicted" => Ok(Self::Evicted),
+            "reconnecting" => Ok(Self::Reconnecting),
+            _ => Err(InvalidToolServiceHealthState {
+                state: value.to_string(),
+            }),
+        }
+    }
+
+    pub fn parse_opt(value: Option<&str>) -> Option<Self> {
+        value.and_then(|value| Self::parse(value).ok())
+    }
+
+    /// Collapse to the operator-facing three-state projection.
+    /// `Healthy` -> `Healthy`, `Degraded` -> `Stale`,
+    /// `Evicted` | `Reconnecting` -> `Unreachable`.
+    pub const fn project(self) -> ToolServiceHealthProjection {
+        match self {
+            Self::Healthy => ToolServiceHealthProjection::Healthy,
+            Self::Degraded => ToolServiceHealthProjection::Stale,
+            Self::Evicted | Self::Reconnecting => ToolServiceHealthProjection::Unreachable,
+        }
+    }
+}
+
+impl ToolServiceHealthProjection {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Healthy => "healthy",
+            Self::Stale => "stale",
+            Self::Unreachable => "unreachable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidToolServiceHealthState {
+    state: String,
+}
+
+impl InvalidToolServiceHealthState {
+    pub fn value(&self) -> &str {
+        &self.state
+    }
+}
+
+impl Display for InvalidToolServiceHealthState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid tool service health state: {}", self.state)
+    }
+}
+
+impl Error for InvalidToolServiceHealthState {}
+
+impl TryFrom<&str> for ToolServiceHealthState {
+    type Error = InvalidToolServiceHealthState;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl Display for ToolServiceHealthState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl Display for ToolServiceHealthProjection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_str_round_trips_for_every_state() {
+        for state in ToolServiceHealthState::ALL {
+            assert_eq!(ToolServiceHealthState::parse(state.as_str()), Ok(state));
+        }
+    }
+
+    #[test]
+    fn projection_table_matches_health_checker() {
+        use ToolServiceHealthProjection as P;
+        use ToolServiceHealthState::*;
+        assert_eq!(Healthy.project(), P::Healthy);
+        assert_eq!(Degraded.project(), P::Stale);
+        assert_eq!(Evicted.project(), P::Unreachable);
+        assert_eq!(Reconnecting.project(), P::Unreachable);
+    }
+
+    #[test]
+    fn projection_words_are_not_valid_states() {
+        assert!(ToolServiceHealthState::parse("stale").is_err());
+        assert!(ToolServiceHealthState::parse("unreachable").is_err());
+    }
+
+    #[test]
+    fn parse_opt_rejects_missing_and_unknown() {
+        assert_eq!(ToolServiceHealthState::parse_opt(None), None);
+        assert_eq!(ToolServiceHealthState::parse_opt(Some("bogus")), None);
+        assert_eq!(
+            ToolServiceHealthState::parse_opt(Some("healthy")),
+            Some(ToolServiceHealthState::Healthy)
+        );
+    }
+}

--- a/crates/gents/src/health_checker.rs
+++ b/crates/gents/src/health_checker.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
+use gents_protocol::tool_service_health::ToolServiceHealthProjection;
+
 use crate::graphql::escape_graphql_string;
 use crate::mcp_pool::{resolve_mcp_url, McpPool};
 
@@ -61,6 +63,16 @@ impl std::fmt::Display for HealthStatus {
     }
 }
 
+impl From<ToolServiceHealthProjection> for HealthStatus {
+    fn from(projection: ToolServiceHealthProjection) -> Self {
+        match projection {
+            ToolServiceHealthProjection::Healthy => Self::Healthy,
+            ToolServiceHealthProjection::Stale => Self::Stale,
+            ToolServiceHealthProjection::Unreachable => Self::Unreachable,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ServiceHealthEntry {
     health: ServiceHealth,
@@ -94,7 +106,7 @@ impl ServiceHealthEntry {
     ) -> Self {
         Self {
             health: ServiceHealth {
-                status: model.state.project(),
+                status: model.state.project().into(),
                 last_seen,
                 last_error,
             },
@@ -106,46 +118,13 @@ impl ServiceHealthEntry {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HealthStateInternal {
-    Healthy,
-    Degraded,
-    Evicted,
-    Reconnecting,
-}
-
-impl HealthStateInternal {
-    fn project(self) -> HealthStatus {
-        match self {
-            Self::Healthy => HealthStatus::Healthy,
-            Self::Degraded => HealthStatus::Stale,
-            Self::Evicted | Self::Reconnecting => HealthStatus::Unreachable,
-        }
-    }
-
-    /// String form persisted to the `ToolServiceHealthState` DefraDB
-    /// collection. Mirrors `HealthState.toDefraDB` in
-    /// `Proofs/MCPHealth/State.lean` exactly — including `degraded` rather
-    /// than the public `HealthStatus::Stale` projection name. Operators read
-    /// the precise internal-state vocabulary so the panel can distinguish
-    /// the staleness flavor of degraded (heartbeat lag, `failure_count = 0`)
-    /// from the failure-count flavor (`1 <= failure_count < K`).
-    ///
-    /// `Reconnecting` is reachable only via `ProbeEvent::BackoffExpiry` in
-    /// the Lean model; the production cycle does not emit that event today
-    /// (the loop skips while backoff is active, then probes directly), so
-    /// rows with `status: "reconnecting"` will only appear once the cycle
-    /// is extended to bridge the gap. The persisted vocabulary covers it
-    /// so future production emission needs no schema change.
-    fn to_defradb(self) -> &'static str {
-        match self {
-            Self::Healthy => "healthy",
-            Self::Degraded => "degraded",
-            Self::Evicted => "evicted",
-            Self::Reconnecting => "reconnecting",
-        }
-    }
-}
+/// `Reconnecting` is reachable only via `ProbeEvent::BackoffExpiry` in the
+/// Lean model; the production cycle does not emit that event today (the
+/// loop skips while backoff is active, then probes directly), so rows with
+/// `status: "reconnecting"` will only appear once the cycle is extended to
+/// bridge the gap. The persisted vocabulary covers it so future production
+/// emission needs no schema change.
+type HealthStateInternal = gents_protocol::tool_service_health::ToolServiceHealthState;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ServiceModelInternal {
@@ -249,7 +228,7 @@ impl ServiceHealthMap {
             .map(|(service_id, entry)| MCPServiceHealthSnapshot {
                 service_id: service_id.clone(),
                 endpoint: entry.endpoint.clone(),
-                status: entry.model.state.to_defradb().to_string(),
+                status: entry.model.state.as_str().to_string(),
                 tool_count: entry.tool_count,
                 failure_count: entry.model.failure_count,
                 k_max,
@@ -1011,25 +990,16 @@ mod tests {
     use crate::mcp_pool::McpPool;
 
     fn health_state_from_lean(case: &LeanMcpHealthCase, state: &str) -> HealthStateInternal {
-        match state {
-            "healthy" => HealthStateInternal::Healthy,
-            "degraded" => HealthStateInternal::Degraded,
-            "evicted" => HealthStateInternal::Evicted,
-            "reconnecting" => HealthStateInternal::Reconnecting,
-            other => panic!(
+        HealthStateInternal::parse(state).unwrap_or_else(|_| {
+            panic!(
                 "Lean MCP health case {} produced unknown state {:?}",
-                case.name, other
-            ),
-        }
+                case.name, state
+            )
+        })
     }
 
     fn health_state_name(state: HealthStateInternal) -> &'static str {
-        match state {
-            HealthStateInternal::Healthy => "healthy",
-            HealthStateInternal::Degraded => "degraded",
-            HealthStateInternal::Evicted => "evicted",
-            HealthStateInternal::Reconnecting => "reconnecting",
-        }
+        state.as_str()
     }
 
     fn probe_event_from_lean(case: &LeanMcpHealthCase) -> ProbeEvent {

--- a/crates/gents/src/tool_surface/build.rs
+++ b/crates/gents/src/tool_surface/build.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 use defra_node::EmbeddedNode;
+use gents_protocol::tool_service_health::{ToolServiceHealthProjection, ToolServiceHealthState};
 
 use crate::toolset::{
     default_read_only_command_policy, CommandExecutionMode, CommandExecutionPolicy, ToolSet,
@@ -468,9 +469,11 @@ pub(super) async fn online_mcp_service_ids(node: &EmbeddedNode) -> Result<Vec<St
 }
 
 /// MCP services whose operator registry row is online and whose agent-scoped
-/// measured health permits calls. `degraded` remains callable (the normal
-/// health gate warns but proceeds); `evicted`, `reconnecting`, and missing
-/// measurements do not satisfy a required-service dependency.
+/// measured health permits calls, per `ToolServiceHealthState::project`
+/// (the single owner of the classification): `Healthy` and `Stale` remain
+/// callable (the normal health gate warns but proceeds on `Stale`);
+/// `Unreachable` and missing/unrecognized measurements do not satisfy a
+/// required-service dependency.
 pub(crate) async fn measured_available_mcp_service_ids(
     node: &EmbeddedNode,
     agent_did: &str,
@@ -582,7 +585,12 @@ pub(crate) async fn measured_available_mcp_service_ids(
             let service_id = row.get("service_id")?.as_str()?.trim();
             let endpoint = row.get("endpoint")?.as_str()?.trim();
             let status = row.get("status")?.as_str()?.trim();
-            (matches!(status, "healthy" | "degraded")
+            let callable = matches!(
+                ToolServiceHealthState::parse_opt(Some(status))
+                    .map(ToolServiceHealthState::project),
+                Some(ToolServiceHealthProjection::Healthy | ToolServiceHealthProjection::Stale)
+            );
+            (callable
                 && expected_endpoints
                     .get(service_id)
                     .is_some_and(|endpoints| endpoints.contains(endpoint)))

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,9 +15,9 @@ export type DesktopBridgeContract = GeneratedBridgeContract;
 export const PACKAGE_VERSION = "0.15.0";
 // The client and bridge share one exact breaking contract. Sync status comes
 // from database-owned gauges; goal permissions are explicit fields.
-export const BRIDGE_CONTRACT_VERSION = "6.1";
+export const BRIDGE_CONTRACT_VERSION = "6.2";
 export const EXPECTED_BRIDGE_WIRE_SCHEMA_HASH =
-  "67594ec0a37b28e01076fc29b20bf04a87a76f51373c698a156bc0a7b9d90a02";
+  "df5cd8234a352627975cc23f8b8f258d7d0675a4c544d4a8f8b02b930f35010e";
 
 export function assertExactBridgeContract(
   contract: DesktopBridgeContract,

--- a/packages/gents-desktop-client/src/generated/MCPServiceHealthView.ts
+++ b/packages/gents-desktop-client/src/generated/MCPServiceHealthView.ts
@@ -8,9 +8,11 @@
  * desktop sees the K-model state evolve over time without needing an
  * in-process agent runtime.
  *
- * `status` is the internal `HealthStateInternal` projection
- * (`healthy` / `stale` / `evicted` / `reconnecting`) so the operator UI
- * can distinguish back-off from in-flight retry; the public three-state
- * `HealthStatus` collapses `evicted` and `reconnecting` to `unreachable`.
+ * `status` is the internal `ToolServiceHealthState` vocabulary
+ * (`healthy` / `degraded` / `evicted` / `reconnecting`) so the operator UI
+ * can distinguish back-off from in-flight retry; `display_state` is the
+ * collapsed three-state projection (`healthy` / `stale` / `unreachable`),
+ * projection owned by `ToolServiceHealthState::project` — the panel and
+ * table classify against `display_state` only, never `status`.
  */
-export type MCPServiceHealthView = { serviceId: string, agentDid: string | null, endpoint: string | null, status: string | null, toolCount: number | null, failureCount: number | null, kMax: number | null, backoffUntil: string | null, lastProbeAt: string | null, lastSeen: string | null, lastErrorClass: string | null, lastErrorMessage: string | null, updatedAt: string | null, };
+export type MCPServiceHealthView = { serviceId: string, agentDid: string | null, endpoint: string | null, status: string | null, displayState: string, toolCount: number | null, failureCount: number | null, kMax: number | null, backoffUntil: string | null, lastProbeAt: string | null, lastSeen: string | null, lastErrorClass: string | null, lastErrorMessage: string | null, updatedAt: string | null, };

--- a/packages/gents-desktop-operations/src/components/mcpHealth/McpHealthPanelView.tsx
+++ b/packages/gents-desktop-operations/src/components/mcpHealth/McpHealthPanelView.tsx
@@ -42,7 +42,6 @@ export function McpHealthPanelView({
       degraded: 0,
       reconnecting: 0,
       evicted: 0,
-      stuck: 0,
       unknown: 0,
     };
     for (const service of services) {
@@ -55,7 +54,7 @@ export function McpHealthPanelView({
   const filterCounts = useMemo(() => {
     const all = services.length;
     const unhealthy = services.filter(
-      (s) => projectStatus(visualState(s)) !== "healthy",
+      (s) => projectStatus(s) !== "healthy",
     ).length;
     const reconnecting = services.filter(
       (s) => visualState(s) === "reconnecting",

--- a/packages/gents-desktop-operations/src/components/mcpHealth/McpHealthSummary.tsx
+++ b/packages/gents-desktop-operations/src/components/mcpHealth/McpHealthSummary.tsx
@@ -23,7 +23,6 @@ export function McpHealthSummary({
         label="reconnecting"
       />
       <SummaryPill color="red" count={summary.evicted} label="evicted" />
-      <SummaryPill color="red" count={summary.stuck} label="stuck" />
       {summary.unknown > 0 ? (
         <SummaryPill color="gray" count={summary.unknown} label="unknown" />
       ) : null}

--- a/packages/gents-desktop-operations/src/components/mcpHealth/McpHealthTable.tsx
+++ b/packages/gents-desktop-operations/src/components/mcpHealth/McpHealthTable.tsx
@@ -100,6 +100,7 @@ function ServiceRows({
         : visual === "reconnecting"
           ? "blue"
           : "red";
+  const projection = projectStatus(service);
   const k = service.kMax ?? 0;
   const fc = service.failureCount ?? 0;
   const probeText = probeOutcome
@@ -147,7 +148,7 @@ function ServiceRows({
               className={`mcp-health-dot mcp-health-dot-${dotClass} mcp-health-dot-${visual}`}
               aria-hidden
             />
-            {statusLabel(visual)}
+            {statusLabel(projection)}
           </span>
         </td>
         <td>
@@ -224,7 +225,7 @@ function ServiceRows({
                     "status",
                     `${service.status ?? "unknown"} (visual: ${visual})`,
                   ],
-                  ["projected status", projectStatus(visual)],
+                  ["projected status", projection],
                   ["failure_count", `${fc} / ${k} (K)`],
                   ["backoff_until", service.backoffUntil ?? "—"],
                   ["last_probe_at", service.lastProbeAt ?? "—"],

--- a/packages/gents-desktop-operations/src/components/mcpHealth/mcpHealthModel.test.ts
+++ b/packages/gents-desktop-operations/src/components/mcpHealth/mcpHealthModel.test.ts
@@ -9,36 +9,64 @@ function service(
   return {
     serviceId: "svc-1",
     status: "healthy",
+    displayState: "healthy",
     failureCount: 0,
     kMax: 3,
     lastSeen: new Date().toISOString(),
     ...overrides,
-  };
+  } as MCPServiceHealthView;
 }
 
 describe("mcpHealthModel", () => {
-  it("projects stale rows into degraded visual state", () => {
-    const visual = visualState(service({ status: "stale" }));
-
-    expect(visual).toBe("degraded");
-    expect(projectStatus(visual)).toBe("stale");
-  });
-
-  it("marks evicted services as stuck when failure count exceeds two K", () => {
-    const visual = visualState(
-      service({ status: "evicted", failureCount: 6, kMax: 3 }),
+  it("visualState mirrors the raw persisted status, normalizing legacy stale", () => {
+    expect(visualState(service({ status: "stale" }))).toBe("degraded");
+    expect(visualState(service({ status: "evicted" }))).toBe("evicted");
+    expect(visualState(service({ status: "reconnecting" }))).toBe(
+      "reconnecting",
     );
-
-    expect(visual).toBe("stuck");
-    expect(projectStatus(visual)).toBe("unreachable");
+    expect(visualState(service({ status: null }))).toBe("unknown");
   });
 
-  it("matches reconnecting filter only for reconnecting visual state", () => {
+  it("projectStatus is a pass-through of the server-projected displayState", () => {
+    expect(projectStatus(service({ displayState: "healthy" }))).toBe(
+      "healthy",
+    );
+    expect(projectStatus(service({ displayState: "stale" }))).toBe("stale");
+    expect(projectStatus(service({ displayState: "unreachable" }))).toBe(
+      "unreachable",
+    );
+  });
+
+  it("projectStatus falls back to unknown for a missing/unrecognized displayState", () => {
+    expect(
+      projectStatus(service({ displayState: undefined as unknown as string })),
+    ).toBe("unknown");
+    expect(
+      projectStatus(service({ displayState: "bogus" as unknown as string })),
+    ).toBe("unknown");
+  });
+
+  it("matches reconnecting filter only for reconnecting raw status", () => {
     expect(
       matchesFilter(service({ status: "reconnecting" }), "reconnecting"),
     ).toBe(true);
     expect(matchesFilter(service({ status: "evicted" }), "reconnecting")).toBe(
       false,
     );
+  });
+
+  it("matches unhealthy filter off the projected displayState, not the raw status", () => {
+    expect(
+      matchesFilter(
+        service({ status: "evicted", displayState: "unreachable" }),
+        "unhealthy",
+      ),
+    ).toBe(true);
+    expect(
+      matchesFilter(
+        service({ status: "healthy", displayState: "healthy" }),
+        "unhealthy",
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/gents-desktop-operations/src/components/mcpHealth/mcpHealthModel.ts
+++ b/packages/gents-desktop-operations/src/components/mcpHealth/mcpHealthModel.ts
@@ -3,18 +3,18 @@ import type { MCPServiceHealthView } from "@source-inc/gents-desktop-client";
 export type FilterId = "all" | "unhealthy" | "reconnecting";
 
 export type VisualState =
-  "healthy" | "degraded" | "evicted" | "reconnecting" | "stuck" | "unknown";
+  "healthy" | "degraded" | "evicted" | "reconnecting" | "unknown";
 
+export type DisplayProjection = "healthy" | "stale" | "unreachable" | "unknown";
+
+// Raw persisted `status` typed for presentation (dot color, CSS class).
+// This mirrors the server's raw vocabulary verbatim — it does not
+// classify or invent any state. The single owner of MCP health
+// classification is `MCPServiceHealthView.displayState`
+// (`ToolServiceHealthState::project` in Rust); see `projectStatus`.
 export function visualState(service: MCPServiceHealthView): VisualState {
   const raw = (service.status ?? "").toLowerCase();
   const status = raw === "stale" ? "degraded" : raw;
-  const failureCount = service.failureCount ?? 0;
-  const kMax = service.kMax ?? 1;
-  const stuck =
-    (status === "evicted" || status === "reconnecting") &&
-    (failureCount >= 2 * Math.max(1, kMax) ||
-      isLastSeenOlderThan(service, 5 * 60_000));
-  if (stuck) return "stuck";
   switch (status) {
     case "healthy":
       return "healthy";
@@ -29,29 +29,30 @@ export function visualState(service: MCPServiceHealthView): VisualState {
   }
 }
 
-export function projectStatus(
-  visual: VisualState,
-): "healthy" | "stale" | "unreachable" | "unknown" {
-  if (visual === "healthy") return "healthy";
-  if (visual === "degraded") return "stale";
-  if (visual === "evicted" || visual === "reconnecting" || visual === "stuck") {
-    return "unreachable";
+// Pass-through of the server-projected `displayState`. This is the only
+// classification the desktop performs — no TS heuristic re-derives it
+// from `status`/`failureCount`/`lastSeen`. The `"unknown"` fallback is
+// the single place a missing/unrecognized `displayState` is handled.
+export function projectStatus(service: MCPServiceHealthView): DisplayProjection {
+  const displayState = service.displayState;
+  if (
+    displayState === "healthy" ||
+    displayState === "stale" ||
+    displayState === "unreachable"
+  ) {
+    return displayState;
   }
   return "unknown";
 }
 
-export function statusLabel(visual: VisualState): string {
-  switch (visual) {
+export function statusLabel(projection: DisplayProjection): string {
+  switch (projection) {
     case "healthy":
       return "healthy";
-    case "degraded":
-      return "degraded";
-    case "evicted":
-      return "evicted (backoff)";
-    case "reconnecting":
-      return "reconnecting";
-    case "stuck":
-      return "stuck";
+    case "stale":
+      return "stale";
+    case "unreachable":
+      return "unreachable";
     default:
       return "unknown";
   }
@@ -62,9 +63,8 @@ export function matchesFilter(
   filter: FilterId,
 ): boolean {
   if (filter === "all") return true;
-  const visual = visualState(service);
-  if (filter === "unhealthy") return projectStatus(visual) !== "healthy";
-  if (filter === "reconnecting") return visual === "reconnecting";
+  if (filter === "unhealthy") return projectStatus(service) !== "healthy";
+  if (filter === "reconnecting") return visualState(service) === "reconnecting";
   return true;
 }
 
@@ -98,16 +98,6 @@ export function backoffRemaining(backoffUntil: string | null | undefined): {
   const remainingMs = target - Date.now();
   if (remainingMs <= 0) return { remainingMs: 0, text: "backoff expired" };
   return { remainingMs, text: `retry in ${formatRemaining(remainingMs)}` };
-}
-
-function isLastSeenOlderThan(
-  service: MCPServiceHealthView,
-  ms: number,
-): boolean {
-  if (!service.lastSeen) return false;
-  const ts = Date.parse(service.lastSeen);
-  if (Number.isNaN(ts)) return false;
-  return Date.now() - ts > ms;
 }
 
 function formatRemaining(ms: number): string {


### PR DESCRIPTION
Closes #1333. Stacked on #1353 (base branch `so/1332-backend-availability`).

## What changed

MCP tool-service health has one classification, computed in Rust and shipped on the wire.

- `gents_protocol::tool_service_health::ToolServiceHealthState` (persisted vocabulary `healthy | degraded | evicted | reconnecting`, strict parse) with `project()` to `healthy | stale | unreachable`; the runtime's Lean-mirrored `HealthStateInternal` uses it, and the `toDefraDB` vocabulary fence still passes.
- `MCPServiceHealthView.displayState` carries the projection (bridge contract 6.1 → 6.2, additive; a row with an unknown persisted status is an error, not `unknown`). The desktop's `mcpHealthModel.ts` keeps labels and glyphs only: the client-side re-bucketing and the synthetic `stuck` state (invented from a five-minute wall clock and a failure-count heuristic, ignoring the server's `backoff_until`) are deleted. This is the same anti-pattern the client sync cutover removed for `stalled`.
- The CLI's MCP pool totals bucket by the owned projection.
- The gate's grep found a fourth classifier in `tool_surface/build.rs` (`measured_available_mcp_service_ids`); it now reads the owned projection too.

## Net code

The new shared module in `gents-protocol` and its tests add lines; the runtime classifier, the CLI re-bucketing, and the TS heuristic are deletions. Production code outside the new owner is roughly flat.

## Verification

Protocol round-trip and projection tests; bridge `view_from_row` test; TS `projectStatus` tests; `cargo test -p gents --lib health_checker lean_vocab`, `cargo test -p gents-protocol`, `cargo test -p gents-cli --lib http::mcp_pool`, `cargo test -p gents-desktop-bridge -p gents-desktop-core`, TS build/tests, `cargo check --workspace --all-targets`, `cargo fmt --all --check`. CHANGELOG Unreleased carries the contract line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eatk66c9sS6vPq2nasHJVd
