### PR TITLE
One subagent tree builder in gents; one deadline-expiry predicate (#1334)

### DIFF
--- a/apps/gents-desktop/src-tauri/src/bin/bridge_runner/http/routes.rs
+++ b/apps/gents-desktop/src-tauri/src/bin/bridge_runner/http/routes.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use gents::backend_registry::{derive_display_state, list_all_backends};
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
+use gents::subagent_tree::{build_local_subagent_tree, effective_subagent_tree_max_depth};
 use gents_desktop_core::client::ClientCore;
 use gents_desktop_core::local_runtime::fetch_runtime_connection_payload;
 use serde::{Deserialize, Serialize};
@@ -29,11 +30,8 @@ use gents_desktop_bridge::commands::{
 use gents_desktop_bridge::snapshot::operations_snapshot::{
     project_backgrounded_tools, stuck_diagnostics_from_tool_calls, ToolCallRow,
 };
-use gents_desktop_bridge::snapshot::subagent_tree::{
-    build_local_subagent_tree, effective_subagent_tree_max_depth,
-};
 use gents_desktop_bridge::tauri_commands::operations::{
-    list_tool_call_holds_for_core, resolve_tool_call_hold_for_core,
+    list_tool_call_holds_for_core, resolve_tool_call_hold_for_core, subagent_tree_view_from_gents,
 };
 use gents_desktop_bridge::types::{
     AgentConfigSaveRequest, BackendHealthView, BackendSaveRequest, BehaviorSaveRequest,
@@ -783,14 +781,15 @@ async fn list_subagent_tree_response(
     {
         anyhow::bail!("no agent selected; pass agentDid explicitly");
     }
-    build_local_subagent_tree(
+    let tree = build_local_subagent_tree(
         core.node_arc(),
         root_request_id,
         request.include_terminal.unwrap_or(false),
         effective_subagent_tree_max_depth(request.max_depth),
     )
     .await
-    .context("local subagent tree query failed")
+    .context("local subagent tree query failed")?;
+    Ok(subagent_tree_view_from_gents(tree))
 }
 
 async fn list_backends_with_health(core: Arc<ClientCore>) -> Result<Vec<BackendHealthView>> {

--- a/crates/gents-cli/src/http/fleet_slots.rs
+++ b/crates/gents-cli/src/http/fleet_slots.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use gents::tool_call_lifecycle::deadline_is_expired;
 use gents::{call_state_holds_backend_slot, UNKNOWN_PROBE_STATUS};
 use gents_protocol::row::{
     project_behavior_readiness_summary, AgentBehaviorReadinessRow, BehaviorReadinessState,
@@ -449,15 +450,6 @@ fn apply_call_state(call_state: &str, counts: &mut SlotCounts) {
     } else if call_state == "queued" {
         counts.queued += 1;
     }
-}
-
-fn deadline_is_expired(now: DateTime<Utc>, deadline: Option<&str>) -> bool {
-    let Some(deadline) = deadline.map(str::trim).filter(|value| !value.is_empty()) else {
-        return false;
-    };
-    DateTime::parse_from_rfc3339(deadline)
-        .map(|deadline| deadline.with_timezone(&Utc) < now)
-        .unwrap_or(false)
 }
 
 fn clean_optional_string(value: Option<&str>) -> String {

--- a/crates/gents-cli/src/http/liveness.rs
+++ b/crates/gents-cli/src/http/liveness.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use gents::tool_call_lifecycle::deadline_at_is_expired;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -97,7 +98,7 @@ pub(crate) fn compute_request_liveness_summary(
             let running_age_ms = started_at
                 .map(|started| millis_between(started, now).max(0))
                 .unwrap_or(0);
-            let deadline_expired = deadline_at.is_some_and(|deadline| now > deadline);
+            let deadline_expired = deadline_at_is_expired(now, deadline_at);
             ActiveToolCall {
                 request_id: row.request_id.clone(),
                 tool_call_id: row.tool_call_id.clone(),
@@ -122,7 +123,7 @@ pub(crate) fn compute_request_liveness_summary(
         active_request_ids.push(row.request_id.clone());
         let claimed_at = parse_optional_rfc3339(row.claimed_at.as_deref());
         let deadline = parse_optional_rfc3339(row.deadline.as_deref());
-        let deadline_expired = deadline.is_some_and(|deadline| now > deadline);
+        let deadline_expired = deadline_at_is_expired(now, deadline);
         if deadline_expired {
             expired_processing_count += 1;
         }

--- a/crates/gents-cli/src/http/subagent_tree.rs
+++ b/crates/gents-cli/src/http/subagent_tree.rs
@@ -78,8 +78,7 @@ pub(crate) async fn subagent_tree_handler(
         }
     };
     let include_terminal = query.include_terminal.unwrap_or(false);
-    let max_depth =
-        effective_subagent_tree_max_depth(query.max_depth.map(|value| value as u32));
+    let max_depth = effective_subagent_tree_max_depth(query.max_depth.map(|value| value as u32));
 
     match load_subagent_tree_snapshot(
         &state.graphql,
@@ -115,8 +114,7 @@ pub(crate) async fn load_subagent_tree_snapshot(
         label: None,
         access: ConfigAccess::Graphql(graphql.to_string()),
     }];
-    let tree = build_subagent_tree(&accesses, root_request_id, include_terminal, max_depth)
-        .await?;
+    let tree = build_subagent_tree(&accesses, root_request_id, include_terminal, max_depth).await?;
     if !tree.partial_errors.is_empty() {
         anyhow::bail!(tree.partial_errors.join("; "));
     }

--- a/crates/gents-cli/src/http/subagent_tree.rs
+++ b/crates/gents-cli/src/http/subagent_tree.rs
@@ -1,6 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
-
-use anyhow::{Context, Result};
+use anyhow::Result;
 use axum::{
     extract::{Query, State},
     http::{header, StatusCode},
@@ -8,19 +6,16 @@ use axum::{
     Json,
 };
 use chrono::Utc;
-use gents::{
-    graphql::escape_graphql_string, ConfigAccess, DescendantGraphAccess, DescendantQuery,
-    MAX_DESCENDANT_PAGE_LIMIT,
+use gents::config_client::ConfigAccess;
+use gents::subagent_tree::{
+    build_subagent_tree, effective_subagent_tree_max_depth, SubagentTreeAccess,
+    SubagentTreeEdge as OwnedSubagentTreeEdge, SubagentTreeNode as OwnedSubagentTreeNode,
 };
-use gents_protocol::client_protocol::RequestLifecycleState;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
-use crate::{http::router::RuntimeHttpState, post_graphql};
+use crate::http::router::RuntimeHttpState;
 
 const SNAPSHOT_SOURCE: &str = "graphql.subagent_tree";
-const DEFAULT_MAX_DEPTH: usize = 8;
-const HARD_MAX_DEPTH: usize = 32;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -67,32 +62,6 @@ pub(crate) struct SubagentTreeQuery {
     max_depth: Option<usize>,
 }
 
-#[derive(Debug, Deserialize)]
-struct RootRequestEnvelope {
-    #[serde(rename = "AgentRequest", default)]
-    requests: Vec<RequestRow>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct RequestRow {
-    #[serde(default)]
-    request_id: String,
-    #[serde(default)]
-    session_id: Option<String>,
-    #[serde(default)]
-    agent_did: Option<String>,
-    #[serde(default)]
-    behavior_id: Option<String>,
-    #[serde(default)]
-    lifecycle_state: Option<String>,
-    #[serde(default)]
-    subagent_depth: Option<i64>,
-    #[serde(default)]
-    caused_by_parent_request_id: Option<String>,
-    #[serde(default)]
-    caused_by_parent_tool_call_id: Option<String>,
-}
-
 pub(crate) async fn subagent_tree_handler(
     State(state): State<RuntimeHttpState>,
     Query(query): Query<SubagentTreeQuery>,
@@ -109,10 +78,8 @@ pub(crate) async fn subagent_tree_handler(
         }
     };
     let include_terminal = query.include_terminal.unwrap_or(false);
-    let max_depth = query
-        .max_depth
-        .map(|value| value.min(HARD_MAX_DEPTH))
-        .unwrap_or(DEFAULT_MAX_DEPTH);
+    let max_depth =
+        effective_subagent_tree_max_depth(query.max_depth.map(|value| value as u32));
 
     match load_subagent_tree_snapshot(
         &state.graphql,
@@ -132,6 +99,11 @@ pub(crate) async fn subagent_tree_handler(
     }
 }
 
+/// Delegates the graph walk to the owned `gents::subagent_tree` projector
+/// (#1334) against a single GraphQL access, then maps the result into this
+/// route's JSON DTO. A dead access surfaces the same way an inline query
+/// failure used to: as an `Err` the handler turns into a 500, since the CLI
+/// has exactly one access and nothing else can answer for it.
 pub(crate) async fn load_subagent_tree_snapshot(
     graphql: &str,
     root_request_id: &str,
@@ -139,181 +111,49 @@ pub(crate) async fn load_subagent_tree_snapshot(
     max_depth: usize,
 ) -> Result<SubagentTreeSnapshot> {
     let generated_at = Utc::now();
-    let mut nodes: BTreeMap<String, SubagentTreeNode> = BTreeMap::new();
-    if let Some(root) = fetch_root_request(graphql, root_request_id).await? {
-        nodes.insert(root.request_id.clone(), request_row_into_node(root));
-    }
-    let access = ConfigAccess::Graphql(graphql.to_string());
-    let mut canonical_edges = Vec::new();
-    let mut after = None;
-    loop {
-        let page = gents::resolve_descendant_graph(
-            DescendantGraphAccess::Config(&access),
-            &DescendantQuery {
-                after: after.clone(),
-                limit: MAX_DESCENDANT_PAGE_LIMIT,
-                ..DescendantQuery::all(root_request_id)
-            },
-        )
+    let accesses = [SubagentTreeAccess {
+        label: None,
+        access: ConfigAccess::Graphql(graphql.to_string()),
+    }];
+    let tree = build_subagent_tree(&accesses, root_request_id, include_terminal, max_depth)
         .await?;
-        canonical_edges.extend(page.edges);
-        if !page.has_more {
-            break;
-        }
-        after = page.next_cursor;
+    if !tree.partial_errors.is_empty() {
+        anyhow::bail!(tree.partial_errors.join("; "));
     }
-
-    let truncated = canonical_edges.iter().any(|edge| edge.depth > max_depth);
-    canonical_edges.retain(|edge| edge.depth <= max_depth);
-    let mut edges = canonical_edges
-        .iter()
-        .map(|edge| {
-            nodes.insert(
-                edge.child_request_id.clone(),
-                SubagentTreeNode {
-                    request_id: edge.child_request_id.clone(),
-                    session_id: edge.child_session_id.clone(),
-                    agent_did: edge.principal_did.clone(),
-                    behavior_id: edge.behavior_id.clone(),
-                    lifecycle_state: Some(edge.lifecycle_state.clone()),
-                    subagent_depth: Some(edge.depth as i64),
-                    caused_by_parent_request_id: Some(edge.immediate_parent_request_id.clone()),
-                    caused_by_parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
-                },
-            );
-            SubagentTreeEdge {
-                parent_request_id: edge.immediate_parent_request_id.clone(),
-                child_request_id: edge.child_request_id.clone(),
-                parent_tool_call_id: Some(edge.immediate_parent_tool_call_id.clone()),
-                tool_name: Some("spawn_subagent".to_string()),
-                await_mode: Some(edge.await_mode.clone()),
-                cancel_policy: edge.cancel_policy.clone(),
-                lifecycle_state: Some(edge.lifecycle_state.clone()),
-            }
-        })
-        .collect::<Vec<_>>();
-
-    if !include_terminal {
-        prune_terminal_subtrees(&mut nodes, &mut edges, root_request_id);
-    }
-
-    edges.sort_by(|left, right| {
-        (
-            left.parent_request_id.as_str(),
-            left.child_request_id.as_str(),
-        )
-            .cmp(&(
-                right.parent_request_id.as_str(),
-                right.child_request_id.as_str(),
-            ))
-    });
-
-    let nodes = nodes.into_values().collect::<Vec<_>>();
 
     Ok(SubagentTreeSnapshot {
         generated_at: generated_at.to_rfc3339(),
         source: SNAPSHOT_SOURCE.to_string(),
-        root_request_id: root_request_id.to_string(),
-        nodes,
-        edges,
-        truncated,
+        root_request_id: tree.root_request_id,
+        nodes: tree.nodes.into_iter().map(subagent_tree_node_dto).collect(),
+        edges: tree.edges.into_iter().map(subagent_tree_edge_dto).collect(),
+        truncated: tree.truncated,
     })
 }
 
-fn request_row_into_node(row: RequestRow) -> SubagentTreeNode {
+fn subagent_tree_node_dto(node: OwnedSubagentTreeNode) -> SubagentTreeNode {
     SubagentTreeNode {
-        request_id: clean_string(&row.request_id),
-        session_id: clean_optional_string(row.session_id.as_deref()),
-        agent_did: clean_optional_string(row.agent_did.as_deref()),
-        behavior_id: clean_optional_string(row.behavior_id.as_deref()),
-        lifecycle_state: clean_optional_string(row.lifecycle_state.as_deref()),
-        subagent_depth: row.subagent_depth,
-        caused_by_parent_request_id: clean_optional_string(
-            row.caused_by_parent_request_id.as_deref(),
-        ),
-        caused_by_parent_tool_call_id: clean_optional_string(
-            row.caused_by_parent_tool_call_id.as_deref(),
-        ),
+        request_id: node.request_id,
+        session_id: node.session_id,
+        agent_did: node.agent_did,
+        behavior_id: node.behavior_id,
+        lifecycle_state: node.lifecycle_state,
+        subagent_depth: node.subagent_depth,
+        caused_by_parent_request_id: node.caused_by_parent_request_id,
+        caused_by_parent_tool_call_id: node.caused_by_parent_tool_call_id,
     }
 }
 
-async fn fetch_root_request(graphql: &str, root_request_id: &str) -> Result<Option<RequestRow>> {
-    let escaped = escape_graphql_string(root_request_id);
-    let query = format!(
-        r#"{{
-            AgentRequest(
-                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
-                limit: 1
-            ) {{
-                request_id
-                session_id
-                agent_did
-                behavior_id
-                lifecycle_state
-                subagent_depth
-                caused_by_parent_request_id
-                caused_by_parent_tool_call_id
-            }}
-        }}"#
-    );
-    let response = post_graphql(graphql, &query).await?;
-    let envelope: RootRequestEnvelope = decode_data_object(response, "root request lookup")?;
-    Ok(envelope.requests.into_iter().next())
-}
-
-fn decode_data_object<T: serde::de::DeserializeOwned>(response: Value, context: &str) -> Result<T> {
-    let data = response
-        .get("data")
-        .filter(|data| data.is_object())
-        .cloned()
-        .with_context(|| format!("{context} response missing object data: {response}"))?;
-    serde_json::from_value(data).with_context(|| format!("decoding {context}"))
-}
-
-fn prune_terminal_subtrees(
-    nodes: &mut BTreeMap<String, SubagentTreeNode>,
-    edges: &mut Vec<SubagentTreeEdge>,
-    root_request_id: &str,
-) {
-    let mut children: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    for edge in edges.iter() {
-        children
-            .entry(edge.parent_request_id.clone())
-            .or_default()
-            .push(edge.child_request_id.clone());
+fn subagent_tree_edge_dto(edge: OwnedSubagentTreeEdge) -> SubagentTreeEdge {
+    SubagentTreeEdge {
+        parent_request_id: edge.parent_request_id,
+        child_request_id: edge.child_request_id,
+        parent_tool_call_id: edge.parent_tool_call_id,
+        tool_name: edge.tool_name,
+        await_mode: edge.await_mode,
+        cancel_policy: edge.cancel_policy,
+        lifecycle_state: edge.lifecycle_state,
     }
-
-    let mut keep: BTreeSet<String> = BTreeSet::new();
-    fn mark(
-        request_id: &str,
-        nodes: &BTreeMap<String, SubagentTreeNode>,
-        children: &BTreeMap<String, Vec<String>>,
-        keep: &mut BTreeSet<String>,
-    ) -> bool {
-        let live_self = nodes
-            .get(request_id)
-            .map(|node| !RequestLifecycleState::is_terminal_str(node.lifecycle_state.as_deref()))
-            .unwrap_or(false);
-        let mut keep_self = live_self;
-        if let Some(child_ids) = children.get(request_id) {
-            for child_id in child_ids {
-                if mark(child_id, nodes, children, keep) {
-                    keep_self = true;
-                }
-            }
-        }
-        if keep_self {
-            keep.insert(request_id.to_string());
-        }
-        keep_self
-    }
-    mark(root_request_id, nodes, &children, &mut keep);
-    keep.insert(root_request_id.to_string());
-
-    nodes.retain(|request_id, _| keep.contains(request_id));
-    edges.retain(|edge| {
-        keep.contains(&edge.parent_request_id) && keep.contains(&edge.child_request_id)
-    });
 }
 
 fn clean_optional_string(value: Option<&str>) -> Option<String> {
@@ -321,10 +161,6 @@ fn clean_optional_string(value: Option<&str>) -> Option<String> {
         let trimmed = value.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
-}
-
-fn clean_string(value: &str) -> String {
-    value.trim().to_string()
 }
 
 #[cfg(test)]

--- a/crates/gents-desktop-bridge/src/snapshot.rs
+++ b/crates/gents-desktop-bridge/src/snapshot.rs
@@ -188,9 +188,6 @@ pub use operations_signature::{
     compute_preview_signature, PreviewSignatureInput, PreviewSignatureRow,
 };
 
-#[path = "snapshot/subagent_tree.rs"]
-pub mod subagent_tree;
-
 #[path = "snapshot/session.rs"]
 mod session;
 pub use session::apply_session_timeline_page;

--- a/crates/gents-desktop-bridge/src/tauri_commands/operations.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/operations.rs
@@ -4,8 +4,12 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use gents::backend_registry::{derive_display_state, list_all_backends};
+use gents::config_client::ConfigAccess;
 use gents::defra_node::EmbeddedNode;
 use gents::graphql::escape_graphql_string;
+use gents::subagent_tree::{
+    build_subagent_tree, effective_subagent_tree_max_depth, SubagentTree, SubagentTreeAccess,
+};
 use gents_desktop_core::client::ClientCore;
 #[cfg(test)]
 use reqwest::Url;
@@ -15,9 +19,6 @@ use crate::commands::mcp_health::{load_mcp_services_with_health, probe_mcp_servi
 use crate::snapshot::operations_snapshot::{
     project_backgrounded_tools, stuck_diagnostics_from_tool_calls, ToolCallRow,
 };
-use crate::snapshot::subagent_tree::{
-    build_subagent_tree, effective_subagent_tree_max_depth, SubagentTreeAccess, TreeQueryAccess,
-};
 use crate::state::{current_core, DesktopAppState};
 use crate::types::{
     BackendHealthView, CascadeCancelPreview, DesktopInterruptRequest, DesktopListHoldsRequest,
@@ -25,7 +26,7 @@ use crate::types::{
     DesktopPreviewInterruptCascadeRequest, DesktopProbeMcpServiceRequest,
     DesktopResolveHoldRequest, HeldToolCallView, InferenceCallSummaryView, InterruptRequestResult,
     MCPServiceHealthView, McpServiceProbeResult, NativeExecutorStatusView, ResolveHoldResult,
-    RuntimeLivenessView, SubagentTreeView,
+    RuntimeLivenessView, SubagentEdgeView, SubagentNodeView, SubagentTreeView,
 };
 
 const BACKGROUND_TOOL_CALL_LIMIT: usize = 256;
@@ -232,7 +233,7 @@ pub async fn desktop_list_subagent_tree(
 
     let mut accesses = vec![SubagentTreeAccess {
         label: None,
-        access: TreeQueryAccess::Local(core.node_arc()),
+        access: ConfigAccess::Local(core.node_arc()),
     }];
     for record in core.peer_records().await {
         let Some(graphql) = record
@@ -245,18 +246,59 @@ pub async fn desktop_list_subagent_tree(
         };
         accesses.push(SubagentTreeAccess {
             label: Some(record.label.clone()),
-            access: TreeQueryAccess::Graphql(graphql.to_string()),
+            access: ConfigAccess::Graphql(graphql.to_string()),
         });
     }
 
-    build_subagent_tree(
+    let tree = build_subagent_tree(
         &accesses,
         root_request_id,
         request.include_terminal.unwrap_or(false),
         effective_subagent_tree_max_depth(request.max_depth),
     )
     .await
-    .map_err(|error| BridgeError::untyped(format!("subagent tree query failed: {error:#}")))
+    .map_err(|error| BridgeError::untyped(format!("subagent tree query failed: {error:#}")))?;
+
+    Ok(subagent_tree_view_from_gents(tree))
+}
+
+/// The bridge's TS-bound presentation shape, built from the owned
+/// `gents::subagent_tree` projection (#1334).
+fn subagent_tree_view_from_gents(tree: SubagentTree) -> SubagentTreeView {
+    SubagentTreeView {
+        root_request_id: tree.root_request_id,
+        nodes: tree
+            .nodes
+            .into_iter()
+            .map(|node| SubagentNodeView {
+                request_id: node.request_id,
+                resolved_via: node.resolved_via,
+                session_id: node.session_id,
+                agent_did: node.agent_did,
+                behavior_id: node.behavior_id,
+                lifecycle_state: node.lifecycle_state,
+                subagent_depth: node.subagent_depth,
+                caused_by_parent_request_id: node.caused_by_parent_request_id,
+                caused_by_parent_tool_call_id: node.caused_by_parent_tool_call_id,
+                backend_id: node.backend_id,
+            })
+            .collect(),
+        edges: tree
+            .edges
+            .into_iter()
+            .map(|edge| SubagentEdgeView {
+                parent_request_id: edge.parent_request_id,
+                child_request_id: edge.child_request_id,
+                parent_tool_call_id: edge.parent_tool_call_id,
+                tool_name: edge.tool_name,
+                await_mode: edge.await_mode,
+                cancel_policy: edge.cancel_policy,
+                lifecycle_state: edge.lifecycle_state,
+            })
+            .collect(),
+        truncated: tree.truncated,
+        partial_errors: tree.partial_errors,
+    }
 }
 
 #[cfg(test)]

--- a/crates/gents-desktop-bridge/src/tauri_commands/operations.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/operations.rs
@@ -263,8 +263,10 @@ pub async fn desktop_list_subagent_tree(
 }
 
 /// The bridge's TS-bound presentation shape, built from the owned
-/// `gents::subagent_tree` projection (#1334).
-fn subagent_tree_view_from_gents(tree: SubagentTree) -> SubagentTreeView {
+/// `gents::subagent_tree` projection (#1334). `pub` so the fixture-host's
+/// bridge_runner HTTP shim (a separate crate wrapping the same local-node
+/// query) shares the conversion rather than duplicating it.
+pub fn subagent_tree_view_from_gents(tree: SubagentTree) -> SubagentTreeView {
     SubagentTreeView {
         root_request_id: tree.root_request_id,
         nodes: tree

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -119,6 +119,7 @@ pub mod self_config;
 pub mod session;
 pub mod skills;
 pub mod streaming;
+pub mod subagent_tree;
 pub mod template;
 pub mod tool_call_lifecycle;
 pub mod tool_control;

--- a/crates/gents/src/subagent_tree.rs
+++ b/crates/gents/src/subagent_tree.rs
@@ -1,22 +1,83 @@
-use std::collections::{BTreeMap, BTreeSet};
+//! One projector for the subagent tree: root request plus descendant nodes
+//! and edges, depth-bounded, with fully-terminal subtrees prunable (#1334).
+//!
+//! Two callers walk this graph: the CLI's `/subagents/tree` HTTP route (a
+//! single [`ConfigAccess::Graphql`] endpoint) and the desktop bridge's Tauri
+//! command (the local embedded node plus zero or more peer GraphQL
+//! endpoints, aggregated with per-access partial-failure reporting via
+//! [`SubagentTreeAccess::label`]). Both map [`SubagentTree`] into their own
+//! presentation DTO; this module owns only the graph walk and the terminal
+//! predicate ([`gents_protocol::request_lifecycle::RequestLifecycleState::is_terminal_str`]).
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use gents::defra_node::EmbeddedNode;
-use gents::graphql::escape_graphql_string;
-use gents::{
-    ConfigAccess, DescendantEdge, DescendantGraphAccess, DescendantQuery, MAX_DESCENDANT_PAGE_LIMIT,
-};
-use gents_protocol::graphql::{execute_graphql_async, GraphqlRequestOptions};
+use defra_node::EmbeddedNode;
 use gents_protocol::request_lifecycle::RequestLifecycleState;
 use serde::Deserialize;
-use serde_json::Value;
 
-use crate::types::{SubagentEdgeView, SubagentNodeView, SubagentTreeView};
+use crate::config_client::ConfigAccess;
+use crate::descendant_graph::{
+    resolve_descendant_graph, DescendantEdge, DescendantGraphAccess, DescendantQuery,
+    MAX_DESCENDANT_PAGE_LIMIT,
+};
+use crate::graphql::escape_graphql_string;
 
 pub const DEFAULT_SUBAGENT_TREE_MAX_DEPTH: usize = 8;
 pub const HARD_SUBAGENT_TREE_MAX_DEPTH: usize = 32;
+
+/// Clamp a caller-supplied max depth to the hard ceiling, defaulting when
+/// none was supplied.
+pub fn effective_subagent_tree_max_depth(max_depth: Option<u32>) -> usize {
+    max_depth
+        .map(|value| (value as usize).min(HARD_SUBAGENT_TREE_MAX_DEPTH))
+        .unwrap_or(DEFAULT_SUBAGENT_TREE_MAX_DEPTH)
+}
+
+/// One query source contributing to the tree, labeled for partial-error
+/// attribution. `label: None` means the local node.
+pub struct SubagentTreeAccess {
+    pub label: Option<String>,
+    pub access: ConfigAccess,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubagentTreeNode {
+    pub request_id: String,
+    /// Peer label the row was resolved from; `None` = the local node.
+    pub resolved_via: Option<String>,
+    pub session_id: Option<String>,
+    pub agent_did: Option<String>,
+    pub behavior_id: Option<String>,
+    pub lifecycle_state: Option<String>,
+    pub subagent_depth: Option<i64>,
+    pub caused_by_parent_request_id: Option<String>,
+    pub caused_by_parent_tool_call_id: Option<String>,
+    pub backend_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentTreeEdge {
+    pub parent_request_id: String,
+    pub child_request_id: String,
+    pub parent_tool_call_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub await_mode: Option<String>,
+    pub cancel_policy: Option<String>,
+    pub lifecycle_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubagentTree {
+    pub root_request_id: String,
+    pub nodes: Vec<SubagentTreeNode>,
+    pub edges: Vec<SubagentTreeEdge>,
+    pub truncated: bool,
+    /// Accesses that could not be queried this walk; the tree may be missing
+    /// their branches. Empty when every access answered.
+    pub partial_errors: Vec<String>,
+}
 
 #[derive(Debug, Deserialize)]
 struct RootRequestEnvelope {
@@ -46,58 +107,18 @@ struct RequestRow {
     backend_id: Option<String>,
 }
 
-pub fn effective_subagent_tree_max_depth(max_depth: Option<u32>) -> usize {
-    max_depth
-        .map(|value| (value as usize).min(HARD_SUBAGENT_TREE_MAX_DEPTH))
-        .unwrap_or(DEFAULT_SUBAGENT_TREE_MAX_DEPTH)
-}
-
-pub struct SubagentTreeAccess {
-    pub label: Option<String>,
-    pub access: TreeQueryAccess,
-}
-
-pub enum TreeQueryAccess {
-    Local(Arc<EmbeddedNode>),
-    Graphql(String),
-}
-
-impl TreeQueryAccess {
-    async fn execute(&self, query: &str) -> Result<Value> {
-        match self {
-            Self::Local(node) => {
-                let response = node.execute(query).await;
-                if response.has_errors() {
-                    let errors = response
-                        .errors
-                        .iter()
-                        .map(|error| error.message.as_str())
-                        .collect::<Vec<_>>()
-                        .join("; ");
-                    anyhow::bail!("graphql returned errors: {errors}");
-                }
-                Ok(serde_json::json!({
-                    "data": response.data.unwrap_or(Value::Null),
-                }))
-            }
-            Self::Graphql(endpoint) => {
-                execute_graphql_async(endpoint, query, GraphqlRequestOptions::default()).await
-            }
-        }
-    }
-}
-
-#[allow(dead_code)]
+/// Build the tree from a single local embedded node — the common case for a
+/// caller with no peers to aggregate.
 pub async fn build_local_subagent_tree(
     node: Arc<EmbeddedNode>,
     root_request_id: &str,
     include_terminal: bool,
     max_depth: usize,
-) -> Result<SubagentTreeView> {
+) -> Result<SubagentTree> {
     build_subagent_tree(
         &[SubagentTreeAccess {
             label: None,
-            access: TreeQueryAccess::Local(node),
+            access: ConfigAccess::Local(node),
         }],
         root_request_id,
         include_terminal,
@@ -106,13 +127,17 @@ pub async fn build_local_subagent_tree(
     .await
 }
 
+/// Build the tree by aggregating one or more query accesses. A failing
+/// access is recorded in `partial_errors` (once) and skipped rather than
+/// failing the whole walk, so a live tree still renders when a peer
+/// deployment is unreachable.
 pub async fn build_subagent_tree(
     accesses: &[SubagentTreeAccess],
     root_request_id: &str,
     include_terminal: bool,
     max_depth: usize,
-) -> Result<SubagentTreeView> {
-    let mut nodes: BTreeMap<String, SubagentNodeView> = BTreeMap::new();
+) -> Result<SubagentTree> {
+    let mut nodes: BTreeMap<String, SubagentTreeNode> = BTreeMap::new();
     let mut partial_errors: Vec<String> = Vec::new();
     let mut dead_accesses: BTreeSet<usize> = BTreeSet::new();
 
@@ -142,14 +167,10 @@ pub async fn build_subagent_tree(
         if dead_accesses.contains(&index) {
             continue;
         }
-        let access = match &entry.access {
-            TreeQueryAccess::Local(node) => ConfigAccess::Local(node.clone()),
-            TreeQueryAccess::Graphql(endpoint) => ConfigAccess::Graphql(endpoint.clone()),
-        };
         let mut after = None;
         loop {
-            let page = match gents::resolve_descendant_graph(
-                DescendantGraphAccess::Config(&access),
+            let page = match resolve_descendant_graph(
+                DescendantGraphAccess::Config(&entry.access),
                 &DescendantQuery {
                     after: after.clone(),
                     limit: MAX_DESCENDANT_PAGE_LIMIT,
@@ -198,7 +219,7 @@ pub async fn build_subagent_tree(
     {
         nodes.insert(
             edge.child_request_id.clone(),
-            SubagentNodeView {
+            SubagentTreeNode {
                 request_id: edge.child_request_id.clone(),
                 resolved_via,
                 session_id: edge.child_session_id.clone(),
@@ -211,7 +232,7 @@ pub async fn build_subagent_tree(
                 backend_id: None,
             },
         );
-        edges.push(SubagentEdgeView {
+        edges.push(SubagentTreeEdge {
             parent_request_id: edge.immediate_parent_request_id,
             child_request_id: edge.child_request_id,
             parent_tool_call_id: Some(edge.immediate_parent_tool_call_id),
@@ -237,7 +258,7 @@ pub async fn build_subagent_tree(
             ))
     });
 
-    Ok(SubagentTreeView {
+    Ok(SubagentTree {
         root_request_id: root_request_id.to_string(),
         nodes: nodes.into_values().collect(),
         edges,
@@ -259,8 +280,8 @@ fn record_dead_access(
     }
 }
 
-fn request_row_into_node(row: RequestRow) -> SubagentNodeView {
-    SubagentNodeView {
+fn request_row_into_node(row: RequestRow) -> SubagentTreeNode {
+    SubagentTreeNode {
         request_id: clean_string(&row.request_id),
         resolved_via: None,
         session_id: clean_optional_string(row.session_id.as_deref()),
@@ -279,7 +300,7 @@ fn request_row_into_node(row: RequestRow) -> SubagentNodeView {
 }
 
 async fn fetch_root_request(
-    access: &TreeQueryAccess,
+    access: &ConfigAccess,
     root_request_id: &str,
 ) -> Result<Option<RequestRow>> {
     let escaped = escape_graphql_string(root_request_id);
@@ -307,7 +328,7 @@ async fn fetch_root_request(
 }
 
 async fn execute_access_query<T: serde::de::DeserializeOwned>(
-    access: &TreeQueryAccess,
+    access: &ConfigAccess,
     query: &str,
     context: &str,
 ) -> Result<T> {
@@ -323,8 +344,8 @@ async fn execute_access_query<T: serde::de::DeserializeOwned>(
 }
 
 fn prune_terminal_subtrees(
-    nodes: &mut BTreeMap<String, SubagentNodeView>,
-    edges: &mut Vec<SubagentEdgeView>,
+    nodes: &mut BTreeMap<String, SubagentTreeNode>,
+    edges: &mut Vec<SubagentTreeEdge>,
     root_request_id: &str,
 ) {
     let mut children: BTreeMap<String, Vec<String>> = BTreeMap::new();
@@ -338,7 +359,7 @@ fn prune_terminal_subtrees(
     let mut keep: BTreeSet<String> = BTreeSet::new();
     fn mark(
         request_id: &str,
-        nodes: &BTreeMap<String, SubagentNodeView>,
+        nodes: &BTreeMap<String, SubagentTreeNode>,
         children: &BTreeMap<String, Vec<String>>,
         keep: &mut BTreeSet<String>,
     ) -> bool {
@@ -378,3 +399,7 @@ fn clean_optional_string(value: Option<&str>) -> Option<String> {
 fn clean_string(value: &str) -> String {
     value.trim().to_string()
 }
+
+#[cfg(test)]
+#[path = "subagent_tree/tests.rs"]
+mod tests;

--- a/crates/gents/src/subagent_tree/tests.rs
+++ b/crates/gents/src/subagent_tree/tests.rs
@@ -1,0 +1,584 @@
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use axum::{extract::State, routing::post, Json, Router};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+
+use super::*;
+
+#[derive(Clone)]
+struct MockGraphqlState {
+    responses: Arc<Mutex<Vec<Value>>>,
+}
+
+async fn mock_graphql(State(state): State<MockGraphqlState>, Json(_body): Json<Value>) -> Json<Value> {
+    let mut responses = state.responses.lock().unwrap();
+    let response = if responses.len() == 1 {
+        responses[0].clone()
+    } else {
+        responses.remove(0)
+    };
+    Json(response)
+}
+
+async fn spawn_mock_graphql(responses: Vec<Value>) -> anyhow::Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr: SocketAddr = listener.local_addr()?;
+    let router = Router::new()
+        .route("/api/v0/graphql", post(mock_graphql))
+        .with_state(MockGraphqlState {
+            responses: Arc::new(Mutex::new(responses)),
+        });
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    Ok(format!("http://{addr}/api/v0/graphql"))
+}
+
+/// A GraphQL endpoint address nothing is listening on. `execute_graphql_async`
+/// retries a bounded number of times, so a request against it fails fast with
+/// a connection error rather than hanging.
+async fn dead_graphql_endpoint() -> anyhow::Result<String> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    drop(listener);
+    Ok(format!("http://{addr}/api/v0/graphql"))
+}
+
+fn root_response() -> Value {
+    json!({
+        "data": {
+            "AgentRequest": [
+                {
+                    "request_id": "req-root",
+                    "session_id": "sess-root",
+                    "agent_did": "deployment-a",
+                    "behavior_id": "amy-general",
+                    "lifecycle_state": "Processing",
+                    "subagent_depth": 0,
+                    "caused_by_parent_request_id": null,
+                    "caused_by_parent_tool_call_id": null,
+                    "backend_id": null
+                }
+            ]
+        }
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn canonical_root_response(
+    request_id: &str,
+    doc_id: &str,
+    session_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+    lifecycle_state: &str,
+) -> Value {
+    json!({
+        "data": { "AgentRequest": [{
+            "_docID": doc_id,
+            "request_id": request_id,
+            "agent_did": agent_did,
+            "requester_did": null,
+            "behavior_id": behavior_id,
+            "session_id": session_id,
+            "lifecycle_state": lifecycle_state,
+            "caused_by_parent_request_id": null,
+            "caused_by_parent_request_doc_id": null,
+            "caused_by_parent_tool_call_id": null,
+            "caused_by_parent_tool_call_doc_id": null
+        }]}
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn canonical_bridge_row(
+    doc_id: &str,
+    parent_request_id: &str,
+    parent_doc_id: &str,
+    parent_session_id: &str,
+    parent_agent_did: &str,
+    tool_call_id: &str,
+    child_request_id: &str,
+    await_mode: &str,
+    lifecycle_state: &str,
+) -> Value {
+    json!({
+        "_docID": doc_id,
+        "request_id": parent_request_id,
+        "request_doc_id": parent_doc_id,
+        "session_id": parent_session_id,
+        "agent_did": parent_agent_did,
+        "requester_did": null,
+        "tool_call_id": tool_call_id,
+        "args": format!(r#"{{"name":"{child_request_id}"}}"#),
+        "result": if lifecycle_state == "completed" { "done" } else { "" },
+        "status": lifecycle_state,
+        "lifecycle_state": lifecycle_state,
+        "started_at": "2026-08-01T00:00:00Z",
+        "completed_at": if lifecycle_state == "completed" {
+            Some("2026-08-01T00:00:01Z")
+        } else {
+            None
+        },
+        "await_mode": await_mode,
+        "cancel_policy": "cascade",
+        "child_request_id": child_request_id,
+        "spawn_target_did": null,
+        "unclaimed_deadline_at": null
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn canonical_child_row(
+    doc_id: &str,
+    request_id: &str,
+    session_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+    lifecycle_state: &str,
+    parent_request_id: &str,
+    parent_doc_id: &str,
+    parent_tool_call_id: &str,
+    parent_tool_doc_id: &str,
+) -> Value {
+    json!({
+        "_docID": doc_id,
+        "request_id": request_id,
+        "agent_did": agent_did,
+        "requester_did": null,
+        "behavior_id": behavior_id,
+        "session_id": session_id,
+        "lifecycle_state": lifecycle_state,
+        "caused_by_parent_request_id": parent_request_id,
+        "caused_by_parent_request_doc_id": parent_doc_id,
+        "caused_by_parent_tool_call_id": parent_tool_call_id,
+        "caused_by_parent_tool_call_doc_id": parent_tool_doc_id
+    })
+}
+
+fn canonical_bridges_response(rows: Vec<Value>) -> Value {
+    json!({ "data": { "AgentToolCall": rows } })
+}
+
+fn canonical_children_response(rows: Vec<Value>) -> Value {
+    json!({ "data": { "AgentRequest": rows } })
+}
+
+fn canonical_messages_empty() -> Value {
+    json!({ "data": { "AgentMessage": [] } })
+}
+
+fn canonical_standard_walk_responses() -> Vec<Value> {
+    vec![
+        root_response(),
+        canonical_root_response(
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "amy-general",
+            "processing",
+        ),
+        canonical_bridges_response(vec![canonical_bridge_row(
+            "doc-tc-bridge",
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "tc-bridge",
+            "req-child",
+            "background",
+            "running",
+        )]),
+        canonical_children_response(vec![canonical_child_row(
+            "doc-child",
+            "req-child",
+            "sess-child",
+            "deployment-b",
+            "amy-code",
+            "processing",
+            "req-root",
+            "doc-root",
+            "tc-bridge",
+            "doc-tc-bridge",
+        )]),
+        canonical_bridges_response(Vec::new()),
+        canonical_messages_empty(),
+    ]
+}
+
+fn single_access(graphql: String) -> Vec<SubagentTreeAccess> {
+    vec![SubagentTreeAccess {
+        label: None,
+        access: ConfigAccess::Graphql(graphql),
+    }]
+}
+
+#[test]
+fn effective_subagent_tree_max_depth_defaults_and_clamps() {
+    assert_eq!(
+        effective_subagent_tree_max_depth(None),
+        DEFAULT_SUBAGENT_TREE_MAX_DEPTH
+    );
+    assert_eq!(effective_subagent_tree_max_depth(Some(3)), 3);
+    assert_eq!(
+        effective_subagent_tree_max_depth(Some(1_000)),
+        HARD_SUBAGENT_TREE_MAX_DEPTH
+    );
+}
+
+#[tokio::test]
+async fn tree_walks_cross_deployment_bridge_and_carries_metadata() -> anyhow::Result<()> {
+    let graphql = spawn_mock_graphql(canonical_standard_walk_responses()).await?;
+    let tree = build_subagent_tree(&single_access(graphql), "req-root", false, 4).await?;
+
+    assert_eq!(tree.root_request_id, "req-root");
+    assert!(!tree.truncated, "shallow tree should not be truncated");
+    assert!(tree.partial_errors.is_empty());
+    assert_eq!(tree.nodes.len(), 2);
+    assert_eq!(tree.edges.len(), 1);
+
+    let root = tree
+        .nodes
+        .iter()
+        .find(|node| node.request_id == "req-root")
+        .expect("root node");
+    assert_eq!(root.agent_did.as_deref(), Some("deployment-a"));
+    assert_eq!(root.subagent_depth, Some(0));
+    assert_eq!(root.resolved_via, None);
+
+    let child = tree
+        .nodes
+        .iter()
+        .find(|node| node.request_id == "req-child")
+        .expect("child node");
+    assert_eq!(child.agent_did.as_deref(), Some("deployment-b"));
+    assert_eq!(child.caused_by_parent_request_id.as_deref(), Some("req-root"));
+    assert_eq!(
+        child.caused_by_parent_tool_call_id.as_deref(),
+        Some("tc-bridge")
+    );
+
+    let edge = &tree.edges[0];
+    assert_eq!(edge.parent_request_id, "req-root");
+    assert_eq!(edge.child_request_id, "req-child");
+    assert_eq!(edge.tool_name.as_deref(), Some("spawn_subagent"));
+    assert_eq!(edge.await_mode.as_deref(), Some("background"));
+    assert_eq!(edge.cancel_policy.as_deref(), Some("cascade"));
+    assert_eq!(edge.lifecycle_state.as_deref(), Some("running"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn tree_respects_max_depth_and_sets_truncated_flag() -> anyhow::Result<()> {
+    let root = json!({
+        "data": {
+            "AgentRequest": [
+                {
+                    "request_id": "req-root",
+                    "agent_did": "deployment-a",
+                    "lifecycle_state": "Processing",
+                    "subagent_depth": 0
+                }
+            ]
+        }
+    });
+    let canonical_root = canonical_root_response(
+        "req-root",
+        "doc-root",
+        "sess-root",
+        "deployment-a",
+        "amy-general",
+        "processing",
+    );
+    let canonical_level_one = canonical_bridges_response(vec![canonical_bridge_row(
+        "doc-tc-a",
+        "req-root",
+        "doc-root",
+        "sess-root",
+        "deployment-a",
+        "tc-a",
+        "req-a",
+        "background",
+        "running",
+    )]);
+    let canonical_child_a = canonical_children_response(vec![canonical_child_row(
+        "doc-a",
+        "req-a",
+        "sess-a",
+        "deployment-a",
+        "amy-code",
+        "processing",
+        "req-root",
+        "doc-root",
+        "tc-a",
+        "doc-tc-a",
+    )]);
+    let canonical_level_two = canonical_bridges_response(vec![canonical_bridge_row(
+        "doc-tc-b",
+        "req-a",
+        "doc-a",
+        "sess-a",
+        "deployment-a",
+        "tc-b",
+        "req-b",
+        "foreground",
+        "running",
+    )]);
+    let canonical_child_b = canonical_children_response(vec![canonical_child_row(
+        "doc-b",
+        "req-b",
+        "sess-b",
+        "deployment-a",
+        "amy-review",
+        "processing",
+        "req-a",
+        "doc-a",
+        "tc-b",
+        "doc-tc-b",
+    )]);
+    let graphql = spawn_mock_graphql(vec![
+        root,
+        canonical_root,
+        canonical_level_one,
+        canonical_child_a,
+        canonical_level_two,
+        canonical_child_b,
+        canonical_bridges_response(Vec::new()),
+        canonical_messages_empty(),
+    ])
+    .await?;
+    let tree = build_subagent_tree(&single_access(graphql), "req-root", true, 1).await?;
+    assert!(tree.truncated, "max_depth=1 should set truncated");
+    assert_eq!(tree.nodes.len(), 2);
+    assert_eq!(tree.edges.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tree_prunes_fully_terminal_subtrees_when_include_terminal_is_false() -> anyhow::Result<()>
+{
+    let root = json!({
+        "data": {
+            "AgentRequest": [
+                {
+                    "request_id": "req-root",
+                    "agent_did": "deployment-a",
+                    "lifecycle_state": "Processing",
+                    "subagent_depth": 0
+                }
+            ]
+        }
+    });
+    let canonical_root = canonical_root_response(
+        "req-root",
+        "doc-root",
+        "sess-root",
+        "deployment-a",
+        "amy-general",
+        "processing",
+    );
+    let bridges = canonical_bridges_response(vec![
+        canonical_bridge_row(
+            "doc-tc-live",
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "tc-live",
+            "req-live",
+            "background",
+            "running",
+        ),
+        canonical_bridge_row(
+            "doc-tc-dead",
+            "req-root",
+            "doc-root",
+            "sess-root",
+            "deployment-a",
+            "tc-dead",
+            "req-dead",
+            "foreground",
+            "completed",
+        ),
+    ]);
+    let children = canonical_children_response(vec![
+        canonical_child_row(
+            "doc-live",
+            "req-live",
+            "sess-live",
+            "deployment-a",
+            "amy-code",
+            "processing",
+            "req-root",
+            "doc-root",
+            "tc-live",
+            "doc-tc-live",
+        ),
+        canonical_child_row(
+            "doc-dead",
+            "req-dead",
+            "sess-dead",
+            "deployment-a",
+            "amy-code",
+            "completed",
+            "req-root",
+            "doc-root",
+            "tc-dead",
+            "doc-tc-dead",
+        ),
+    ]);
+    let graphql = spawn_mock_graphql(vec![
+        root,
+        canonical_root,
+        bridges,
+        children,
+        canonical_bridges_response(Vec::new()),
+        canonical_messages_empty(),
+    ])
+    .await?;
+    let tree = build_subagent_tree(&single_access(graphql), "req-root", false, 4).await?;
+    let request_ids = tree
+        .nodes
+        .iter()
+        .map(|node| node.request_id.as_str())
+        .collect::<Vec<_>>();
+    assert!(request_ids.contains(&"req-root"));
+    assert!(request_ids.contains(&"req-live"));
+    assert!(
+        !request_ids.contains(&"req-dead"),
+        "terminal request without live descendants should be pruned"
+    );
+    assert!(
+        tree.edges
+            .iter()
+            .all(|edge| edge.child_request_id != "req-dead"),
+        "edges into a pruned node should also be dropped"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn tree_aggregates_labeled_accesses_and_records_partial_error_for_dead_peer(
+) -> anyhow::Result<()> {
+    let local = spawn_mock_graphql(canonical_standard_walk_responses()).await?;
+    let dead_peer = dead_graphql_endpoint().await?;
+
+    let accesses = vec![
+        SubagentTreeAccess {
+            label: None,
+            access: ConfigAccess::Graphql(local),
+        },
+        SubagentTreeAccess {
+            label: Some("peer-b".to_string()),
+            access: ConfigAccess::Graphql(dead_peer),
+        },
+    ];
+
+    let tree = build_subagent_tree(&accesses, "req-root", false, 4).await?;
+
+    assert_eq!(tree.nodes.len(), 2, "the healthy access still resolves");
+    assert_eq!(
+        tree.partial_errors.len(),
+        1,
+        "the dead peer should be recorded once, not once per query"
+    );
+    assert!(
+        tree.partial_errors[0].contains("peer-b"),
+        "partial error should identify the dead access by label: {:?}",
+        tree.partial_errors
+    );
+
+    let root = tree
+        .nodes
+        .iter()
+        .find(|node| node.request_id == "req-root")
+        .expect("root node");
+    assert_eq!(
+        root.resolved_via, None,
+        "root resolved through the unlabeled local access"
+    );
+
+    Ok(())
+}
+
+async fn create_root_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let session_id = escape_graphql_string(session_id);
+    let agent_did = escape_graphql_string(agent_did);
+    let behavior_id = escape_graphql_string(behavior_id);
+    let now = chrono::Utc::now().to_rfc3339();
+    let response = node
+        .execute(&format!(
+            r#"mutation {{
+                create_AgentRequest(input: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    session_id: "{session_id}",
+                    retry_parent_request: "",
+                    retry_root_request: "{request_id}",
+                    superseded_by_request: "",
+                    content: "subagent tree root fixture",
+                    lifecycle_state: "processing",
+                    backend_id: "",
+                    execution_origin: "interactive",
+                    metadata: "",
+                    failure_reason: "",
+                    created_at: "{now}",
+                    retry_count: 0,
+                    max_retries: 3,
+                    subagent_depth: 0
+                }}) {{ _docID }}
+            }}"#
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+}
+
+#[tokio::test]
+async fn build_local_subagent_tree_resolves_the_root_from_the_embedded_node() -> anyhow::Result<()>
+{
+    let node = Arc::new(EmbeddedNode::builder().build().await?);
+    crate::schema::ensure_runtime_schemas(node.as_ref()).await?;
+    create_root_request(
+        node.as_ref(),
+        "req-root",
+        "sess-root",
+        "did:test:local",
+        "amy-general",
+    )
+    .await;
+
+    let tree = build_local_subagent_tree(
+        node,
+        "req-root",
+        true,
+        DEFAULT_SUBAGENT_TREE_MAX_DEPTH,
+    )
+    .await?;
+
+    assert_eq!(tree.root_request_id, "req-root");
+    assert!(tree.partial_errors.is_empty());
+    assert!(!tree.truncated);
+    assert_eq!(tree.edges.len(), 0);
+    assert_eq!(tree.nodes.len(), 1);
+    let root = &tree.nodes[0];
+    assert_eq!(root.request_id, "req-root");
+    assert_eq!(root.agent_did.as_deref(), Some("did:test:local"));
+    assert_eq!(root.behavior_id.as_deref(), Some("amy-general"));
+    assert_eq!(root.resolved_via, None);
+
+    Ok(())
+}

--- a/crates/gents/src/subagent_tree/tests.rs
+++ b/crates/gents/src/subagent_tree/tests.rs
@@ -9,6 +9,15 @@ use tokio::net::TcpListener;
 
 use super::*;
 
+// The end-to-end walk (cross-deployment bridge metadata, max-depth
+// truncation, terminal-subtree pruning) is golden-tested against this same
+// shared code path by `gents-cli`'s `http::subagent_tree` fixture tests,
+// which call `build_subagent_tree` through `load_subagent_tree_snapshot`.
+// This module covers what only the owner itself can exercise: the max-depth
+// clamp, multi-access aggregation with partial-failure reporting (the
+// bridge's cross-deployment case, which the CLI's single-access route never
+// exercises), and the local embedded-node access path.
+
 #[derive(Clone)]
 struct MockGraphqlState {
     responses: Arc<Mutex<Vec<Value>>>,
@@ -214,13 +223,6 @@ fn canonical_standard_walk_responses() -> Vec<Value> {
     ]
 }
 
-fn single_access(graphql: String) -> Vec<SubagentTreeAccess> {
-    vec![SubagentTreeAccess {
-        label: None,
-        access: ConfigAccess::Graphql(graphql),
-    }]
-}
-
 #[test]
 fn effective_subagent_tree_max_depth_defaults_and_clamps() {
     assert_eq!(
@@ -232,241 +234,6 @@ fn effective_subagent_tree_max_depth_defaults_and_clamps() {
         effective_subagent_tree_max_depth(Some(1_000)),
         HARD_SUBAGENT_TREE_MAX_DEPTH
     );
-}
-
-#[tokio::test]
-async fn tree_walks_cross_deployment_bridge_and_carries_metadata() -> anyhow::Result<()> {
-    let graphql = spawn_mock_graphql(canonical_standard_walk_responses()).await?;
-    let tree = build_subagent_tree(&single_access(graphql), "req-root", false, 4).await?;
-
-    assert_eq!(tree.root_request_id, "req-root");
-    assert!(!tree.truncated, "shallow tree should not be truncated");
-    assert!(tree.partial_errors.is_empty());
-    assert_eq!(tree.nodes.len(), 2);
-    assert_eq!(tree.edges.len(), 1);
-
-    let root = tree
-        .nodes
-        .iter()
-        .find(|node| node.request_id == "req-root")
-        .expect("root node");
-    assert_eq!(root.agent_did.as_deref(), Some("deployment-a"));
-    assert_eq!(root.subagent_depth, Some(0));
-    assert_eq!(root.resolved_via, None);
-
-    let child = tree
-        .nodes
-        .iter()
-        .find(|node| node.request_id == "req-child")
-        .expect("child node");
-    assert_eq!(child.agent_did.as_deref(), Some("deployment-b"));
-    assert_eq!(
-        child.caused_by_parent_request_id.as_deref(),
-        Some("req-root")
-    );
-    assert_eq!(
-        child.caused_by_parent_tool_call_id.as_deref(),
-        Some("tc-bridge")
-    );
-
-    let edge = &tree.edges[0];
-    assert_eq!(edge.parent_request_id, "req-root");
-    assert_eq!(edge.child_request_id, "req-child");
-    assert_eq!(edge.tool_name.as_deref(), Some("spawn_subagent"));
-    assert_eq!(edge.await_mode.as_deref(), Some("background"));
-    assert_eq!(edge.cancel_policy.as_deref(), Some("cascade"));
-    assert_eq!(edge.lifecycle_state.as_deref(), Some("running"));
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn tree_respects_max_depth_and_sets_truncated_flag() -> anyhow::Result<()> {
-    let root = json!({
-        "data": {
-            "AgentRequest": [
-                {
-                    "request_id": "req-root",
-                    "agent_did": "deployment-a",
-                    "lifecycle_state": "Processing",
-                    "subagent_depth": 0
-                }
-            ]
-        }
-    });
-    let canonical_root = canonical_root_response(
-        "req-root",
-        "doc-root",
-        "sess-root",
-        "deployment-a",
-        "amy-general",
-        "processing",
-    );
-    let canonical_level_one = canonical_bridges_response(vec![canonical_bridge_row(
-        "doc-tc-a",
-        "req-root",
-        "doc-root",
-        "sess-root",
-        "deployment-a",
-        "tc-a",
-        "req-a",
-        "background",
-        "running",
-    )]);
-    let canonical_child_a = canonical_children_response(vec![canonical_child_row(
-        "doc-a",
-        "req-a",
-        "sess-a",
-        "deployment-a",
-        "amy-code",
-        "processing",
-        "req-root",
-        "doc-root",
-        "tc-a",
-        "doc-tc-a",
-    )]);
-    let canonical_level_two = canonical_bridges_response(vec![canonical_bridge_row(
-        "doc-tc-b",
-        "req-a",
-        "doc-a",
-        "sess-a",
-        "deployment-a",
-        "tc-b",
-        "req-b",
-        "foreground",
-        "running",
-    )]);
-    let canonical_child_b = canonical_children_response(vec![canonical_child_row(
-        "doc-b",
-        "req-b",
-        "sess-b",
-        "deployment-a",
-        "amy-review",
-        "processing",
-        "req-a",
-        "doc-a",
-        "tc-b",
-        "doc-tc-b",
-    )]);
-    let graphql = spawn_mock_graphql(vec![
-        root,
-        canonical_root,
-        canonical_level_one,
-        canonical_child_a,
-        canonical_level_two,
-        canonical_child_b,
-        canonical_bridges_response(Vec::new()),
-        canonical_messages_empty(),
-    ])
-    .await?;
-    let tree = build_subagent_tree(&single_access(graphql), "req-root", true, 1).await?;
-    assert!(tree.truncated, "max_depth=1 should set truncated");
-    assert_eq!(tree.nodes.len(), 2);
-    assert_eq!(tree.edges.len(), 1);
-    Ok(())
-}
-
-#[tokio::test]
-async fn tree_prunes_fully_terminal_subtrees_when_include_terminal_is_false() -> anyhow::Result<()>
-{
-    let root = json!({
-        "data": {
-            "AgentRequest": [
-                {
-                    "request_id": "req-root",
-                    "agent_did": "deployment-a",
-                    "lifecycle_state": "Processing",
-                    "subagent_depth": 0
-                }
-            ]
-        }
-    });
-    let canonical_root = canonical_root_response(
-        "req-root",
-        "doc-root",
-        "sess-root",
-        "deployment-a",
-        "amy-general",
-        "processing",
-    );
-    let bridges = canonical_bridges_response(vec![
-        canonical_bridge_row(
-            "doc-tc-live",
-            "req-root",
-            "doc-root",
-            "sess-root",
-            "deployment-a",
-            "tc-live",
-            "req-live",
-            "background",
-            "running",
-        ),
-        canonical_bridge_row(
-            "doc-tc-dead",
-            "req-root",
-            "doc-root",
-            "sess-root",
-            "deployment-a",
-            "tc-dead",
-            "req-dead",
-            "foreground",
-            "completed",
-        ),
-    ]);
-    let children = canonical_children_response(vec![
-        canonical_child_row(
-            "doc-live",
-            "req-live",
-            "sess-live",
-            "deployment-a",
-            "amy-code",
-            "processing",
-            "req-root",
-            "doc-root",
-            "tc-live",
-            "doc-tc-live",
-        ),
-        canonical_child_row(
-            "doc-dead",
-            "req-dead",
-            "sess-dead",
-            "deployment-a",
-            "amy-code",
-            "completed",
-            "req-root",
-            "doc-root",
-            "tc-dead",
-            "doc-tc-dead",
-        ),
-    ]);
-    let graphql = spawn_mock_graphql(vec![
-        root,
-        canonical_root,
-        bridges,
-        children,
-        canonical_bridges_response(Vec::new()),
-        canonical_messages_empty(),
-    ])
-    .await?;
-    let tree = build_subagent_tree(&single_access(graphql), "req-root", false, 4).await?;
-    let request_ids = tree
-        .nodes
-        .iter()
-        .map(|node| node.request_id.as_str())
-        .collect::<Vec<_>>();
-    assert!(request_ids.contains(&"req-root"));
-    assert!(request_ids.contains(&"req-live"));
-    assert!(
-        !request_ids.contains(&"req-dead"),
-        "terminal request without live descendants should be pruned"
-    );
-    assert!(
-        tree.edges
-            .iter()
-            .all(|edge| edge.child_request_id != "req-dead"),
-        "edges into a pruned node should also be dropped"
-    );
-    Ok(())
 }
 
 #[tokio::test]
@@ -489,6 +256,10 @@ async fn tree_aggregates_labeled_accesses_and_records_partial_error_for_dead_pee
     let tree = build_subagent_tree(&accesses, "req-root", false, 4).await?;
 
     assert_eq!(tree.nodes.len(), 2, "the healthy access still resolves");
+    assert!(
+        !tree.truncated,
+        "the healthy access's shallow tree is not truncated"
+    );
     assert_eq!(
         tree.partial_errors.len(),
         1,
@@ -509,6 +280,12 @@ async fn tree_aggregates_labeled_accesses_and_records_partial_error_for_dead_pee
         root.resolved_via, None,
         "root resolved through the unlabeled local access"
     );
+    let child = tree
+        .nodes
+        .iter()
+        .find(|node| node.request_id == "req-child")
+        .expect("child node");
+    assert_eq!(child.agent_did.as_deref(), Some("deployment-b"));
 
     Ok(())
 }

--- a/crates/gents/src/subagent_tree/tests.rs
+++ b/crates/gents/src/subagent_tree/tests.rs
@@ -14,7 +14,10 @@ struct MockGraphqlState {
     responses: Arc<Mutex<Vec<Value>>>,
 }
 
-async fn mock_graphql(State(state): State<MockGraphqlState>, Json(_body): Json<Value>) -> Json<Value> {
+async fn mock_graphql(
+    State(state): State<MockGraphqlState>,
+    Json(_body): Json<Value>,
+) -> Json<Value> {
     let mut responses = state.responses.lock().unwrap();
     let response = if responses.len() == 1 {
         responses[0].clone()
@@ -257,7 +260,10 @@ async fn tree_walks_cross_deployment_bridge_and_carries_metadata() -> anyhow::Re
         .find(|node| node.request_id == "req-child")
         .expect("child node");
     assert_eq!(child.agent_did.as_deref(), Some("deployment-b"));
-    assert_eq!(child.caused_by_parent_request_id.as_deref(), Some("req-root"));
+    assert_eq!(
+        child.caused_by_parent_request_id.as_deref(),
+        Some("req-root")
+    );
     assert_eq!(
         child.caused_by_parent_tool_call_id.as_deref(),
         Some("tc-bridge")
@@ -561,13 +567,8 @@ async fn build_local_subagent_tree_resolves_the_root_from_the_embedded_node() ->
     )
     .await;
 
-    let tree = build_local_subagent_tree(
-        node,
-        "req-root",
-        true,
-        DEFAULT_SUBAGENT_TREE_MAX_DEPTH,
-    )
-    .await?;
+    let tree =
+        build_local_subagent_tree(node, "req-root", true, DEFAULT_SUBAGENT_TREE_MAX_DEPTH).await?;
 
     assert_eq!(tree.root_request_id, "req-root");
     assert!(tree.partial_errors.is_empty());

--- a/crates/gents/src/tool_call_lifecycle.rs
+++ b/crates/gents/src/tool_call_lifecycle.rs
@@ -272,8 +272,9 @@ pub(crate) mod subagent_workspace;
 mod transition;
 
 pub use recovery::{
-    BackgroundCompletionSideEffectReport, OrphanedBackgroundToolReport, SubagentLivenessReport,
-    TerminalParentToolReport, ToolCallRecoveryReport,
+    deadline_at_is_expired, deadline_is_expired, BackgroundCompletionSideEffectReport,
+    OrphanedBackgroundToolReport, SubagentLivenessReport, TerminalParentToolReport,
+    ToolCallRecoveryReport,
 };
 pub use runtime::ToolOutcome;
 pub use subagent_request::{

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -630,6 +630,44 @@ mod tests {
         assert_eq!(RecoveryOutcome::Cancelled.failure_class(), None);
     }
 
+    /// The one deadline-expiry predicate (#1334), shared by tool-call
+    /// recovery here and by `gents-cli`'s fleet-slot and liveness
+    /// snapshots. Past deadlines (including exactly `now`) are expired;
+    /// future, missing, and malformed deadlines are documented as not
+    /// expired.
+    #[test]
+    fn deadline_is_expired_covers_past_future_missing_and_malformed() {
+        let now = DateTime::parse_from_rfc3339("2026-09-03T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let past = "2026-09-03T11:59:59Z";
+        let exactly_now = "2026-09-03T12:00:00Z";
+        let future = "2026-09-03T12:00:01Z";
+
+        assert!(deadline_is_expired(now, Some(past)), "past deadline");
+        assert!(
+            deadline_is_expired(now, Some(exactly_now)),
+            "a deadline reached exactly now has expired"
+        );
+        assert!(!deadline_is_expired(now, Some(future)), "future deadline");
+        assert!(!deadline_is_expired(now, None), "missing deadline");
+        assert!(
+            !deadline_is_expired(now, Some("not-a-timestamp")),
+            "malformed deadline"
+        );
+        assert!(
+            !deadline_is_expired(now, Some("   ")),
+            "blank deadline is documented as missing, not malformed"
+        );
+
+        // The typed variant agrees with the string-form convenience.
+        assert_eq!(
+            deadline_at_is_expired(now, parse_datetime(Some(past))),
+            deadline_is_expired(now, Some(past)),
+        );
+        assert!(!deadline_at_is_expired(now, None));
+    }
+
     #[test]
     fn background_completion_reason_comes_from_cursor_not_tool_text() {
         let row = TerminalBackgroundToolRow {
@@ -1686,7 +1724,7 @@ async fn terminalize_expired_child_with_row(
     let Some(deadline_at) = parse_datetime(child.deadline.as_deref()) else {
         return Ok(false);
     };
-    if Utc::now() < deadline_at {
+    if !deadline_at_is_expired(Utc::now(), Some(deadline_at)) {
         return Ok(false);
     }
 
@@ -2123,6 +2161,21 @@ fn parse_datetime(value: Option<&str>) -> Option<DateTime<Utc>> {
         .map(|datetime| datetime.with_timezone(&Utc))
 }
 
+/// Whether an already-parsed deadline has been reached or passed as of
+/// `now`. A missing deadline never expires (#1334 — the one deadline-expiry
+/// predicate; also used by `gents-cli`'s fleet-slot and liveness snapshots).
+pub fn deadline_at_is_expired(now: DateTime<Utc>, deadline_at: Option<DateTime<Utc>>) -> bool {
+    deadline_at.is_some_and(|deadline| now >= deadline)
+}
+
+/// String-form convenience over [`deadline_at_is_expired`]: parses an
+/// RFC3339 `deadline_at` and reports whether it has expired as of `now`. A
+/// missing or malformed deadline is documented as *not* expired — there is
+/// no evidence to expire the row on.
+pub fn deadline_is_expired(now: DateTime<Utc>, deadline_at: Option<&str>) -> bool {
+    deadline_at_is_expired(now, parse_datetime(deadline_at))
+}
+
 /// Shared startup/periodic classifier. Branch order is Lean-fenced by
 /// `restartDisposition` and `orphanedBackgroundToolCause`.
 fn classify_running_tool_recovery(
@@ -2130,11 +2183,9 @@ fn classify_running_tool_recovery(
     parent: Option<&ParentRequestRow>,
     now: DateTime<Utc>,
 ) -> Option<RecoveryOutcome> {
-    if parse_datetime(row.deadline_at.as_deref()).is_some_and(|deadline| now >= deadline) {
+    if deadline_is_expired(now, row.deadline_at.as_deref()) {
         Some(RecoveryOutcome::TimedOut)
-    } else if parse_datetime(row.unclaimed_deadline_at.as_deref())
-        .is_some_and(|deadline| now >= deadline)
-    {
+    } else if deadline_is_expired(now, row.unclaimed_deadline_at.as_deref()) {
         Some(RecoveryOutcome::UnclaimedCrossDeploymentSpawn)
     } else if is_background_tool_row(row)
         && parent.is_some_and(|parent| !request_is_terminal(parent))


### PR DESCRIPTION
Closes #1334. Stacked on #1355 (base branch `so/1333-mcp-health`).

## What changed

The subagent tree projection (root request → descendant nodes and edges, depth-bounded, terminal subtrees pruned) has one owner: `gents::subagent_tree`. The CLI's `/subagents/tree` route and the desktop bridge's Tauri command both call it and keep only their transport shape (JSON DTOs, views). The two copies (about 1,270 lines with identical function names) are gone; depth defaults live once.

Deadline expiry is one predicate in `gents` (note: the CLI's liveness and fleet-slots views previously used strict `>`; the shared predicate treats `now == deadline` as expired, matching recovery), used by the CLI's liveness and fleet-slots views and by tool-call recovery.

Per the correction on #1334: the bridge's `operations_snapshot.rs` terminal list classifies tool-call rows and stays; the tool-call side is #1339/#1341.

## Verification

Both copies' existing fixture-tree tests moved with the builder and stay green; `cargo test -p gents --lib subagent_tree tool_call_lifecycle`, `cargo test -p gents-cli`, `cargo test -p gents-desktop-bridge`, `cargo check --workspace --all-targets`, `cargo fmt --all --check`; grep gate: `fn build_subagent_tree|fn prune_terminal_subtrees|fn request_row_into_node` exist only under `crates/gents/src/subagent_tree*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eatk66c9sS6vPq2nasHJVd
