### PR TITLE
One validator per config document; every write door calls it (#1331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 ### Fixed
 
 - Config documents are validated by one owner regardless of write path;
-  `gents config agent-behavior set` now rejects unknown backends, models,
+  `gents config behavior set` now rejects unknown backends, models,
   tool selections and profiles.
 - `/healthz` and `gents fleet-slots` now report backends the local prober has
   vetoed as degraded/not accepting, matching admission.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ### Fixed
 
+- Config documents are validated by one owner regardless of write path;
+  `gents config agent-behavior set` now rejects unknown backends, models,
+  tool selections and profiles.
 - `/healthz` and `gents fleet-slots` now report backends the local prober has
   vetoed as degraded/not accepting, matching admission.
 - `Goal.tokens_used` now reports the charged total (input incl. cached +

--- a/apps/gents-desktop/src-tauri/src/runner/live_fixture/agent.rs
+++ b/apps/gents-desktop/src-tauri/src/runner/live_fixture/agent.rs
@@ -9,7 +9,7 @@ use gents::{
     cli_tool, default_behavior_id_for_agent, default_inference_profile_id_for_behavior,
     default_tool_selection_id_for_behavior, ensure_agent_principal, load_agent_behavior,
     subagent_target_entry, upsert_agent_behavior, AgentIdentity, DocumentRuntimeOptions, Gents,
-    KeyIdentity, ToolCeiling,
+    InferenceBackend, KeyIdentity, ToolCeiling,
 };
 use gents_desktop_core::client::ClientCore;
 use gents_protocol::row::{
@@ -308,6 +308,18 @@ async fn upsert_inference_backend(
     backend_id: &str,
     backend: &AgentBackendConfig,
 ) -> Result<()> {
+    let txn = gents::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+    let validation = async {
+        let existing =
+            gents::config_client::load_inference_backend_in_txn(&txn, backend_id).await?;
+        live_backend_candidate(existing, backend_id, backend).validate(None)
+    }
+    .await;
+    if let Err(error) = validation {
+        let _ = txn.discard().await;
+        return Err(error);
+    }
+
     let escaped_backend_id = escape_graphql_string(backend_id);
     let escaped_endpoint = escape_graphql_string(&backend.endpoint);
     let escaped_provider_kind = escape_graphql_string(backend.provider_kind.as_str());
@@ -347,11 +359,47 @@ async fn upsert_inference_backend(
             ) {{ _docID }}
         }}"#
     );
-    let response = node.execute(&mutation).await;
-    if response.has_errors() {
-        anyhow::bail!("upsert inference backend failed: {:?}", response.errors);
+    match txn.execute(&mutation).await {
+        Ok(_) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
     }
-    Ok(())
+}
+
+fn live_backend_candidate(
+    existing: Option<InferenceBackend>,
+    backend_id: &str,
+    backend: &AgentBackendConfig,
+) -> InferenceBackend {
+    let existing_openai_wire_api = existing
+        .as_ref()
+        .and_then(|backend| backend.openai_wire_api);
+    let existing_api_key = existing
+        .as_ref()
+        .and_then(|backend| backend.api_key.clone());
+    let existing_api_key_env_var = existing
+        .as_ref()
+        .and_then(|backend| backend.api_key_env_var.clone());
+
+    InferenceBackend {
+        backend_id: backend_id.to_string(),
+        name: backend_id.to_string(),
+        provider_kind: backend.provider_kind,
+        openai_wire_api: existing_openai_wire_api,
+        endpoint: backend.endpoint.clone(),
+        // The fixture mutation intentionally preserves an existing credential
+        // when the corresponding override is absent. Validate that effective
+        // document so switching credential modes cannot leave both populated.
+        api_key: backend.api_key.clone().or(existing_api_key),
+        api_key_env_var: backend.api_key_env_var.clone().or(existing_api_key_env_var),
+        max_concurrent: 2,
+        max_queue_depth: 100,
+        enabled: true,
+        models: vec![backend.model_name.clone()],
+        probe_status: "healthy".to_string(),
+    }
 }
 
 async fn bind_default_behavior_backend(
@@ -421,5 +469,44 @@ async fn wait_for_runtime_process_state(
             );
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gents::BackendProviderKind;
+
+    #[test]
+    fn live_backend_candidate_validates_preserved_credentials() {
+        let existing = InferenceBackend {
+            backend_id: "backend".to_string(),
+            name: "backend".to_string(),
+            provider_kind: BackendProviderKind::OpenAiCompatible,
+            openai_wire_api: None,
+            endpoint: "http://old.example/v1".to_string(),
+            api_key: Some("stored-secret".to_string()),
+            api_key_env_var: None,
+            max_concurrent: 1,
+            max_queue_depth: 10,
+            enabled: true,
+            models: vec!["old-model".to_string()],
+            probe_status: "healthy".to_string(),
+        };
+        let requested = AgentBackendConfig {
+            endpoint: "http://new.example/v1".to_string(),
+            model_name: "new-model".to_string(),
+            provider_kind: BackendProviderKind::OpenAiCompatible,
+            api_key: None,
+            api_key_env_var: Some("BACKEND_API_KEY".to_string()),
+        };
+
+        let error = live_backend_candidate(Some(existing), "backend", &requested)
+            .validate(None)
+            .expect_err("the preserved raw key must conflict with the new env reference");
+
+        assert!(error
+            .to_string()
+            .contains("must not set both api_key and api_key_env_var"));
     }
 }

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use gents::{
     backend_registry::list_enabled_backends, list_agent_behaviors, load_agent_behavior,
-    AgentBehaviorDocument, ConfigReferences, InferenceBackend,
+    AgentBehaviorDocument, InferenceBackend,
 };
 use gents_codex_protocol as codex;
 use gents_protocol::row::{
@@ -276,19 +276,6 @@ async fn apply_model_to_bound_behavior(
     let mut behavior = load_bound_behavior(state).await?;
     behavior.backend_id = Some(selection.backend_id.clone());
     behavior.model_name = Some(selection.model_name.clone());
-    // Single owner (#1331): confirm the backend still exists and still
-    // advertises this model through the same validator every other write
-    // door calls, rather than trusting `resolve_model_selection`'s own
-    // backend/model match alone. `resolve_model_selection` picks a
-    // candidate from the readiness-filtered "available" set for product
-    // reasons (don't offer a disabled/unready backend); this is the
-    // unconditional correctness gate right before the write.
-    let refs = ConfigReferences::load(&state.node, state.agent_did.as_ref())
-        .await
-        .context("loading config references to validate the selected model")?;
-    behavior
-        .validate_references(&refs)
-        .context("selected backend/model failed reference validation")?;
     let access = ConfigAccess::Graphql(state.graphql.as_ref().to_string());
     write_agent_behavior_document(&access, &behavior)
         .await

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use gents::{
     backend_registry::list_enabled_backends, list_agent_behaviors, load_agent_behavior,
-    AgentBehaviorDocument, InferenceBackend,
+    AgentBehaviorDocument, ConfigReferences, InferenceBackend,
 };
 use gents_codex_protocol as codex;
 use gents_protocol::row::{
@@ -276,6 +276,19 @@ async fn apply_model_to_bound_behavior(
     let mut behavior = load_bound_behavior(state).await?;
     behavior.backend_id = Some(selection.backend_id.clone());
     behavior.model_name = Some(selection.model_name.clone());
+    // Single owner (#1331): confirm the backend still exists and still
+    // advertises this model through the same validator every other write
+    // door calls, rather than trusting `resolve_model_selection`'s own
+    // backend/model match alone. `resolve_model_selection` picks a
+    // candidate from the readiness-filtered "available" set for product
+    // reasons (don't offer a disabled/unready backend); this is the
+    // unconditional correctness gate right before the write.
+    let refs = ConfigReferences::load(state.node.as_ref(), state.agent_did.as_ref())
+        .await
+        .context("loading config references to validate the selected model")?;
+    behavior
+        .validate_references(&refs)
+        .context("selected backend/model failed reference validation")?;
     let access = ConfigAccess::Graphql(state.graphql.as_ref().to_string());
     write_agent_behavior_document(&access, &behavior)
         .await
@@ -286,11 +299,21 @@ async fn apply_model_to_bound_behavior(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::codex_shim::CodexSidecar;
+    use gents::config_client::{
+        write_inference_backend_document, ConfigAccess as LocalConfigAccess,
+        InferenceBackendUpsertDocument,
+    };
+    use gents::{defra_node::EmbeddedNode, upsert_agent_behavior, BackendProviderKind};
     use gents_protocol::row::{
         AgentBehaviorReadinessRow, BehaviorReadinessEntry, BehaviorReadinessProcessState,
         BehaviorReadinessSnapshot, BehaviorReadinessState, BehaviorReadinessUnavailableReason,
         BEHAVIOR_READINESS_FORMAT_VERSION,
     };
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Mutex;
 
     fn behavior(behavior_id: &str, backend_id: &str) -> AgentBehaviorDocument {
         AgentBehaviorDocument {
@@ -443,5 +466,140 @@ mod tests {
             agent_did,
             observed_at
         ));
+    }
+
+    async fn shim_state_for(
+        node: &Arc<EmbeddedNode>,
+        agent_did: &str,
+        behavior_id: &str,
+    ) -> ShimState {
+        ShimState {
+            codex_home: std::env::temp_dir(),
+            trace_path: std::env::temp_dir().join("codex-shim-model-test-trace.jsonl"),
+            cwd: std::env::temp_dir(),
+            fs_root: None,
+            node: node.clone(),
+            background_execution_registry: gents::BackgroundExecutionRegistry::default(),
+            // Never dialed: `apply_model_to_bound_behavior` validates
+            // references before it ever reaches the write, so a rejected
+            // selection never touches this endpoint.
+            graphql: Arc::from("http://127.0.0.1:0/graphql"),
+            agent_did: Arc::from(agent_did),
+            behavior_id: Arc::from(behavior_id),
+            id_counter: Arc::new(AtomicU64::new(1)),
+            timeout: Duration::from_secs(5),
+            poll_interval: Duration::from_millis(10),
+            sidecar: Arc::new(Mutex::new(CodexSidecar::default())),
+            auth_token: None,
+        }
+    }
+
+    /// Single owner (#1331): `apply_model_to_bound_behavior` must reject a
+    /// backend/model pair the backend doesn't advertise through
+    /// `AgentBehavior::validate_references`, the same validator every other
+    /// config write door calls — not just trust `resolve_model_selection`'s
+    /// own match.
+    #[tokio::test]
+    async fn apply_model_to_bound_behavior_rejects_an_unadvertised_model() {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        gents::ensure_runtime_schemas(&node).await.unwrap();
+
+        let local_access = LocalConfigAccess::Local(node.clone());
+        write_inference_backend_document(
+            &local_access,
+            &InferenceBackendUpsertDocument {
+                backend_id: "backend-a".to_string(),
+                name: "Backend A".to_string(),
+                provider_kind: BackendProviderKind::OpenAiCompatible,
+                openai_wire_api: None,
+                endpoint: "http://127.0.0.1:11434/v1".to_string(),
+                api_key: None,
+                api_key_env_var: None,
+                max_concurrent: 4,
+                max_queue_depth: 100,
+                enabled: true,
+                models_on_add: vec!["model-x".to_string()],
+                models_on_update: None,
+                probe_status: "healthy".to_string(),
+            },
+        )
+        .await
+        .expect("seed backend");
+
+        let agent_did = "did:test:codex-shim";
+        let mut default_behavior = behavior("default", "backend-a");
+        default_behavior.model_name = Some("model-x".to_string());
+        upsert_agent_behavior(&node, &default_behavior)
+            .await
+            .expect("seed behavior");
+
+        let state = shim_state_for(&node, agent_did, "default").await;
+        let selection = ModelSelection {
+            backend_id: "backend-a".to_string(),
+            model_name: "not-advertised".to_string(),
+        };
+
+        let error = apply_model_to_bound_behavior(&state, &selection)
+            .await
+            .expect_err("an unadvertised model must be rejected");
+        // `{:#}` (anyhow's alternate Display) walks the full context chain;
+        // `{}` would only show this call's own wrapping context.
+        assert!(
+            format!("{error:#}").contains("does not advertise"),
+            "{error:#}"
+        );
+    }
+
+    /// The mirror-image happy path: a genuinely-advertised model commits.
+    #[tokio::test]
+    async fn apply_model_to_bound_behavior_accepts_an_advertised_model() {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        gents::ensure_runtime_schemas(&node).await.unwrap();
+
+        let local_access = LocalConfigAccess::Local(node.clone());
+        write_inference_backend_document(
+            &local_access,
+            &InferenceBackendUpsertDocument {
+                backend_id: "backend-a".to_string(),
+                name: "Backend A".to_string(),
+                provider_kind: BackendProviderKind::OpenAiCompatible,
+                openai_wire_api: None,
+                endpoint: "http://127.0.0.1:11434/v1".to_string(),
+                api_key: None,
+                api_key_env_var: None,
+                max_concurrent: 4,
+                max_queue_depth: 100,
+                enabled: true,
+                models_on_add: vec!["model-x".to_string(), "model-y".to_string()],
+                models_on_update: None,
+                probe_status: "healthy".to_string(),
+            },
+        )
+        .await
+        .expect("seed backend");
+
+        let agent_did = "did:test:codex-shim";
+        let mut default_behavior = behavior("default", "backend-a");
+        default_behavior.model_name = Some("model-x".to_string());
+        upsert_agent_behavior(&node, &default_behavior)
+            .await
+            .expect("seed behavior");
+
+        let state = shim_state_for(&node, agent_did, "default").await;
+        let selection = ModelSelection {
+            backend_id: "backend-a".to_string(),
+            model_name: "model-y".to_string(),
+        };
+
+        // The write itself dials the dummy `graphql` endpoint and will fail
+        // to connect — that failure, distinct from a validation rejection,
+        // is exactly the signal that validation passed.
+        let error = apply_model_to_bound_behavior(&state, &selection)
+            .await
+            .expect_err("the dummy graphql endpoint is unreachable");
+        assert!(
+            !format!("{error:#}").contains("does not advertise"),
+            "an advertised model must clear validation: {error:#}"
+        );
     }
 }

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -273,11 +273,19 @@ async fn apply_model_to_bound_behavior(
     state: &ShimState,
     selection: &ModelSelection,
 ) -> Result<()> {
+    let access = ConfigAccess::Graphql(state.graphql.as_ref().to_string());
+    apply_model_to_bound_behavior_with_access(state, selection, &access).await
+}
+
+async fn apply_model_to_bound_behavior_with_access(
+    state: &ShimState,
+    selection: &ModelSelection,
+    access: &ConfigAccess,
+) -> Result<()> {
     let mut behavior = load_bound_behavior(state).await?;
     behavior.backend_id = Some(selection.backend_id.clone());
     behavior.model_name = Some(selection.model_name.clone());
-    let access = ConfigAccess::Graphql(state.graphql.as_ref().to_string());
-    write_agent_behavior_document(&access, &behavior)
+    write_agent_behavior_document(access, &behavior)
         .await
         .context("writing AgentBehavior with selected backend model")?;
     Ok(())
@@ -467,9 +475,6 @@ mod tests {
             fs_root: None,
             node: node.clone(),
             background_execution_registry: gents::BackgroundExecutionRegistry::default(),
-            // Never dialed: `apply_model_to_bound_behavior` validates
-            // references before it ever reaches the write, so a rejected
-            // selection never touches this endpoint.
             graphql: Arc::from("http://127.0.0.1:0/graphql"),
             agent_did: Arc::from(agent_did),
             behavior_id: Arc::from(behavior_id),
@@ -525,8 +530,9 @@ mod tests {
             backend_id: "backend-a".to_string(),
             model_name: "not-advertised".to_string(),
         };
+        let access = ConfigAccess::Local(node);
 
-        let error = apply_model_to_bound_behavior(&state, &selection)
+        let error = apply_model_to_bound_behavior_with_access(&state, &selection, &access)
             .await
             .expect_err("an unadvertised model must be rejected");
         // `{:#}` (anyhow's alternate Display) walks the full context chain;
@@ -577,16 +583,16 @@ mod tests {
             backend_id: "backend-a".to_string(),
             model_name: "model-y".to_string(),
         };
+        let access = ConfigAccess::Local(node.clone());
 
-        // The write itself dials the dummy `graphql` endpoint and will fail
-        // to connect — that failure, distinct from a validation rejection,
-        // is exactly the signal that validation passed.
-        let error = apply_model_to_bound_behavior(&state, &selection)
+        apply_model_to_bound_behavior_with_access(&state, &selection, &access)
             .await
-            .expect_err("the dummy graphql endpoint is unreachable");
-        assert!(
-            !format!("{error:#}").contains("does not advertise"),
-            "an advertised model must clear validation: {error:#}"
-        );
+            .expect("an advertised model must pass validation and commit");
+        let updated = load_agent_behavior(node.as_ref(), "default")
+            .await
+            .expect("reload behavior")
+            .expect("behavior remains present");
+        assert_eq!(updated.backend_id.as_deref(), Some("backend-a"));
+        assert_eq!(updated.model_name.as_deref(), Some("model-y"));
     }
 }

--- a/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
+++ b/crates/gents-cli/src/commands/codex_shim/handlers/models.rs
@@ -283,7 +283,7 @@ async fn apply_model_to_bound_behavior(
     // candidate from the readiness-filtered "available" set for product
     // reasons (don't offer a disabled/unready backend); this is the
     // unconditional correctness gate right before the write.
-    let refs = ConfigReferences::load(state.node.as_ref(), state.agent_did.as_ref())
+    let refs = ConfigReferences::load(&state.node, state.agent_did.as_ref())
         .await
         .context("loading config references to validate the selected model")?;
     behavior

--- a/crates/gents-cli/src/commands/config/backend.rs
+++ b/crates/gents-cli/src/commands/config/backend.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
-use gents::{discover_backend_models, BackendProviderKind};
+use gents::{discover_backend_models, BackendProviderKind, InferenceBackend};
 use serde_json::{json, Value};
 
 use crate::cli::*;
@@ -16,8 +16,42 @@ use crate::{
     EXPORT_INFERENCE_BACKEND_FIELDS,
 };
 
+/// Decode this command's resolved args into the document type
+/// `InferenceBackend::validate` owns. `models` isn't a `backend set` flag —
+/// this writer always stamps the `"default"` placeholder
+/// `write_inference_backend_document` below actually sends — so the
+/// no-lockout conjunct never fires here (it needs a non-empty advertised
+/// list to compare a current model against).
+fn to_document_backend(
+    args: &BackendUpsertArgs,
+    backend: &ResolvedBackendConfig,
+) -> InferenceBackend {
+    InferenceBackend {
+        backend_id: args.backend_id.clone(),
+        name: args.name.clone(),
+        provider_kind: backend.provider_kind,
+        openai_wire_api: backend.openai_wire_api,
+        endpoint: backend.endpoint.clone(),
+        api_key: backend.api_key.clone(),
+        api_key_env_var: backend.api_key_env_var.clone(),
+        max_concurrent: args.max_concurrent,
+        max_queue_depth: args.max_queue_depth,
+        enabled: args.enabled,
+        models: vec!["default".to_string()],
+        probe_status: args.probe_status.clone(),
+    }
+}
+
 pub(super) async fn backend_set(args: BackendUpsertArgs) -> Result<()> {
     let backend = resolve_backend_upsert_config(&args)?;
+    // Document rules (backend_id/endpoint non-empty, api_key shape,
+    // max_concurrent/max_queue_depth positive) are owned by
+    // `InferenceBackend::validate` (#1331) — previously unchecked by this
+    // writer entirely (the api_key-xor-env_var shape check in
+    // `resolve_backend_upsert_config` above is a separate, earlier,
+    // raw-flag sanity check shared with `gents init`; this is the
+    // document-shape gate right before the write).
+    to_document_backend(&args, &backend).validate(None)?;
     let access = ConfigAccess::Graphql(args.graphql.clone());
     let doc = InferenceBackendUpsertDocument {
         backend_id: args.backend_id.clone(),

--- a/crates/gents-cli/src/commands/config/behavior.rs
+++ b/crates/gents-cli/src/commands/config/behavior.rs
@@ -6,7 +6,7 @@ use gents::agent::persona_presets::{self, PresetFields};
 use gents::graphql::escape_graphql_string;
 use gents::{
     default_behavior_id_for_agent, AgentBehaviorDocument as AgentBehavior, AgentIdentity,
-    Collection, ConfigReferences,
+    Collection,
 };
 use gents_protocol::persona::{LocalPersonaRequestRecord, PERSONA_AUTHORITY_LOCAL_SELF};
 use serde::Deserialize;
@@ -54,12 +54,9 @@ pub(super) async fn behavior_set(args: BehaviorUpsertArgs) -> Result<()> {
         skill_excludes: Vec::new(),
         created_at: Some(chrono::Utc::now().to_rfc3339()),
     };
-    // `write_agent_behavior_document` writes exactly what it's given — this
-    // is a raw field edit, deliberately outside persona admission (see the
-    // module doc on `gents::agent::persona_ops`). It's this call site's job
-    // to validate references first, against the single owner (#1331).
-    let refs = ConfigReferences::load_via_access(&access, &args.agent_did).await?;
-    behavior.validate_references(&refs)?;
+    // This raw field edit deliberately stays outside persona admission (see
+    // `gents::agent::persona_ops`). The shared writer owns effective-row
+    // projection and reference validation for this sparse update.
     let doc_id = write_agent_behavior_document(&access, &behavior).await?;
     let output = json!({
         "doc_id": doc_id,
@@ -450,7 +447,14 @@ mod tests {
         apply_persona_request, PersonaCatalogView, PersonaOp, PersonaRequestDoc,
     };
     use gents::agent::persona_presets::PRESET_WRITE;
-    use gents::{ensure_runtime_schemas, load_tool_selection};
+    use gents::config_client::{
+        write_inference_backend_document, ConfigAccess as LocalConfigAccess,
+        InferenceBackendUpsertDocument,
+    };
+    use gents::{
+        ensure_runtime_schemas, load_tool_selection, upsert_inference_profile, BackendProviderKind,
+        InferenceProfile, UNKNOWN_PROBE_STATUS,
+    };
 
     use super::*;
     use crate::cli::ToolPackageArg;
@@ -483,6 +487,34 @@ mod tests {
             .await
             .expect("runtime schemas register");
         let node = Arc::new(node);
+
+        write_inference_backend_document(
+            &LocalConfigAccess::Local(node.clone()),
+            &InferenceBackendUpsertDocument {
+                backend_id: "openai".to_string(),
+                name: "OpenAI".to_string(),
+                provider_kind: BackendProviderKind::OpenAiCompatible,
+                openai_wire_api: None,
+                endpoint: "https://api.openai.com/v1".to_string(),
+                api_key: None,
+                api_key_env_var: None,
+                max_concurrent: 1,
+                max_queue_depth: 1,
+                enabled: true,
+                models_on_add: vec!["gpt-5".to_string()],
+                models_on_update: None,
+                probe_status: UNKNOWN_PROBE_STATUS.to_string(),
+            },
+        )
+        .await?;
+        upsert_inference_profile(
+            &node,
+            &InferenceProfile {
+                profile_id: "profile-1".to_string(),
+                ..Default::default()
+            },
+        )
+        .await?;
 
         let doc = PersonaRequestDoc {
             request_key: "drift-guard-1".to_string(),

--- a/crates/gents-cli/src/commands/config/behavior.rs
+++ b/crates/gents-cli/src/commands/config/behavior.rs
@@ -6,7 +6,7 @@ use gents::agent::persona_presets::{self, PresetFields};
 use gents::graphql::escape_graphql_string;
 use gents::{
     default_behavior_id_for_agent, AgentBehaviorDocument as AgentBehavior, AgentIdentity,
-    Collection,
+    Collection, ConfigReferences,
 };
 use gents_protocol::persona::{LocalPersonaRequestRecord, PERSONA_AUTHORITY_LOCAL_SELF};
 use serde::Deserialize;
@@ -54,6 +54,12 @@ pub(super) async fn behavior_set(args: BehaviorUpsertArgs) -> Result<()> {
         skill_excludes: Vec::new(),
         created_at: Some(chrono::Utc::now().to_rfc3339()),
     };
+    // `write_agent_behavior_document` writes exactly what it's given — this
+    // is a raw field edit, deliberately outside persona admission (see the
+    // module doc on `gents::agent::persona_ops`). It's this call site's job
+    // to validate references first, against the single owner (#1331).
+    let refs = ConfigReferences::load_via_access(&access, &args.agent_did).await?;
+    behavior.validate_references(&refs)?;
     let doc_id = write_agent_behavior_document(&access, &behavior).await?;
     let output = json!({
         "doc_id": doc_id,

--- a/crates/gents-cli/src/commands/config/binding.rs
+++ b/crates/gents-cli/src/commands/config/binding.rs
@@ -735,9 +735,12 @@ mod tests {
 
         let mut errors = Vec::new();
         desired_state::validate::validate_manifest(&manifest, &mut errors);
+        // `ToolSelectionDocument::validate` (#1331, the single owner) reports
+        // this now; the manifest-side `validate_subagent_targets` no longer
+        // re-checks entry parseability (fix round 1).
         assert!(
             errors.iter().any(|msg| {
-                msg.contains("is not valid SubagentTarget JSON") && msg.contains("broken")
+                msg.contains("is not a valid SubagentTarget JSON object") && msg.contains("broken")
             }),
             "malformed entry must still produce an actionable validation error, got {errors:?}"
         );

--- a/crates/gents-cli/src/commands/config/profile.rs
+++ b/crates/gents-cli/src/commands/config/profile.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use gents::document_config::InferenceProfile;
 use gents::graphql::escape_graphql_string;
 use serde_json::json;
 
@@ -13,42 +14,39 @@ use crate::optional_string_field;
 use crate::post_graphql;
 use crate::print_json;
 
+/// Decode this command's args into the document type
+/// `InferenceProfile::validate` owns. The two are field-for-field identical.
+fn to_document_profile(args: &InferenceProfileUpsertArgs) -> InferenceProfile {
+    InferenceProfile {
+        profile_id: args.profile_id.clone(),
+        display_name: args.display_name.clone(),
+        context_window: args.context_window,
+        max_output_tokens: args.max_output_tokens,
+        max_turns: args.max_turns,
+        temperature: args.temperature,
+        top_p: args.top_p,
+        top_k: args.top_k,
+        seed: args.seed,
+        min_p: args.min_p,
+        frequency_penalty: args.frequency_penalty,
+        presence_penalty: args.presence_penalty,
+        repetition_penalty: args.repetition_penalty,
+        reasoning_effort: args.reasoning_effort.clone(),
+        stream_batch_ms: args.stream_batch_ms,
+        stream_liveness_timeout_secs: args.stream_liveness_timeout_secs,
+        deadline_duration_secs: args.deadline_duration_secs,
+        retry_max_transport: args.retry_max_transport,
+        retry_backoff_ms: args.retry_backoff_ms.clone(),
+        retry_max_resample: args.retry_max_resample,
+        retry_allow_repair: args.retry_allow_repair,
+        retry_interactive_max: args.retry_interactive_max,
+    }
+}
+
 pub(super) async fn inference_profile_set(args: InferenceProfileUpsertArgs) -> Result<()> {
-    if args
-        .stream_liveness_timeout_secs
-        .is_some_and(|value| value <= 0)
-    {
-        anyhow::bail!("stream_liveness_timeout_secs must be positive");
-    }
-    if args
-        .top_p
-        .is_some_and(|value| !(0.0..=1.0).contains(&value))
-    {
-        anyhow::bail!("top_p must be within [0, 1]");
-    }
-    if args
-        .min_p
-        .is_some_and(|value| !(0.0..=1.0).contains(&value))
-    {
-        anyhow::bail!("min_p must be within [0, 1]");
-    }
-    if args.top_k.is_some_and(|value| value <= 0) {
-        anyhow::bail!("top_k must be positive");
-    }
-    if args.seed.is_some_and(|value| value < 0) {
-        anyhow::bail!("seed must be non-negative");
-    }
-    if args.repetition_penalty.is_some_and(|value| value <= 0.0) {
-        anyhow::bail!("repetition_penalty must be positive");
-    }
-    for (name, value) in [
-        ("frequency_penalty", args.frequency_penalty),
-        ("presence_penalty", args.presence_penalty),
-    ] {
-        if value.is_some_and(|value| !(-2.0..=2.0).contains(&value)) {
-            anyhow::bail!("{name} must be within [-2, 2]");
-        }
-    }
+    // Document rules (bounds, sampling ranges, reasoning_effort vocabulary)
+    // are owned by `InferenceProfile::validate` (#1331).
+    to_document_profile(&args).validate()?;
 
     let add_fields = vec![
         Some(format!(

--- a/crates/gents-cli/src/commands/config/profile.rs
+++ b/crates/gents-cli/src/commands/config/profile.rs
@@ -1,17 +1,9 @@
 use anyhow::Result;
 use gents::document_config::InferenceProfile;
-use gents::graphql::escape_graphql_string;
 use serde_json::json;
 
 use crate::cli::*;
-use crate::config_writes::mint_recreate_identity_timestamp;
-use crate::extract_mutation_doc_id;
-use crate::optional_bool_field;
-use crate::optional_f64_field;
-use crate::optional_i64_field;
-use crate::optional_i64_list_field;
-use crate::optional_string_field;
-use crate::post_graphql;
+use crate::config_writes::{write_inference_profile_document, ConfigAccess};
 use crate::print_json;
 
 /// Decode this command's args into the document type
@@ -44,96 +36,8 @@ fn to_document_profile(args: &InferenceProfileUpsertArgs) -> InferenceProfile {
 }
 
 pub(super) async fn inference_profile_set(args: InferenceProfileUpsertArgs) -> Result<()> {
-    // Document rules (bounds, sampling ranges, reasoning_effort vocabulary)
-    // are owned by `InferenceProfile::validate` (#1331).
-    to_document_profile(&args).validate()?;
-
-    let add_fields = vec![
-        Some(format!(
-            r#"profile_id: "{}""#,
-            escape_graphql_string(&args.profile_id)
-        )),
-        optional_string_field("display_name", args.display_name.as_deref()),
-        optional_i64_field("context_window", args.context_window),
-        optional_i64_field("max_output_tokens", args.max_output_tokens),
-        optional_i64_field("max_turns", args.max_turns),
-        optional_f64_field("temperature", args.temperature),
-        optional_f64_field("top_p", args.top_p),
-        optional_i64_field("top_k", args.top_k),
-        optional_i64_field("seed", args.seed),
-        optional_f64_field("min_p", args.min_p),
-        optional_f64_field("frequency_penalty", args.frequency_penalty),
-        optional_f64_field("presence_penalty", args.presence_penalty),
-        optional_f64_field("repetition_penalty", args.repetition_penalty),
-        optional_string_field("reasoning_effort", args.reasoning_effort.as_deref()),
-        optional_i64_field("stream_batch_ms", args.stream_batch_ms),
-        optional_i64_field(
-            "stream_liveness_timeout_secs",
-            args.stream_liveness_timeout_secs,
-        ),
-        optional_i64_field("deadline_duration_secs", args.deadline_duration_secs),
-        optional_i64_field("retry_max_transport", args.retry_max_transport),
-        optional_i64_list_field("retry_backoff_ms", args.retry_backoff_ms.as_deref()),
-        optional_i64_field("retry_max_resample", args.retry_max_resample),
-        optional_bool_field("retry_allow_repair", args.retry_allow_repair),
-        optional_i64_field("retry_interactive_max", args.retry_interactive_max),
-        Some(format!(
-            r#"updated_at: "{}""#,
-            escape_graphql_string(&mint_recreate_identity_timestamp())
-        )),
-    ]
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>()
-    .join(",\n                    ");
-    let update_fields = vec![
-        optional_string_field("display_name", args.display_name.as_deref()),
-        optional_i64_field("context_window", args.context_window),
-        optional_i64_field("max_output_tokens", args.max_output_tokens),
-        optional_i64_field("max_turns", args.max_turns),
-        optional_f64_field("temperature", args.temperature),
-        optional_f64_field("top_p", args.top_p),
-        optional_i64_field("top_k", args.top_k),
-        optional_i64_field("seed", args.seed),
-        optional_f64_field("min_p", args.min_p),
-        optional_f64_field("frequency_penalty", args.frequency_penalty),
-        optional_f64_field("presence_penalty", args.presence_penalty),
-        optional_f64_field("repetition_penalty", args.repetition_penalty),
-        optional_string_field("reasoning_effort", args.reasoning_effort.as_deref()),
-        optional_i64_field("stream_batch_ms", args.stream_batch_ms),
-        optional_i64_field(
-            "stream_liveness_timeout_secs",
-            args.stream_liveness_timeout_secs,
-        ),
-        optional_i64_field("deadline_duration_secs", args.deadline_duration_secs),
-        optional_i64_field("retry_max_transport", args.retry_max_transport),
-        optional_i64_list_field("retry_backoff_ms", args.retry_backoff_ms.as_deref()),
-        optional_i64_field("retry_max_resample", args.retry_max_resample),
-        optional_bool_field("retry_allow_repair", args.retry_allow_repair),
-        optional_i64_field("retry_interactive_max", args.retry_interactive_max),
-    ]
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>()
-    .join(",\n                    ");
-    let mutation = format!(
-        r#"mutation {{
-            upsert_InferenceProfile(
-                filter: {{ profile_id: {{ _eq: "{profile_id}" }} }},
-                add: {{
-                    {add_fields}
-                }},
-                update: {{
-                    {update_fields}
-                }}
-            ) {{ _docID }}
-        }}"#,
-        profile_id = escape_graphql_string(&args.profile_id),
-        add_fields = add_fields,
-        update_fields = update_fields,
-    );
-    let response = post_graphql(&args.graphql, &mutation).await?;
-    let doc_id = extract_mutation_doc_id(&response, "InferenceProfile")?;
+    let access = ConfigAccess::Graphql(args.graphql.clone());
+    let doc_id = write_inference_profile_document(&access, &to_document_profile(&args)).await?;
     let output = json!({
         "doc_id": doc_id,
         "profile_id": args.profile_id,

--- a/crates/gents-cli/src/commands/config/tools.rs
+++ b/crates/gents-cli/src/commands/config/tools.rs
@@ -201,7 +201,6 @@ fn tool_selection_command_plan(args: &ToolSelectionUpsertArgs) -> Result<ToolSel
         enable_lsp: None,
         lsp_config: None,
     };
-    selection.validate()?;
     Ok(ToolSelectionCommandPlan {
         selection,
         file_tools_mode,

--- a/crates/gents-cli/src/config_import/lean_apply_write_boundary_tests.rs
+++ b/crates/gents-cli/src/config_import/lean_apply_write_boundary_tests.rs
@@ -689,7 +689,9 @@ async fn recording_graphql_handler(
         }
         Json(json!({ "data": aliased_mutation_response(&query) }))
     } else {
-        Json(json!({ "data": empty_collection_query_response(&query) }))
+        Json(json!({
+            "data": recorded_collection_query_response(&state, tx_id.as_deref(), &query)
+        }))
     }
 }
 
@@ -720,6 +722,63 @@ fn empty_collection_query_response(query: &str) -> Value {
                 Value::Array(Vec::new()),
             );
         }
+    }
+    Value::Object(data)
+}
+
+fn recorded_collection_query_response(
+    state: &RecordingGraphqlState,
+    tx_id: Option<&str>,
+    query: &str,
+) -> Value {
+    let mut events = state.committed.lock().expect("committed lock").clone();
+    if let Some(tx_id) = tx_id {
+        if let Some(pending) = state.transactions.lock().expect("tx lock").get(tx_id) {
+            events.extend(pending.iter().cloned());
+        }
+    }
+
+    let mut visible = Vec::<ObservedWrite>::new();
+    for event in events {
+        visible.retain(|write| {
+            write.collection != event.collection || write.unique_value != event.unique_value
+        });
+        if event.kind != "delete" {
+            visible.push(event);
+        }
+    }
+
+    let mut data = empty_collection_query_response(query)
+        .as_object()
+        .cloned()
+        .expect("empty collection response is an object");
+    for collection in [
+        Collection::InferenceBackend,
+        Collection::ToolSelection,
+        Collection::InferenceProfile,
+        Collection::Skill,
+    ] {
+        if !query.contains(collection.graphql_type()) {
+            continue;
+        }
+        let rows = visible
+            .iter()
+            .filter(|write| write.collection == collection)
+            .map(|write| {
+                let mut row = Map::new();
+                row.insert(
+                    collection.unique_field().to_string(),
+                    Value::String(write.unique_value.clone()),
+                );
+                if collection == Collection::InferenceBackend {
+                    // Empty is the production no-lockout representation for an
+                    // unrestricted backend model set.
+                    row.insert("models".to_string(), Value::Array(Vec::new()));
+                }
+                Value::Object(row)
+            })
+            .collect();
+        data.insert(collection.graphql_type().to_string(), Value::Array(rows));
     }
     Value::Object(data)
 }
@@ -1351,6 +1410,63 @@ async fn config_apply_txn_discard_leaves_committed_empty() {
 mod recorder_unit_tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn recorder_queries_read_committed_and_current_transaction_state() {
+        let state = RecordingGraphqlState::default();
+        state
+            .committed
+            .lock()
+            .expect("committed lock")
+            .push(ObservedWrite {
+                kind: "live".to_string(),
+                collection: Collection::InferenceBackend,
+                unique_value: "committed-backend".to_string(),
+            });
+        state.transactions.lock().expect("tx lock").insert(
+            "current".to_string(),
+            vec![
+                ObservedWrite {
+                    kind: "delete".to_string(),
+                    collection: Collection::InferenceBackend,
+                    unique_value: "committed-backend".to_string(),
+                },
+                ObservedWrite {
+                    kind: "write".to_string(),
+                    collection: Collection::InferenceBackend,
+                    unique_value: "pending-backend".to_string(),
+                },
+            ],
+        );
+        state.transactions.lock().expect("tx lock").insert(
+            "other".to_string(),
+            vec![ObservedWrite {
+                kind: "write".to_string(),
+                collection: Collection::InferenceBackend,
+                unique_value: "other-backend".to_string(),
+            }],
+        );
+
+        let query = "{ InferenceBackend { backend_id models } }";
+        assert_eq!(
+            recorded_collection_query_response(&state, Some("current"), query),
+            json!({
+                "InferenceBackend": [{
+                    "backend_id": "pending-backend",
+                    "models": [],
+                }],
+            })
+        );
+        assert_eq!(
+            recorded_collection_query_response(&state, None, query),
+            json!({
+                "InferenceBackend": [{
+                    "backend_id": "committed-backend",
+                    "models": [],
+                }],
+            })
+        );
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn recorder_begin_returns_numeric_id_and_commit_appends_to_committed() {

--- a/crates/gents-cli/src/config_writes/mod.rs
+++ b/crates/gents-cli/src/config_writes/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use gents::config_client::{
-    mint_recreate_identity, mint_recreate_identity_timestamp, write_agent_behavior_document,
-    write_event_trigger_document, write_inference_backend_document, write_schedule_document,
+    mint_recreate_identity, write_agent_behavior_document, write_event_trigger_document,
+    write_inference_backend_document, write_inference_profile_document, write_schedule_document,
     write_task_document, write_tool_selection_document,
     write_tool_selection_document_with_clear_fields, ConfigAccess, ConfigApplyTxn,
     ExistingDocumentRef, InferenceBackendUpsertDocument,

--- a/crates/gents-cli/src/desired_state/tests/validation/agent.rs
+++ b/crates/gents-cli/src/desired_state/tests/validation/agent.rs
@@ -44,12 +44,11 @@ fn validate_rejects_non_positive_deadline_without_relationship_error() {
 }
 
 #[test]
-fn validate_reports_the_first_invalid_timeout_without_relationship_error() {
-    // `InferenceProfile::validate` (#1331, the single owner) returns
-    // `Result<()>` — one error per profile, not an accumulating list — so
-    // when both timeouts are invalid, only the first-checked rule
-    // (stream_liveness_timeout_secs) surfaces; the relationship check never
-    // runs because validation already failed.
+fn validate_reports_each_invalid_timeout_without_relationship_error() {
+    // `InferenceProfile::validate` (#1331, the single owner) reports every
+    // violated rule at once (fix round 1) — both timeout bounds surface
+    // when both are invalid, and the relationship check is still skipped
+    // (neither individual bound is valid enough to compare).
     let mut manifest = empty_manifest("did:test:test");
     let mut profile = profile("invalid-timeouts");
     profile.stream_liveness_timeout_secs = Some(0);
@@ -65,10 +64,10 @@ fn validate_reports_the_first_invalid_timeout_without_relationship_error() {
         "expected liveness validation error, got {errors:?}"
     );
     assert!(
-        !errors
+        errors
             .iter()
             .any(|message| message.contains("deadline_duration_secs must be positive")),
-        "expected the deadline rule to not run once liveness already failed, got {errors:?}"
+        "expected deadline validation error, got {errors:?}"
     );
     assert!(
         !errors

--- a/crates/gents-cli/src/desired_state/tests/validation/agent.rs
+++ b/crates/gents-cli/src/desired_state/tests/validation/agent.rs
@@ -44,7 +44,12 @@ fn validate_rejects_non_positive_deadline_without_relationship_error() {
 }
 
 #[test]
-fn validate_reports_each_invalid_timeout_without_relationship_error() {
+fn validate_reports_the_first_invalid_timeout_without_relationship_error() {
+    // `InferenceProfile::validate` (#1331, the single owner) returns
+    // `Result<()>` — one error per profile, not an accumulating list — so
+    // when both timeouts are invalid, only the first-checked rule
+    // (stream_liveness_timeout_secs) surfaces; the relationship check never
+    // runs because validation already failed.
     let mut manifest = empty_manifest("did:test:test");
     let mut profile = profile("invalid-timeouts");
     profile.stream_liveness_timeout_secs = Some(0);
@@ -60,10 +65,10 @@ fn validate_reports_each_invalid_timeout_without_relationship_error() {
         "expected liveness validation error, got {errors:?}"
     );
     assert!(
-        errors
+        !errors
             .iter()
             .any(|message| message.contains("deadline_duration_secs must be positive")),
-        "expected deadline validation error, got {errors:?}"
+        "expected the deadline rule to not run once liveness already failed, got {errors:?}"
     );
     assert!(
         !errors

--- a/crates/gents-cli/src/desired_state/tests/validation/agent.rs
+++ b/crates/gents-cli/src/desired_state/tests/validation/agent.rs
@@ -75,6 +75,14 @@ fn validate_reports_each_invalid_timeout_without_relationship_error() {
             .any(|message| message.contains("must be less than deadline_duration_secs")),
         "expected no relationship error for invalid timeouts, got {errors:?}"
     );
+    assert_eq!(
+        errors
+            .iter()
+            .filter(|message| message.contains("InferenceProfile invalid-timeouts"))
+            .count(),
+        2,
+        "each invalid profile bound must be a separate error-list entry: {errors:?}"
+    );
 }
 
 #[test]
@@ -293,6 +301,66 @@ fn behavior_model_must_be_advertised_by_its_backend() {
             "behavior default selects model GLM-5.2 which backend reviewers does not advertise",
         )
     }));
+}
+
+#[test]
+fn behavior_validation_reports_each_missing_reference_separately() {
+    let mut manifest = template_manifest(None, None);
+    let behavior = &mut manifest.agent_behaviors[0];
+    behavior.backend_id = Some("missing-backend".to_string());
+    behavior.tool_selection_id = Some("missing-tools".to_string());
+    behavior.inference_profile_id = Some("missing-profile".to_string());
+    behavior.skill_refs = vec!["missing-skill-a".to_string(), "missing-skill-b".to_string()];
+    behavior.skill_excludes = vec!["missing-skill-c".to_string()];
+
+    let errors = validation_errors(&manifest);
+    let expected = [
+        "missing backend_id missing-backend",
+        "missing tool_selection_id missing-tools",
+        "missing inference_profile_id missing-profile",
+        "missing skill_ref missing-skill-a",
+        "missing skill_ref missing-skill-b",
+        "missing skill_exclude missing-skill-c",
+    ];
+
+    for expected_message in expected {
+        assert_eq!(
+            errors
+                .iter()
+                .filter(|error| error.contains(expected_message))
+                .count(),
+            1,
+            "expected one separate {expected_message:?} error, got {errors:?}"
+        );
+    }
+
+    assert_eq!(
+        errors.len(),
+        expected.len(),
+        "expected one error-list entry per missing reference, got {errors:?}"
+    );
+}
+
+#[test]
+fn backend_validation_reports_each_violation_separately() {
+    let mut manifest = template_manifest(None, None);
+    let mut invalid = backend("invalid-backend");
+    invalid.endpoint = "  ".to_string();
+    invalid.max_concurrent = 0;
+    invalid.max_queue_depth = -1;
+    manifest.inference_backends.push(invalid);
+
+    let errors = validation_errors(&manifest);
+    assert_eq!(errors.len(), 3, "{errors:?}");
+    assert!(errors
+        .iter()
+        .any(|error| error.contains("endpoint must not be empty")));
+    assert!(errors
+        .iter()
+        .any(|error| error.contains("max_concurrent must be positive")));
+    assert!(errors
+        .iter()
+        .any(|error| error.contains("max_queue_depth must be positive")));
 }
 
 fn manifest_with_reasoning_effort(reasoning_effort: Option<&str>) -> DesiredStateManifest {

--- a/crates/gents-cli/src/desired_state/tests/validation/tooling.rs
+++ b/crates/gents-cli/src/desired_state/tests/validation/tooling.rs
@@ -23,6 +23,34 @@ fn validate_rejects_empty_string_in_subagent_targets() {
 }
 
 #[test]
+fn validate_reports_each_tool_selection_violation_separately() {
+    let mut manifest = manifest_with_default_behavior();
+    let mut selection = sample_tool_selection("invalid-tools");
+    selection.agent_did = "did:test:test".to_string();
+    selection.subagent_targets = vec![String::new()];
+    selection.backgroundable_tool_names = vec![String::new()];
+    selection.subagent_background_enabled = false;
+    selection.subagent_default_await_mode = Some("background".to_string());
+    manifest.tool_selections.push(selection);
+
+    let errors = validation_errors(&manifest);
+    let owned_errors = errors
+        .iter()
+        .filter(|error| error.starts_with("tool selection invalid-tools:"))
+        .collect::<Vec<_>>();
+    assert_eq!(owned_errors.len(), 3, "{errors:?}");
+    assert!(owned_errors
+        .iter()
+        .any(|error| error.contains("subagent_targets[0]")));
+    assert!(owned_errors
+        .iter()
+        .any(|error| error.contains("backgroundable_tool_names[0]")));
+    assert!(owned_errors
+        .iter()
+        .any(|error| error.contains("subagent_default_await_mode")));
+}
+
+#[test]
 fn validate_rejects_subagent_spawn_enabled_without_targets() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");

--- a/crates/gents-cli/src/desired_state/tests/validation/tooling.rs
+++ b/crates/gents-cli/src/desired_state/tests/validation/tooling.rs
@@ -9,10 +9,15 @@ fn validate_rejects_empty_string_in_subagent_targets() {
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
+    // `ToolSelectionDocument::validate` (#1331, the single owner) reports
+    // this now; its message doesn't repeat the selection_id (a document
+    // validator sees one document, not the manifest it came from) — the
+    // manifest-side `validate_subagent_targets` no longer re-checks entry
+    // parseability, only duplicate names and cross-deployment permission.
     assert!(
         errors
             .iter()
-            .any(|msg| msg.contains("subagent_targets") && msg.contains("agent-tools")),
+            .any(|msg| msg.contains("subagent_targets[0] is empty")),
         "expected empty subagent_targets entry rejection, got {errors:?}"
     );
 }

--- a/crates/gents-cli/src/desired_state/validate/agent.rs
+++ b/crates/gents-cli/src/desired_state/validate/agent.rs
@@ -8,8 +8,8 @@ use gents::{
     UNKNOWN_PROBE_STATUS,
 };
 
-use super::super::{DesiredAgentBehavior, DesiredInferenceBackend, DesiredInferenceProfile};
 use super::super::DesiredStateManifest;
+use super::super::{DesiredAgentBehavior, DesiredInferenceBackend, DesiredInferenceProfile};
 use super::storage::non_empty;
 
 /// Decode a manifest backend into the document type `InferenceBackend::validate`

--- a/crates/gents-cli/src/desired_state/validate/agent.rs
+++ b/crates/gents-cli/src/desired_state/validate/agent.rs
@@ -1,12 +1,89 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use gents::template::{
     catalog::default_catalog, reads::validate_system_template, validate_request_context_template,
 };
-use gents::{DEFAULT_DEADLINE_DURATION_SECS, DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS};
+use gents::{
+    AgentBehaviorDocument, ConfigReferences, InferenceBackend, InferenceProfile,
+    UNKNOWN_PROBE_STATUS,
+};
 
+use super::super::{DesiredAgentBehavior, DesiredInferenceBackend, DesiredInferenceProfile};
 use super::super::DesiredStateManifest;
 use super::storage::non_empty;
+
+/// Decode a manifest backend into the document type `InferenceBackend::validate`
+/// owns. `probe_status` is runtime-owned (not part of desired state) and does
+/// not affect validation.
+fn to_document_backend(backend: &DesiredInferenceBackend) -> InferenceBackend {
+    InferenceBackend {
+        backend_id: backend.backend_id.clone(),
+        name: backend.name.clone(),
+        provider_kind: backend.provider_kind,
+        openai_wire_api: backend.openai_wire_api,
+        endpoint: backend.endpoint.clone(),
+        api_key: backend.api_key.clone(),
+        api_key_env_var: backend.api_key_env_var.clone(),
+        max_concurrent: backend.max_concurrent,
+        max_queue_depth: backend.max_queue_depth,
+        enabled: backend.enabled,
+        models: backend.models.clone(),
+        probe_status: UNKNOWN_PROBE_STATUS.to_string(),
+    }
+}
+
+/// Decode a manifest profile into the document type `InferenceProfile::validate`
+/// owns. The two structs are field-for-field identical; this is a plain copy.
+fn to_document_profile(profile: &DesiredInferenceProfile) -> InferenceProfile {
+    InferenceProfile {
+        profile_id: profile.profile_id.clone(),
+        display_name: profile.display_name.clone(),
+        context_window: profile.context_window,
+        max_output_tokens: profile.max_output_tokens,
+        max_turns: profile.max_turns,
+        temperature: profile.temperature,
+        top_p: profile.top_p,
+        top_k: profile.top_k,
+        seed: profile.seed,
+        min_p: profile.min_p,
+        frequency_penalty: profile.frequency_penalty,
+        presence_penalty: profile.presence_penalty,
+        repetition_penalty: profile.repetition_penalty,
+        reasoning_effort: profile.reasoning_effort.clone(),
+        stream_batch_ms: profile.stream_batch_ms,
+        stream_liveness_timeout_secs: profile.stream_liveness_timeout_secs,
+        deadline_duration_secs: profile.deadline_duration_secs,
+        retry_max_transport: profile.retry_max_transport,
+        retry_backoff_ms: profile.retry_backoff_ms.clone(),
+        retry_max_resample: profile.retry_max_resample,
+        retry_allow_repair: profile.retry_allow_repair,
+        retry_interactive_max: profile.retry_interactive_max,
+    }
+}
+
+/// Decode a manifest behavior into the document type
+/// `AgentBehavior::validate_references` owns.
+fn to_document_behavior(behavior: &DesiredAgentBehavior) -> AgentBehaviorDocument {
+    AgentBehaviorDocument {
+        behavior_id: behavior.behavior_id.clone(),
+        agent_did: behavior.agent_did.clone(),
+        display_name: behavior.display_name.clone(),
+        description: behavior.description.clone(),
+        summary: behavior.summary.clone(),
+        system_prompt: behavior.system_prompt.clone(),
+        request_context_template: behavior.request_context_template.clone(),
+        backend_id: behavior.backend_id.clone(),
+        model_name: behavior.model_name.clone(),
+        tool_selection_id: behavior.tool_selection_id.clone(),
+        inference_profile_id: behavior.inference_profile_id.clone(),
+        compaction_strategy: behavior.compaction_strategy.clone(),
+        compaction_threshold: behavior.compaction_threshold,
+        enabled: behavior.enabled,
+        skill_refs: behavior.skill_refs.clone(),
+        skill_excludes: behavior.skill_excludes.clone(),
+        created_at: None,
+    }
+}
 
 pub(super) fn validate_principal<'a>(
     manifest: &'a DesiredStateManifest,
@@ -26,17 +103,14 @@ pub(super) fn validate_backends(
     let mut backend_ids = BTreeSet::new();
     let mut backend_models = HashMap::<String, BTreeSet<String>>::new();
     for backend in &manifest.inference_backends {
+        // Manifest-shape: duplicate backend_id detection has no document
+        // equivalent (a document validator sees one document at a time).
         let backend_id = backend.backend_id.trim();
-        if backend_id.is_empty() {
-            errors.push(
-                "inference-backends.json contains a backend with an empty backend_id".to_string(),
-            );
-        } else if !backend_ids.insert(backend_id.to_string()) {
+        if !backend_id.is_empty() && !backend_ids.insert(backend_id.to_string()) {
             errors.push(format!(
                 "duplicate backend_id in inference-backends.json: {backend_id}"
             ));
         }
-
         if !backend_id.is_empty() {
             backend_models.insert(
                 backend_id.to_string(),
@@ -50,42 +124,15 @@ pub(super) fn validate_backends(
             );
         }
 
-        if backend.endpoint.trim().is_empty() {
-            errors.push(format!(
-                "backend {} in inference-backends.json must contain a non-empty endpoint",
-                backend.backend_id
-            ));
-        }
-
-        if backend
-            .api_key
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| value.is_empty())
-        {
-            errors.push(format!(
-                "backend {} in inference-backends.json contains an empty api_key",
-                backend.backend_id
-            ));
-        }
-
-        if backend
-            .api_key
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_some()
-            && backend
-                .api_key_env_var
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .is_some()
-        {
-            errors.push(format!(
-                "backend {} in inference-backends.json must not set both api_key and api_key_env_var",
-                backend.backend_id
-            ));
+        // Document rules (empty backend_id/endpoint, api_key shape,
+        // max_concurrent/max_queue_depth) are owned by
+        // `InferenceBackend::validate`. `current_model=None`: desired state
+        // validates backends independently of behaviors and separately
+        // checks each behavior's model against its backend's advertised list
+        // in `validate_behaviors`, so the no-lockout conjunct never fires
+        // here.
+        if let Err(error) = to_document_backend(backend).validate(None) {
+            errors.push(error.to_string());
         }
     }
     (backend_ids, backend_models)
@@ -97,6 +144,11 @@ pub(super) fn validate_profiles(
 ) -> BTreeSet<String> {
     let mut profile_ids = BTreeSet::new();
     for profile in &manifest.inference_profiles {
+        // Manifest-shape: empty/duplicate profile_id detection has no
+        // document equivalent (`InferenceProfile::validate` does not check
+        // profile_id — a document validator sees one document at a time and
+        // cannot compare it against siblings; emptiness here is a manifest
+        // authoring mistake naming the file it came from).
         let profile_id = profile.profile_id.trim();
         if profile_id.is_empty() {
             errors.push(
@@ -107,57 +159,12 @@ pub(super) fn validate_profiles(
                 "duplicate profile_id in inference-profiles.json: {profile_id}"
             ));
         }
-        let stream_liveness_timeout_secs = match profile.stream_liveness_timeout_secs {
-            Some(value) if value <= 0 => {
-                errors.push(format!(
-                    "InferenceProfile {profile_id} stream_liveness_timeout_secs must be positive"
-                ));
-                None
-            }
-            Some(value) => Some(value),
-            None => Some(DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS as i64),
-        };
-        let deadline_duration_secs = match profile.deadline_duration_secs {
-            Some(value) if value <= 0 => {
-                errors.push(format!(
-                    "InferenceProfile {profile_id} deadline_duration_secs must be positive"
-                ));
-                None
-            }
-            Some(value) => Some(value),
-            None => Some(DEFAULT_DEADLINE_DURATION_SECS as i64),
-        };
-        if let (Some(stream_liveness_timeout_secs), Some(deadline_duration_secs)) =
-            (stream_liveness_timeout_secs, deadline_duration_secs)
-        {
-            if stream_liveness_timeout_secs >= deadline_duration_secs {
-                errors.push(format!(
-                    "InferenceProfile {profile_id} stream_liveness_timeout_secs ({stream_liveness_timeout_secs}) must be less than deadline_duration_secs ({deadline_duration_secs})"
-                ));
-            }
-        }
-        if profile.seed.is_some_and(|value| value < 0) {
-            errors.push(format!(
-                "InferenceProfile {profile_id} seed must be non-negative"
-            ));
-        }
-        // Empty reasoning effort is unset: DefraDB may materialize nullable
-        // strings as empty values, and exported manifests must round-trip.
-        if profile
-            .reasoning_effort
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_some_and(|value| {
-                !matches!(
-                    value,
-                    "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
-                )
-            })
-        {
-            errors.push(format!(
-                "InferenceProfile {profile_id} reasoning_effort must be one of: none, minimal, low, medium, high, xhigh, max, ultra"
-            ));
+
+        // Document rules (empty profile_id, timeout/deadline bounds and
+        // relationship, seed, reasoning_effort vocabulary) are owned by
+        // `InferenceProfile::validate`.
+        if let Err(error) = to_document_profile(profile).validate() {
+            errors.push(error.to_string());
         }
     }
     profile_ids
@@ -211,8 +218,31 @@ pub(super) fn validate_behaviors(
     skill_ids: &BTreeSet<String>,
     errors: &mut Vec<String>,
 ) -> BTreeSet<String> {
+    // Document rule: reference existence (backend, model advertised by the
+    // backend, tool selection, profile, skill refs/excludes) is owned by
+    // `AgentBehavior::validate_references`. `backend_ids` names every backend
+    // that validated cleanly in `validate_backends`, so this snapshot only
+    // needs the id -> models map for the ones actually referenceable.
+    let refs = ConfigReferences {
+        backends: backend_ids
+            .iter()
+            .map(|id| {
+                let models = backend_models
+                    .get(id)
+                    .map(|models| models.iter().cloned().collect())
+                    .unwrap_or_default();
+                (id.clone(), models)
+            })
+            .collect::<BTreeMap<_, _>>(),
+        tool_selections: tool_selection_ids.clone(),
+        profiles: profile_ids.clone(),
+        skills: skill_ids.clone(),
+    };
+
     let mut behavior_ids = BTreeSet::new();
     for behavior in &manifest.agent_behaviors {
+        // Manifest-shape: empty/duplicate behavior_id and principal
+        // ownership have no document equivalent.
         let behavior_id = behavior.behavior_id.trim();
         if behavior_id.is_empty() {
             errors.push(
@@ -231,41 +261,8 @@ pub(super) fn validate_behaviors(
             ));
         }
 
-        if let Some(backend_id) = non_empty(&behavior.backend_id) {
-            if !backend_ids.contains(backend_id) {
-                errors.push(format!(
-                    "behavior {} references missing backend_id {}",
-                    behavior.behavior_id, backend_id
-                ));
-            } else if let Some(model_name) = non_empty(&behavior.model_name) {
-                let advertised = backend_models
-                    .get(backend_id)
-                    .expect("known backend has a model entry");
-                if !advertised.is_empty() && !advertised.contains(model_name) {
-                    errors.push(format!(
-                        "behavior {} selects model {} which backend {} does not advertise",
-                        behavior.behavior_id, model_name, backend_id
-                    ));
-                }
-            }
-        }
-
-        if let Some(selection_id) = non_empty(&behavior.tool_selection_id) {
-            if !tool_selection_ids.contains(selection_id) {
-                errors.push(format!(
-                    "behavior {} references missing tool_selection_id {}",
-                    behavior.behavior_id, selection_id
-                ));
-            }
-        }
-
-        if let Some(profile_id) = non_empty(&behavior.inference_profile_id) {
-            if !profile_ids.contains(profile_id) {
-                errors.push(format!(
-                    "behavior {} references missing inference_profile_id {}",
-                    behavior.behavior_id, profile_id
-                ));
-            }
+        if let Err(error) = to_document_behavior(behavior).validate_references(&refs) {
+            errors.push(error.to_string());
         }
 
         if let Some(system_prompt) = behavior.system_prompt.as_deref() {
@@ -278,25 +275,6 @@ pub(super) fn validate_behaviors(
                 request_context_template,
                 errors,
             );
-        }
-
-        for skill_ref in &behavior.skill_refs {
-            let skill_ref = skill_ref.trim();
-            if !skill_ref.is_empty() && !skill_ids.contains(skill_ref) {
-                errors.push(format!(
-                    "behavior {} references missing skill_ref {} (import the skill first)",
-                    behavior.behavior_id, skill_ref
-                ));
-            }
-        }
-        for skill_exclude in &behavior.skill_excludes {
-            let skill_exclude = skill_exclude.trim();
-            if !skill_exclude.is_empty() && !skill_ids.contains(skill_exclude) {
-                errors.push(format!(
-                    "behavior {} references missing skill_exclude {}",
-                    behavior.behavior_id, skill_exclude
-                ));
-            }
         }
     }
     behavior_ids

--- a/crates/gents-cli/src/desired_state/validate/agent.rs
+++ b/crates/gents-cli/src/desired_state/validate/agent.rs
@@ -131,9 +131,7 @@ pub(super) fn validate_backends(
         // checks each behavior's model against its backend's advertised list
         // in `validate_behaviors`, so the no-lockout conjunct never fires
         // here.
-        if let Err(error) = to_document_backend(backend).validate(None) {
-            errors.push(error.to_string());
-        }
+        errors.extend(to_document_backend(backend).validation_violations(None));
     }
     (backend_ids, backend_models)
 }
@@ -160,12 +158,10 @@ pub(super) fn validate_profiles(
             ));
         }
 
-        // Document rules (empty profile_id, timeout/deadline bounds and
-        // relationship, seed, reasoning_effort vocabulary) are owned by
+        // Document rules (timeout/deadline bounds and relationship, seed,
+        // reasoning_effort vocabulary) are owned by
         // `InferenceProfile::validate`.
-        if let Err(error) = to_document_profile(profile).validate() {
-            errors.push(error.to_string());
-        }
+        errors.extend(to_document_profile(profile).validation_violations());
     }
     profile_ids
 }
@@ -220,9 +216,9 @@ pub(super) fn validate_behaviors(
 ) -> BTreeSet<String> {
     // Document rule: reference existence (backend, model advertised by the
     // backend, tool selection, profile, skill refs/excludes) is owned by
-    // `AgentBehavior::validate_references`. `backend_ids` names every backend
-    // that validated cleanly in `validate_backends`, so this snapshot only
-    // needs the id -> models map for the ones actually referenceable.
+    // `AgentBehavior::validate_references`. `backend_ids` names every
+    // non-empty manifest backend id; document-shape violations for those
+    // backends are reported independently by `validate_backends`.
     let refs = ConfigReferences {
         backends: backend_ids
             .iter()
@@ -261,9 +257,10 @@ pub(super) fn validate_behaviors(
             ));
         }
 
-        if let Err(error) = to_document_behavior(behavior).validate_references(&refs) {
-            errors.push(error.to_string());
-        }
+        // Each violation becomes its own error-list entry (not one joined
+        // string) — `reference_violations` is the Vec-returning variant of
+        // `AgentBehavior::validate_references` for exactly this reason.
+        errors.extend(to_document_behavior(behavior).reference_violations(&refs));
 
         if let Some(system_prompt) = behavior.system_prompt.as_deref() {
             validate_behavior_system_template(&behavior.behavior_id, system_prompt, errors);

--- a/crates/gents-cli/src/desired_state/validate/tooling.rs
+++ b/crates/gents-cli/src/desired_state/validate/tooling.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use gents::{
     is_reserved_builtin_tool_name, CommandExecutionMode, CommandNetworkMode, SubagentTarget,
-    SurfaceToolDecl, WriteToolDecl, KEY_BACKEND_KEYRING,
+    SurfaceToolDecl, ToolSelectionDocument, WriteToolDecl, KEY_BACKEND_KEYRING,
 };
 
 use super::super::{
@@ -156,6 +156,63 @@ fn is_eth_address(value: &str) -> bool {
         && value[2..].bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+/// Decode a manifest tool selection into the document type
+/// `ToolSelectionDocument::validate` owns. `write_tools` is deliberately left
+/// `None`: its field-level checks only make sense over the inline ∪
+/// surface-expanded list, which only `validate_tool_selection_surface_links`
+/// (a cross-document, manifest-only concern — `DatastoreToolSurface` doesn't
+/// exist as a concept inside one `ToolSelectionDocument`) can assemble.
+fn to_document_tool_selection(selection: &DesiredToolSelection) -> ToolSelectionDocument {
+    fn some(values: &[String]) -> Option<Vec<String>> {
+        Some(values.to_vec())
+    }
+    ToolSelectionDocument {
+        selection_id: selection.selection_id.clone(),
+        agent_did: selection.agent_did.clone(),
+        display_name: selection.display_name.clone(),
+        tool_policy_version: Some(selection.tool_policy_version.clone()),
+        enable_file_tools: Some(selection.enable_file_tools),
+        file_tools_mode: Some(selection.file_tools_mode.clone()),
+        file_tool_root: selection.file_tool_root.clone(),
+        enable_bash: Some(selection.enable_bash),
+        bash_mode: Some(selection.bash_mode.clone()),
+        command_execution_policy: selection.command_execution_policy.clone(),
+        command_allowed_argv_prefixes: some(&selection.command_allowed_argv_prefixes),
+        command_forbidden_argv_prefixes: some(&selection.command_forbidden_argv_prefixes),
+        read_only_command_allowlist: some(&selection.read_only_command_allowlist),
+        command_network_mode: selection.command_network_mode.clone(),
+        cli_tool_names: some(&selection.cli_tool_names),
+        enable_meta_tools: Some(selection.enable_meta_tools),
+        enable_goal_tools: selection.enable_goal_tools.flatten(),
+        enable_goal_creation: selection.enable_goal_creation.flatten(),
+        allowed_mcp_service_ids: some(&selection.allowed_mcp_service_ids),
+        required_mcp_service_ids: some(&selection.required_mcp_service_ids),
+        backgroundable_tool_names: some(&selection.backgroundable_tool_names),
+        approval_required_tools: None,
+        subagent_targets: some(&selection.subagent_targets),
+        subagent_spawn_enabled: Some(selection.subagent_spawn_enabled),
+        subagent_steering_enabled: Some(selection.subagent_steering_enabled),
+        subagent_background_enabled: Some(selection.subagent_background_enabled),
+        subagent_default_await_mode: selection.subagent_default_await_mode.clone(),
+        subagent_allow_cross_deployment: Some(selection.subagent_allow_cross_deployment),
+        cross_deployment_spawn_timeout_seconds: selection.cross_deployment_spawn_timeout_seconds,
+        enable_memory: Some(selection.enable_memory),
+        enable_session_history_tool: Some(selection.enable_session_history_tool),
+        enable_context_budget: Some(selection.enable_context_budget),
+        enable_defra_query: Some(selection.enable_defra_query),
+        defra_query_collections: some(&selection.defra_query_collections),
+        write_tools: None,
+        datastore_tool_surface_ids: some(&selection.datastore_tool_surface_ids),
+        eth_tool_ids: some(&selection.eth_tool_ids),
+        enable_self_config: Some(selection.enable_self_config),
+        self_config_categories: some(&selection.self_config_categories),
+        self_config_no_lockout: Some(selection.self_config_no_lockout),
+        self_config_dry_run: Some(selection.self_config_dry_run),
+        enable_lsp: Some(selection.enable_lsp),
+        lsp_config: selection.lsp_config.clone(),
+    }
+}
+
 pub(super) fn validate_tool_selections(
     manifest: &DesiredStateManifest,
     principal_agent_did: &str,
@@ -163,6 +220,9 @@ pub(super) fn validate_tool_selections(
 ) -> BTreeSet<String> {
     let mut tool_selection_ids = BTreeSet::new();
     for selection in &manifest.tool_selections {
+        // Manifest-shape: empty/duplicate selection_id and principal
+        // ownership have no document equivalent (a document validator sees
+        // one document at a time and doesn't know the current principal).
         let selection_id = selection.selection_id.trim();
         if selection_id.is_empty() {
             errors.push(
@@ -182,47 +242,24 @@ pub(super) fn validate_tool_selections(
             ));
         }
 
-        if let Some(mode) = selection
-            .subagent_default_await_mode
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            match mode {
-                "foreground" => {}
-                "background" if selection.subagent_background_enabled => {}
-                "background" => errors.push(format!(
-                    "tool selection {} sets subagent_default_await_mode=background but subagent_background_enabled is false",
-                    selection.selection_id
-                )),
-                other => errors.push(format!(
-                    "tool selection {} has invalid subagent_default_await_mode {other:?}; expected foreground or background",
-                    selection.selection_id
-                )),
-            }
+        // Document rules (subagent_default_await_mode vs
+        // subagent_background_enabled, backgroundable_tool_names emptiness,
+        // subagent_targets structural validity, required_mcp_service_ids
+        // needing enable_meta_tools and staying inside
+        // allowed_mcp_service_ids, self_config_categories vocabulary) are
+        // owned by `ToolSelectionDocument::validate`.
+        if let Err(error) = to_document_tool_selection(selection).validate() {
+            errors.push(error.to_string());
         }
 
+        // Manifest-shape: command_execution_policy/command_network_mode
+        // parsing and the two argv-prefix JSON shape checks have no document
+        // equivalent (the document stores them as plain strings/lists; the
+        // richer enum/JSON-array shape is a manifest-authoring concern).
         if let Some(mode) = selection.command_execution_policy.as_deref() {
             if let Err(error) = CommandExecutionMode::parse(mode) {
                 errors.push(format!(
                     "tool selection {} has invalid command_execution_policy: {error}",
-                    selection.selection_id
-                ));
-            }
-        }
-
-        for (index, tool_name) in selection.backgroundable_tool_names.iter().enumerate() {
-            if tool_name.trim().is_empty() {
-                errors.push(format!(
-                    "tool selection {} has empty backgroundable_tool_names[{index}]",
-                    selection.selection_id
-                ));
-            }
-        }
-        for (index, target) in selection.subagent_targets.iter().enumerate() {
-            if target.trim().is_empty() {
-                errors.push(format!(
-                    "tool selection {} has empty subagent_targets[{index}]",
                     selection.selection_id
                 ));
             }
@@ -247,34 +284,22 @@ pub(super) fn validate_tool_selections(
             &selection.command_forbidden_argv_prefixes,
             errors,
         );
+        // Manifest-shape: `allowed_mcp_service_ids` entry emptiness has no
+        // document equivalent (`ToolSelectionDocument::validate` only checks
+        // `required_mcp_service_ids` entries, since only those are
+        // referenced by the no-lockout-adjacent callable-dependency rule).
         validate_tool_selection_non_empty_entries(
             &selection.selection_id,
             "allowed_mcp_service_ids",
             &selection.allowed_mcp_service_ids,
             errors,
         );
-        validate_tool_selection_non_empty_entries(
-            &selection.selection_id,
-            "required_mcp_service_ids",
-            &selection.required_mcp_service_ids,
-            errors,
-        );
-        if !selection.required_mcp_service_ids.is_empty() && !selection.enable_meta_tools {
-            errors.push(format!(
-                "tool selection {} requires MCP services but enable_meta_tools is false",
-                selection.selection_id
-            ));
-        }
-        if !selection.allowed_mcp_service_ids.is_empty() {
-            for service_id in &selection.required_mcp_service_ids {
-                if !selection.allowed_mcp_service_ids.contains(service_id) {
-                    errors.push(format!(
-                        "tool selection {} requires MCP service {} outside allowed_mcp_service_ids",
-                        selection.selection_id, service_id
-                    ));
-                }
-            }
-        }
+        // Manifest-shape: duplicate subagent target names and the
+        // cross-deployment permission gate have no document equivalent
+        // (`ToolSelectionDocument::validate` only checks each entry's own
+        // structural validity, which this also re-checks — a SubagentTarget
+        // parse failure or structural gap surfaces from both, redundantly
+        // but not incorrectly).
         validate_subagent_targets(
             &selection.selection_id,
             selection.agent_did.trim(),
@@ -287,13 +312,11 @@ pub(super) fn validate_tool_selections(
         // when no surfaces are linked).
         validate_tool_selection_surface_links(manifest, selection, errors);
         validate_eth_tool_links(manifest, selection, errors);
-        if selection.subagent_spawn_enabled {
-            if selection.subagent_targets.is_empty() {
-                errors.push(format!(
-                    "tool selection {} sets subagent_spawn_enabled but has no subagent_targets; the tools would be inert",
-                    selection.selection_id
-                ));
-            }
+        if selection.subagent_spawn_enabled && selection.subagent_targets.is_empty() {
+            errors.push(format!(
+                "tool selection {} sets subagent_spawn_enabled but has no subagent_targets; the tools would be inert",
+                selection.selection_id
+            ));
         }
     }
     tool_selection_ids

--- a/crates/gents-cli/src/desired_state/validate/tooling.rs
+++ b/crates/gents-cli/src/desired_state/validate/tooling.rs
@@ -445,19 +445,15 @@ fn validate_subagent_targets(
 ) {
     let mut seen_names: HashSet<String> = HashSet::new();
     for entry in entries {
-        let target = match SubagentTarget::parse(entry) {
-            Ok(target) => target,
-            Err(error) => {
-                errors.push(format!(
-                "tool selection {selection_id} subagent_targets entry {entry:?} is not valid SubagentTarget JSON: {error}"
-            ));
-                continue;
-            }
+        // Malformed/structurally-invalid entries are already reported by
+        // `ToolSelectionDocument::validate` (#1331, the single owner —
+        // called earlier in `validate_tool_selections`); skip them here
+        // without a second error message. Parsing still has to run because
+        // the checks below need the decoded fields.
+        let Ok(target) = SubagentTarget::parse(entry) else {
+            continue;
         };
         if !target.is_structurally_valid() {
-            errors.push(format!(
-            "tool selection {selection_id} subagent_targets entry {entry:?} must have non-empty name, agent_did, and behavior_id"
-        ));
             continue;
         }
         if !seen_names.insert(target.name.trim().to_string()) {

--- a/crates/gents-cli/src/desired_state/validate/tooling.rs
+++ b/crates/gents-cli/src/desired_state/validate/tooling.rs
@@ -248,9 +248,12 @@ pub(super) fn validate_tool_selections(
         // needing enable_meta_tools and staying inside
         // allowed_mcp_service_ids, self_config_categories vocabulary) are
         // owned by `ToolSelectionDocument::validate`.
-        if let Err(error) = to_document_tool_selection(selection).validate() {
-            errors.push(error.to_string());
-        }
+        errors.extend(
+            to_document_tool_selection(selection)
+                .validation_violations()
+                .into_iter()
+                .map(|error| format!("tool selection {}: {error}", selection.selection_id)),
+        );
 
         // Manifest-shape: command_execution_policy/command_network_mode
         // parsing and the two argv-prefix JSON shape checks have no document
@@ -296,10 +299,9 @@ pub(super) fn validate_tool_selections(
         );
         // Manifest-shape: duplicate subagent target names and the
         // cross-deployment permission gate have no document equivalent
-        // (`ToolSelectionDocument::validate` only checks each entry's own
-        // structural validity, which this also re-checks — a SubagentTarget
-        // parse failure or structural gap surfaces from both, redundantly
-        // but not incorrectly).
+        // (`ToolSelectionDocument::validate` checks each entry's own
+        // structural validity; this pass skips malformed entries and handles
+        // only the cross-entry/cross-document rules below).
         validate_subagent_targets(
             &selection.selection_id,
             selection.agent_did.trim(),

--- a/crates/gents-cli/src/graphql_access.rs
+++ b/crates/gents-cli/src/graphql_access.rs
@@ -3,12 +3,7 @@ use gents_protocol::graphql::{
     extract_mutation_doc_id as shared_extract_mutation_doc_id,
     graphql_endpoint_available as shared_graphql_endpoint_available,
     graphql_input_literal as shared_graphql_input_literal, graphql_rows_from_response,
-    graphql_string_list_literal as shared_graphql_string_list_literal,
-    optional_bool_field as shared_optional_bool_field,
-    optional_f64_field as shared_optional_f64_field,
-    optional_i64_field as shared_optional_i64_field,
-    optional_i64_list_field as shared_optional_i64_list_field,
-    optional_string_field as shared_optional_string_field, GraphqlRequestOptions,
+    graphql_string_list_literal as shared_graphql_string_list_literal, GraphqlRequestOptions,
 };
 use serde_json::Value;
 
@@ -66,24 +61,4 @@ pub(crate) fn graphql_input_literal(value: &Value) -> Result<String> {
 
 pub(crate) fn extract_mutation_doc_id(response: &Value, collection_name: &str) -> Result<String> {
     shared_extract_mutation_doc_id(response, collection_name)
-}
-
-pub(crate) fn optional_i64_field(name: &str, value: Option<i64>) -> Option<String> {
-    shared_optional_i64_field(name, value)
-}
-
-pub(crate) fn optional_f64_field(name: &str, value: Option<f64>) -> Option<String> {
-    shared_optional_f64_field(name, value)
-}
-
-pub(crate) fn optional_bool_field(name: &str, value: Option<bool>) -> Option<String> {
-    shared_optional_bool_field(name, value)
-}
-
-pub(crate) fn optional_i64_list_field(name: &str, value: Option<&[i64]>) -> Option<String> {
-    shared_optional_i64_list_field(name, value)
-}
-
-pub(crate) fn optional_string_field(name: &str, value: Option<&str>) -> Option<String> {
-    shared_optional_string_field(name, value)
 }

--- a/crates/gents-cli/tests/suites/cli_config_crud.rs
+++ b/crates/gents-cli/tests/suites/cli_config_crud.rs
@@ -175,6 +175,81 @@ async fn config_core_documents_list_show_and_rm() -> Result<()> {
     Ok(())
 }
 
+/// #1331: `behavior set` writes `AgentBehavior` directly (not through
+/// persona admission — see `gents::agent::persona_ops`'s module doc), so
+/// it's this call site's job to validate references before writing. A
+/// dangling `--tool-selection-id` must be rejected with the single owner's
+/// message (`AgentBehavior::validate_references`), not silently written.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn behavior_set_rejects_missing_tool_selection() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-behavior-set-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let port = allocate_port()?;
+    let agent_name = format!("cli-behavior-set-{}", Uuid::new_v4().simple());
+    let graphql = graphql_url(port);
+
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            "--inference-url",
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let behavior_id = format!("{agent_name}-missing-tools");
+    let rejection = run_cli_failure_stderr(
+        &home_dir,
+        &[
+            "config",
+            "behavior",
+            "set",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--behavior-id",
+            &behavior_id,
+            "--tool-selection-id",
+            "does-not-exist",
+        ],
+    )?;
+    assert!(
+        rejection.contains("references missing tool_selection_id does-not-exist"),
+        "{rejection}"
+    );
+
+    // The rejected write must not have landed.
+    let show = run_cli_failure_stderr(
+        &home_dir,
+        &[
+            "config",
+            "behavior",
+            "show",
+            &behavior_id,
+            "--graphql",
+            &graphql,
+        ],
+    )?;
+    assert!(
+        show.contains("not found") || show.contains("missing"),
+        "{show}"
+    );
+
+    Ok(())
+}
+
 async fn assert_list_show_rm(
     home_dir: &std::path::Path,
     graphql: &str,

--- a/crates/gents-desktop-core/src/client/mutations/manage/behavior.rs
+++ b/crates/gents-desktop-core/src/client/mutations/manage/behavior.rs
@@ -1,18 +1,50 @@
 use anyhow::{bail, Context, Result};
 use chrono::Utc;
 use defra_node::EmbeddedNode;
+use gents::config_client::ConfigApplyTxn;
+use gents::{AgentBehaviorDocument, ConfigReferences};
 use gents_protocol::row::AgentBehaviorRow;
 use serde_json::Value;
 
 use super::super::graphql::{
-    escape_graphql_string, execute_mutation, graphql_optional_bool_field,
-    graphql_optional_float_field, graphql_string_field, graphql_string_list_field, join_fields,
-    normalize_required,
+    escape_graphql_string, graphql_optional_bool_field, graphql_optional_float_field,
+    graphql_string_field, graphql_string_list_field, join_fields, normalize_required,
 };
 
 pub async fn upsert_agent_behavior(node: &EmbeddedNode, row: &AgentBehaviorRow) -> Result<()> {
+    let behavior = agent_behavior_document(row)?;
     let mutation = build_upsert_agent_behavior_mutation(row)?;
-    execute_mutation(node, &mutation, "upsert_agent_behavior").await
+    let txn = ConfigApplyTxn::begin_local(node, None).await?;
+    let result = async {
+        let references = ConfigReferences::load_in_txn(&txn, &behavior.agent_did).await?;
+        behavior.validate_references(&references)?;
+        // Keep the desktop encoder: represented row options are authoritative
+        // clears, while columns absent from AgentBehaviorRow (description,
+        // summary, request_context_template) remain stored state.
+        txn.execute(&mutation).await?;
+        Ok(())
+    }
+    .await;
+    match result {
+        Ok(()) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+fn agent_behavior_document(row: &AgentBehaviorRow) -> Result<AgentBehaviorDocument> {
+    let agent_did = normalize_required(
+        "agent_did",
+        row.agent_did
+            .as_deref()
+            .context("agent_did is required for AgentBehavior")?,
+    )?;
+    let mut value = serde_json::to_value(row)?;
+    value["agent_did"] = Value::String(agent_did.to_string());
+    value["enabled"] = Value::Bool(row.enabled.unwrap_or(false));
+    Ok(serde_json::from_value(value)?)
 }
 
 fn build_upsert_agent_behavior_mutation(row: &AgentBehaviorRow) -> Result<String> {
@@ -191,8 +223,10 @@ fn build_delete_agent_behavior_mutation(agent_did: &str, behavior_id: &str) -> R
 }
 
 #[cfg(test)]
-mod delete_tests {
-    use super::build_delete_agent_behavior_mutation;
+mod tests {
+    use super::{agent_behavior_document, build_delete_agent_behavior_mutation};
+    use gents::ConfigReferences;
+    use gents_protocol::row::AgentBehaviorRow;
 
     #[test]
     fn delete_is_scoped_to_agent_and_escapes_values() {
@@ -201,5 +235,26 @@ mod delete_tests {
 
         assert!(mutation.contains(r#"agent_did: { _eq: "did:test:remote" }"#));
         assert!(mutation.contains(r#"behavior_id: { _eq: "say-\"hi\"" }"#));
+    }
+
+    #[test]
+    fn behavior_row_reports_all_missing_references() {
+        let row: AgentBehaviorRow = serde_json::from_value(serde_json::json!({
+            "behavior_id": "amy",
+            "agent_did": "did:test:amy",
+            "backend_id": "missing-backend",
+            "tool_selection_id": "missing-tools",
+            "inference_profile_id": "missing-profile"
+        }))
+        .expect("behavior row");
+        let behavior = agent_behavior_document(&row).expect("behavior document");
+
+        let error = behavior
+            .validate_references(&ConfigReferences::default())
+            .expect_err("invalid behavior")
+            .to_string();
+        assert!(error.contains("missing backend_id missing-backend"));
+        assert!(error.contains("missing tool_selection_id missing-tools"));
+        assert!(error.contains("missing inference_profile_id missing-profile"));
     }
 }

--- a/crates/gents-desktop-core/src/client/mutations/manage/inference.rs
+++ b/crates/gents-desktop-core/src/client/mutations/manage/inference.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use defra_node::EmbeddedNode;
+use gents::InferenceBackend;
 use gents_protocol::row::InferenceBackendRow;
 use serde_json::Value;
 
@@ -13,6 +14,10 @@ pub async fn upsert_inference_backend(
     node: &EmbeddedNode,
     row: &InferenceBackendRow,
 ) -> Result<()> {
+    validate_inference_backend(row)?;
+    // Keep the desktop encoder: it owns last_probe and preserves its existing
+    // full-row null/list behavior, neither of which the config-client backend
+    // writer represents exactly.
     let backend_id = normalize_required("backend_id", &row.backend_id)?;
 
     let add_fields = [
@@ -107,6 +112,43 @@ pub async fn upsert_inference_backend(
         update_fields = join_fields(&update_fields),
     );
     execute_mutation(node, &mutation, "upsert_inference_backend").await
+}
+
+fn validate_inference_backend(row: &InferenceBackendRow) -> Result<()> {
+    let value = serde_json::to_value(row)?;
+    let mut backend = InferenceBackend::from_value(&value)?;
+    // `from_value` normalizes blank credentials for runtime consumption. Keep
+    // the submitted values for write-boundary validation, where an explicitly
+    // blank credential is an invalid document rather than an absent one.
+    backend.api_key = row.api_key.clone();
+    backend.api_key_env_var = row.api_key_env_var.clone();
+    backend.validate(None)
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::validate_inference_backend;
+    use gents_protocol::row::InferenceBackendRow;
+
+    #[test]
+    fn rejects_a_row_that_sets_both_credential_sources() {
+        let row: InferenceBackendRow = serde_json::from_value(serde_json::json!({
+            "backend_id": "backend",
+            "name": "Backend",
+            "provider_kind": "OpenAiCompatible",
+            "endpoint": "https://example.test/v1",
+            "api_key": "secret",
+            "api_key_env_var": "BACKEND_API_KEY",
+            "max_concurrent": 1,
+            "enabled": true
+        }))
+        .expect("backend row");
+
+        let error = validate_inference_backend(&row).expect_err("invalid backend");
+        assert!(error
+            .to_string()
+            .contains("must not set both api_key and api_key_env_var"));
+    }
 }
 
 pub async fn delete_inference_backend(node: &EmbeddedNode, backend_id: &str) -> Result<usize> {

--- a/crates/gents-desktop-core/src/client/mutations/manage/profile.rs
+++ b/crates/gents-desktop-core/src/client/mutations/manage/profile.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use defra_node::EmbeddedNode;
+use gents::InferenceProfile;
 use gents_protocol::row::InferenceProfileRow;
 use serde_json::Value;
 
@@ -14,26 +15,10 @@ pub async fn upsert_inference_profile(
     row: &InferenceProfileRow,
 ) -> Result<()> {
     let profile_id = normalize_required("profile_id", &row.profile_id)?;
-    if row
-        .stream_liveness_timeout_secs
-        .is_some_and(|value| value <= 0)
-    {
-        anyhow::bail!("stream_liveness_timeout_secs must be positive");
-    }
-    if row.seed.is_some_and(|value| value < 0) {
-        anyhow::bail!("seed must be non-negative");
-    }
-    if row.reasoning_effort.as_deref().is_some_and(|value| {
-        !matches!(
-            value,
-            "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
-        )
-    }) {
-        anyhow::bail!(
-            "reasoning_effort must be one of: none, minimal, low, medium, high, xhigh, max, ultra"
-        );
-    }
+    validate_inference_profile(row)?;
 
+    // Keep the desktop encoder: absent row values are authoritative clears
+    // here, while the canonical document upsert omits absent numeric fields.
     let add_fields = [
         Some(format!(
             r#"profile_id: "{}""#,
@@ -192,6 +177,33 @@ pub async fn upsert_inference_profile(
         update_fields = join_fields(&update_fields),
     );
     execute_mutation(node, &mutation, "upsert_inference_profile").await
+}
+
+fn validate_inference_profile(row: &InferenceProfileRow) -> Result<()> {
+    let profile: InferenceProfile = serde_json::from_value(serde_json::to_value(row)?)?;
+    profile.validate()
+}
+
+#[cfg(test)]
+mod validation_tests {
+    use super::validate_inference_profile;
+    use gents_protocol::row::InferenceProfileRow;
+
+    #[test]
+    fn rejects_every_invalid_profile_field_in_one_error() {
+        let row: InferenceProfileRow = serde_json::from_value(serde_json::json!({
+            "profile_id": "invalid-profile",
+            "top_p": 2.0,
+            "seed": -1
+        }))
+        .expect("profile row");
+
+        let error = validate_inference_profile(&row)
+            .expect_err("invalid profile")
+            .to_string();
+        assert!(error.contains("top_p must be within [0, 1]"));
+        assert!(error.contains("seed must be non-negative"));
+    }
 }
 
 pub async fn delete_inference_profile(node: &EmbeddedNode, profile_id: &str) -> Result<usize> {

--- a/crates/gents-desktop-core/src/client/mutations/manage/tools.rs
+++ b/crates/gents-desktop-core/src/client/mutations/manage/tools.rs
@@ -1,5 +1,8 @@
 use anyhow::{bail, Context, Result};
 use defra_node::EmbeddedNode;
+use gents::config_client::ConfigApplyTxn;
+use gents::ToolSelectionDocument;
+use gents_protocol::graphql::graphql_rows_from_response;
 use gents_protocol::row::{ToolSelectionRow, ToolServiceRegistryRow};
 use serde_json::Value;
 
@@ -11,10 +14,53 @@ use super::super::graphql::{
 
 pub async fn upsert_tool_selection(node: &EmbeddedNode, row: &ToolSelectionRow) -> Result<()> {
     let mutation = build_upsert_tool_selection_mutation(row)?;
-    execute_mutation(node, &mutation, "upsert_tool_selection").await
+    let mut candidate = tool_selection_document(row)?;
+    let txn = ConfigApplyTxn::begin_local(node, None).await?;
+    let result = async {
+        if let Some(existing) = preserved_tool_selection_fields(&txn, &row.selection_id).await? {
+            // These columns are not represented by this desktop mutation, so
+            // they remain stored state rather than being cleared by the save.
+            candidate.read_only_command_allowlist = existing.read_only_command_allowlist;
+            candidate.approval_required_tools = existing.approval_required_tools;
+        }
+        candidate.validate()?;
+        txn.execute(&mutation).await?;
+        Ok(())
+    }
+    .await;
+    match result {
+        Ok(()) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn preserved_tool_selection_fields(
+    txn: &ConfigApplyTxn<'_>,
+    selection_id: &str,
+) -> Result<Option<ToolSelectionDocument>> {
+    let selection_id = escape_graphql_string(selection_id);
+    let response = txn
+        .execute(&format!(
+            r#"{{ ToolSelection(
+                filter: {{ selection_id: {{ _eq: "{selection_id}" }} }}, limit: 1
+            ) {{ selection_id agent_did read_only_command_allowlist approval_required_tools }} }}"#
+        ))
+        .await?;
+    graphql_rows_from_response(&response, "ToolSelection")
+        .into_iter()
+        .next()
+        .map(serde_json::from_value)
+        .transpose()
+        .context("decoding preserved ToolSelection fields")
 }
 
 fn build_upsert_tool_selection_mutation(row: &ToolSelectionRow) -> Result<String> {
+    // Keep the desktop encoder: the canonical upsert writes columns this path
+    // historically leaves alone and omits an absent cross-deployment timeout
+    // where the desktop's full-row save explicitly clears it.
     let selection_id = normalize_required("selection_id", &row.selection_id)?;
     let agent_did = normalize_required(
         "agent_did",
@@ -342,6 +388,10 @@ fn build_upsert_tool_selection_mutation(row: &ToolSelectionRow) -> Result<String
     ))
 }
 
+fn tool_selection_document(row: &ToolSelectionRow) -> Result<ToolSelectionDocument> {
+    serde_json::from_value(serde_json::to_value(row)?).map_err(Into::into)
+}
+
 pub async fn upsert_tool_service_registry(
     node: &EmbeddedNode,
     row: &ToolServiceRegistryRow,
@@ -498,8 +548,13 @@ fn build_delete_tool_service_registry_mutation(service_id: &str) -> Result<Strin
 }
 
 #[cfg(test)]
-mod delete_tests {
-    use super::build_delete_tool_selection_mutation;
+mod tests {
+    use super::{
+        build_delete_tool_selection_mutation, tool_selection_document, upsert_tool_selection,
+    };
+    use defra_node::{EmbeddedNode, StorageBackend};
+    use gents::ensure_runtime_schemas;
+    use gents_protocol::row::ToolSelectionRow;
 
     #[test]
     fn tool_selection_delete_is_scoped_to_agent_and_escapes_values() {
@@ -508,5 +563,58 @@ mod delete_tests {
 
         assert!(mutation.contains(r#"agent_did: { _eq: "did:test:remote" }"#));
         assert!(mutation.contains(r#"selection_id: { _eq: "tools-\"safe\"" }"#));
+    }
+
+    #[test]
+    fn upsert_rejects_an_invalid_subagent_target() {
+        let row: ToolSelectionRow = serde_json::from_value(serde_json::json!({
+            "selection_id": "tools",
+            "agent_did": "did:test:amy",
+            "subagent_targets": ["bare-behavior-id"]
+        }))
+        .expect("tool selection row");
+
+        let error = tool_selection_document(&row)
+            .expect("tool selection document")
+            .validate()
+            .expect_err("invalid tool selection")
+            .to_string();
+        assert!(error.contains("not a valid SubagentTarget JSON object"));
+    }
+
+    #[tokio::test]
+    async fn upsert_validates_preserved_approval_tools() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let node = EmbeddedNode::builder()
+            .data_path(dir.path().join("data"))
+            .with_storage_backend(StorageBackend::Regolith)
+            .build()
+            .await
+            .expect("node");
+        ensure_runtime_schemas(&node).await.expect("schemas");
+        let response = node
+            .execute(
+                r#"mutation { create_ToolSelection(input: {
+                    selection_id: "desktop-tools", agent_did: "did:test:desktop",
+                    display_name: "Original", approval_required_tools: [""]
+                }) { _docID } }"#,
+            )
+            .await;
+        assert!(!response.has_errors(), "seed: {:?}", response.errors);
+
+        let row: ToolSelectionRow = serde_json::from_value(serde_json::json!({
+            "selection_id": "desktop-tools",
+            "agent_did": "did:test:desktop",
+            "display_name": "Updated"
+        }))
+        .expect("tool selection row");
+        let error = upsert_tool_selection(&node, &row)
+            .await
+            .expect_err("preserved invalid approval tool must reject the save")
+            .to_string();
+        assert!(
+            error.contains("approval_required_tools[0] is empty"),
+            "{error}"
+        );
     }
 }

--- a/crates/gents-desktop-core/tests/manage_view.rs
+++ b/crates/gents-desktop-core/tests/manage_view.rs
@@ -57,7 +57,7 @@ async fn manage_document_saves_refresh_store() -> Result<()> {
         temperature: Some(0.2),
         stream_batch_ms: Some(50),
         stream_liveness_timeout_secs: Some(300),
-        deadline_duration_secs: Some(300),
+        deadline_duration_secs: Some(600),
         retry_max_transport: None,
         retry_backoff_ms: None,
         retry_max_resample: None,
@@ -113,7 +113,12 @@ async fn manage_document_saves_refresh_store() -> Result<()> {
         enable_context_budget: Some(true),
         enable_defra_query: Some(true),
         defra_query_collections: vec!["AgentSession".to_string()],
-        subagent_targets: vec!["amy-research".to_string()],
+        subagent_targets: vec![gents::subagent_target_entry(
+            "amy-research",
+            "did:test:amy",
+            "amy-research",
+            None,
+        )],
         subagent_spawn_enabled: Some(true),
         subagent_steering_enabled: Some(true),
         subagent_background_enabled: Some(true),
@@ -213,7 +218,8 @@ async fn manage_document_saves_refresh_store() -> Result<()> {
         tools.backgroundable_tool_names,
         vec!["read_file".to_string()]
     );
-    assert_eq!(tools.subagent_targets, vec!["amy-research".to_string()]);
+    assert_eq!(tools.subagent_targets.len(), 1);
+    assert!(tools.subagent_targets[0].contains("amy-research"));
     assert_eq!(tools.subagent_spawn_enabled, Some(true));
     assert_eq!(tools.subagent_steering_enabled, Some(true));
     assert_eq!(tools.subagent_background_enabled, Some(true));

--- a/crates/gents-protocol/src/request_admission.rs
+++ b/crates/gents-protocol/src/request_admission.rs
@@ -743,6 +743,11 @@ pub struct AgentRequestCreate {
 }
 
 impl AgentRequestCreate {
+    // This is the one required-field constructor for request creation
+    // (#1336). Bundling these independent identity/admission fields into a
+    // second parameter object would recreate another owner for the wire
+    // contract just to satisfy an argument-count heuristic.
+    #[allow(clippy::too_many_arguments)]
     pub fn base(
         request_id: impl Into<String>,
         agent_did: impl Into<String>,

--- a/crates/gents/examples/serve_default_behavior.rs
+++ b/crates/gents/examples/serve_default_behavior.rs
@@ -8,8 +8,8 @@ use gents::graphql::escape_graphql_string;
 use gents::{
     ensure_agent_principal, ensure_runtime_schemas, upsert_agent_behavior,
     upsert_inference_profile, upsert_tool_selection, AgentBehaviorDocument, AgentIdentity,
-    DocumentRuntimeOptions, Gents, InferenceProfile, KeyIdentity, McpPool, ToolCeiling,
-    ToolSelectionDocument, DEFAULT_MAX_TURNS,
+    BackendProviderKind, DocumentRuntimeOptions, Gents, InferenceBackend, InferenceProfile,
+    KeyIdentity, McpPool, ToolCeiling, ToolSelectionDocument, DEFAULT_MAX_TURNS,
 };
 use tokio::sync::watch;
 
@@ -215,6 +215,46 @@ async fn seed_demo_documents(
 }
 
 async fn upsert_demo_backend(node: &EmbeddedNode, backend_id: &str, endpoint: &str) -> Result<()> {
+    let txn = gents::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+    let existing = match gents::config_client::load_inference_backend_in_txn(&txn, backend_id).await
+    {
+        Ok(existing) => existing,
+        Err(error) => {
+            let _ = txn.discard().await;
+            return Err(error);
+        }
+    };
+    let candidate = match existing {
+        Some(mut existing) => {
+            // The update clause below deliberately preserves provider,
+            // credential, queue, and model fields.
+            existing.name = backend_id.to_string();
+            existing.endpoint = endpoint.to_string();
+            existing.max_concurrent = 2;
+            existing.enabled = true;
+            existing.probe_status = "healthy".to_string();
+            existing
+        }
+        None => InferenceBackend {
+            backend_id: backend_id.to_string(),
+            name: backend_id.to_string(),
+            provider_kind: BackendProviderKind::OpenAiCompatible,
+            openai_wire_api: None,
+            endpoint: endpoint.to_string(),
+            api_key: None,
+            api_key_env_var: None,
+            max_concurrent: 2,
+            max_queue_depth: 100,
+            enabled: true,
+            models: vec!["default".to_string()],
+            probe_status: "healthy".to_string(),
+        },
+    };
+    if let Err(error) = candidate.validate(None) {
+        let _ = txn.discard().await;
+        return Err(error);
+    }
+
     let mutation = format!(
         r#"mutation {{
             upsert_InferenceBackend(
@@ -222,8 +262,10 @@ async fn upsert_demo_backend(node: &EmbeddedNode, backend_id: &str, endpoint: &s
                 add: {{
                     backend_id: "{backend_id}",
                     name: "{backend_id}",
+                    provider_kind: "OpenAiCompatible",
                     endpoint: "{endpoint}",
                     max_concurrent: 2,
+                    max_queue_depth: 100,
                     enabled: true,
                     models: ["default"],
                     probe_status: "healthy"
@@ -240,9 +282,11 @@ async fn upsert_demo_backend(node: &EmbeddedNode, backend_id: &str, endpoint: &s
         backend_id = escape_graphql_string(backend_id),
         endpoint = escape_graphql_string(endpoint),
     );
-    let response = node.execute(&mutation).await;
-    if response.has_errors() {
-        anyhow::bail!("upsert demo backend failed: {:?}", response.errors);
+    match txn.execute(&mutation).await {
+        Ok(_) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
     }
-    Ok(())
 }

--- a/crates/gents/src/agent/p2p_reconcile/persona_requests.rs
+++ b/crates/gents/src/agent/p2p_reconcile/persona_requests.rs
@@ -841,6 +841,14 @@ mod tests {
         Arc::new(node)
     }
 
+    async fn build_apply_node(tempdir: &tempfile::TempDir) -> Arc<EmbeddedNode> {
+        let node = build_node(tempdir).await;
+        crate::agent::persona_ops::seed_persona_validation_references(&node)
+            .await
+            .expect("persona validation references seed");
+        node
+    }
+
     fn happy_catalog(agent_did: &str) -> PersonaCatalogView {
         PersonaCatalogView {
             available_models: BTreeSet::from(["openai|gpt-5".to_string()]),
@@ -1054,7 +1062,7 @@ mod tests {
     #[tokio::test]
     async fn pending_admit_applies_and_marks_behavior_id() -> Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let node = build_node(&tempdir).await;
+        let node = build_apply_node(&tempdir).await;
 
         let doc = pending_create_doc("req-1", "did:key:agent");
         let mut catalog_by_agent = BTreeMap::new();
@@ -1112,7 +1120,7 @@ mod tests {
     #[tokio::test]
     async fn terminal_rows_are_untouched() -> Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let node = build_node(&tempdir).await;
+        let node = build_apply_node(&tempdir).await;
 
         let pending_doc = pending_create_doc("req-pending", "did:key:agent");
         let mut applied_doc = pending_create_doc("req-already-applied", "did:key:agent");
@@ -1145,7 +1153,7 @@ mod tests {
     #[tokio::test]
     async fn one_bad_row_does_not_wedge_the_sweep() -> Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let node = build_node(&tempdir).await;
+        let node = build_apply_node(&tempdir).await;
 
         let good_doc = pending_create_doc("req-good", "did:key:good-agent");
         let bad_doc = pending_create_doc("req-bad", "did:key:bad-agent");
@@ -1191,7 +1199,7 @@ mod tests {
     #[tokio::test]
     async fn crash_between_apply_and_mark_repairs_without_duplicate() -> Result<()> {
         let tempdir = tempfile::tempdir()?;
-        let node = build_node(&tempdir).await;
+        let node = build_apply_node(&tempdir).await;
 
         let doc = pending_create_doc("req-repair", "did:key:repair-agent");
         let agent_did = doc.agent_did.clone();

--- a/crates/gents/src/agent/persona_ops.rs
+++ b/crates/gents/src/agent/persona_ops.rs
@@ -22,6 +22,21 @@
 //!   `request_key` after a successful create returns the prior outcome
 //!   (`repaired: true`) instead of minting a duplicate behavior.
 //!
+//! Not every `AgentBehavior` write goes through this module, and that's by
+//! design, not drift: the "gents CLI" above means the persona-request
+//! subcommands (`config behavior create|clone|disable`), which submit a
+//! `PersonaConfigRequest` row like the reconciler and the self-config tool
+//! do. `config agent-behavior set` (a raw field edit — display name,
+//! backend/model, tool selection, profile, prompt, compaction knobs — with
+//! no catalog/preset semantics) and the codex-shim model switch are
+//! deliberately outside persona admission: they write `AgentBehavior`
+//! directly via `config_client::write_agent_behavior_document` after
+//! validating references through `AgentBehavior::validate_references`
+//! (`document_config`, #1331) instead of through [`decide_persona_request`].
+//! The persona model owns catalog/preset-based persona operations
+//! (phone-authored); referential validity for a plain field edit is owned by
+//! `document_config`, not by this module.
+//!
 //! See `crate::agent::persona_presets` for why a "preset" name alone
 //! under-provisions a `ToolSelection` — this module is the place that closes
 //! that gap by copying the init-parity extras verbatim from

--- a/crates/gents/src/agent/persona_ops.rs
+++ b/crates/gents/src/agent/persona_ops.rs
@@ -860,6 +860,48 @@ async fn apply_disable(
 }
 
 #[cfg(test)]
+pub(crate) async fn seed_persona_validation_references(node: &EmbeddedNode) -> Result<()> {
+    let response = node
+        .execute(
+            r#"mutation {
+                openai: create_InferenceBackend(input: {
+                    backend_id: "openai"
+                    name: "OpenAI"
+                    provider_kind: "OpenAiCompatible"
+                    max_concurrent: 1
+                    max_queue_depth: 1
+                    enabled: true
+                    models: ["gpt-5"]
+                }) { _docID }
+                anthropic: create_InferenceBackend(input: {
+                    backend_id: "anthropic"
+                    name: "Anthropic"
+                    provider_kind: "Anthropic"
+                    max_concurrent: 1
+                    max_queue_depth: 1
+                    enabled: true
+                    models: ["claude"]
+                }) { _docID }
+                profile1: create_InferenceProfile(input: {
+                    profile_id: "profile-1"
+                    display_name: "Profile 1"
+                }) { _docID }
+                profile2: create_InferenceProfile(input: {
+                    profile_id: "profile-2"
+                    display_name: "Profile 2"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    anyhow::ensure!(
+        !response.has_errors(),
+        "seed persona validation references: {:?}",
+        response.errors
+    );
+    Ok(())
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1358,6 +1400,9 @@ mod tests {
         crate::ensure_runtime_schemas(&node)
             .await
             .expect("runtime schemas register");
+        seed_persona_validation_references(&node)
+            .await
+            .expect("persona validation references seed");
         Arc::new(node)
     }
 
@@ -1756,6 +1801,16 @@ mod tests {
         let tempdir = tempfile::tempdir()?;
         let node = build_node(&tempdir).await;
         let access = ConfigAccess::Local(node.clone());
+
+        write_tool_selection_document(
+            &access,
+            &ToolSelectionDocument {
+                selection_id: "sel-disable".to_string(),
+                agent_did: "did:key:disable-agent".to_string(),
+                ..Default::default()
+            },
+        )
+        .await?;
 
         let behavior = AgentBehaviorDocument {
             behavior_id: "disable-behavior".to_string(),

--- a/crates/gents/src/agent/persona_ops.rs
+++ b/crates/gents/src/agent/persona_ops.rs
@@ -26,7 +26,7 @@
 //! design, not drift: the "gents CLI" above means the persona-request
 //! subcommands (`config behavior create|clone|disable`), which submit a
 //! `PersonaConfigRequest` row like the reconciler and the self-config tool
-//! do. `config agent-behavior set` (a raw field edit — display name,
+//! do. `config behavior set` (a raw field edit — display name,
 //! backend/model, tool selection, profile, prompt, compaction knobs — with
 //! no catalog/preset semantics) and the codex-shim model switch are
 //! deliberately outside persona admission: they write `AgentBehavior`

--- a/crates/gents/src/agent/runtime/tests/startup_recovery.rs
+++ b/crates/gents/src/agent/runtime/tests/startup_recovery.rs
@@ -292,14 +292,21 @@ async fn run_agent_fails_when_all_behaviors_are_unavailable_due_to_invalid_confi
     )
     .await;
     let default_behavior_id = crate::default_behavior_id_for_agent(identity.did());
-    let mut default_behavior = crate::load_agent_behavior(node.as_ref(), &default_behavior_id)
-        .await
-        .unwrap()
-        .expect("default behavior document");
-    default_behavior.tool_selection_id = Some("missing-tool-selection".to_string());
-    crate::upsert_agent_behavior(node.as_ref(), &default_behavior)
-        .await
-        .unwrap();
+    // This test exercises startup handling for corrupt persisted configuration.
+    // The public writer correctly rejects the dangling reference, so inject the
+    // invalid row through the storage boundary instead.
+    let escaped_behavior_id = escape_graphql_string(&default_behavior_id);
+    let escaped_tool_selection_id = escape_graphql_string("missing-tool-selection");
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentBehavior(
+                filter: {{ behavior_id: {{ _eq: "{escaped_behavior_id}" }} }},
+                input: {{ tool_selection_id: "{escaped_tool_selection_id}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
 
     let agent = crate::Gents::from_default_behavior_documents(
         node.clone(),

--- a/crates/gents/src/agent/tests/document_loading.rs
+++ b/crates/gents/src/agent/tests/document_loading.rs
@@ -527,7 +527,7 @@ async fn from_default_behavior_documents_loads_runnable_behaviors_and_tracks_una
             system_prompt: Some("You write code.".to_string()),
             request_context_template: None,
             backend_id: Some("backend-healthy".to_string()),
-            model_name: Some("gpt-code".to_string()),
+            model_name: Some("default".to_string()),
             tool_selection_id: None,
             inference_profile_id: Some(default_profile_id),
             compaction_strategy: Some("StripThenSummarize".to_string()),
@@ -550,8 +550,8 @@ async fn from_default_behavior_documents_loads_runnable_behaviors_and_tracks_una
             summary: None,
             system_prompt: Some("This backend is missing.".to_string()),
             request_context_template: None,
-            backend_id: Some("backend-missing".to_string()),
-            model_name: Some("gpt-missing".to_string()),
+            backend_id: None,
+            model_name: None,
             tool_selection_id: None,
             inference_profile_id: None,
             compaction_strategy: Some("StripThenSummarize".to_string()),
@@ -562,6 +562,26 @@ async fn from_default_behavior_documents_loads_runnable_behaviors_and_tracks_una
     )
     .await
     .unwrap();
+    // This row deliberately represents persisted corruption so the loader's
+    // unavailable-behavior path remains covered. The guarded writer rejects
+    // dangling backend references, as it should; inject the corruption raw.
+    let escaped_did = crate::graphql::escape_graphql_string(&did);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentBehavior(
+                filter: {{
+                    behavior_id: {{ _eq: "broken" }},
+                    agent_did: {{ _eq: "{escaped_did}" }}
+                }},
+                input: {{
+                    backend_id: "backend-missing",
+                    model_name: "gpt-missing"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
     crate::upsert_agent_behavior(
         node.as_ref(),
         &AgentBehavior {
@@ -599,7 +619,7 @@ async fn from_default_behavior_documents_loads_runnable_behaviors_and_tracks_una
             system_prompt: Some("Backend is unhealthy.".to_string()),
             request_context_template: None,
             backend_id: Some("backend-unhealthy".to_string()),
-            model_name: Some("gpt-unhealthy".to_string()),
+            model_name: Some("default".to_string()),
             tool_selection_id: None,
             inference_profile_id: None,
             compaction_strategy: Some("StripThenSummarize".to_string()),

--- a/crates/gents/src/backend_registry.rs
+++ b/crates/gents/src/backend_registry.rs
@@ -169,7 +169,10 @@ impl InferenceBackend {
         }
         if let Some(current_model) = current_model.map(str::trim).filter(|v| !v.is_empty()) {
             if !self.models.is_empty()
-                && !self.models.iter().any(|model| model.trim() == current_model)
+                && !self
+                    .models
+                    .iter()
+                    .any(|model| model.trim() == current_model)
             {
                 anyhow::bail!(
                     "backend {} models would drop the current model {current_model:?}; no-lockout guard",

--- a/crates/gents/src/backend_registry.rs
+++ b/crates/gents/src/backend_registry.rs
@@ -122,50 +122,64 @@ impl InferenceBackend {
     /// opt-in no-lockout guard does; desired state — which validates backends
     /// independently of behaviors, and separately checks each behavior's
     /// model against its backend's advertised list — passes `None`).
-    pub fn validate(&self, current_model: Option<&str>) -> Result<()> {
+    pub fn validation_violations(&self, current_model: Option<&str>) -> Vec<String> {
+        self.validation_violations_with_api_key_presence(current_model, false)
+    }
+
+    fn validation_violations_with_api_key_presence(
+        &self,
+        current_model: Option<&str>,
+        stored_api_key_is_present: bool,
+    ) -> Vec<String> {
+        let mut violations = Vec::new();
+
         if self.backend_id.trim().is_empty() {
-            anyhow::bail!("backend_id must not be empty");
+            violations.push("backend_id must not be empty".to_string());
         }
         if self.endpoint.trim().is_empty() {
-            anyhow::bail!("backend {} endpoint must not be empty", self.backend_id);
+            violations.push(format!(
+                "backend {} endpoint must not be empty",
+                self.backend_id
+            ));
         }
         if self
             .api_key
             .as_deref()
             .is_some_and(|value| value.trim().is_empty())
         {
-            anyhow::bail!(
+            violations.push(format!(
                 "backend {} api_key must not be empty when present",
                 self.backend_id
-            );
+            ));
         }
-        let has_api_key = self
-            .api_key
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|value| !value.is_empty());
+        let has_api_key = stored_api_key_is_present
+            || self
+                .api_key
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty());
         let has_api_key_env_var = self
             .api_key_env_var
             .as_deref()
             .map(str::trim)
             .is_some_and(|value| !value.is_empty());
         if has_api_key && has_api_key_env_var {
-            anyhow::bail!(
+            violations.push(format!(
                 "backend {} must not set both api_key and api_key_env_var",
                 self.backend_id
-            );
+            ));
         }
         if self.max_concurrent <= 0 {
-            anyhow::bail!(
+            violations.push(format!(
                 "backend {} max_concurrent must be positive",
                 self.backend_id
-            );
+            ));
         }
         if self.max_queue_depth <= 0 {
-            anyhow::bail!(
+            violations.push(format!(
                 "backend {} max_queue_depth must be positive",
                 self.backend_id
-            );
+            ));
         }
         if let Some(current_model) = current_model.map(str::trim).filter(|v| !v.is_empty()) {
             if !self.models.is_empty()
@@ -174,13 +188,34 @@ impl InferenceBackend {
                     .iter()
                     .any(|model| model.trim() == current_model)
             {
-                anyhow::bail!(
+                violations.push(format!(
                     "backend {} models would drop the current model {current_model:?}; no-lockout guard",
                     self.backend_id
-                );
+                ));
             }
         }
-        Ok(())
+        violations
+    }
+
+    /// Validate a secret-redacted backend projection. Self-config never
+    /// reads the stored key value, but it must still enforce the same XOR
+    /// rule when a separate presence-only query says one exists.
+    pub fn validate_with_api_key_presence(
+        &self,
+        current_model: Option<&str>,
+        stored_api_key_is_present: bool,
+    ) -> Result<()> {
+        let violations = self
+            .validation_violations_with_api_key_presence(current_model, stored_api_key_is_present);
+        if violations.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(violations.join("; "))
+        }
+    }
+
+    pub fn validate(&self, current_model: Option<&str>) -> Result<()> {
+        self.validate_with_api_key_presence(current_model, false)
     }
 }
 

--- a/crates/gents/src/backend_registry.rs
+++ b/crates/gents/src/backend_registry.rs
@@ -110,6 +110,75 @@ impl InferenceBackend {
     pub fn display_state(&self) -> &'static str {
         derive_display_state(self.enabled, &self.probe_status)
     }
+
+    /// Validate this backend — the single owner every write path (CLI
+    /// desired state, self-config's `configure_backend`) calls. `provider_kind`
+    /// is already a typed enum by construction ([`Self::from_value`] fails to
+    /// parse an invalid string), so that rule is enforced by the type, not
+    /// repeated here.
+    ///
+    /// `current_model` is the model a specific behavior currently binds
+    /// against this backend, if the caller has one in scope (self-config's
+    /// opt-in no-lockout guard does; desired state — which validates backends
+    /// independently of behaviors, and separately checks each behavior's
+    /// model against its backend's advertised list — passes `None`).
+    pub fn validate(&self, current_model: Option<&str>) -> Result<()> {
+        if self.backend_id.trim().is_empty() {
+            anyhow::bail!("backend_id must not be empty");
+        }
+        if self.endpoint.trim().is_empty() {
+            anyhow::bail!("backend {} endpoint must not be empty", self.backend_id);
+        }
+        if self
+            .api_key
+            .as_deref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            anyhow::bail!(
+                "backend {} api_key must not be empty when present",
+                self.backend_id
+            );
+        }
+        let has_api_key = self
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
+        let has_api_key_env_var = self
+            .api_key_env_var
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
+        if has_api_key && has_api_key_env_var {
+            anyhow::bail!(
+                "backend {} must not set both api_key and api_key_env_var",
+                self.backend_id
+            );
+        }
+        if self.max_concurrent <= 0 {
+            anyhow::bail!(
+                "backend {} max_concurrent must be positive",
+                self.backend_id
+            );
+        }
+        if self.max_queue_depth <= 0 {
+            anyhow::bail!(
+                "backend {} max_queue_depth must be positive",
+                self.backend_id
+            );
+        }
+        if let Some(current_model) = current_model.map(str::trim).filter(|v| !v.is_empty()) {
+            if !self.models.is_empty()
+                && !self.models.iter().any(|model| model.trim() == current_model)
+            {
+                anyhow::bail!(
+                    "backend {} models would drop the current model {current_model:?}; no-lockout guard",
+                    self.backend_id
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Pure function backing [`InferenceBackend::display_state`]. Lives outside

--- a/crates/gents/src/backend_registry/tests.rs
+++ b/crates/gents/src/backend_registry/tests.rs
@@ -311,10 +311,7 @@ fn inference_backend_validate_rejects_non_positive_max_queue_depth() {
 #[test]
 fn inference_backend_validate_no_lockout_rejects_dropping_the_current_model() {
     let backend = base_backend(); // models: ["d4f"]
-    let error = backend
-        .validate(Some("gone"))
-        .unwrap_err()
-        .to_string();
+    let error = backend.validate(Some("gone")).unwrap_err().to_string();
     assert!(
         error.contains("would drop the current model \"gone\""),
         "{error}"

--- a/crates/gents/src/backend_registry/tests.rs
+++ b/crates/gents/src/backend_registry/tests.rs
@@ -336,3 +336,40 @@ fn inference_backend_validate_no_lockout_is_skipped_without_a_current_model() {
     let backend = base_backend(); // models: ["d4f"]
     assert!(backend.validate(None).is_ok());
 }
+
+#[test]
+fn inference_backend_validation_reports_every_violation() {
+    let mut backend = base_backend();
+    backend.endpoint = "  ".to_string();
+    backend.max_concurrent = 0;
+    backend.max_queue_depth = -1;
+
+    let violations = backend.validation_violations(None);
+    assert_eq!(violations.len(), 3, "{violations:?}");
+    assert!(violations
+        .iter()
+        .any(|error| error.contains("endpoint must not be empty")));
+    assert!(violations
+        .iter()
+        .any(|error| error.contains("max_concurrent must be positive")));
+    assert!(violations
+        .iter()
+        .any(|error| error.contains("max_queue_depth must be positive")));
+}
+
+#[test]
+fn inference_backend_validation_honors_redacted_api_key_presence() {
+    let mut backend = base_backend();
+    backend.api_key = None;
+    backend.api_key_env_var = Some("BACKEND_API_KEY".to_string());
+
+    assert!(backend.validate(None).is_ok());
+    let error = backend
+        .validate_with_api_key_presence(None, true)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("must not set both api_key and api_key_env_var"),
+        "{error}"
+    );
+}

--- a/crates/gents/src/backend_registry/tests.rs
+++ b/crates/gents/src/backend_registry/tests.rs
@@ -210,3 +210,132 @@ fn resolved_api_key_none_when_unset() {
     let backend = backend_with_keys(None, Some("BACKEND_REGISTRY_TEST_KEY_MISSING"));
     assert_eq!(backend.resolved_api_key(), None);
 }
+
+// ---------------------------------------------------------------------------
+// InferenceBackend::validate (#1331) — table-driven from the historical
+// gents-cli desired-state rules (crates/gents-cli/src/desired_state/validate/agent.rs).
+// ---------------------------------------------------------------------------
+
+fn base_backend() -> InferenceBackend {
+    InferenceBackend {
+        backend_id: "reviewers".to_string(),
+        name: "Reviewers".to_string(),
+        provider_kind: BackendProviderKind::OpenAiCompatible,
+        openai_wire_api: None,
+        endpoint: "http://127.0.0.1:8000/v1".to_string(),
+        api_key: None,
+        api_key_env_var: None,
+        max_concurrent: 4,
+        max_queue_depth: 8,
+        enabled: true,
+        models: vec!["d4f".to_string()],
+        probe_status: UNKNOWN_PROBE_STATUS.to_string(),
+    }
+}
+
+#[test]
+fn inference_backend_validate_accepts_a_well_formed_backend() {
+    assert!(base_backend().validate(None).is_ok());
+}
+
+#[test]
+fn inference_backend_validate_rejects_empty_backend_id() {
+    let mut backend = base_backend();
+    backend.backend_id = "  ".to_string();
+    let error = backend.validate(None).unwrap_err().to_string();
+    assert!(error.contains("backend_id must not be empty"), "{error}");
+}
+
+#[test]
+fn inference_backend_validate_rejects_empty_endpoint() {
+    let mut backend = base_backend();
+    backend.endpoint = "  ".to_string();
+    let error = backend.validate(None).unwrap_err().to_string();
+    assert!(error.contains("endpoint must not be empty"), "{error}");
+}
+
+#[test]
+fn inference_backend_validate_rejects_empty_api_key() {
+    let mut backend = base_backend();
+    backend.api_key = Some("   ".to_string());
+    let error = backend.validate(None).unwrap_err().to_string();
+    assert!(error.contains("api_key must not be empty"), "{error}");
+}
+
+#[test]
+fn inference_backend_validate_rejects_api_key_and_env_var_together() {
+    let mut backend = base_backend();
+    backend.api_key = Some("sk-live".to_string());
+    backend.api_key_env_var = Some("BACKEND_API_KEY".to_string());
+    let error = backend.validate(None).unwrap_err().to_string();
+    assert!(
+        error.contains("must not set both api_key and api_key_env_var"),
+        "{error}"
+    );
+}
+
+#[test]
+fn inference_backend_validate_accepts_api_key_xor_env_var() {
+    let mut with_key = base_backend();
+    with_key.api_key = Some("sk-live".to_string());
+    assert!(with_key.validate(None).is_ok());
+
+    let mut with_env_var = base_backend();
+    with_env_var.api_key_env_var = Some("BACKEND_API_KEY".to_string());
+    assert!(with_env_var.validate(None).is_ok());
+}
+
+#[test]
+fn inference_backend_validate_rejects_non_positive_max_concurrent() {
+    for value in [0, -1] {
+        let mut backend = base_backend();
+        backend.max_concurrent = value;
+        let error = backend.validate(None).unwrap_err().to_string();
+        assert!(error.contains("max_concurrent must be positive"), "{error}");
+    }
+}
+
+#[test]
+fn inference_backend_validate_rejects_non_positive_max_queue_depth() {
+    for value in [0, -1] {
+        let mut backend = base_backend();
+        backend.max_queue_depth = value;
+        let error = backend.validate(None).unwrap_err().to_string();
+        assert!(
+            error.contains("max_queue_depth must be positive"),
+            "{error}"
+        );
+    }
+}
+
+#[test]
+fn inference_backend_validate_no_lockout_rejects_dropping_the_current_model() {
+    let backend = base_backend(); // models: ["d4f"]
+    let error = backend
+        .validate(Some("gone"))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("would drop the current model \"gone\""),
+        "{error}"
+    );
+}
+
+#[test]
+fn inference_backend_validate_no_lockout_accepts_the_current_model_still_listed() {
+    let backend = base_backend(); // models: ["d4f"]
+    assert!(backend.validate(Some("d4f")).is_ok());
+}
+
+#[test]
+fn inference_backend_validate_no_lockout_is_skipped_when_models_list_is_empty() {
+    let mut backend = base_backend();
+    backend.models = Vec::new();
+    assert!(backend.validate(Some("anything")).is_ok());
+}
+
+#[test]
+fn inference_backend_validate_no_lockout_is_skipped_without_a_current_model() {
+    let backend = base_backend(); // models: ["d4f"]
+    assert!(backend.validate(None).is_ok());
+}

--- a/crates/gents/src/collection.rs
+++ b/crates/gents/src/collection.rs
@@ -32,6 +32,15 @@ pub enum Collection {
 /// a subset, but must preserve this order. Deletes intentionally have no
 /// equivalent runtime API: pruning is an operator CLI concern, never a package
 /// installation primitive.
+///
+/// This is a *linear refinement* of the Lean-proven rank,
+/// [`Collection::apply_order`] (`ApplyReconcile.Collection.applyOrder`):
+/// [`Collection::apply_order`] only orders collections whose ranks differ (a
+/// partial order — same-rank collections have no proven relative order), and
+/// this array totals that partial order into one concrete write sequence by
+/// picking one linear order among the choices the rank leaves open. Reordering
+/// entries *within* a rank is free; moving a collection across a rank
+/// boundary is not — see `linear_apply_order_refines_the_lean_rank` below.
 pub const DESIRED_STATE_APPLY_ORDER: [Collection; 14] = [
     Collection::InferenceBackend,
     Collection::InferenceProfile,
@@ -216,6 +225,41 @@ mod tests {
     fn all_collections_have_distinct_display_strings() {
         let names: BTreeSet<String> = Collection::ALL.iter().map(|c| c.to_string()).collect();
         assert_eq!(names.len(), Collection::ALL.len());
+    }
+
+    #[test]
+    fn linear_apply_order_refines_the_lean_rank() {
+        // DESIRED_STATE_APPLY_ORDER is a linear refinement of the Lean-proven
+        // partial order (Collection::apply_order): consecutive entries must
+        // never step DOWN in rank. Stepping up (including staying flat, for
+        // same-rank neighbors) is exactly what "refinement" allows.
+        let ranks: Vec<u8> = DESIRED_STATE_APPLY_ORDER
+            .iter()
+            .map(|c| c.apply_order())
+            .collect();
+        for window in ranks.windows(2) {
+            let (previous, next) = (window[0], window[1]);
+            assert!(
+                previous <= next,
+                "DESIRED_STATE_APPLY_ORDER places a higher-rank collection \
+                 before a lower-rank one: rank {previous} is immediately \
+                 followed by rank {next} in {DESIRED_STATE_APPLY_ORDER:?}"
+            );
+        }
+
+        // Every canonical variant appears in the array exactly once — the
+        // refinement is total, not a subset.
+        assert_eq!(DESIRED_STATE_APPLY_ORDER.len(), Collection::ALL.len());
+        for variant in Collection::ALL {
+            assert_eq!(
+                DESIRED_STATE_APPLY_ORDER
+                    .iter()
+                    .filter(|c| **c == variant)
+                    .count(),
+                1,
+                "DESIRED_STATE_APPLY_ORDER must list {variant:?} exactly once"
+            );
+        }
     }
 
     #[test]

--- a/crates/gents/src/config_client/agent_behavior.rs
+++ b/crates/gents/src/config_client/agent_behavior.rs
@@ -1,27 +1,41 @@
 use crate::graphql::escape_graphql_string;
 use crate::AgentBehaviorDocument as AgentBehavior;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
-use super::ConfigAccess;
-use gents_protocol::graphql::{graphql_bool_literal, optional_f64_field, optional_string_field};
+use super::{ConfigAccess, ConfigApplyTxn};
+use gents_protocol::graphql::{
+    graphql_bool_literal, graphql_rows_from_response, optional_f64_field, optional_string_field,
+};
 
-/// Raw upsert of one `AgentBehavior` document. This function does NOT
-/// validate references (backend/model/tool_selection/profile/skill) — it
-/// writes exactly what it's given. Every caller except first-run `init`
-/// (which writes before a catalog exists to check references against) MUST
-/// call [`crate::AgentBehaviorDocument::validate_references`] against a
-/// current [`crate::ConfigReferences`] snapshot first; see
-/// `gents-cli/src/commands/config/behavior.rs::behavior_set` and
-/// `gents-cli/src/commands/codex_shim/handlers/models.rs::apply_model_to_bound_behavior`
-/// for the validated call sites. `crate::agent::persona_ops` is the other
-/// writer of this document (catalog/preset-based persona operations); raw
-/// field edits from the CLI go through this function and
-/// `validate_references` instead, deliberately outside persona admission —
-/// see the module doc on `persona_ops` for why.
+/// Upsert one `AgentBehavior` after validating its references against the
+/// same access path used for the mutation. For an update, validation projects
+/// the sparse input onto the stored document first, exactly matching the
+/// writer's `None`-means-preserve semantics.
 pub async fn write_agent_behavior_document(
     access: &ConfigAccess,
     behavior: &AgentBehavior,
 ) -> Result<String> {
+    let txn = access.begin_apply_txn().await?;
+    let result = write_agent_behavior_in_txn(&txn, behavior).await;
+    match result {
+        Ok(doc_id) => {
+            txn.commit().await?;
+            Ok(doc_id)
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn write_agent_behavior_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    behavior: &AgentBehavior,
+) -> Result<String> {
+    let effective = effective_agent_behavior(txn, behavior).await?;
+    let refs = crate::ConfigReferences::load_in_txn(txn, &effective.agent_did).await?;
+    effective.validate_references(&refs)?;
     let created_at = behavior
         .created_at
         .clone()
@@ -118,8 +132,245 @@ pub async fn write_agent_behavior_document(
         add_fields = add_fields,
         update_fields = update_fields,
     );
-    let response = access
-        .execute_mutation(&mutation, "upsert AgentBehavior")
-        .await?;
+    let response = txn.execute(&mutation).await?;
     gents_protocol::graphql::extract_mutation_doc_id(&response, "AgentBehavior")
+}
+
+async fn effective_agent_behavior(
+    txn: &ConfigApplyTxn<'_>,
+    patch: &AgentBehavior,
+) -> Result<AgentBehavior> {
+    let existing = load_agent_behavior_in_txn(txn, &patch.behavior_id).await?;
+    let mut effective = merge_agent_behavior_patch(existing.clone(), patch.clone());
+    if existing.is_none() {
+        // This imperative writer does not own the apply-managed skill arrays.
+        // On create DefraDB therefore persists their empty defaults.
+        effective.skill_refs.clear();
+        effective.skill_excludes.clear();
+    }
+    Ok(effective)
+}
+
+pub(crate) async fn load_agent_behavior_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    behavior_id: &str,
+) -> Result<Option<AgentBehavior>> {
+    let behavior_id = escape_graphql_string(behavior_id);
+    let query = format!(
+        r#"{{
+            AgentBehavior(
+                filter: {{ behavior_id: {{ _eq: "{behavior_id}" }} }},
+                limit: 1
+            ) {{
+                behavior_id agent_did display_name description summary system_prompt
+                request_context_template backend_id model_name tool_selection_id
+                inference_profile_id compaction_strategy compaction_threshold enabled
+                skill_refs skill_excludes created_at
+            }}
+        }}"#
+    );
+    let response = txn.execute(&query).await?;
+    graphql_rows_from_response(&response, "AgentBehavior")
+        .into_iter()
+        .next()
+        .map(serde_json::from_value)
+        .transpose()
+        .context("decoding existing AgentBehavior")
+}
+
+fn merge_agent_behavior_patch(
+    existing: Option<AgentBehavior>,
+    patch: AgentBehavior,
+) -> AgentBehavior {
+    let Some(mut effective) = existing else {
+        return patch;
+    };
+
+    effective.agent_did = patch.agent_did;
+    effective.enabled = patch.enabled;
+    macro_rules! apply_optional {
+        ($field:ident) => {
+            if patch.$field.is_some() {
+                effective.$field = patch.$field;
+            }
+        };
+    }
+    apply_optional!(display_name);
+    apply_optional!(description);
+    apply_optional!(summary);
+    apply_optional!(system_prompt);
+    apply_optional!(request_context_template);
+    apply_optional!(backend_id);
+    apply_optional!(model_name);
+    apply_optional!(tool_selection_id);
+    apply_optional!(inference_profile_id);
+    apply_optional!(compaction_strategy);
+    apply_optional!(compaction_threshold);
+    effective
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ensure_runtime_schemas, load_agent_behavior};
+    use defra_node::{EmbeddedNode, StorageBackend};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn create_validates_the_skill_arrays_the_writer_actually_persists() -> Result<()> {
+        let node = Arc::new(EmbeddedNode::builder().build().await?);
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node.clone());
+        let behavior = AgentBehavior {
+            behavior_id: "behavior-create".to_string(),
+            agent_did: "did:test:owner".to_string(),
+            display_name: None,
+            description: None,
+            summary: None,
+            system_prompt: None,
+            request_context_template: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            skill_refs: vec!["not-written".to_string()],
+            skill_excludes: vec!["also-not-written".to_string()],
+            created_at: None,
+        };
+
+        write_agent_behavior_document(&access, &behavior).await?;
+        let stored = load_agent_behavior(&node, &behavior.behavior_id)
+            .await?
+            .expect("created behavior");
+        assert!(stored.skill_refs.is_empty());
+        assert!(stored.skill_excludes.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sparse_backend_change_validates_the_preserved_model() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(dir.path().join("data"))
+                .with_storage_backend(StorageBackend::Regolith)
+                .build()
+                .await?,
+        );
+        ensure_runtime_schemas(&node).await?;
+        let response = node
+            .execute(
+                r#"mutation {
+                    a: create_InferenceBackend(input: {
+                        backend_id: "backend-a", name: "A", provider_kind: "OpenAiCompatible",
+                        endpoint: "http://a.test/v1", max_concurrent: 1, max_queue_depth: 1,
+                        enabled: true, models: ["model-a"], probe_status: "healthy"
+                    }) { _docID }
+                    b: create_InferenceBackend(input: {
+                        backend_id: "backend-b", name: "B", provider_kind: "OpenAiCompatible",
+                        endpoint: "http://b.test/v1", max_concurrent: 1, max_queue_depth: 1,
+                        enabled: true, models: ["model-b"], probe_status: "healthy"
+                    }) { _docID }
+                }"#,
+            )
+            .await;
+        assert!(
+            !response.has_errors(),
+            "seed backends: {:?}",
+            response.errors
+        );
+
+        let access = ConfigAccess::Local(node.clone());
+        let behavior = AgentBehavior {
+            behavior_id: "behavior".to_string(),
+            agent_did: "did:test:owner".to_string(),
+            display_name: None,
+            description: None,
+            summary: None,
+            system_prompt: None,
+            request_context_template: None,
+            backend_id: Some("backend-a".to_string()),
+            model_name: Some("model-a".to_string()),
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            skill_refs: Vec::new(),
+            skill_excludes: Vec::new(),
+            created_at: None,
+        };
+        write_agent_behavior_document(&access, &behavior).await?;
+
+        let mut patch = behavior.clone();
+        patch.backend_id = Some("backend-b".to_string());
+        patch.model_name = None;
+        let error = write_agent_behavior_document(&access, &patch)
+            .await
+            .expect_err("preserved model must be checked against the new backend")
+            .to_string();
+        assert!(error.contains("does not advertise"), "{error}");
+
+        let stored = load_agent_behavior(&node, "behavior")
+            .await?
+            .expect("stored behavior");
+        assert_eq!(stored.backend_id.as_deref(), Some("backend-a"));
+        assert_eq!(stored.model_name.as_deref(), Some("model-a"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn document_upsert_validates_preserved_skill_references() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(dir.path().join("data"))
+                .with_storage_backend(StorageBackend::Regolith)
+                .build()
+                .await?,
+        );
+        ensure_runtime_schemas(&node).await?;
+        let response = node
+            .execute(
+                r#"mutation { create_AgentBehavior(input: {
+                    behavior_id: "direct-behavior", agent_did: "did:test:direct",
+                    display_name: "Original", enabled: true, skill_refs: ["missing-skill"]
+                }) { _docID } }"#,
+            )
+            .await;
+        assert!(!response.has_errors(), "seed: {:?}", response.errors);
+
+        let behavior = AgentBehavior {
+            behavior_id: "direct-behavior".to_string(),
+            agent_did: "did:test:direct".to_string(),
+            display_name: Some("Updated".to_string()),
+            description: None,
+            summary: None,
+            system_prompt: None,
+            request_context_template: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            skill_refs: Vec::new(),
+            skill_excludes: Vec::new(),
+            created_at: None,
+        };
+        let error = crate::upsert_agent_behavior(&node, &behavior)
+            .await
+            .expect_err("preserved missing skill reference must reject the upsert")
+            .to_string();
+        assert!(error.contains("missing skill_ref missing-skill"), "{error}");
+        let stored = load_agent_behavior(&node, &behavior.behavior_id)
+            .await?
+            .expect("stored behavior");
+        assert_eq!(stored.display_name.as_deref(), Some("Original"));
+        Ok(())
+    }
 }

--- a/crates/gents/src/config_client/agent_behavior.rs
+++ b/crates/gents/src/config_client/agent_behavior.rs
@@ -5,6 +5,19 @@ use anyhow::Result;
 use super::ConfigAccess;
 use gents_protocol::graphql::{graphql_bool_literal, optional_f64_field, optional_string_field};
 
+/// Raw upsert of one `AgentBehavior` document. This function does NOT
+/// validate references (backend/model/tool_selection/profile/skill) — it
+/// writes exactly what it's given. Every caller except first-run `init`
+/// (which writes before a catalog exists to check references against) MUST
+/// call [`crate::AgentBehaviorDocument::validate_references`] against a
+/// current [`crate::ConfigReferences`] snapshot first; see
+/// `gents-cli/src/commands/config/behavior.rs::behavior_set` and
+/// `gents-cli/src/commands/codex_shim/handlers/models.rs::apply_model_to_bound_behavior`
+/// for the validated call sites. `crate::agent::persona_ops` is the other
+/// writer of this document (catalog/preset-based persona operations); raw
+/// field edits from the CLI go through this function and
+/// `validate_references` instead, deliberately outside persona admission —
+/// see the module doc on `persona_ops` for why.
 pub async fn write_agent_behavior_document(
     access: &ConfigAccess,
     behavior: &AgentBehavior,

--- a/crates/gents/src/config_client/common.rs
+++ b/crates/gents/src/config_client/common.rs
@@ -1,8 +1,53 @@
 use anyhow::Result;
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use std::sync::atomic::{AtomicI64, Ordering};
 
 use super::ExistingDocumentRef;
+
+/// Project a sparse document onto an existing row using the config-client
+/// convention: non-null fields replace stored values, ignored fields remain
+/// stored, and explicit clears become null.
+pub(super) fn merge_sparse_document<T>(
+    existing: Option<T>,
+    patch: &T,
+    ignored_fields: &[&str],
+    clear_fields: &[&str],
+) -> Result<T>
+where
+    T: Clone + Serialize + DeserializeOwned,
+{
+    let Some(existing) = existing else {
+        let mut candidate = serde_json::to_value(patch)?;
+        let candidate = candidate
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("serialized config patch was not an object"))?;
+        // Ignored fields are not emitted by the writer on either branch. A
+        // create therefore persists their schema defaults, not the values in
+        // the caller's wider document type.
+        for field in ignored_fields {
+            candidate.remove(*field);
+        }
+        return serde_json::from_value(Value::Object(candidate.clone())).map_err(Into::into);
+    };
+    let mut effective = serde_json::to_value(existing)?;
+    let effective = effective
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("serialized config document was not an object"))?;
+    let patch = serde_json::to_value(patch)?;
+    let patch = patch
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("serialized config patch was not an object"))?;
+    for (field, value) in patch {
+        if !ignored_fields.contains(&field.as_str()) && !value.is_null() {
+            effective.insert(field.clone(), value.clone());
+        }
+    }
+    for field in clear_fields {
+        effective.insert((*field).to_string(), Value::Null);
+    }
+    serde_json::from_value(Value::Object(effective.clone())).map_err(Into::into)
+}
 
 pub(super) async fn query_documents_by_unique_value(
     txn: &super::ConfigApplyTxn<'_>,

--- a/crates/gents/src/config_client/desired_state.rs
+++ b/crates/gents/src/config_client/desired_state.rs
@@ -290,6 +290,9 @@ async fn apply_generic_document(
     unique_value: &str,
     document: &DesiredStateApplyDocument,
 ) -> Result<String> {
+    if collection == Collection::AgentBehavior {
+        validate_agent_behavior_document(txn, unique_value, document).await?;
+    }
     let collection_name = collection.graphql_type();
     let unique_field = collection.unique_field();
     // The existing desired-state path uses an upsert for generic config
@@ -306,6 +309,34 @@ async fn apply_generic_document(
     );
     let response = txn.execute(&mutation).await?;
     extract_mutation_doc_id(&response, collection_name)
+}
+
+async fn validate_agent_behavior_document(
+    txn: &ConfigApplyTxn<'_>,
+    behavior_id: &str,
+    document: &DesiredStateApplyDocument,
+) -> Result<()> {
+    let candidate =
+        if let Some(existing) = super::load_agent_behavior_in_txn(txn, behavior_id).await? {
+            let mut candidate = serde_json::to_value(existing)?;
+            let candidate_fields = candidate
+                .as_object_mut()
+                .context("serialized AgentBehavior was not an object")?;
+            let update = sanitize_update_input(&document.update);
+            let update_fields = update
+                .as_object()
+                .context("desired-state AgentBehavior update was not an object")?;
+            for (field, value) in update_fields {
+                candidate_fields.insert(field.clone(), value.clone());
+            }
+            candidate
+        } else {
+            sanitize_create_input(&document.add)
+        };
+    let behavior: crate::AgentBehaviorDocument = serde_json::from_value(candidate)
+        .context("decode effective desired-state AgentBehavior")?;
+    let references = crate::ConfigReferences::load_in_txn(txn, &behavior.agent_did).await?;
+    behavior.validate_references(&references)
 }
 
 #[cfg(test)]

--- a/crates/gents/src/config_client/inference_backend.rs
+++ b/crates/gents/src/config_client/inference_backend.rs
@@ -1,9 +1,30 @@
 use crate::graphql::escape_graphql_string;
 use crate::{BackendProviderKind, OpenAiWireApi};
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::{mint_recreate_identity_timestamp, ConfigAccess};
 use gents_protocol::graphql::{graphql_bool_literal, nullable_string_field, string_list_field};
+
+pub async fn load_inference_backend_in_txn(
+    txn: &super::ConfigApplyTxn<'_>,
+    backend_id: &str,
+) -> Result<Option<crate::InferenceBackend>> {
+    let backend_id = escape_graphql_string(backend_id);
+    let response = txn
+        .execute(&format!(
+            r#"{{ InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{backend_id}" }} }}, limit: 1
+            ) {{ backend_id name provider_kind openai_wire_api endpoint api_key api_key_env_var
+                 max_concurrent max_queue_depth enabled models probe_status }} }}"#
+        ))
+        .await?;
+    gents_protocol::graphql::graphql_rows_from_response(&response, "InferenceBackend")
+        .into_iter()
+        .next()
+        .map(|row| crate::InferenceBackend::from_value(&row))
+        .transpose()
+        .context("decoding existing InferenceBackend")
+}
 
 #[derive(Debug, Clone)]
 pub struct InferenceBackendUpsertDocument {
@@ -26,6 +47,24 @@ pub async fn write_inference_backend_document(
     access: &ConfigAccess,
     backend: &InferenceBackendUpsertDocument,
 ) -> Result<String> {
+    crate::InferenceBackend {
+        backend_id: backend.backend_id.clone(),
+        name: backend.name.clone(),
+        provider_kind: backend.provider_kind,
+        openai_wire_api: backend.openai_wire_api,
+        endpoint: backend.endpoint.clone(),
+        api_key: backend.api_key.clone(),
+        api_key_env_var: backend.api_key_env_var.clone(),
+        max_concurrent: backend.max_concurrent,
+        max_queue_depth: backend.max_queue_depth,
+        enabled: backend.enabled,
+        models: backend
+            .models_on_update
+            .clone()
+            .unwrap_or_else(|| backend.models_on_add.clone()),
+        probe_status: backend.probe_status.clone(),
+    }
+    .validate(None)?;
     let recreate_identity = escape_graphql_string(&mint_recreate_identity_timestamp());
     let models_add = string_list_field("models", &backend.models_on_add)
         .ok_or_else(|| anyhow::anyhow!("backend models field could not be rendered"))?;

--- a/crates/gents/src/config_client/inference_profile.rs
+++ b/crates/gents/src/config_client/inference_profile.rs
@@ -1,0 +1,175 @@
+use anyhow::{Context, Result};
+use gents_protocol::graphql::{
+    extract_mutation_doc_id, graphql_rows_from_response, optional_bool_field, optional_f64_field,
+    optional_i64_field, optional_i64_list_field, optional_string_field,
+};
+
+use crate::document_config::InferenceProfile;
+use crate::graphql::escape_graphql_string;
+
+use super::{mint_recreate_identity_timestamp, ConfigAccess, ConfigApplyTxn};
+
+/// Upsert a possibly sparse profile after validating the effective stored
+/// document in the same transaction as the mutation.
+pub async fn write_inference_profile_document(
+    access: &ConfigAccess,
+    profile: &InferenceProfile,
+) -> Result<String> {
+    let txn = access.begin_apply_txn().await?;
+    let result = write_inference_profile_in_txn(&txn, profile).await;
+    match result {
+        Ok(doc_id) => {
+            txn.commit().await?;
+            Ok(doc_id)
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn write_inference_profile_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    patch: &InferenceProfile,
+) -> Result<String> {
+    effective_inference_profile(txn, patch).await?.validate()?;
+    let mutation = sparse_inference_profile_mutation(patch);
+    let response = txn.execute(&mutation).await?;
+    extract_mutation_doc_id(&response, "InferenceProfile")
+}
+
+pub(crate) async fn effective_inference_profile(
+    txn: &ConfigApplyTxn<'_>,
+    patch: &InferenceProfile,
+) -> Result<InferenceProfile> {
+    let profile_id = escape_graphql_string(&patch.profile_id);
+    let query = format!(
+        r#"{{
+            InferenceProfile(
+                filter: {{ profile_id: {{ _eq: "{profile_id}" }} }},
+                limit: 1
+            ) {{
+                profile_id display_name context_window max_output_tokens max_turns temperature
+                top_p top_k seed min_p frequency_penalty presence_penalty repetition_penalty
+                reasoning_effort stream_batch_ms stream_liveness_timeout_secs
+                deadline_duration_secs retry_max_transport retry_backoff_ms retry_max_resample
+                retry_allow_repair retry_interactive_max
+            }}
+        }}"#
+    );
+    let response = txn.execute(&query).await?;
+    let existing = graphql_rows_from_response(&response, "InferenceProfile")
+        .into_iter()
+        .next()
+        .map(serde_json::from_value)
+        .transpose()
+        .context("decoding existing InferenceProfile")?;
+    super::common::merge_sparse_document(existing, patch, &[], &[])
+}
+
+fn sparse_inference_profile_mutation(profile: &InferenceProfile) -> String {
+    let profile_id = escape_graphql_string(&profile.profile_id);
+    let fields = vec![
+        optional_string_field("display_name", profile.display_name.as_deref()),
+        optional_i64_field("context_window", profile.context_window),
+        optional_i64_field("max_output_tokens", profile.max_output_tokens),
+        optional_i64_field("max_turns", profile.max_turns),
+        optional_f64_field("temperature", profile.temperature),
+        optional_f64_field("top_p", profile.top_p),
+        optional_i64_field("top_k", profile.top_k),
+        optional_i64_field("seed", profile.seed),
+        optional_f64_field("min_p", profile.min_p),
+        optional_f64_field("frequency_penalty", profile.frequency_penalty),
+        optional_f64_field("presence_penalty", profile.presence_penalty),
+        optional_f64_field("repetition_penalty", profile.repetition_penalty),
+        optional_string_field("reasoning_effort", profile.reasoning_effort.as_deref()),
+        optional_i64_field("stream_batch_ms", profile.stream_batch_ms),
+        optional_i64_field(
+            "stream_liveness_timeout_secs",
+            profile.stream_liveness_timeout_secs,
+        ),
+        optional_i64_field("deadline_duration_secs", profile.deadline_duration_secs),
+        optional_i64_field("retry_max_transport", profile.retry_max_transport),
+        optional_i64_list_field("retry_backoff_ms", profile.retry_backoff_ms.as_deref()),
+        optional_i64_field("retry_max_resample", profile.retry_max_resample),
+        optional_bool_field("retry_allow_repair", profile.retry_allow_repair),
+        optional_i64_field("retry_interactive_max", profile.retry_interactive_max),
+    ];
+    let update_fields = fields
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(",\n                    ");
+    let mut add_fields = vec![format!(r#"profile_id: "{profile_id}""#)];
+    add_fields.extend(fields.into_iter().flatten());
+    add_fields.push(format!(
+        r#"updated_at: "{}""#,
+        escape_graphql_string(&mint_recreate_identity_timestamp())
+    ));
+    let add_fields = add_fields.join(",\n                    ");
+    format!(
+        r#"mutation {{
+            upsert_InferenceProfile(
+                filter: {{ profile_id: {{ _eq: "{profile_id}" }} }},
+                add: {{
+                    {add_fields}
+                }},
+                update: {{
+                    {update_fields}
+                }}
+            ) {{ _docID }}
+        }}"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ensure_runtime_schemas, load_inference_profile};
+    use defra_node::{EmbeddedNode, StorageBackend};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn sparse_deadline_change_validates_preserved_liveness_timeout() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(dir.path().join("data"))
+                .with_storage_backend(StorageBackend::Regolith)
+                .build()
+                .await?,
+        );
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node.clone());
+
+        let initial = InferenceProfile {
+            profile_id: "profile".to_string(),
+            stream_liveness_timeout_secs: Some(4_000),
+            deadline_duration_secs: Some(5_000),
+            ..Default::default()
+        };
+        write_inference_profile_document(&access, &initial).await?;
+
+        let patch = InferenceProfile {
+            profile_id: initial.profile_id.clone(),
+            deadline_duration_secs: Some(3_600),
+            ..Default::default()
+        };
+        let error = write_inference_profile_document(&access, &patch)
+            .await
+            .expect_err("preserved liveness timeout must be checked against the new deadline")
+            .to_string();
+        assert!(
+            error.contains("must be less than deadline_duration_secs"),
+            "{error}"
+        );
+
+        let stored = load_inference_profile(&node, &initial.profile_id)
+            .await?
+            .expect("stored profile");
+        assert_eq!(stored.deadline_duration_secs, Some(5_000));
+        Ok(())
+    }
+}

--- a/crates/gents/src/config_client/mod.rs
+++ b/crates/gents/src/config_client/mod.rs
@@ -27,6 +27,7 @@ mod common;
 mod desired_state;
 mod event_trigger;
 mod inference_backend;
+mod inference_profile;
 mod schedule;
 mod schema_contract;
 mod task;
@@ -34,6 +35,7 @@ mod txn;
 
 pub mod patch;
 
+pub(crate) use agent_behavior::load_agent_behavior_in_txn;
 pub use agent_behavior::write_agent_behavior_document;
 pub use approval::{list_held_tool_calls, write_tool_approval, HeldToolCall, ToolApprovalVerdict};
 pub use common::{mint_recreate_identity, mint_recreate_identity_timestamp};
@@ -46,10 +48,15 @@ pub(crate) use desired_state::{
     verify_existing_desired_state_plan,
 };
 pub use event_trigger::write_event_trigger_document;
-pub use inference_backend::{write_inference_backend_document, InferenceBackendUpsertDocument};
+pub use inference_backend::{
+    load_inference_backend_in_txn, write_inference_backend_document, InferenceBackendUpsertDocument,
+};
+pub(crate) use inference_profile::effective_inference_profile;
+pub use inference_profile::write_inference_profile_document;
 pub use schedule::write_schedule_document;
 pub(crate) use schema_contract::collection_schema_contract_digest;
 pub use task::write_task_document;
+pub(crate) use tool_selection::effective_tool_selection;
 pub use tool_selection::{
     write_tool_selection_document, write_tool_selection_document_with_clear_fields,
 };

--- a/crates/gents/src/config_client/tool_selection.rs
+++ b/crates/gents/src/config_client/tool_selection.rs
@@ -1,9 +1,11 @@
 use crate::graphql::escape_graphql_string;
 use crate::ToolSelectionDocument;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
-use super::{mint_recreate_identity_timestamp, ConfigAccess};
-use gents_protocol::graphql::{optional_bool_field, optional_string_field, string_list_field};
+use super::{mint_recreate_identity_timestamp, ConfigAccess, ConfigApplyTxn};
+use gents_protocol::graphql::{
+    graphql_rows_from_response, optional_bool_field, optional_string_field, string_list_field,
+};
 
 pub async fn write_tool_selection_document(
     access: &ConfigAccess,
@@ -17,6 +19,42 @@ pub async fn write_tool_selection_document_with_clear_fields(
     selection: &ToolSelectionDocument,
     clear_update_fields: &[&str],
 ) -> Result<String> {
+    const CLEARABLE_FIELDS: &[&str] = &[
+        "bash_mode",
+        "command_execution_policy",
+        "command_network_mode",
+        "cross_deployment_spawn_timeout_seconds",
+        "display_name",
+        "file_tool_root",
+        "file_tools_mode",
+    ];
+    for field in clear_update_fields {
+        if !CLEARABLE_FIELDS.contains(field) {
+            anyhow::bail!("unsupported ToolSelection clear field {field:?}");
+        }
+    }
+    let txn = access.begin_apply_txn().await?;
+    let result = write_tool_selection_in_txn(&txn, selection, clear_update_fields).await;
+    match result {
+        Ok(doc_id) => {
+            txn.commit().await?;
+            Ok(doc_id)
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn write_tool_selection_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    selection: &ToolSelectionDocument,
+    clear_update_fields: &[&str],
+) -> Result<String> {
+    effective_tool_selection(txn, selection, &["write_tools"], clear_update_fields)
+        .await?
+        .validate()?;
     let add_fields = format!(
         "{},\n                    updated_at: \"{}\"",
         tool_selection_fields(selection, true),
@@ -51,18 +89,106 @@ pub async fn write_tool_selection_document_with_clear_fields(
         add_fields = add_fields,
         update_fields = update_fields,
     );
-    let response = access
-        .execute_mutation(&mutation, "upsert ToolSelection")
-        .await?;
+    let response = txn.execute(&mutation).await?;
     gents_protocol::graphql::extract_mutation_doc_id(&response, "ToolSelection")
+}
+
+pub(crate) async fn effective_tool_selection(
+    txn: &ConfigApplyTxn<'_>,
+    patch: &ToolSelectionDocument,
+    ignored_fields: &[&str],
+    clear_fields: &[&str],
+) -> Result<ToolSelectionDocument> {
+    let existing = load_tool_selection_in_txn(txn, &patch.selection_id).await?;
+    super::common::merge_sparse_document(existing, patch, ignored_fields, clear_fields)
+}
+
+pub(crate) async fn load_tool_selection_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    selection_id: &str,
+) -> Result<Option<ToolSelectionDocument>> {
+    let selection_id = escape_graphql_string(selection_id);
+    let query = format!(
+        r#"{{
+            ToolSelection(
+                filter: {{ selection_id: {{ _eq: "{selection_id}" }} }},
+                limit: 1
+            ) {{
+                selection_id agent_did display_name tool_policy_version enable_file_tools
+                file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy
+                command_allowed_argv_prefixes command_forbidden_argv_prefixes
+                read_only_command_allowlist command_network_mode cli_tool_names enable_meta_tools
+                enable_goal_tools enable_goal_creation allowed_mcp_service_ids
+                required_mcp_service_ids backgroundable_tool_names approval_required_tools
+                enable_memory enable_session_history_tool enable_context_budget enable_defra_query
+                defra_query_collections subagent_targets subagent_spawn_enabled
+                subagent_steering_enabled subagent_background_enabled subagent_default_await_mode
+                subagent_allow_cross_deployment cross_deployment_spawn_timeout_seconds
+                write_tools datastore_tool_surface_ids eth_tool_ids enable_self_config
+                self_config_categories self_config_no_lockout self_config_dry_run enable_lsp lsp_config
+            }}
+        }}"#
+    );
+    let response = txn.execute(&query).await?;
+    graphql_rows_from_response(&response, "ToolSelection")
+        .into_iter()
+        .next()
+        .map(serde_json::from_value)
+        .transpose()
+        .context("decoding existing ToolSelection")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ensure_runtime_schemas, load_tool_selection};
+    use crate::{ensure_runtime_schemas, load_tool_selection, WriteToolDecl};
     use anyhow::Result;
     use defra_node::{EmbeddedNode, StorageBackend};
+
+    #[tokio::test]
+    async fn create_validates_the_write_tools_the_writer_actually_persists() -> Result<()> {
+        let node = std::sync::Arc::new(EmbeddedNode::builder().build().await?);
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node.clone());
+        let selection = ToolSelectionDocument {
+            selection_id: "imperative-create".to_string(),
+            agent_did: "did:test:owner".to_string(),
+            write_tools: Some(vec![WriteToolDecl {
+                tool_name: "".to_string(),
+                collection: "Invalid collection".to_string(),
+                description: String::new(),
+                fields: Vec::new(),
+                output_obligation: None,
+            }]),
+            ..Default::default()
+        };
+
+        write_tool_selection_document(&access, &selection).await?;
+        let stored = load_tool_selection(&node, &selection.selection_id)
+            .await?
+            .expect("created selection");
+        assert!(stored.write_tools.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn clear_fields_reject_unknown_graphql_names_before_access() {
+        let access = ConfigAccess::Graphql("not-an-endpoint".to_string());
+        let selection = ToolSelectionDocument {
+            selection_id: "selection".to_string(),
+            agent_did: "did:test:owner".to_string(),
+            ..Default::default()
+        };
+        let error = write_tool_selection_document_with_clear_fields(
+            &access,
+            &selection,
+            &["display_name } mutation { delete_AgentRequest"],
+        )
+        .await
+        .expect_err("unknown clear field must be rejected")
+        .to_string();
+        assert!(error.contains("unsupported ToolSelection clear field"));
+    }
 
     /// Round-trip test: write a `ToolSelectionDocument` with subagent
     /// enablement fields set, then read it back and assert every field persisted.
@@ -379,6 +505,87 @@ mod tests {
             .is_empty());
         assert_eq!(loaded.cross_deployment_spawn_timeout_seconds, None);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sparse_meta_tools_change_validates_preserved_required_services() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let node = EmbeddedNode::builder()
+            .data_path(tempdir.path().join("data"))
+            .with_storage_backend(StorageBackend::Regolith)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(std::sync::Arc::new(node));
+
+        let initial = ToolSelectionDocument {
+            selection_id: "required-services".to_string(),
+            agent_did: "did:test:required-services".to_string(),
+            enable_meta_tools: Some(true),
+            allowed_mcp_service_ids: Some(vec!["required".to_string()]),
+            required_mcp_service_ids: Some(vec!["required".to_string()]),
+            ..Default::default()
+        };
+        write_tool_selection_document(&access, &initial).await?;
+
+        let patch = ToolSelectionDocument {
+            selection_id: initial.selection_id.clone(),
+            agent_did: initial.agent_did.clone(),
+            enable_meta_tools: Some(false),
+            ..Default::default()
+        };
+        let error = write_tool_selection_document(&access, &patch)
+            .await
+            .expect_err("preserved required services must keep meta tools enabled")
+            .to_string();
+        assert!(error.contains("needs enable_meta_tools=true"), "{error}");
+
+        let node = match &access {
+            ConfigAccess::Local(node) => node,
+            ConfigAccess::Graphql(_) => unreachable!(),
+        };
+        let stored = load_tool_selection(node, &initial.selection_id)
+            .await?
+            .expect("stored selection");
+        assert_eq!(stored.enable_meta_tools, Some(true));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn document_upsert_validates_preserved_required_services() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let node = EmbeddedNode::builder()
+            .data_path(tempdir.path().join("data"))
+            .with_storage_backend(StorageBackend::Regolith)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let initial = ToolSelectionDocument {
+            selection_id: "direct-required-services".to_string(),
+            agent_did: "did:test:direct-required-services".to_string(),
+            enable_meta_tools: Some(true),
+            allowed_mcp_service_ids: Some(vec!["required".to_string()]),
+            required_mcp_service_ids: Some(vec!["required".to_string()]),
+            ..Default::default()
+        };
+        crate::upsert_tool_selection(&node, &initial).await?;
+
+        let patch = ToolSelectionDocument {
+            selection_id: initial.selection_id.clone(),
+            agent_did: initial.agent_did.clone(),
+            enable_meta_tools: Some(false),
+            ..Default::default()
+        };
+        let error = crate::upsert_tool_selection(&node, &patch)
+            .await
+            .expect_err("direct upsert must validate preserved required services")
+            .to_string();
+        assert!(error.contains("needs enable_meta_tools=true"), "{error}");
+        let stored = load_tool_selection(&node, &initial.selection_id)
+            .await?
+            .expect("stored selection");
+        assert_eq!(stored.enable_meta_tools, Some(true));
         Ok(())
     }
 }

--- a/crates/gents/src/document_config/behavior.rs
+++ b/crates/gents/src/document_config/behavior.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
 
 use super::graphql_fields;
+use super::references::ConfigReferences;
 use super::serde_helpers::{first_row_with_doc_id, rows_with_doc_id};
 
 const DEFAULT_BEHAVIOR_LABEL: &str = "Default";
@@ -36,6 +37,86 @@ pub struct AgentBehavior {
     )]
     pub skill_excludes: Vec<String>,
     pub created_at: Option<String>,
+}
+
+impl AgentBehavior {
+    /// Validate this behavior's document references — the single owner
+    /// every write path (CLI desired state, self-config's
+    /// `configure_behavior`) calls. Checks that `backend_id`, `model_name`
+    /// (against the backend's advertised models), `tool_selection_id`,
+    /// `inference_profile_id`, and every `skill_refs`/`skill_excludes` entry
+    /// name something that actually exists in `refs`. Structural checks
+    /// (empty ids, ownership, template syntax) stay with each write path —
+    /// they are shape checks on the manifest/patch, not document
+    /// references (#1331).
+    pub fn validate_references(&self, refs: &ConfigReferences) -> Result<()> {
+        fn non_empty(value: Option<&str>) -> Option<&str> {
+            value.map(str::trim).filter(|value| !value.is_empty())
+        }
+
+        if let Some(backend_id) = non_empty(self.backend_id.as_deref()) {
+            let Some(advertised) = refs.backends.get(backend_id) else {
+                anyhow::bail!(
+                    "behavior {} references missing backend_id {}",
+                    self.behavior_id,
+                    backend_id
+                );
+            };
+            if let Some(model_name) = non_empty(self.model_name.as_deref()) {
+                if !advertised.is_empty() && !advertised.iter().any(|model| model == model_name) {
+                    anyhow::bail!(
+                        "behavior {} selects model {} which backend {} does not advertise",
+                        self.behavior_id,
+                        model_name,
+                        backend_id
+                    );
+                }
+            }
+        }
+
+        if let Some(selection_id) = non_empty(self.tool_selection_id.as_deref()) {
+            if !refs.tool_selections.contains(selection_id) {
+                anyhow::bail!(
+                    "behavior {} references missing tool_selection_id {}",
+                    self.behavior_id,
+                    selection_id
+                );
+            }
+        }
+
+        if let Some(profile_id) = non_empty(self.inference_profile_id.as_deref()) {
+            if !refs.profiles.contains(profile_id) {
+                anyhow::bail!(
+                    "behavior {} references missing inference_profile_id {}",
+                    self.behavior_id,
+                    profile_id
+                );
+            }
+        }
+
+        for skill_ref in &self.skill_refs {
+            let skill_ref = skill_ref.trim();
+            if !skill_ref.is_empty() && !refs.skills.contains(skill_ref) {
+                anyhow::bail!(
+                    "behavior {} references missing skill_ref {} (import the skill first)",
+                    self.behavior_id,
+                    skill_ref
+                );
+            }
+        }
+        for skill_exclude in &self.skill_excludes {
+            let skill_exclude = skill_exclude.trim();
+            if !skill_exclude.is_empty() && !refs.skills.contains(skill_exclude) {
+                anyhow::bail!(
+                    "behavior {} references missing skill_exclude {}",
+                    self.behavior_id,
+                    skill_exclude
+                );
+            }
+        }
+
+        Ok(())
+    }
 }
 
 pub async fn load_agent_behavior(

--- a/crates/gents/src/document_config/behavior.rs
+++ b/crates/gents/src/document_config/behavior.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use defra_node::EmbeddedNode;
 use serde::{Deserialize, Serialize};
 
-use crate::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
+use crate::graphql::escape_graphql_string;
 
 use super::graphql_fields;
 use super::references::ConfigReferences;
@@ -40,8 +40,8 @@ pub struct AgentBehavior {
 }
 
 impl AgentBehavior {
-    /// Validate this behavior's document references — the single owner
-    /// every write path (CLI desired state, self-config's
+    /// Every violated reference rule, in rule-check order — the single
+    /// owner every write path (CLI desired state, self-config's
     /// `configure_behavior`) calls. Checks that `backend_id`, `model_name`
     /// (against the backend's advertised models), `tool_selection_id`,
     /// `inference_profile_id`, and every `skill_refs`/`skill_excludes` entry
@@ -49,73 +49,94 @@ impl AgentBehavior {
     /// (empty ids, ownership, template syntax) stay with each write path —
     /// they are shape checks on the manifest/patch, not document
     /// references (#1331).
-    pub fn validate_references(&self, refs: &ConfigReferences) -> Result<()> {
+    ///
+    /// Reports every violation at once, not just the first — a behavior can
+    /// dangle on more than one reference simultaneously (e.g. a missing
+    /// backend, tool selection, and profile all at once), and desired
+    /// state's per-behavior error list should surface each as its own entry
+    /// rather than hide the rest behind whichever was checked first. Empty
+    /// means every reference is valid.
+    pub fn reference_violations(&self, refs: &ConfigReferences) -> Vec<String> {
         fn non_empty(value: Option<&str>) -> Option<&str> {
             value.map(str::trim).filter(|value| !value.is_empty())
         }
 
+        let mut violations = Vec::new();
+
         if let Some(backend_id) = non_empty(self.backend_id.as_deref()) {
-            let Some(advertised) = refs.backends.get(backend_id) else {
-                anyhow::bail!(
+            match refs.backends.get(backend_id) {
+                None => violations.push(format!(
                     "behavior {} references missing backend_id {}",
-                    self.behavior_id,
-                    backend_id
-                );
-            };
-            if let Some(model_name) = non_empty(self.model_name.as_deref()) {
-                if !advertised.is_empty() && !advertised.iter().any(|model| model == model_name) {
-                    anyhow::bail!(
-                        "behavior {} selects model {} which backend {} does not advertise",
-                        self.behavior_id,
-                        model_name,
-                        backend_id
-                    );
+                    self.behavior_id, backend_id
+                )),
+                Some(advertised) => {
+                    if let Some(model_name) = non_empty(self.model_name.as_deref()) {
+                        if !advertised.is_empty()
+                            && !advertised.iter().any(|model| model == model_name)
+                        {
+                            violations.push(format!(
+                                "behavior {} selects model {} which backend {} does not advertise",
+                                self.behavior_id, model_name, backend_id
+                            ));
+                        }
+                    }
                 }
             }
         }
 
         if let Some(selection_id) = non_empty(self.tool_selection_id.as_deref()) {
             if !refs.tool_selections.contains(selection_id) {
-                anyhow::bail!(
+                violations.push(format!(
                     "behavior {} references missing tool_selection_id {}",
-                    self.behavior_id,
-                    selection_id
-                );
+                    self.behavior_id, selection_id
+                ));
             }
         }
 
         if let Some(profile_id) = non_empty(self.inference_profile_id.as_deref()) {
             if !refs.profiles.contains(profile_id) {
-                anyhow::bail!(
+                violations.push(format!(
                     "behavior {} references missing inference_profile_id {}",
-                    self.behavior_id,
-                    profile_id
-                );
+                    self.behavior_id, profile_id
+                ));
             }
         }
 
         for skill_ref in &self.skill_refs {
             let skill_ref = skill_ref.trim();
             if !skill_ref.is_empty() && !refs.skills.contains(skill_ref) {
-                anyhow::bail!(
+                violations.push(format!(
                     "behavior {} references missing skill_ref {} (import the skill first)",
-                    self.behavior_id,
-                    skill_ref
-                );
+                    self.behavior_id, skill_ref
+                ));
             }
         }
         for skill_exclude in &self.skill_excludes {
             let skill_exclude = skill_exclude.trim();
             if !skill_exclude.is_empty() && !refs.skills.contains(skill_exclude) {
-                anyhow::bail!(
+                violations.push(format!(
                     "behavior {} references missing skill_exclude {}",
-                    self.behavior_id,
-                    skill_exclude
-                );
+                    self.behavior_id, skill_exclude
+                ));
             }
         }
 
-        Ok(())
+        violations
+    }
+
+    /// `Result` wrapper over [`Self::reference_violations`] for callers that
+    /// just want pass/fail with one informative message (self-config,
+    /// the CLI's raw-write doors) — every violation joined into one error.
+    /// Desired state calls [`Self::reference_violations`] directly instead,
+    /// so each violation becomes its own entry in its per-manifest error
+    /// list.
+    pub fn validate_references(&self, refs: &ConfigReferences) -> Result<()> {
+        let violations = self.reference_violations(refs);
+        if violations.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(violations.join("; "))
+        }
     }
 }
 
@@ -263,6 +284,39 @@ pub(crate) async fn list_agent_behavior_records(
 }
 
 pub async fn upsert_agent_behavior(node: &EmbeddedNode, behavior: &AgentBehavior) -> Result<()> {
+    let txn = crate::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+    let result = async {
+        let mut effective = behavior.clone();
+        if let Some(existing) =
+            crate::config_client::load_agent_behavior_in_txn(&txn, &behavior.behavior_id).await?
+        {
+            // This legacy full-row encoder never writes the skill arrays, so
+            // those two fields remain stored state during an update.
+            effective.skill_refs = existing.skill_refs;
+            effective.skill_excludes = existing.skill_excludes;
+        } else {
+            // This legacy encoder never writes the skill arrays on create,
+            // so validate the empty defaults DefraDB will persist.
+            effective.skill_refs.clear();
+            effective.skill_excludes.clear();
+        }
+        let refs = ConfigReferences::load_in_txn(&txn, &effective.agent_did).await?;
+        effective.validate_references(&refs)?;
+        txn.execute(&upsert_agent_behavior_mutation(behavior))
+            .await?;
+        Ok(())
+    }
+    .await;
+    match result {
+        Ok(()) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+fn upsert_agent_behavior_mutation(behavior: &AgentBehavior) -> String {
     let escaped_behavior_id = escape_graphql_string(&behavior.behavior_id);
     let escaped_agent_did = escape_graphql_string(&behavior.agent_did);
     let created_at = behavior
@@ -352,7 +406,7 @@ pub async fn upsert_agent_behavior(node: &EmbeddedNode, behavior: &AgentBehavior
     .collect::<Vec<_>>()
     .join(",\n                    ");
 
-    let mutation = format!(
+    format!(
         r#"mutation {{
             upsert_AgentBehavior(
                 filter: {{ behavior_id: {{ _eq: "{escaped_behavior_id}" }} }},
@@ -364,10 +418,7 @@ pub async fn upsert_agent_behavior(node: &EmbeddedNode, behavior: &AgentBehavior
                 }}
             ) {{ _docID }}
         }}"#
-    );
-
-    graphql_mutation_with_transaction_retry(node, &mutation, "upsert AgentBehavior").await?;
-    Ok(())
+    )
 }
 
 pub(super) async fn create_default_behavior(

--- a/crates/gents/src/document_config/inference_profile.rs
+++ b/crates/gents/src/document_config/inference_profile.rs
@@ -9,7 +9,7 @@ use crate::config::{
     DEFAULT_MAX_TURNS, DEFAULT_STREAM_BATCH_MS, DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS,
 };
 use crate::config_client::mint_recreate_identity_timestamp;
-use crate::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
+use crate::graphql::escape_graphql_string;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct InferenceProfile {
@@ -46,7 +46,7 @@ impl InferenceProfile {
     /// desired-state rules exactly so no case is lost by the move (#1331),
     /// and reports every violated rule at once so a `config apply` user who
     /// broke two fields sees both in one round trip.
-    pub fn validate(&self) -> Result<()> {
+    pub fn validation_violations(&self) -> Vec<String> {
         let profile_id = self.profile_id.trim();
         let mut violations: Vec<String> = Vec::new();
 
@@ -144,6 +144,11 @@ impl InferenceProfile {
             ));
         }
 
+        violations
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let violations = self.validation_violations();
         if violations.is_empty() {
             Ok(())
         } else {
@@ -350,11 +355,23 @@ pub async fn upsert_inference_profile(
     node: &EmbeddedNode,
     profile: &InferenceProfile,
 ) -> Result<()> {
-    profile.validate()?;
-    let mutation = upsert_inference_profile_mutation(profile);
-
-    graphql_mutation_with_transaction_retry(node, &mutation, "upsert InferenceProfile").await?;
-    Ok(())
+    let txn = crate::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+    let result = async {
+        crate::config_client::effective_inference_profile(&txn, profile)
+            .await?
+            .validate()?;
+        txn.execute(&upsert_inference_profile_mutation(profile))
+            .await?;
+        Ok(())
+    }
+    .await;
+    match result {
+        Ok(()) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
 }
 
 pub(crate) fn upsert_inference_profile_mutation(profile: &InferenceProfile) -> String {

--- a/crates/gents/src/document_config/inference_profile.rs
+++ b/crates/gents/src/document_config/inference_profile.rs
@@ -39,6 +39,57 @@ pub struct InferenceProfile {
     pub retry_interactive_max: Option<i64>,
 }
 
+impl InferenceProfile {
+    /// Validate this profile's bounds — the single owner every write path
+    /// (CLI desired state, self-config, `upsert_inference_profile`) calls.
+    /// Mirrors the historical `gents-cli` desired-state rules exactly so no
+    /// case is lost by the move (#1331).
+    pub fn validate(&self) -> Result<()> {
+        let profile_id = self.profile_id.trim();
+        let stream_liveness_timeout_secs = match self.stream_liveness_timeout_secs {
+            Some(value) if value <= 0 => anyhow::bail!(
+                "InferenceProfile {profile_id} stream_liveness_timeout_secs must be positive"
+            ),
+            Some(value) => value,
+            None => DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS as i64,
+        };
+        let deadline_duration_secs = match self.deadline_duration_secs {
+            Some(value) if value <= 0 => anyhow::bail!(
+                "InferenceProfile {profile_id} deadline_duration_secs must be positive"
+            ),
+            Some(value) => value,
+            None => DEFAULT_DEADLINE_DURATION_SECS as i64,
+        };
+        if stream_liveness_timeout_secs >= deadline_duration_secs {
+            anyhow::bail!(
+                "InferenceProfile {profile_id} stream_liveness_timeout_secs ({stream_liveness_timeout_secs}) must be less than deadline_duration_secs ({deadline_duration_secs})"
+            );
+        }
+        if self.seed.is_some_and(|value| value < 0) {
+            anyhow::bail!("InferenceProfile {profile_id} seed must be non-negative");
+        }
+        // Empty reasoning effort is unset: DefraDB may materialize nullable
+        // strings as empty values, and exported manifests must round-trip.
+        if self
+            .reasoning_effort
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_some_and(|value| {
+                !matches!(
+                    value,
+                    "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
+                )
+            })
+        {
+            anyhow::bail!(
+                "InferenceProfile {profile_id} reasoning_effort must be one of: none, minimal, low, medium, high, xhigh, max, ultra"
+            );
+        }
+        Ok(())
+    }
+}
+
 const DEFAULT_INFERENCE_PROFILE_LABEL: &str = "Default";
 
 pub fn default_inference_profile_id_for_behavior(behavior_id: &str) -> String {
@@ -237,9 +288,7 @@ pub async fn upsert_inference_profile(
     node: &EmbeddedNode,
     profile: &InferenceProfile,
 ) -> Result<()> {
-    if profile.seed.is_some_and(|seed| seed < 0) {
-        anyhow::bail!("seed must be non-negative");
-    }
+    profile.validate()?;
     let mutation = upsert_inference_profile_mutation(profile);
 
     graphql_mutation_with_transaction_retry(node, &mutation, "upsert InferenceProfile").await?;

--- a/crates/gents/src/document_config/inference_profile.rs
+++ b/crates/gents/src/document_config/inference_profile.rs
@@ -41,13 +41,11 @@ pub struct InferenceProfile {
 
 impl InferenceProfile {
     /// Validate this profile's bounds — the single owner every write path
-    /// (CLI desired state, self-config, `upsert_inference_profile`) calls.
-    /// Mirrors the historical `gents-cli` desired-state rules exactly so no
-    /// case is lost by the move (#1331).
-    /// Validate this profile's bounds. Reports every violated rule at once
-    /// (not just the first) — cheap here, and it means a `config apply`
-    /// user who broke two fields at once sees both in one round trip
-    /// instead of fixing them one at a time.
+    /// (CLI desired state, self-config, `profile set`,
+    /// `upsert_inference_profile`) calls. Mirrors the historical `gents-cli`
+    /// desired-state rules exactly so no case is lost by the move (#1331),
+    /// and reports every violated rule at once so a `config apply` user who
+    /// broke two fields sees both in one round trip.
     pub fn validate(&self) -> Result<()> {
         let profile_id = self.profile_id.trim();
         let mut violations: Vec<String> = Vec::new();

--- a/crates/gents/src/document_config/inference_profile.rs
+++ b/crates/gents/src/document_config/inference_profile.rs
@@ -44,29 +44,88 @@ impl InferenceProfile {
     /// (CLI desired state, self-config, `upsert_inference_profile`) calls.
     /// Mirrors the historical `gents-cli` desired-state rules exactly so no
     /// case is lost by the move (#1331).
+    /// Validate this profile's bounds. Reports every violated rule at once
+    /// (not just the first) — cheap here, and it means a `config apply`
+    /// user who broke two fields at once sees both in one round trip
+    /// instead of fixing them one at a time.
     pub fn validate(&self) -> Result<()> {
         let profile_id = self.profile_id.trim();
+        let mut violations: Vec<String> = Vec::new();
+
         let stream_liveness_timeout_secs = match self.stream_liveness_timeout_secs {
-            Some(value) if value <= 0 => anyhow::bail!(
-                "InferenceProfile {profile_id} stream_liveness_timeout_secs must be positive"
-            ),
-            Some(value) => value,
-            None => DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS as i64,
+            Some(value) if value <= 0 => {
+                violations.push(format!(
+                    "InferenceProfile {profile_id} stream_liveness_timeout_secs must be positive"
+                ));
+                None
+            }
+            Some(value) => Some(value),
+            None => Some(DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS as i64),
         };
         let deadline_duration_secs = match self.deadline_duration_secs {
-            Some(value) if value <= 0 => anyhow::bail!(
-                "InferenceProfile {profile_id} deadline_duration_secs must be positive"
-            ),
-            Some(value) => value,
-            None => DEFAULT_DEADLINE_DURATION_SECS as i64,
+            Some(value) if value <= 0 => {
+                violations.push(format!(
+                    "InferenceProfile {profile_id} deadline_duration_secs must be positive"
+                ));
+                None
+            }
+            Some(value) => Some(value),
+            None => Some(DEFAULT_DEADLINE_DURATION_SECS as i64),
         };
-        if stream_liveness_timeout_secs >= deadline_duration_secs {
-            anyhow::bail!(
-                "InferenceProfile {profile_id} stream_liveness_timeout_secs ({stream_liveness_timeout_secs}) must be less than deadline_duration_secs ({deadline_duration_secs})"
-            );
+        // Only compare the two bounds when both are individually valid — an
+        // already-invalid bound would make this comparison noise on top of
+        // the violation already reported above.
+        if let (Some(stream_liveness_timeout_secs), Some(deadline_duration_secs)) =
+            (stream_liveness_timeout_secs, deadline_duration_secs)
+        {
+            if stream_liveness_timeout_secs >= deadline_duration_secs {
+                violations.push(format!(
+                    "InferenceProfile {profile_id} stream_liveness_timeout_secs ({stream_liveness_timeout_secs}) must be less than deadline_duration_secs ({deadline_duration_secs})"
+                ));
+            }
         }
         if self.seed.is_some_and(|value| value < 0) {
-            anyhow::bail!("InferenceProfile {profile_id} seed must be non-negative");
+            violations.push(format!(
+                "InferenceProfile {profile_id} seed must be non-negative"
+            ));
+        }
+        // Sampling bounds (#1331 fix round 1 — previously only enforced by
+        // the `gents config profile set` imperative writer, not the owner).
+        if self
+            .top_p
+            .is_some_and(|value| !(0.0..=1.0).contains(&value))
+        {
+            violations.push(format!(
+                "InferenceProfile {profile_id} top_p must be within [0, 1]"
+            ));
+        }
+        if self
+            .min_p
+            .is_some_and(|value| !(0.0..=1.0).contains(&value))
+        {
+            violations.push(format!(
+                "InferenceProfile {profile_id} min_p must be within [0, 1]"
+            ));
+        }
+        if self.top_k.is_some_and(|value| value <= 0) {
+            violations.push(format!(
+                "InferenceProfile {profile_id} top_k must be positive"
+            ));
+        }
+        if self.repetition_penalty.is_some_and(|value| value <= 0.0) {
+            violations.push(format!(
+                "InferenceProfile {profile_id} repetition_penalty must be positive"
+            ));
+        }
+        for (name, value) in [
+            ("frequency_penalty", self.frequency_penalty),
+            ("presence_penalty", self.presence_penalty),
+        ] {
+            if value.is_some_and(|value| !(-2.0..=2.0).contains(&value)) {
+                violations.push(format!(
+                    "InferenceProfile {profile_id} {name} must be within [-2, 2]"
+                ));
+            }
         }
         // Empty reasoning effort is unset: DefraDB may materialize nullable
         // strings as empty values, and exported manifests must round-trip.
@@ -82,11 +141,16 @@ impl InferenceProfile {
                 )
             })
         {
-            anyhow::bail!(
+            violations.push(format!(
                 "InferenceProfile {profile_id} reasoning_effort must be one of: none, minimal, low, medium, high, xhigh, max, ultra"
-            );
+            ));
         }
-        Ok(())
+
+        if violations.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(violations.join("; "))
+        }
     }
 }
 

--- a/crates/gents/src/document_config/mod.rs
+++ b/crates/gents/src/document_config/mod.rs
@@ -8,6 +8,7 @@ mod graph_run;
 mod graphql_fields;
 mod inference_profile;
 mod principal;
+mod references;
 mod schedule;
 mod serde_helpers;
 mod skill;
@@ -19,6 +20,8 @@ mod tool_selection;
 pub(crate) use chain_key_binding::load_chain_key_binding;
 pub use principal::{load_agent_principal, upsert_agent_principal, AgentPrincipal};
 pub(crate) use principal::{load_agent_principal_by_doc_id, load_agent_principal_record};
+
+pub use references::ConfigReferences;
 
 use behavior::create_default_behavior;
 #[allow(unused_imports)]

--- a/crates/gents/src/document_config/mod.rs
+++ b/crates/gents/src/document_config/mod.rs
@@ -39,6 +39,7 @@ pub use inference_profile::{
 #[allow(unused_imports)]
 pub(crate) use inference_profile::{
     load_inference_profile_by_doc_id, load_inference_profile_record,
+    upsert_inference_profile_mutation,
 };
 
 pub use serde_helpers::deserialize_dual_shape;

--- a/crates/gents/src/document_config/references.rs
+++ b/crates/gents/src/document_config/references.rs
@@ -1,18 +1,15 @@
 //! The id/model sets a config document's reference fields are checked
-//! against (#1331). One loader, built from the current node state, feeds
+//! against (#1331). One transactional loader feeds
 //! every referential validator: `AgentBehavior::validate_references` is the
 //! only consumer today, but the shape generalizes to any document that
 //! points at a backend, tool selection, profile, or skill.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
-
 use anyhow::Result;
-use defra_node::EmbeddedNode;
 use gents_protocol::graphql::graphql_rows_from_response;
 use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
 
-use crate::config_client::ConfigAccess;
+use crate::config_client::ConfigApplyTxn;
 use crate::graphql::escape_graphql_string;
 
 /// Snapshot of the config documents a referencing document (today, only
@@ -31,25 +28,35 @@ pub struct ConfigReferences {
 }
 
 impl ConfigReferences {
-    /// Load the reference sets for `agent_did` from the current node state.
-    /// A thin wrapper over [`Self::load_via_access`] — every query this
-    /// needs already runs the same way over `ConfigAccess::Local` as over
-    /// HTTP, so there is exactly one query path for both, not two to keep
-    /// in sync.
-    pub async fn load(node: &Arc<EmbeddedNode>, agent_did: &str) -> Result<Self> {
-        Self::load_via_access(&ConfigAccess::Local(Arc::clone(node)), agent_did).await
+    /// Load the same reference snapshot through an already-open config
+    /// transaction. Behavior validation must share the transaction's read set
+    /// with its eventual write so a concurrent delete cannot make a previously
+    /// validated reference dangle at commit time.
+    pub async fn load_in_txn(txn: &ConfigApplyTxn<'_>, agent_did: &str) -> Result<Self> {
+        Self::from_row_sets(
+            query_rows_in_txn(
+                txn,
+                "InferenceBackend",
+                "{ InferenceBackend { backend_id models } }",
+            )
+            .await?,
+            query_rows_in_txn(txn, "ToolSelection", &tool_selection_query(agent_did)).await?,
+            query_rows_in_txn(
+                txn,
+                "InferenceProfile",
+                "{ InferenceProfile { profile_id } }",
+            )
+            .await?,
+            query_rows_in_txn(txn, "Skill", &skill_query(agent_did)).await?,
+        )
     }
 
-    /// Load the reference sets for `agent_did` via [`ConfigAccess`] (HTTP
-    /// GraphQL or local node) — the CLI's raw-write commands (`config
-    /// behavior set`, the codex-shim model switch) hold a `ConfigAccess`,
-    /// not an `Arc<EmbeddedNode>`, but [`Self::load`] delegates here too so
-    /// there is one implementation regardless of caller. Fetches only the
-    /// id columns (+ `models`, for backends) a referential-existence check
-    /// needs — not a full document decode.
-    pub async fn load_via_access(access: &ConfigAccess, agent_did: &str) -> Result<Self> {
-        let escaped_agent_did = escape_graphql_string(agent_did);
-
+    fn from_row_sets(
+        backend_rows: Vec<Value>,
+        tool_selection_rows: Vec<Value>,
+        profile_rows: Vec<Value>,
+        skill_rows: Vec<Value>,
+    ) -> Result<Self> {
         // Read directly rather than through
         // `crate::backend_registry::InferenceBackend::from_value`: that
         // parser requires every column (`max_concurrent`, `enabled`, …) an
@@ -57,12 +64,6 @@ impl ConfigReferences {
         // check has no business failing every principal's config
         // validation over one malformed row elsewhere in the collection. A
         // row with no usable `backend_id` is skipped, not fatal.
-        let backend_rows = query_rows(
-            access,
-            "InferenceBackend",
-            "{ InferenceBackend { backend_id models } }",
-        )
-        .await?;
         let backends = backend_rows
             .into_iter()
             .filter_map(|row| {
@@ -82,32 +83,8 @@ impl ConfigReferences {
             })
             .collect();
 
-        let tool_selection_rows = query_rows(
-            access,
-            "ToolSelection",
-            &format!(
-                r#"{{ ToolSelection(filter: {{ agent_did: {{ _eq: "{escaped_agent_did}" }} }}) {{ selection_id }} }}"#
-            ),
-        )
-        .await?;
         let tool_selections = string_field_set(&tool_selection_rows, "selection_id");
-
-        let profile_rows = query_rows(
-            access,
-            "InferenceProfile",
-            "{ InferenceProfile { profile_id } }",
-        )
-        .await?;
         let profiles = string_field_set(&profile_rows, "profile_id");
-
-        let skill_rows = query_rows(
-            access,
-            "Skill",
-            &format!(
-                r#"{{ Skill(filter: {{ agent_did: {{ _eq: "{escaped_agent_did}" }} }}) {{ skill_id }} }}"#
-            ),
-        )
-        .await?;
         let skills = string_field_set(&skill_rows, "skill_id");
 
         Ok(Self {
@@ -119,9 +96,25 @@ impl ConfigReferences {
     }
 }
 
-async fn query_rows(access: &ConfigAccess, collection: &str, query: &str) -> Result<Vec<Value>> {
-    let response = access.execute(query).await?;
+async fn query_rows_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    collection: &str,
+    query: &str,
+) -> Result<Vec<Value>> {
+    let response = txn.execute(query).await?;
     Ok(graphql_rows_from_response(&response, collection))
+}
+
+fn tool_selection_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(
+        r#"{{ ToolSelection(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ selection_id }} }}"#
+    )
+}
+
+fn skill_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(r#"{{ Skill(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}) {{ skill_id }} }}"#)
 }
 
 fn string_field_set(rows: &[Value], field: &str) -> BTreeSet<String> {

--- a/crates/gents/src/document_config/references.rs
+++ b/crates/gents/src/document_config/references.rs
@@ -9,8 +9,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::Result;
 use defra_node::EmbeddedNode;
 
-use crate::backend_registry::list_backend_records;
-
 use super::inference_profile::list_inference_profile_records;
 use super::skill::list_skill_records;
 use super::tool_selection::list_tool_selection_records;
@@ -33,11 +31,7 @@ pub struct ConfigReferences {
 impl ConfigReferences {
     /// Load the reference sets for `agent_did` from the current node state.
     pub async fn load(node: &EmbeddedNode, agent_did: &str) -> Result<Self> {
-        let backends = list_backend_records(node)
-            .await?
-            .into_iter()
-            .map(|(_, backend)| (backend.backend_id, backend.models))
-            .collect();
+        let backends = list_backend_id_models(node).await?;
         let tool_selections = list_tool_selection_records(node, agent_did)
             .await?
             .into_iter()
@@ -60,4 +54,49 @@ impl ConfigReferences {
             skills,
         })
     }
+}
+
+/// `backend_id` -> advertised `models`, read directly rather than through
+/// [`crate::backend_registry::InferenceBackend::from_value`]: that parser
+/// requires every column (`max_concurrent`, `enabled`, …) an unrelated
+/// backend may not have set, and a referential-existence check has no
+/// business failing every principal's config validation over one malformed
+/// row elsewhere in the collection. A row with no usable `backend_id` is
+/// skipped, not fatal.
+async fn list_backend_id_models(node: &EmbeddedNode) -> Result<BTreeMap<String, Vec<String>>> {
+    let query = r#"{
+            InferenceBackend(order: { backend_id: ASC }) {
+                backend_id
+                models
+            }
+        }"#;
+    let resp = node.execute(query).await;
+    if resp.has_errors() {
+        anyhow::bail!("list InferenceBackend (id/models) failed: {:?}", resp.errors);
+    }
+    let rows = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("InferenceBackend"))
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let backend_id = row.get("backend_id")?.as_str()?.to_string();
+            let models = row
+                .get("models")
+                .and_then(serde_json::Value::as_array)
+                .map(|models| {
+                    models
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+            Some((backend_id, models))
+        })
+        .collect())
 }

--- a/crates/gents/src/document_config/references.rs
+++ b/crates/gents/src/document_config/references.rs
@@ -5,6 +5,7 @@
 //! points at a backend, tool selection, profile, or skill.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use anyhow::Result;
 use defra_node::EmbeddedNode;
@@ -13,10 +14,6 @@ use serde_json::Value;
 
 use crate::config_client::ConfigAccess;
 use crate::graphql::escape_graphql_string;
-
-use super::inference_profile::list_inference_profile_records;
-use super::skill::list_skill_records;
-use super::tool_selection::list_tool_selection_records;
 
 /// Snapshot of the config documents a referencing document (today, only
 /// `AgentBehavior`) may point at. Backends and profiles are global by
@@ -35,41 +32,31 @@ pub struct ConfigReferences {
 
 impl ConfigReferences {
     /// Load the reference sets for `agent_did` from the current node state.
-    pub async fn load(node: &EmbeddedNode, agent_did: &str) -> Result<Self> {
-        let backends = list_backend_id_models(node).await?;
-        let tool_selections = list_tool_selection_records(node, agent_did)
-            .await?
-            .into_iter()
-            .map(|(_, selection)| selection.selection_id)
-            .collect();
-        let profiles = list_inference_profile_records(node)
-            .await?
-            .into_iter()
-            .map(|(_, profile)| profile.profile_id)
-            .collect();
-        let skills = list_skill_records(node, agent_did)
-            .await?
-            .into_iter()
-            .map(|(_, skill)| skill.skill_id)
-            .collect();
-        Ok(Self {
-            backends,
-            tool_selections,
-            profiles,
-            skills,
-        })
+    /// A thin wrapper over [`Self::load_via_access`] — every query this
+    /// needs already runs the same way over `ConfigAccess::Local` as over
+    /// HTTP, so there is exactly one query path for both, not two to keep
+    /// in sync.
+    pub async fn load(node: &Arc<EmbeddedNode>, agent_did: &str) -> Result<Self> {
+        Self::load_via_access(&ConfigAccess::Local(Arc::clone(node)), agent_did).await
     }
 
     /// Load the reference sets for `agent_did` via [`ConfigAccess`] (HTTP
-    /// GraphQL or local node) — the counterpart to [`Self::load`] for
-    /// callers that only hold a `ConfigAccess`, not an `&EmbeddedNode` (the
-    /// CLI's raw-write commands: `config agent-behavior set`, the codex-shim
-    /// model switch). Fetches only the id columns (+ `models`, for backends)
-    /// a referential-existence check needs — not a full document decode —
-    /// reusing the same shape of query as [`Self::load`].
+    /// GraphQL or local node) — the CLI's raw-write commands (`config
+    /// behavior set`, the codex-shim model switch) hold a `ConfigAccess`,
+    /// not an `Arc<EmbeddedNode>`, but [`Self::load`] delegates here too so
+    /// there is one implementation regardless of caller. Fetches only the
+    /// id columns (+ `models`, for backends) a referential-existence check
+    /// needs — not a full document decode.
     pub async fn load_via_access(access: &ConfigAccess, agent_did: &str) -> Result<Self> {
         let escaped_agent_did = escape_graphql_string(agent_did);
 
+        // Read directly rather than through
+        // `crate::backend_registry::InferenceBackend::from_value`: that
+        // parser requires every column (`max_concurrent`, `enabled`, …) an
+        // unrelated backend may not have set, and a referential-existence
+        // check has no business failing every principal's config
+        // validation over one malformed row elsewhere in the collection. A
+        // row with no usable `backend_id` is skipped, not fatal.
         let backend_rows = query_rows(
             access,
             "InferenceBackend",
@@ -141,52 +128,4 @@ fn string_field_set(rows: &[Value], field: &str) -> BTreeSet<String> {
     rows.iter()
         .filter_map(|row| row.get(field)?.as_str().map(str::to_string))
         .collect()
-}
-
-/// `backend_id` -> advertised `models`, read directly rather than through
-/// [`crate::backend_registry::InferenceBackend::from_value`]: that parser
-/// requires every column (`max_concurrent`, `enabled`, …) an unrelated
-/// backend may not have set, and a referential-existence check has no
-/// business failing every principal's config validation over one malformed
-/// row elsewhere in the collection. A row with no usable `backend_id` is
-/// skipped, not fatal.
-async fn list_backend_id_models(node: &EmbeddedNode) -> Result<BTreeMap<String, Vec<String>>> {
-    let query = r#"{
-            InferenceBackend(order: { backend_id: ASC }) {
-                backend_id
-                models
-            }
-        }"#;
-    let resp = node.execute(query).await;
-    if resp.has_errors() {
-        anyhow::bail!(
-            "list InferenceBackend (id/models) failed: {:?}",
-            resp.errors
-        );
-    }
-    let rows = resp
-        .data
-        .as_ref()
-        .and_then(|data| data.get("InferenceBackend"))
-        .and_then(serde_json::Value::as_array)
-        .cloned()
-        .unwrap_or_default();
-    Ok(rows
-        .into_iter()
-        .filter_map(|row| {
-            let backend_id = row.get("backend_id")?.as_str()?.to_string();
-            let models = row
-                .get("models")
-                .and_then(serde_json::Value::as_array)
-                .map(|models| {
-                    models
-                        .iter()
-                        .filter_map(serde_json::Value::as_str)
-                        .map(str::to_string)
-                        .collect()
-                })
-                .unwrap_or_default();
-            Some((backend_id, models))
-        })
-        .collect())
 }

--- a/crates/gents/src/document_config/references.rs
+++ b/crates/gents/src/document_config/references.rs
@@ -1,0 +1,63 @@
+//! The id/model sets a config document's reference fields are checked
+//! against (#1331). One loader, built from the current node state, feeds
+//! every referential validator: `AgentBehavior::validate_references` is the
+//! only consumer today, but the shape generalizes to any document that
+//! points at a backend, tool selection, profile, or skill.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Result;
+use defra_node::EmbeddedNode;
+
+use crate::backend_registry::list_backend_records;
+
+use super::inference_profile::list_inference_profile_records;
+use super::skill::list_skill_records;
+use super::tool_selection::list_tool_selection_records;
+
+/// Snapshot of the config documents a referencing document (today, only
+/// `AgentBehavior`) may point at. Backends and profiles are global by
+/// design (see `self_config::backend_request`/`profile_request`); tool
+/// selections and skills are scoped to the referencing document's own
+/// principal.
+#[derive(Debug, Clone, Default)]
+pub struct ConfigReferences {
+    /// `backend_id` -> the models it advertises (empty means "any model is
+    /// accepted", matching `InferenceBackend`'s own no-lockout semantics).
+    pub backends: BTreeMap<String, Vec<String>>,
+    pub tool_selections: BTreeSet<String>,
+    pub profiles: BTreeSet<String>,
+    pub skills: BTreeSet<String>,
+}
+
+impl ConfigReferences {
+    /// Load the reference sets for `agent_did` from the current node state.
+    pub async fn load(node: &EmbeddedNode, agent_did: &str) -> Result<Self> {
+        let backends = list_backend_records(node)
+            .await?
+            .into_iter()
+            .map(|(_, backend)| (backend.backend_id, backend.models))
+            .collect();
+        let tool_selections = list_tool_selection_records(node, agent_did)
+            .await?
+            .into_iter()
+            .map(|(_, selection)| selection.selection_id)
+            .collect();
+        let profiles = list_inference_profile_records(node)
+            .await?
+            .into_iter()
+            .map(|(_, profile)| profile.profile_id)
+            .collect();
+        let skills = list_skill_records(node, agent_did)
+            .await?
+            .into_iter()
+            .map(|(_, skill)| skill.skill_id)
+            .collect();
+        Ok(Self {
+            backends,
+            tool_selections,
+            profiles,
+            skills,
+        })
+    }
+}

--- a/crates/gents/src/document_config/references.rs
+++ b/crates/gents/src/document_config/references.rs
@@ -8,6 +8,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Result;
 use defra_node::EmbeddedNode;
+use gents_protocol::graphql::graphql_rows_from_response;
+use serde_json::Value;
+
+use crate::config_client::ConfigAccess;
+use crate::graphql::escape_graphql_string;
 
 use super::inference_profile::list_inference_profile_records;
 use super::skill::list_skill_records;
@@ -54,6 +59,88 @@ impl ConfigReferences {
             skills,
         })
     }
+
+    /// Load the reference sets for `agent_did` via [`ConfigAccess`] (HTTP
+    /// GraphQL or local node) — the counterpart to [`Self::load`] for
+    /// callers that only hold a `ConfigAccess`, not an `&EmbeddedNode` (the
+    /// CLI's raw-write commands: `config agent-behavior set`, the codex-shim
+    /// model switch). Fetches only the id columns (+ `models`, for backends)
+    /// a referential-existence check needs — not a full document decode —
+    /// reusing the same shape of query as [`Self::load`].
+    pub async fn load_via_access(access: &ConfigAccess, agent_did: &str) -> Result<Self> {
+        let escaped_agent_did = escape_graphql_string(agent_did);
+
+        let backend_rows = query_rows(
+            access,
+            "InferenceBackend",
+            "{ InferenceBackend { backend_id models } }",
+        )
+        .await?;
+        let backends = backend_rows
+            .into_iter()
+            .filter_map(|row| {
+                let backend_id = row.get("backend_id")?.as_str()?.to_string();
+                let models = row
+                    .get("models")
+                    .and_then(Value::as_array)
+                    .map(|models| {
+                        models
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                Some((backend_id, models))
+            })
+            .collect();
+
+        let tool_selection_rows = query_rows(
+            access,
+            "ToolSelection",
+            &format!(
+                r#"{{ ToolSelection(filter: {{ agent_did: {{ _eq: "{escaped_agent_did}" }} }}) {{ selection_id }} }}"#
+            ),
+        )
+        .await?;
+        let tool_selections = string_field_set(&tool_selection_rows, "selection_id");
+
+        let profile_rows = query_rows(
+            access,
+            "InferenceProfile",
+            "{ InferenceProfile { profile_id } }",
+        )
+        .await?;
+        let profiles = string_field_set(&profile_rows, "profile_id");
+
+        let skill_rows = query_rows(
+            access,
+            "Skill",
+            &format!(
+                r#"{{ Skill(filter: {{ agent_did: {{ _eq: "{escaped_agent_did}" }} }}) {{ skill_id }} }}"#
+            ),
+        )
+        .await?;
+        let skills = string_field_set(&skill_rows, "skill_id");
+
+        Ok(Self {
+            backends,
+            tool_selections,
+            profiles,
+            skills,
+        })
+    }
+}
+
+async fn query_rows(access: &ConfigAccess, collection: &str, query: &str) -> Result<Vec<Value>> {
+    let response = access.execute(query).await?;
+    Ok(graphql_rows_from_response(&response, collection))
+}
+
+fn string_field_set(rows: &[Value], field: &str) -> BTreeSet<String> {
+    rows.iter()
+        .filter_map(|row| row.get(field)?.as_str().map(str::to_string))
+        .collect()
 }
 
 /// `backend_id` -> advertised `models`, read directly rather than through

--- a/crates/gents/src/document_config/references.rs
+++ b/crates/gents/src/document_config/references.rs
@@ -72,7 +72,10 @@ async fn list_backend_id_models(node: &EmbeddedNode) -> Result<BTreeMap<String, 
         }"#;
     let resp = node.execute(query).await;
     if resp.has_errors() {
-        anyhow::bail!("list InferenceBackend (id/models) failed: {:?}", resp.errors);
+        anyhow::bail!(
+            "list InferenceBackend (id/models) failed: {:?}",
+            resp.errors
+        );
     }
     let rows = resp
         .data

--- a/crates/gents/src/document_config/tests.rs
+++ b/crates/gents/src/document_config/tests.rs
@@ -1215,10 +1215,7 @@ fn inference_profile_validate_rejects_reasoning_effort_outside_the_vocabulary() 
     let mut profile = base_profile("bad-effort");
     profile.reasoning_effort = Some("extreme".to_string());
     let error = profile.validate().unwrap_err().to_string();
-    assert!(
-        error.contains("reasoning_effort must be one of"),
-        "{error}"
-    );
+    assert!(error.contains("reasoning_effort must be one of"), "{error}");
 }
 
 // ---------------------------------------------------------------------------
@@ -1287,7 +1284,10 @@ fn agent_behavior_validate_references_rejects_missing_backend() {
     behavior.backend_id = Some("ghost".to_string());
     let refs = ConfigReferences::default();
     let error = behavior.validate_references(&refs).unwrap_err().to_string();
-    assert!(error.contains("references missing backend_id ghost"), "{error}");
+    assert!(
+        error.contains("references missing backend_id ghost"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/crates/gents/src/document_config/tests.rs
+++ b/crates/gents/src/document_config/tests.rs
@@ -1219,6 +1219,105 @@ fn inference_profile_validate_rejects_reasoning_effort_outside_the_vocabulary() 
 }
 
 // ---------------------------------------------------------------------------
+// Sampling bounds (#1331 fix round 1 — moved from the imperative
+// `gents config profile set` writer, the only place that enforced them).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inference_profile_validate_accepts_sampling_bounds_at_their_edges() {
+    let mut profile = base_profile("edges");
+    profile.top_p = Some(0.0);
+    profile.min_p = Some(1.0);
+    profile.top_k = Some(1);
+    profile.repetition_penalty = Some(f64::MIN_POSITIVE);
+    profile.frequency_penalty = Some(-2.0);
+    profile.presence_penalty = Some(2.0);
+    assert!(profile.validate().is_ok());
+}
+
+#[test]
+fn inference_profile_validate_rejects_top_p_outside_unit_interval() {
+    for value in [-0.01, 1.01] {
+        let mut profile = base_profile("top-p");
+        profile.top_p = Some(value);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("top_p must be within [0, 1]"),
+            "{value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_min_p_outside_unit_interval() {
+    for value in [-0.01, 1.01] {
+        let mut profile = base_profile("min-p");
+        profile.min_p = Some(value);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("min_p must be within [0, 1]"),
+            "{value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_non_positive_top_k() {
+    for value in [0, -1] {
+        let mut profile = base_profile("top-k");
+        profile.top_k = Some(value);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(error.contains("top_k must be positive"), "{value}: {error}");
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_non_positive_repetition_penalty() {
+    for value in [0.0, -1.0] {
+        let mut profile = base_profile("rep-penalty");
+        profile.repetition_penalty = Some(value);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("repetition_penalty must be positive"),
+            "{value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_frequency_and_presence_penalty_outside_range() {
+    for value in [-2.01, 2.01] {
+        let mut frequency = base_profile("freq-penalty");
+        frequency.frequency_penalty = Some(value);
+        let error = frequency.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("frequency_penalty must be within [-2, 2]"),
+            "{value}: {error}"
+        );
+
+        let mut presence = base_profile("presence-penalty");
+        presence.presence_penalty = Some(value);
+        let error = presence.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("presence_penalty must be within [-2, 2]"),
+            "{value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_reports_every_violation_at_once() {
+    let mut profile = base_profile("multi-bad");
+    profile.seed = Some(-1);
+    profile.top_p = Some(2.0);
+    profile.top_k = Some(0);
+    let error = profile.validate().unwrap_err().to_string();
+    assert!(error.contains("seed must be non-negative"), "{error}");
+    assert!(error.contains("top_p must be within [0, 1]"), "{error}");
+    assert!(error.contains("top_k must be positive"), "{error}");
+}
+
+// ---------------------------------------------------------------------------
 // InferenceBackend::validate lives in `backend_registry` (crate root); see
 // `crates/gents/src/backend_registry/tests.rs` for its table-driven cases.
 // ---------------------------------------------------------------------------
@@ -1394,4 +1493,71 @@ fn agent_behavior_validate_references_accepts_known_skills() {
     behavior.skill_excludes = vec!["known-skill".to_string()];
     let refs = refs_with(&[], &[], &[], &["known-skill"]);
     assert!(behavior.validate_references(&refs).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// ConfigReferences::load — lenient backend parsing (#1331, fix round 1)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn config_references_load_tolerates_a_malformed_backend_row_beside_a_good_one() {
+    let node = std::sync::Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+    crate::ensure_runtime_schemas(&node).await.unwrap();
+
+    // Missing max_concurrent: `InferenceBackend::from_value` (the strict
+    // registry parser) requires it and would fail on this row. It still has
+    // a usable backend_id, so `ConfigReferences::load` — which reads
+    // backend_id/models directly, not through that parser — must not sink
+    // the whole load over it.
+    let malformed = node
+        .execute(
+            r#"mutation {
+                create_InferenceBackend(input: {
+                    backend_id: "malformed-backend",
+                    name: "Malformed",
+                    provider_kind: "OpenAiCompatible",
+                    endpoint: "http://127.0.0.1:11434/v1",
+                    enabled: true,
+                    models: ["should-not-matter"],
+                    probe_status: "unknown"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    assert!(!malformed.has_errors(), "{:?}", malformed.errors);
+
+    let good = node
+        .execute(
+            r#"mutation {
+                create_InferenceBackend(input: {
+                    backend_id: "good-backend",
+                    name: "Good",
+                    provider_kind: "OpenAiCompatible",
+                    endpoint: "http://127.0.0.1:11434/v1",
+                    max_concurrent: 4,
+                    max_queue_depth: 100,
+                    enabled: true,
+                    models: ["model-a", "model-b"],
+                    probe_status: "healthy"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    assert!(!good.has_errors(), "{:?}", good.errors);
+
+    let refs = ConfigReferences::load(&node, "did:test:whatever")
+        .await
+        .expect("load must tolerate a malformed unrelated backend row");
+
+    assert_eq!(
+        refs.backends.get("good-backend").map(Vec::as_slice),
+        Some(&["model-a".to_string(), "model-b".to_string()][..]),
+        "the good backend's models must still come through"
+    );
+    // The malformed row's own backend_id is fine — only max_concurrent is
+    // missing — so it's present too; ConfigReferences skips a row only when
+    // even backend_id is unusable. The point of this test is that its
+    // absence of max_concurrent doesn't fail the whole load, not that the
+    // row itself is excluded.
+    assert!(refs.backends.contains_key("malformed-backend"));
 }

--- a/crates/gents/src/document_config/tests.rs
+++ b/crates/gents/src/document_config/tests.rs
@@ -889,6 +889,7 @@ async fn inference_profile_completion_retry_fields_round_trip() {
 #[tokio::test]
 async fn inference_profile_upsert_rejects_negative_seed() {
     let node = defra_node::EmbeddedNode::builder().build().await.unwrap();
+    crate::ensure_runtime_schemas(&node).await.unwrap();
     let profile = InferenceProfile {
         profile_id: "negative-seed-profile".to_string(),
         seed: Some(-1),
@@ -1038,6 +1039,31 @@ fn validate_rejects_background_default_when_background_disabled() {
         format!("{}", result.unwrap_err()).contains("subagent_default_await_mode"),
         "error message must mention subagent_default_await_mode"
     );
+}
+
+#[test]
+fn tool_selection_validation_reports_every_violation() {
+    let doc = ToolSelectionDocument {
+        selection_id: "invalid-tools".to_string(),
+        agent_did: "did:test:test".to_string(),
+        subagent_targets: Some(vec![String::new()]),
+        backgroundable_tool_names: Some(vec![String::new()]),
+        subagent_background_enabled: Some(false),
+        subagent_default_await_mode: Some("background".to_string()),
+        ..Default::default()
+    };
+
+    let violations = doc.validation_violations();
+    assert_eq!(violations.len(), 3, "{violations:?}");
+    assert!(violations
+        .iter()
+        .any(|error| error.contains("subagent_targets[0]")));
+    assert!(violations
+        .iter()
+        .any(|error| error.contains("backgroundable_tool_names[0]")));
+    assert!(violations
+        .iter()
+        .any(|error| error.contains("subagent_default_await_mode")));
 }
 
 #[test]
@@ -1495,6 +1521,51 @@ fn agent_behavior_validate_references_accepts_known_skills() {
     assert!(behavior.validate_references(&refs).is_ok());
 }
 
+#[test]
+fn agent_behavior_reference_violations_reports_every_missing_reference_at_once() {
+    // Regression (#1331 fix round 2): a behavior dangling on backend, tool
+    // selection, AND profile simultaneously must surface all three, not
+    // just the first-checked one — this is what desired state's
+    // `config validate` renders as separate error-list entries.
+    let mut behavior = base_behavior("b");
+    behavior.backend_id = Some("missing-backend".to_string());
+    behavior.tool_selection_id = Some("missing-tools".to_string());
+    behavior.inference_profile_id = Some("missing-profile".to_string());
+    let refs = ConfigReferences::default();
+
+    let violations = behavior.reference_violations(&refs);
+    assert_eq!(
+        violations.len(),
+        3,
+        "expected 3 violations, got {violations:?}"
+    );
+    assert!(violations
+        .iter()
+        .any(|msg| msg.contains("missing backend_id missing-backend")));
+    assert!(violations
+        .iter()
+        .any(|msg| msg.contains("missing tool_selection_id missing-tools")));
+    assert!(violations
+        .iter()
+        .any(|msg| msg.contains("missing inference_profile_id missing-profile")));
+
+    // validate_references (the Result wrapper) joins them into one error —
+    // still all three, just not as separate Vec entries.
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(
+        error.contains("missing backend_id missing-backend"),
+        "{error}"
+    );
+    assert!(
+        error.contains("missing tool_selection_id missing-tools"),
+        "{error}"
+    );
+    assert!(
+        error.contains("missing inference_profile_id missing-profile"),
+        "{error}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // ConfigReferences::load — lenient backend parsing (#1331, fix round 1)
 // ---------------------------------------------------------------------------
@@ -1545,9 +1616,13 @@ async fn config_references_load_tolerates_a_malformed_backend_row_beside_a_good_
         .await;
     assert!(!good.has_errors(), "{:?}", good.errors);
 
-    let refs = ConfigReferences::load(&node, "did:test:whatever")
+    let txn = crate::config_client::ConfigApplyTxn::begin_local(&node, None)
+        .await
+        .expect("begin reference-load transaction");
+    let refs = ConfigReferences::load_in_txn(&txn, "did:test:whatever")
         .await
         .expect("load must tolerate a malformed unrelated backend row");
+    txn.discard().await.expect("discard read-only transaction");
 
     assert_eq!(
         refs.backends.get("good-backend").map(Vec::as_slice),

--- a/crates/gents/src/document_config/tests.rs
+++ b/crates/gents/src/document_config/tests.rs
@@ -900,7 +900,7 @@ async fn inference_profile_upsert_rejects_negative_seed() {
             .await
             .unwrap_err()
             .to_string(),
-        "seed must be non-negative"
+        "InferenceProfile negative-seed-profile seed must be non-negative"
     );
 }
 
@@ -1112,4 +1112,286 @@ fn write_tool_fill_grammar_is_exact_and_runtime_fields_cannot_be_required() {
         ..Default::default()
     };
     assert!(doc.validate().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// InferenceProfile::validate (#1331) — table-driven from the historical
+// gents-cli desired-state rules (crates/gents-cli/src/desired_state/validate/agent.rs).
+// ---------------------------------------------------------------------------
+
+fn base_profile(profile_id: &str) -> InferenceProfile {
+    InferenceProfile {
+        profile_id: profile_id.to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn inference_profile_validate_accepts_defaults() {
+    assert!(base_profile("defaults").validate().is_ok());
+}
+
+#[test]
+fn inference_profile_validate_rejects_non_positive_stream_liveness_timeout() {
+    for value in [0, -1] {
+        let mut profile = base_profile("liveness");
+        profile.stream_liveness_timeout_secs = Some(value);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("stream_liveness_timeout_secs must be positive"),
+            "value {value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_non_positive_deadline() {
+    for value in [0, -1] {
+        let mut profile = base_profile("deadline");
+        profile.stream_liveness_timeout_secs = Some(300);
+        profile.deadline_duration_secs = Some(value);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("deadline_duration_secs must be positive"),
+            "value {value}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_liveness_at_or_past_deadline() {
+    for (liveness, deadline) in [(300, 300), (600, 300)] {
+        let mut profile = base_profile("relationship");
+        profile.stream_liveness_timeout_secs = Some(liveness);
+        profile.deadline_duration_secs = Some(deadline);
+        let error = profile.validate().unwrap_err().to_string();
+        assert!(
+            error.contains(&format!(
+                "stream_liveness_timeout_secs ({liveness}) must be less than deadline_duration_secs ({deadline})"
+            )),
+            "liveness {liveness} deadline {deadline}: {error}"
+        );
+    }
+}
+
+#[test]
+fn inference_profile_validate_accepts_liveness_shorter_than_deadline() {
+    let mut profile = base_profile("ok-relationship");
+    profile.stream_liveness_timeout_secs = Some(300);
+    profile.deadline_duration_secs = Some(600);
+    assert!(profile.validate().is_ok());
+}
+
+#[test]
+fn inference_profile_validate_rejects_negative_seed() {
+    let mut profile = base_profile("seeded");
+    profile.seed = Some(-1);
+    let error = profile.validate().unwrap_err().to_string();
+    assert_eq!(error, "InferenceProfile seeded seed must be non-negative");
+}
+
+#[test]
+fn inference_profile_validate_accepts_unset_reasoning_effort_in_every_empty_form() {
+    for unset in [None, Some(""), Some("   ")] {
+        let mut profile = base_profile("unset-effort");
+        profile.reasoning_effort = unset.map(str::to_string);
+        assert!(profile.validate().is_ok(), "unset form {unset:?} failed");
+    }
+}
+
+#[test]
+fn inference_profile_validate_accepts_every_reasoning_effort_in_the_vocabulary() {
+    for value in [
+        "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+    ] {
+        let mut profile = base_profile("vocab");
+        profile.reasoning_effort = Some(value.to_string());
+        assert!(profile.validate().is_ok(), "value {value} failed");
+    }
+}
+
+#[test]
+fn inference_profile_validate_rejects_reasoning_effort_outside_the_vocabulary() {
+    let mut profile = base_profile("bad-effort");
+    profile.reasoning_effort = Some("extreme".to_string());
+    let error = profile.validate().unwrap_err().to_string();
+    assert!(
+        error.contains("reasoning_effort must be one of"),
+        "{error}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// InferenceBackend::validate lives in `backend_registry` (crate root); see
+// `crates/gents/src/backend_registry/tests.rs` for its table-driven cases.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// AgentBehavior::validate_references (#1331)
+// ---------------------------------------------------------------------------
+
+fn base_behavior(behavior_id: &str) -> AgentBehavior {
+    AgentBehavior {
+        behavior_id: behavior_id.to_string(),
+        agent_did: "did:test:agent".to_string(),
+        display_name: None,
+        description: None,
+        summary: None,
+        system_prompt: None,
+        request_context_template: None,
+        backend_id: None,
+        model_name: None,
+        tool_selection_id: None,
+        inference_profile_id: None,
+        compaction_strategy: None,
+        compaction_threshold: None,
+        enabled: true,
+        skill_refs: Vec::new(),
+        skill_excludes: Vec::new(),
+        created_at: None,
+    }
+}
+
+fn refs_with(
+    backends: &[(&str, &[&str])],
+    tool_selections: &[&str],
+    profiles: &[&str],
+    skills: &[&str],
+) -> ConfigReferences {
+    ConfigReferences {
+        backends: backends
+            .iter()
+            .map(|(id, models)| {
+                (
+                    id.to_string(),
+                    models.iter().map(|m| m.to_string()).collect(),
+                )
+            })
+            .collect(),
+        tool_selections: tool_selections.iter().map(|s| s.to_string()).collect(),
+        profiles: profiles.iter().map(|s| s.to_string()).collect(),
+        skills: skills.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+#[test]
+fn agent_behavior_validate_references_accepts_no_references() {
+    let behavior = base_behavior("empty");
+    let refs = ConfigReferences::default();
+    assert!(behavior.validate_references(&refs).is_ok());
+}
+
+#[test]
+fn agent_behavior_validate_references_rejects_missing_backend() {
+    let mut behavior = base_behavior("b");
+    behavior.backend_id = Some("ghost".to_string());
+    let refs = ConfigReferences::default();
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(error.contains("references missing backend_id ghost"), "{error}");
+}
+
+#[test]
+fn agent_behavior_validate_references_rejects_model_not_advertised() {
+    let mut behavior = base_behavior("b");
+    behavior.backend_id = Some("reviewers".to_string());
+    behavior.model_name = Some("GLM-5.2".to_string());
+    let refs = refs_with(&[("reviewers", &["d4f"])], &[], &[], &[]);
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(
+        error.contains("selects model GLM-5.2 which backend reviewers does not advertise"),
+        "{error}"
+    );
+}
+
+#[test]
+fn agent_behavior_validate_references_accepts_model_when_backend_advertises_none() {
+    // An empty advertised-models list means "any model is accepted" — the
+    // backend hasn't been probed, or advertises nothing specific.
+    let mut behavior = base_behavior("b");
+    behavior.backend_id = Some("reviewers".to_string());
+    behavior.model_name = Some("anything".to_string());
+    let refs = refs_with(&[("reviewers", &[])], &[], &[], &[]);
+    assert!(behavior.validate_references(&refs).is_ok());
+}
+
+#[test]
+fn agent_behavior_validate_references_accepts_advertised_model() {
+    let mut behavior = base_behavior("b");
+    behavior.backend_id = Some("reviewers".to_string());
+    behavior.model_name = Some("d4f".to_string());
+    let refs = refs_with(&[("reviewers", &["d4f"])], &[], &[], &[]);
+    assert!(behavior.validate_references(&refs).is_ok());
+}
+
+#[test]
+fn agent_behavior_validate_references_rejects_missing_tool_selection() {
+    let mut behavior = base_behavior("b");
+    behavior.tool_selection_id = Some("ghost-tools".to_string());
+    let refs = ConfigReferences::default();
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(
+        error.contains("references missing tool_selection_id ghost-tools"),
+        "{error}"
+    );
+}
+
+#[test]
+fn agent_behavior_validate_references_accepts_known_tool_selection() {
+    let mut behavior = base_behavior("b");
+    behavior.tool_selection_id = Some("known-tools".to_string());
+    let refs = refs_with(&[], &["known-tools"], &[], &[]);
+    assert!(behavior.validate_references(&refs).is_ok());
+}
+
+#[test]
+fn agent_behavior_validate_references_rejects_missing_profile() {
+    let mut behavior = base_behavior("b");
+    behavior.inference_profile_id = Some("ghost-profile".to_string());
+    let refs = ConfigReferences::default();
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(
+        error.contains("references missing inference_profile_id ghost-profile"),
+        "{error}"
+    );
+}
+
+#[test]
+fn agent_behavior_validate_references_accepts_known_profile() {
+    let mut behavior = base_behavior("b");
+    behavior.inference_profile_id = Some("known-profile".to_string());
+    let refs = refs_with(&[], &[], &["known-profile"], &[]);
+    assert!(behavior.validate_references(&refs).is_ok());
+}
+
+#[test]
+fn agent_behavior_validate_references_rejects_missing_skill_ref() {
+    let mut behavior = base_behavior("b");
+    behavior.skill_refs = vec!["ghost-skill".to_string()];
+    let refs = ConfigReferences::default();
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(
+        error.contains("references missing skill_ref ghost-skill"),
+        "{error}"
+    );
+}
+
+#[test]
+fn agent_behavior_validate_references_rejects_missing_skill_exclude() {
+    let mut behavior = base_behavior("b");
+    behavior.skill_excludes = vec!["ghost-skill".to_string()];
+    let refs = ConfigReferences::default();
+    let error = behavior.validate_references(&refs).unwrap_err().to_string();
+    assert!(
+        error.contains("references missing skill_exclude ghost-skill"),
+        "{error}"
+    );
+}
+
+#[test]
+fn agent_behavior_validate_references_accepts_known_skills() {
+    let mut behavior = base_behavior("b");
+    behavior.skill_refs = vec!["known-skill".to_string()];
+    behavior.skill_excludes = vec!["known-skill".to_string()];
+    let refs = refs_with(&[], &[], &[], &["known-skill"]);
+    assert!(behavior.validate_references(&refs).is_ok());
 }

--- a/crates/gents/src/document_config/tool_selection.rs
+++ b/crates/gents/src/document_config/tool_selection.rs
@@ -7,7 +7,7 @@ use super::serde_helpers;
 use crate::config_client::mint_recreate_identity_timestamp;
 use crate::defra_query::DEFRA_QUERY_TOOL_NAME;
 use crate::document_config::SubagentTarget;
-use crate::graphql::{escape_graphql_string, graphql_mutation_with_transaction_retry};
+use crate::graphql::escape_graphql_string;
 use crate::meta_tools::META_TOOL_NAMES;
 use crate::tool_surface::TOOL_POLICY_V1;
 use crate::toolset::{
@@ -706,30 +706,37 @@ impl ToolSelectionDocument {
         preset
     }
 
-    pub fn validate(&self) -> Result<()> {
+    pub fn validation_violations(&self) -> Vec<String> {
+        let mut violations = Vec::new();
+
         if let Some(targets) = &self.subagent_targets {
             for (i, target) in targets.iter().enumerate() {
                 if target.is_empty() {
-                    return Err(anyhow::anyhow!(
+                    violations.push(format!(
                         "subagent_targets[{}] is empty; each entry must be a valid SubagentTarget JSON object",
                         i
                     ));
+                    continue;
                 }
                 // Every non-empty entry must be parseable as a SubagentTarget JSON
                 // object AND pass structural validation (all fields non-empty).
                 // Bare behavior-id strings are not valid — the runtime silently
                 // drops them, which entrenches a silent misconfiguration. Reject
                 // them here with a clear diagnostic.
-                let parsed = SubagentTarget::parse(target).map_err(|e| {
-                    anyhow::anyhow!(
-                        "subagent_targets[{i}] is not a valid SubagentTarget JSON object \
-                         (got {target:?}): {e}; \
+                let parsed = match SubagentTarget::parse(target) {
+                    Ok(parsed) => parsed,
+                    Err(error) => {
+                        violations.push(format!(
+                            "subagent_targets[{i}] is not a valid SubagentTarget JSON object \
+                         (got {target:?}): {error}; \
                          use subagent_target_entry(name, agent_did, behavior_id, description) \
                          to build a valid entry"
-                    )
-                })?;
+                        ));
+                        continue;
+                    }
+                };
                 if !parsed.is_structurally_valid() {
-                    return Err(anyhow::anyhow!(
+                    violations.push(format!(
                         "subagent_targets[{i}] parsed as SubagentTarget but is not structurally \
                          valid (name, agent_did, and behavior_id must all be non-empty): {target:?}"
                     ));
@@ -739,7 +746,7 @@ impl ToolSelectionDocument {
         if let Some(tool_names) = &self.backgroundable_tool_names {
             for (i, tool_name) in tool_names.iter().enumerate() {
                 if tool_name.is_empty() {
-                    return Err(anyhow::anyhow!(
+                    violations.push(format!(
                         "backgroundable_tool_names[{}] is empty; tool names must be non-empty strings",
                         i
                     ));
@@ -748,29 +755,31 @@ impl ToolSelectionDocument {
         }
         if let Some(service_ids) = &self.required_mcp_service_ids {
             if !service_ids.is_empty() && !self.enable_meta_tools.unwrap_or(false) {
-                anyhow::bail!(
+                violations.push(
                     "required_mcp_service_ids needs enable_meta_tools=true so the required services are callable"
+                        .to_string(),
                 );
             }
             let allowed = self.allowed_mcp_service_ids.as_deref().unwrap_or_default();
             for (i, service_id) in service_ids.iter().enumerate() {
                 let service_id = service_id.trim();
                 if service_id.is_empty() {
-                    anyhow::bail!(
+                    violations.push(format!(
                         "required_mcp_service_ids[{i}] is empty; service ids must be non-empty strings"
-                    );
+                    ));
+                    continue;
                 }
                 if !allowed.iter().any(|allowed| allowed.trim() == service_id) {
-                    anyhow::bail!(
+                    violations.push(format!(
                         "required MCP service {service_id:?} is not permitted by allowed_mcp_service_ids"
-                    );
+                    ));
                 }
             }
         }
         if let Some(tool_names) = &self.approval_required_tools {
             for (i, tool_name) in tool_names.iter().enumerate() {
                 if tool_name.is_empty() {
-                    return Err(anyhow::anyhow!(
+                    violations.push(format!(
                         "approval_required_tools[{}] is empty; tool names must be non-empty strings",
                         i
                     ));
@@ -781,7 +790,7 @@ impl ToolSelectionDocument {
             for (i, category) in categories.iter().enumerate() {
                 if !crate::config_client::patch::SELF_CONFIG_CATEGORIES.contains(&category.as_str())
                 {
-                    return Err(anyhow::anyhow!(
+                    violations.push(format!(
                         "self_config_categories[{i}] is {category:?}; valid categories: {}",
                         crate::config_client::patch::SELF_CONFIG_CATEGORIES.join(", ")
                     ));
@@ -798,25 +807,37 @@ impl ToolSelectionDocument {
                 "foreground" => {}
                 "background" if self.subagent_background_enabled.unwrap_or(false) => {}
                 "background" => {
-                    return Err(anyhow::anyhow!(
+                    violations.push(
                         "subagent_default_await_mode cannot be background unless subagent_background_enabled is true"
-                    ));
+                            .to_string(),
+                    );
                 }
                 other => {
-                    return Err(anyhow::anyhow!(
+                    violations.push(format!(
                         "subagent_default_await_mode must be foreground or background, got {other:?}"
                     ));
                 }
             }
         }
         if let Some(decls) = &self.write_tools {
-            validate_write_tool_declarations(
+            if let Err(error) = validate_write_tool_declarations(
                 decls,
                 self.cli_tool_names.as_deref().unwrap_or_default(),
                 &[],
-            )?;
+            ) {
+                violations.push(error.to_string());
+            }
         }
-        Ok(())
+        violations
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let violations = self.validation_violations();
+        if violations.is_empty() {
+            Ok(())
+        } else {
+            anyhow::bail!(violations.join("; "))
+        }
     }
 }
 
@@ -1108,6 +1129,22 @@ pub async fn upsert_tool_selection(
     node: &EmbeddedNode,
     selection: &ToolSelectionDocument,
 ) -> Result<()> {
+    let txn = crate::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+    let validation = async {
+        crate::config_client::effective_tool_selection(
+            &txn,
+            selection,
+            &[],
+            &["file_tool_root", "subagent_default_await_mode"],
+        )
+        .await?
+        .validate()
+    }
+    .await;
+    if let Err(error) = validation {
+        let _ = txn.discard().await;
+        return Err(error);
+    }
     let escaped_selection_id = escape_graphql_string(&selection.selection_id);
     let escaped_agent_did = escape_graphql_string(&selection.agent_did);
 
@@ -1201,10 +1238,10 @@ pub async fn upsert_tool_selection(
             "subagent_background_enabled",
             selection.subagent_background_enabled,
         ),
-        graphql_fields::graphql_string_field(
+        Some(graphql_fields::graphql_nullable_string_field(
             "subagent_default_await_mode",
             selection.subagent_default_await_mode.as_deref(),
-        ),
+        )),
         graphql_fields::graphql_optional_bool_field(
             "subagent_allow_cross_deployment",
             selection.subagent_allow_cross_deployment,
@@ -1357,10 +1394,10 @@ pub async fn upsert_tool_selection(
             "subagent_background_enabled",
             selection.subagent_background_enabled,
         ),
-        graphql_fields::graphql_string_field(
+        Some(graphql_fields::graphql_nullable_string_field(
             "subagent_default_await_mode",
             selection.subagent_default_await_mode.as_deref(),
-        ),
+        )),
         graphql_fields::graphql_optional_bool_field(
             "subagent_allow_cross_deployment",
             selection.subagent_allow_cross_deployment,
@@ -1432,6 +1469,11 @@ pub async fn upsert_tool_selection(
         }}"#
     );
 
-    graphql_mutation_with_transaction_retry(node, &mutation, "upsert ToolSelection").await?;
-    Ok(())
+    match txn.execute(&mutation).await {
+        Ok(_) => txn.commit().await,
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
 }

--- a/crates/gents/src/graph_package/install.rs
+++ b/crates/gents/src/graph_package/install.rs
@@ -919,6 +919,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn install_rejects_a_model_the_bound_backend_does_not_advertise() {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        let access = ConfigAccess::Local(node.clone());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        let mut bindings = create_fixture_bindings(node.as_ref()).await;
+        for role in bindings.roles.values_mut() {
+            role.model_name = Some("not-advertised".to_owned());
+        }
+
+        let error =
+            install_bundled_graph_package(&access, &bindings.owner_did, "code-review", &bindings)
+                .await
+                .expect_err("package behavior must use a model advertised by its backend");
+        assert!(
+            format!("{error:#}").contains("does not advertise"),
+            "{error:#}"
+        );
+        let state = node
+            .execute("{ AgentBehavior { behavior_id model_name } GraphRevision { digest } }")
+            .await;
+        assert!(!state.has_errors(), "{:?}", state.errors);
+        let data = state.data.unwrap();
+        assert!(data["AgentBehavior"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|behavior| {
+                !behavior["behavior_id"]
+                    .as_str()
+                    .is_some_and(|id| id.starts_with("pkg-"))
+                    && behavior["model_name"] != "not-advertised"
+            }));
+        assert!(data["GraphRevision"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn existing_package_schema_must_match_types_indexes_and_immutability() {
         let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
         let access = ConfigAccess::Local(node.clone());

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -198,8 +198,7 @@ pub use document_config::{
     wide_open_tool_selection_id_for_agent, AgentBehavior as AgentBehaviorDocument,
     ChainKeyBindingDocument, ConfigReferences, DatastoreToolSurfaceDocument, EthToolDocument,
     InferenceProfile, MergedSurfaceTools, PrincipalBootstrap, QueryToolDecl, SubagentTarget,
-    SurfaceToolDecl,
-    ToolSelectionDocument, WriteToolDecl, WriteToolField, WriteToolFieldFill,
+    SurfaceToolDecl, ToolSelectionDocument, WriteToolDecl, WriteToolField, WriteToolFieldFill,
     WriteToolOutputObligation, WriteToolOutputObligationScope,
 };
 pub use external_adapter_capture::{

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -196,8 +196,9 @@ pub use document_config::{
     upsert_agent_principal, upsert_chain_key_binding, upsert_chain_key_binding_mutation,
     upsert_inference_profile, upsert_tool_selection, wide_open_tool_selection_document,
     wide_open_tool_selection_id_for_agent, AgentBehavior as AgentBehaviorDocument,
-    ChainKeyBindingDocument, DatastoreToolSurfaceDocument, EthToolDocument, InferenceProfile,
-    MergedSurfaceTools, PrincipalBootstrap, QueryToolDecl, SubagentTarget, SurfaceToolDecl,
+    ChainKeyBindingDocument, ConfigReferences, DatastoreToolSurfaceDocument, EthToolDocument,
+    InferenceProfile, MergedSurfaceTools, PrincipalBootstrap, QueryToolDecl, SubagentTarget,
+    SurfaceToolDecl,
     ToolSelectionDocument, WriteToolDecl, WriteToolField, WriteToolFieldFill,
     WriteToolOutputObligation, WriteToolOutputObligationScope,
 };

--- a/crates/gents/src/self_config/mod.rs
+++ b/crates/gents/src/self_config/mod.rs
@@ -157,13 +157,11 @@ fn outcome_text(outcome: &PatchOutcome) -> Result<String> {
 fn behavior_request(core: &SelfConfigCore, patch: SelfConfigPatch) -> ApplyRequest<'static> {
     let behavior_id = core.behavior_id().to_string();
     let agent_did = core.agent_did().to_string();
-    let node = core.node().clone();
     let mut request = ApplyRequest::new(SelfConfigTarget::AgentBehavior, patch);
     request.resolve_unique = Box::new(move |_| Ok(behavior_id.clone()));
     request.validate = Box::new(move |txn, _anchor, _stored, merged| {
         let merged = merged.clone();
         let agent_did = agent_did.clone();
-        let node = node.clone();
         Box::pin(async move {
             let behavior: crate::AgentBehaviorDocument = decode_merged("AgentBehavior", &merged)?;
 
@@ -204,7 +202,8 @@ fn behavior_request(core: &SelfConfigCore, patch: SelfConfigPatch) -> ApplyReque
             // reference field untouched (e.g. skill_refs when only
             // system_prompt changes), so this needs the full current
             // reference snapshot, not just the fields the patch touches.
-            let refs = crate::document_config::ConfigReferences::load(&node, &agent_did).await?;
+            let refs =
+                crate::document_config::ConfigReferences::load_in_txn(txn, &agent_did).await?;
             behavior.validate_references(&refs)?;
             Ok(())
         })
@@ -282,14 +281,16 @@ fn backend_request(patch: SelfConfigPatch) -> ApplyRequest<'static> {
             .ref_id("backend_id")
             .ok_or_else(|| anyhow!("behavior has no backend_id; bind one via configure_behavior"))
     });
-    request.validate = Box::new(|_txn, _anchor, _stored, merged| {
+    request.validate = Box::new(|txn, _anchor, _stored, merged| {
         let merged = merged.clone();
         Box::pin(async move {
             let backend = crate::InferenceBackend::from_value(&Value::Object(merged))?;
+            let stored_api_key_is_present =
+                backend_has_stored_api_key(txn, &backend.backend_id).await?;
             // `current_model=None`: the no-lockout conjunct is opt-in policy
             // (`self_config_no_lockout`), enforced below in `guard` only when
             // the operator has turned it on.
-            backend.validate(None)
+            backend.validate_with_api_key_presence(None, stored_api_key_is_present)
         })
     });
     request.guard = Box::new(|anchor, merged| {
@@ -311,6 +312,32 @@ fn backend_request(patch: SelfConfigPatch) -> ApplyRequest<'static> {
         backend.validate(current_model)
     });
     request
+}
+
+async fn backend_has_stored_api_key(
+    txn: &crate::config_client::ConfigApplyTxn<'_>,
+    backend_id: &str,
+) -> Result<bool> {
+    let backend_id = crate::graphql::escape_graphql_string(backend_id);
+    let query = format!(
+        r#"{{
+            InferenceBackend(
+                filter: {{
+                    _and: [
+                        {{ backend_id: {{ _eq: "{backend_id}" }} }},
+                        {{ api_key: {{ _ne: "" }} }}
+                    ]
+                }},
+                limit: 1
+            ) {{ backend_id }}
+        }}"#
+    );
+    let response = txn.execute(&query).await?;
+    Ok(response
+        .get("data")
+        .and_then(|data| data.get("InferenceBackend"))
+        .and_then(Value::as_array)
+        .is_some_and(|rows| !rows.is_empty()))
 }
 
 fn mcp_service_request(service_id: String, patch: SelfConfigPatch) -> ApplyRequest<'static> {

--- a/crates/gents/src/self_config/mod.rs
+++ b/crates/gents/src/self_config/mod.rs
@@ -157,54 +157,55 @@ fn outcome_text(outcome: &PatchOutcome) -> Result<String> {
 fn behavior_request(core: &SelfConfigCore, patch: SelfConfigPatch) -> ApplyRequest<'static> {
     let behavior_id = core.behavior_id().to_string();
     let agent_did = core.agent_did().to_string();
+    let node = core.node().clone();
     let mut request = ApplyRequest::new(SelfConfigTarget::AgentBehavior, patch);
     request.resolve_unique = Box::new(move |_| Ok(behavior_id.clone()));
     request.validate = Box::new(move |txn, _anchor, _stored, merged| {
         let merged = merged.clone();
         let agent_did = agent_did.clone();
+        let node = node.clone();
         Box::pin(async move {
             let behavior: crate::AgentBehaviorDocument = decode_merged("AgentBehavior", &merged)?;
-            for (field, target) in [
-                ("tool_selection_id", SelfConfigTarget::ToolSelection),
-                ("inference_profile_id", SelfConfigTarget::InferenceProfile),
-                ("backend_id", SelfConfigTarget::InferenceBackend),
-            ] {
-                if let Some(reference) = merged
-                    .get(field)
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
+
+            // Self only: a patched tool_selection_id must belong to this
+            // agent even if it exists. Not a generic document reference
+            // rule — ToolSelection ownership is self-config policy, not
+            // document shape — so it stays here; existence is checked below
+            // by the owner along with every other reference.
+            if let Some(selection_id) = merged
+                .get("tool_selection_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                if let Some((_, referenced)) = crate::config_client::patch::read_doc_in_txn(
+                    txn,
+                    SelfConfigTarget::ToolSelection,
+                    selection_id,
+                )
+                .await?
                 {
-                    let Some((_, referenced)) =
-                        crate::config_client::patch::read_doc_in_txn(txn, target, reference)
-                            .await?
-                    else {
+                    let owner = referenced
+                        .get("agent_did")
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    if owner != agent_did {
                         bail!(
-                            "behavior.{field} references {reference:?}, which does not exist \
-                             in {}",
-                            target.collection_name()
+                            "behavior.tool_selection_id references {selection_id:?}, which is \
+                             owned by {owner:?}, not this agent — self-config is self only"
                         );
-                    };
-                    // ToolSelection is per-agent: binding another agent's
-                    // selection is invalid config (the document view rejects
-                    // cross-agent rows) and would let configure_tools patch a
-                    // foreign selection. Profiles/backends are global by
-                    // design.
-                    if target == SelfConfigTarget::ToolSelection {
-                        let owner = referenced
-                            .get("agent_did")
-                            .and_then(Value::as_str)
-                            .unwrap_or("");
-                        if owner != agent_did {
-                            bail!(
-                                "behavior.tool_selection_id references {reference:?}, which is \
-                                 owned by {owner:?}, not this agent — self-config is self only"
-                            );
-                        }
                     }
                 }
             }
-            let _ = behavior;
+
+            // Document rule: backend/model/tool_selection/profile/skill
+            // reference existence is owned by
+            // `AgentBehavior::validate_references`. A patch may leave a
+            // reference field untouched (e.g. skill_refs when only
+            // system_prompt changes), so this needs the full current
+            // reference snapshot, not just the fields the patch touches.
+            let refs = crate::document_config::ConfigReferences::load(&node, &agent_did).await?;
+            behavior.validate_references(&refs)?;
             Ok(())
         })
     });
@@ -266,9 +267,9 @@ fn profile_request(patch: SelfConfigPatch) -> ApplyRequest<'static> {
     request.validate = Box::new(|_txn, _anchor, _stored, merged| {
         let merged = merged.clone();
         Box::pin(async move {
-            let _profile: crate::document_config::InferenceProfile =
+            let profile: crate::document_config::InferenceProfile =
                 decode_merged("InferenceProfile", &merged)?;
-            Ok(())
+            profile.validate()
         })
     });
     request
@@ -284,18 +285,11 @@ fn backend_request(patch: SelfConfigPatch) -> ApplyRequest<'static> {
     request.validate = Box::new(|_txn, _anchor, _stored, merged| {
         let merged = merged.clone();
         Box::pin(async move {
-            crate::BackendProviderKind::parse_optional(
-                merged.get("provider_kind").and_then(Value::as_str),
-            )?;
-            for field in ["max_concurrent", "max_queue_depth"] {
-                if let Some(value) = merged.get(field) {
-                    let valid = value.as_i64().is_some_and(|value| value > 0);
-                    if !valid {
-                        bail!("backend.{field} must be a positive integer");
-                    }
-                }
-            }
-            Ok(())
+            let backend = crate::InferenceBackend::from_value(&Value::Object(merged))?;
+            // `current_model=None`: the no-lockout conjunct is opt-in policy
+            // (`self_config_no_lockout`), enforced below in `guard` only when
+            // the operator has turned it on.
+            backend.validate(None)
         })
     });
     request.guard = Box::new(|anchor, merged| {
@@ -305,28 +299,16 @@ fn backend_request(patch: SelfConfigPatch) -> ApplyRequest<'static> {
                  model unresolvable"
             );
         }
-        if let Some(models) = merged.get("models").and_then(Value::as_array) {
-            if !models.is_empty() {
-                if let Some(model_name) = anchor
-                    .doc
-                    .get("model_name")
-                    .and_then(Value::as_str)
-                    .map(str::trim)
-                    .filter(|name| !name.is_empty())
-                {
-                    let listed = models
-                        .iter()
-                        .any(|model| model.as_str() == Some(model_name));
-                    if !listed {
-                        bail!(
-                            "no-lockout guard: the patched models list drops this behavior's \
-                             model {model_name:?}"
-                        );
-                    }
-                }
-            }
-        }
-        Ok(())
+        // Document rule: dropping the current model from `models` is owned
+        // by `InferenceBackend::validate`'s no-lockout conjunct.
+        let backend = crate::InferenceBackend::from_value(&Value::Object(merged.clone()))?;
+        let current_model = anchor
+            .doc
+            .get("model_name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|name| !name.is_empty());
+        backend.validate(current_model)
     });
     request
 }

--- a/crates/gents/src/self_config/ops.rs
+++ b/crates/gents/src/self_config/ops.rs
@@ -96,13 +96,6 @@ impl SelfConfigCore {
         &self.behavior_id
     }
 
-    /// The node handle — used by category `validate` closures that need a
-    /// full reference snapshot (e.g. `behavior_request`'s
-    /// `ConfigReferences::load`) rather than a single txn-scoped read.
-    pub(crate) fn node(&self) -> &Arc<EmbeddedNode> {
-        &self.node
-    }
-
     pub(crate) fn identity(&self) -> Result<Did> {
         Did::new(self.agent_did.clone())
             .map_err(|error| anyhow!("agent DID is not ACP-addressable: {error}"))

--- a/crates/gents/src/self_config/ops.rs
+++ b/crates/gents/src/self_config/ops.rs
@@ -96,6 +96,13 @@ impl SelfConfigCore {
         &self.behavior_id
     }
 
+    /// The node handle — used by category `validate` closures that need a
+    /// full reference snapshot (e.g. `behavior_request`'s
+    /// `ConfigReferences::load`) rather than a single txn-scoped read.
+    pub(crate) fn node(&self) -> &Arc<EmbeddedNode> {
+        &self.node
+    }
+
     pub(crate) fn identity(&self) -> Result<Did> {
         Did::new(self.agent_did.clone())
             .map_err(|error| anyhow!("agent DID is not ACP-addressable: {error}"))

--- a/crates/gents/tests/conformance/persona_request.rs
+++ b/crates/gents/tests/conformance/persona_request.rs
@@ -95,6 +95,34 @@ async fn build_node(tempdir: &tempfile::TempDir) -> Arc<EmbeddedNode> {
     ensure_runtime_schemas(&node)
         .await
         .expect("runtime schemas register");
+    let response = node
+        .execute(
+            r#"mutation {
+                create_InferenceBackend(input: {
+                    backend_id: "openai"
+                    name: "OpenAI"
+                    provider_kind: "OpenAiCompatible"
+                    max_concurrent: 1
+                    max_queue_depth: 1
+                    enabled: true
+                    models: ["gpt-5"]
+                }) { _docID }
+                create_InferenceProfile(input: {
+                    profile_id: "profile-1"
+                    display_name: "Profile 1"
+                }) { _docID }
+                create_ToolSelection(input: {
+                    selection_id: "sel-disable"
+                    agent_did: "did:key:disable-agent"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    assert!(
+        !response.has_errors(),
+        "persona validation references seed: {:?}",
+        response.errors
+    );
     Arc::new(node)
 }
 

--- a/crates/gents/tests/e2e_runtime/document_config_bootstrap.rs
+++ b/crates/gents/tests/e2e_runtime/document_config_bootstrap.rs
@@ -161,6 +161,19 @@ async fn upsert_helpers_roundtrip_behavior_and_profile() {
     let agent_did = "did:test:roundtrip";
     let behavior_id = default_behavior_id_for_agent(agent_did);
 
+    let backend = db
+        .node
+        .execute(
+            r#"mutation { create_InferenceBackend(input: {
+                backend_id: "backend-local", name: "Local",
+                provider_kind: "OpenAiCompatible", endpoint: "http://127.0.0.1:1/v1",
+                max_concurrent: 1, max_queue_depth: 1, enabled: true,
+                models: ["gpt-local"]
+            }) { _docID } }"#,
+        )
+        .await;
+    assert!(!backend.has_errors(), "{:?}", backend.errors);
+
     upsert_inference_profile(
         db.node.as_ref(),
         &InferenceProfile {

--- a/crates/gents/tests/e2e_runtime/self_config_tools.rs
+++ b/crates/gents/tests/e2e_runtime/self_config_tools.rs
@@ -168,7 +168,9 @@ async fn configure_behavior_patches_and_rejects_wholesale() {
     )
     .await
     .expect_err("dangling backend_id must be rejected");
-    assert!(error.contains("does not exist"), "{error}");
+    // `AgentBehavior::validate_references` (#1331, the single owner) phrases
+    // this as "references missing backend_id", not "does not exist".
+    assert!(error.contains("references missing backend_id"), "{error}");
     let behavior = load_agent_behavior(&db.node, BEHAVIOR_ID)
         .await
         .expect("load behavior")

--- a/crates/gents/tests/e2e_runtime/self_config_tools.rs
+++ b/crates/gents/tests/e2e_runtime/self_config_tools.rs
@@ -74,6 +74,8 @@ async fn seed_config(node: &Arc<EmbeddedNode>) {
                 provider_kind: "OpenAiCompatible",
                 endpoint: "http://127.0.0.1:11434/v1",
                 api_key: "sk-secret-should-never-leak",
+                max_concurrent: 1,
+                max_queue_depth: 1,
                 enabled: true,
                 models: ["model-small", "model-large"],
                 probe_status: "healthy"
@@ -385,6 +387,48 @@ async fn configure_rejects_non_scalar_patch_values() {
     assert!(
         rows.is_empty(),
         "no document may be forged in another collection: {rows:?}"
+    );
+}
+
+#[tokio::test]
+async fn configure_backend_rejects_env_var_when_a_secret_key_is_stored() {
+    let db = test_db("self-config-backend-key-xor").await;
+    seed_config(&db.node).await;
+    let tools = build_self_config_tools(
+        db.node.clone(),
+        AGENT_DID.to_string(),
+        None,
+        &tool_config(&["backend"], false, false),
+    );
+
+    let error = call_tool(
+        &tools,
+        "configure_backend",
+        json!({ "patch": { "api_key_env_var": "GENTS_TEST_API_KEY" } }),
+    )
+    .await
+    .expect_err("a stored api_key and api_key_env_var must remain mutually exclusive");
+    assert!(
+        error.contains("must not set both api_key and api_key_env_var"),
+        "{error}"
+    );
+
+    let response = db
+        .node
+        .execute(&format!(
+            r#"{{ InferenceBackend(filter: {{ backend_id: {{ _eq: "{BACKEND_ID}" }} }}) {{ api_key_env_var }} }}"#
+        ))
+        .await;
+    let api_key_env_var = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("InferenceBackend"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("api_key_env_var"));
+    assert!(
+        api_key_env_var.is_none_or(Value::is_null),
+        "rejected patch must not commit: {response:?}"
     );
 }
 


### PR DESCRIPTION
Closes #1331. Stacked on #1356 (base branch `so/1334-subagent-tree`).

## What changed

Each config document has one canonical validator, and production write doors now call it against the document they will actually persist.

- `AgentBehavior` reference validation returns every missing or incompatible reference in stable rule order. Desired-state validation renders those as separate errors; Result-based callers retain every message in one error.
- `InferenceBackend`, `InferenceProfile`, and `ToolSelection` validation likewise accumulate all independent violations instead of stopping at the first.
- Sparse writers load the stored row, merge exactly the fields their mutation changes, validate that effective row, and mutate in the same `ConfigApplyTxn`. This covers imperative CLI writes, document upserts, self-config, persona operations, desired-state/package installation, desktop writers, the desktop live fixture, and the demo backend writer.
- Behavior reference snapshots are loaded in the write transaction, including package-created dependencies earlier in the canonical apply order. Backend secret XOR validation uses presence-only reads where the secret must remain undisclosed.
- CLI-side merge/projector and duplicate rule bodies were removed; the shared runtime boundary owns patch validation and persistence semantics.
- GraphQL clear-field names are allowlisted, interpolated values remain escaped, and empty lists continue to encode as `null` rather than an unsafe `[]` literal.
- Persisted-boundary regressions cover sparse backend/model changes, required MCP services, profile timeout relationships, ignored create fields, package model bindings, secret XOR, desktop preserved fields, and rejection-without-mutation.
- The CLI recording GraphQL boundary projects committed rows plus the current transaction pending rows, honoring deletes and isolating other transactions, so the Lean-derived apply-order fence exercises production read-your-writes semantics.

This is validation/write-boundary plumbing, not a change to legal request or tool lifecycle transitions, so no Lean model change is required.

## Clippy decision

The repository-wide Rust 1.97 clippy command is independently red on main with a broad pre-existing backlog (155 diagnostics across unrelated runtime and test code). This PR does not hide those with crate-level allows. It retains one narrowly documented `too_many_arguments` allow on the canonical `AgentRequestCreate` required-field constructor; introducing a second parameter DTO there would create another owner for the wire contract.

## Verification

- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo test -p gents-cli config_import` (24 passed after the transaction-recorder fix)
- `cargo test -p gents-cli --lib commands::config::`
- `cargo test -p gents-cli --lib desired_state::tests::validation`
- `cargo test -p gents-desktop-core client::mutations::manage -- --nocapture`
- `cargo test -p gents-desktop-core --test manage_view -- --nocapture`
- `cargo check -p gents --example serve_default_behavior`
- `cargo check -p gents-desktop-tauri --all-targets`
- `cargo fmt --all --check`
- `git diff --check`

The full `gents` package gate passed all library, conformance, lifecycle, runtime, subagent, trigger, misc, and doc-test targets (ignored live/external tests remain ignored by design).