### PR TITLE
Provider layer: one client constructor, one credential resolver, one OAuth bearer wrapper (#1338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 - `Goal.tokens_used` now reports the charged total (input incl. cached +
   output), matching the request ledger; `/self` utilization is measured
   against the effective input budget.
+- A backend whose API-key environment variable is unset now fails loudly on
+  every path (previously the builder and prober silently ran without a key).
 
 ## 0.15.0 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
   output), matching the request ledger; `/self` utilization is measured
   against the effective input budget.
 - A backend whose API-key environment variable is unset now fails loudly on
-  every path (previously the builder and prober silently ran without a key).
+  every path (previously the probers silently attempted unauthenticated calls).
 
 ## 0.15.0 - 2026-09-01
 

--- a/crates/gents/src/agent.rs
+++ b/crates/gents/src/agent.rs
@@ -358,11 +358,7 @@ pub(crate) fn behavior_config_from_documents(
         }),
         &crate::template::catalog::default_catalog(),
     )?;
-    let openai_wire_api = crate::OpenAiWireApi::effective_for_provider(
-        backend.provider_kind,
-        backend.openai_wire_api,
-        &backend.backend_id,
-    );
+    let backend_fields = backend.backend_fields();
     let sampling = SamplingConfig {
         temperature: inference_profile.temperature,
         top_p: inference_profile.top_p,
@@ -383,17 +379,20 @@ pub(crate) fn behavior_config_from_documents(
             .transpose()?,
         max_tokens: profile_max_tokens,
     };
-    sampling.validate_for_provider(backend.provider_kind, openai_wire_api)?;
+    sampling.validate_for_provider(
+        backend_fields.backend_provider_kind,
+        backend_fields.openai_wire_api,
+    )?;
 
     Ok(AgentBehavior {
         behavior_id: behavior.behavior_id.clone(),
         principal,
-        backend_id: Some(backend.backend_id.clone()),
-        backend_provider_kind: backend.provider_kind,
-        openai_wire_api,
-        backend_endpoint: backend.endpoint.clone(),
-        backend_api_key: backend.api_key.clone(),
-        backend_api_key_env_var: backend.api_key_env_var.clone(),
+        backend_id: backend_fields.backend_id,
+        backend_provider_kind: backend_fields.backend_provider_kind,
+        openai_wire_api: backend_fields.openai_wire_api,
+        backend_endpoint: backend_fields.backend_endpoint,
+        backend_api_key: backend_fields.backend_api_key,
+        backend_api_key_env_var: backend_fields.backend_api_key_env_var,
         model_name: normalize_optional_string(behavior.model_name.as_deref())
             .unwrap_or(DEFAULT_MODEL_NAME)
             .to_string(),

--- a/crates/gents/src/agent/builder.rs
+++ b/crates/gents/src/agent/builder.rs
@@ -11,6 +11,7 @@ use super::{
 };
 use crate::admission::BackendAdmissionConfig;
 use crate::agent::completion_retry::CompletionRetryProfileFields;
+#[cfg(test)]
 use crate::backend_provider::BackendProviderKind;
 use crate::backend_registry::lookup_backend;
 use crate::compaction::CompactionStrategy;
@@ -556,46 +557,22 @@ impl PendingAgentBehavior {
         }
 
         let behavior_name = self.name.clone();
-        let resolved_backend_id = Some(backend.backend_id);
-        let provider_kind = backend.provider_kind;
-        let openai_wire_api = crate::OpenAiWireApi::effective_for_provider(
-            backend.provider_kind,
-            backend.openai_wire_api,
-            &backend_id,
-        );
-        let endpoint = backend.endpoint;
-        let api_key = backend.api_key;
-        let api_key_env_var = backend.api_key_env_var;
+        let backend_fields = backend.backend_fields();
         let tool_ceiling = tool_ceiling.clone();
 
         Ok(Box::new(move |principal| {
-            self.build_with_resolved_backend(
-                principal,
-                resolved_backend_id,
-                provider_kind,
-                openai_wire_api,
-                endpoint,
-                api_key,
-                api_key_env_var,
-                &tool_ceiling,
-            )
-            .map_err(|error| BehaviorBuildError {
-                behavior_id: behavior_name,
-                error,
-            })
+            self.build_with_resolved_backend(principal, backend_fields, &tool_ceiling)
+                .map_err(|error| BehaviorBuildError {
+                    behavior_id: behavior_name,
+                    error,
+                })
         }))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn build_with_resolved_backend(
         self,
         principal: Arc<AgentPrincipal>,
-        backend_id: Option<String>,
-        backend_provider_kind: BackendProviderKind,
-        openai_wire_api: crate::OpenAiWireApi,
-        backend_endpoint: String,
-        backend_api_key: Option<String>,
-        backend_api_key_env_var: Option<String>,
+        backend_fields: crate::backend_registry::BackendFields,
         tool_ceiling: &ToolCeiling,
     ) -> Result<AgentBehavior> {
         let behavior_name = self.name.clone();
@@ -607,18 +584,20 @@ impl PendingAgentBehavior {
             }),
             &crate::template::catalog::default_catalog(),
         )?;
-        self.sampling
-            .validate_for_provider(backend_provider_kind, openai_wire_api)?;
+        self.sampling.validate_for_provider(
+            backend_fields.backend_provider_kind,
+            backend_fields.openai_wire_api,
+        )?;
 
         Ok(AgentBehavior {
             behavior_id: self.name,
             principal,
-            backend_id,
-            backend_provider_kind,
-            openai_wire_api,
-            backend_endpoint,
-            backend_api_key,
-            backend_api_key_env_var,
+            backend_id: backend_fields.backend_id,
+            backend_provider_kind: backend_fields.backend_provider_kind,
+            openai_wire_api: backend_fields.openai_wire_api,
+            backend_endpoint: backend_fields.backend_endpoint,
+            backend_api_key: backend_fields.backend_api_key,
+            backend_api_key_env_var: backend_fields.backend_api_key_env_var,
             model_name: self.model_name,
             context_window: self.context_window,
             max_output_tokens: self.max_output_tokens,
@@ -662,16 +641,18 @@ impl PendingAgentBehavior {
         });
         self.build_with_resolved_backend(
             principal,
-            backend_id,
-            BackendProviderKind::OpenAiCompatible,
-            crate::OpenAiWireApi::effective_for_provider(
-                BackendProviderKind::OpenAiCompatible,
-                None,
-                "<test>",
-            ),
-            backend_endpoint,
-            None,
-            None,
+            crate::backend_registry::BackendFields {
+                backend_id,
+                backend_provider_kind: BackendProviderKind::OpenAiCompatible,
+                openai_wire_api: crate::OpenAiWireApi::effective_for_provider(
+                    BackendProviderKind::OpenAiCompatible,
+                    None,
+                    "<test>",
+                ),
+                backend_endpoint,
+                backend_api_key: None,
+                backend_api_key_env_var: None,
+            },
             &ToolCeiling::meta_only(),
         )
         .unwrap()

--- a/crates/gents/src/agent/runtime/context.rs
+++ b/crates/gents/src/agent/runtime/context.rs
@@ -161,104 +161,22 @@ impl RuntimeContext {
         )
         .await?;
 
-        match client {
-            crate::llm::backend_client::BackendClient::OpenAiChatCompletions(client) => {
-                Box::pin(self.run_behavior_with_client(
-                    behavior,
-                    request_rx,
-                    slot_generation,
-                    shutdown,
-                    prompt_builder,
-                    preamble,
-                    loop_tools.clone(),
-                    background_tool_registry,
-                    tool_surface.approval_required_tools().to_vec(),
-                    tool_surface.output_obligations(),
-                    client,
-                ))
-                .await
-            }
-            crate::llm::backend_client::BackendClient::OpenAiResponses(client) => {
-                Box::pin(self.run_behavior_with_client(
-                    behavior,
-                    request_rx,
-                    slot_generation,
-                    shutdown,
-                    prompt_builder,
-                    preamble,
-                    loop_tools.clone(),
-                    background_tool_registry,
-                    tool_surface.approval_required_tools().to_vec(),
-                    tool_surface.output_obligations(),
-                    client,
-                ))
-                .await
-            }
-            crate::llm::backend_client::BackendClient::OpenRouter(client) => {
-                Box::pin(self.run_behavior_with_client(
-                    behavior,
-                    request_rx,
-                    slot_generation,
-                    shutdown,
-                    prompt_builder,
-                    preamble,
-                    loop_tools.clone(),
-                    background_tool_registry,
-                    tool_surface.approval_required_tools().to_vec(),
-                    tool_surface.output_obligations(),
-                    client,
-                ))
-                .await
-            }
-            crate::llm::backend_client::BackendClient::ChatGptCodex(client) => {
-                Box::pin(self.run_behavior_with_client(
-                    behavior,
-                    request_rx,
-                    slot_generation,
-                    shutdown,
-                    prompt_builder,
-                    preamble,
-                    loop_tools.clone(),
-                    background_tool_registry,
-                    tool_surface.approval_required_tools().to_vec(),
-                    tool_surface.output_obligations(),
-                    client,
-                ))
-                .await
-            }
-            crate::llm::backend_client::BackendClient::XaiGrokChatCompletions(client) => {
-                Box::pin(self.run_behavior_with_client(
-                    behavior,
-                    request_rx,
-                    slot_generation,
-                    shutdown,
-                    prompt_builder,
-                    preamble,
-                    loop_tools.clone(),
-                    background_tool_registry,
-                    tool_surface.approval_required_tools().to_vec(),
-                    tool_surface.output_obligations(),
-                    client,
-                ))
-                .await
-            }
-            crate::llm::backend_client::BackendClient::XaiGrokResponses(client) => {
-                Box::pin(self.run_behavior_with_client(
-                    behavior,
-                    request_rx,
-                    slot_generation,
-                    shutdown,
-                    prompt_builder,
-                    preamble,
-                    loop_tools.clone(),
-                    background_tool_registry,
-                    tool_surface.approval_required_tools().to_vec(),
-                    tool_surface.output_obligations(),
-                    client,
-                ))
-                .await
-            }
-        }
+        crate::llm::backend_client::with_backend_client!(client, |client| {
+            Box::pin(self.run_behavior_with_client(
+                behavior,
+                request_rx,
+                slot_generation,
+                shutdown,
+                prompt_builder,
+                preamble,
+                loop_tools.clone(),
+                background_tool_registry,
+                tool_surface.approval_required_tools().to_vec(),
+                tool_surface.output_obligations(),
+                client,
+            ))
+            .await
+        })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/gents/src/agent/runtime/context.rs
+++ b/crates/gents/src/agent/runtime/context.rs
@@ -3,13 +3,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::llm::tool::ToolDyn;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use rig::client::CompletionClient;
 use tokio::sync::{mpsc, watch, Mutex};
 
 use crate::admission::AdmissionRegistry;
 use crate::agent::daemon::BehaviorDaemon;
-use crate::backend_provider::BackendProviderKind;
 use crate::completion_factory::build_admitted_model;
 use crate::hook::{BackgroundExecutionRegistry, BackgroundToolRegistry};
 use crate::prompt::LayeredPromptBuilder;
@@ -154,88 +153,16 @@ impl RuntimeContext {
             "building behavior runtime"
         );
 
-        match behavior.backend_provider_kind {
-            BackendProviderKind::OpenAiCompatible => {
-                let build_context = format!(
-                    "building OpenAI-compatible completion client for behavior {} against {}",
-                    behavior.behavior_id, behavior.backend_endpoint
-                );
-                if behavior.openai_wire_api == crate::OpenAiWireApi::ChatCompletions {
-                    let client: rig::providers::openai::CompletionsClient<
-                        crate::inference_http::SessionTaggingHttpClient<
-                            crate::rendered_request::RenderedRequestCapturingHttpClient,
-                        >,
-                    > = crate::inference_http::build_openai_chat_completions_client(
-                        &api_key,
-                        &behavior.backend_endpoint,
-                        crate::inference_http::SessionTaggingHttpClient::new(
-                            crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
-                        ),
-                    )
-                    .with_context(|| build_context.clone())?;
-                    Box::pin(self.run_behavior_with_client(
-                        behavior,
-                        request_rx,
-                        slot_generation,
-                        shutdown,
-                        prompt_builder,
-                        preamble,
-                        loop_tools.clone(),
-                        background_tool_registry,
-                        tool_surface.approval_required_tools().to_vec(),
-                        tool_surface.output_obligations(),
-                        client,
-                    ))
-                    .await
-                } else {
-                    let client: rig::providers::openai::Client<
-                        crate::inference_http::SessionTaggingHttpClient<
-                            crate::inference_http::ResponsesNormalizingHttpClient<
-                                crate::rendered_request::RenderedRequestCapturingHttpClient,
-                            >,
-                        >,
-                    > = crate::inference_http::build_openai_responses_client(
-                        &api_key,
-                        &behavior.backend_endpoint,
-                        crate::inference_http::SessionTaggingHttpClient::new(
-                            crate::inference_http::ResponsesNormalizingHttpClient::new(
-                                crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
-                            ),
-                        ),
-                        Default::default(),
-                    )
-                    .with_context(|| build_context.clone())?;
-                    Box::pin(self.run_behavior_with_client(
-                        behavior,
-                        request_rx,
-                        slot_generation,
-                        shutdown,
-                        prompt_builder,
-                        preamble,
-                        loop_tools.clone(),
-                        background_tool_registry,
-                        tool_surface.approval_required_tools().to_vec(),
-                        tool_surface.output_obligations(),
-                        client,
-                    ))
-                    .await
-                }
-            }
-            BackendProviderKind::OpenRouter => {
-                let build_context = format!(
-                    "building OpenRouter completion client for behavior {} against {}",
-                    behavior.behavior_id, behavior.backend_endpoint
-                );
-                let client: rig::providers::openrouter::Client<
-                    crate::rendered_request::RenderedRequestCapturingHttpClient,
-                > = rig::providers::openrouter::Client::builder()
-                    .api_key(&api_key)
-                    .base_url(&behavior.backend_endpoint)
-                    .http_client(
-                        crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
-                    )
-                    .build()
-                    .with_context(|| build_context.clone())?;
+        let client = crate::llm::backend_client::build_backend_client(
+            self.node.clone(),
+            behavior.as_ref(),
+            &api_key,
+            self.startup_readiness.build_timeout,
+        )
+        .await?;
+
+        match client {
+            crate::llm::backend_client::BackendClient::OpenAiChatCompletions(client) => {
                 Box::pin(self.run_behavior_with_client(
                     behavior,
                     request_rx,
@@ -251,29 +178,7 @@ impl RuntimeContext {
                 ))
                 .await
             }
-            BackendProviderKind::ChatGptCodex => {
-                let client = tokio::time::timeout(
-                    self.startup_readiness.build_timeout,
-                    crate::chatgpt_codex::build_responses_client(
-                        self.node.clone(),
-                        behavior.agent_did(),
-                        &behavior.backend_endpoint,
-                    ),
-                )
-                .await
-                .map_err(|_| {
-                    anyhow::anyhow!(
-                        "timed out after {:?} building the ChatGPT Codex completion client",
-                        self.startup_readiness.build_timeout
-                    )
-                })
-                .and_then(|result| result)
-                .with_context(|| {
-                    format!(
-                        "building ChatGPT Codex completion client for behavior {} against {}",
-                        behavior.behavior_id, behavior.backend_endpoint
-                    )
-                })?;
+            crate::llm::backend_client::BackendClient::OpenAiResponses(client) => {
                 Box::pin(self.run_behavior_with_client(
                     behavior,
                     request_rx,
@@ -289,72 +194,69 @@ impl RuntimeContext {
                 ))
                 .await
             }
-            BackendProviderKind::XaiGrokOAuth => {
-                let build_context = format!(
-                    "building Grok OAuth completion client for behavior {} against {}",
-                    behavior.behavior_id, behavior.backend_endpoint
-                );
-                let timeout_error = || {
-                    anyhow::anyhow!(
-                        "timed out after {:?} building the Grok OAuth completion client",
-                        self.startup_readiness.build_timeout
-                    )
-                };
-                if behavior.openai_wire_api == crate::OpenAiWireApi::ChatCompletions {
-                    let client = tokio::time::timeout(
-                        self.startup_readiness.build_timeout,
-                        crate::xai_grok_oauth::build_chat_completions_client(
-                            self.node.clone(),
-                            behavior.agent_did(),
-                            &behavior.backend_endpoint,
-                        ),
-                    )
-                    .await
-                    .map_err(|_| timeout_error())
-                    .and_then(|result| result)
-                    .with_context(|| build_context.clone())?;
-                    Box::pin(self.run_behavior_with_client(
-                        behavior,
-                        request_rx,
-                        slot_generation,
-                        shutdown,
-                        prompt_builder,
-                        preamble,
-                        loop_tools.clone(),
-                        background_tool_registry,
-                        tool_surface.approval_required_tools().to_vec(),
-                        tool_surface.output_obligations(),
-                        client,
-                    ))
-                    .await
-                } else {
-                    let client = tokio::time::timeout(
-                        self.startup_readiness.build_timeout,
-                        crate::xai_grok_oauth::build_responses_client(
-                            self.node.clone(),
-                            behavior.agent_did(),
-                            &behavior.backend_endpoint,
-                        ),
-                    )
-                    .await
-                    .map_err(|_| timeout_error())
-                    .and_then(|result| result)
-                    .with_context(|| build_context.clone())?;
-                    Box::pin(self.run_behavior_with_client(
-                        behavior,
-                        request_rx,
-                        slot_generation,
-                        shutdown,
-                        prompt_builder,
-                        preamble,
-                        loop_tools.clone(),
-                        background_tool_registry,
-                        tool_surface.approval_required_tools().to_vec(),
-                        tool_surface.output_obligations(),
-                        client,
-                    ))
-                    .await
-                }
+            crate::llm::backend_client::BackendClient::OpenRouter(client) => {
+                Box::pin(self.run_behavior_with_client(
+                    behavior,
+                    request_rx,
+                    slot_generation,
+                    shutdown,
+                    prompt_builder,
+                    preamble,
+                    loop_tools.clone(),
+                    background_tool_registry,
+                    tool_surface.approval_required_tools().to_vec(),
+                    tool_surface.output_obligations(),
+                    client,
+                ))
+                .await
+            }
+            crate::llm::backend_client::BackendClient::ChatGptCodex(client) => {
+                Box::pin(self.run_behavior_with_client(
+                    behavior,
+                    request_rx,
+                    slot_generation,
+                    shutdown,
+                    prompt_builder,
+                    preamble,
+                    loop_tools.clone(),
+                    background_tool_registry,
+                    tool_surface.approval_required_tools().to_vec(),
+                    tool_surface.output_obligations(),
+                    client,
+                ))
+                .await
+            }
+            crate::llm::backend_client::BackendClient::XaiGrokChatCompletions(client) => {
+                Box::pin(self.run_behavior_with_client(
+                    behavior,
+                    request_rx,
+                    slot_generation,
+                    shutdown,
+                    prompt_builder,
+                    preamble,
+                    loop_tools.clone(),
+                    background_tool_registry,
+                    tool_surface.approval_required_tools().to_vec(),
+                    tool_surface.output_obligations(),
+                    client,
+                ))
+                .await
+            }
+            crate::llm::backend_client::BackendClient::XaiGrokResponses(client) => {
+                Box::pin(self.run_behavior_with_client(
+                    behavior,
+                    request_rx,
+                    slot_generation,
+                    shutdown,
+                    prompt_builder,
+                    preamble,
+                    loop_tools.clone(),
+                    background_tool_registry,
+                    tool_surface.approval_required_tools().to_vec(),
+                    tool_surface.output_obligations(),
+                    client,
+                ))
+                .await
             }
         }
     }

--- a/crates/gents/src/backend_health.rs
+++ b/crates/gents/src/backend_health.rs
@@ -236,23 +236,27 @@ pub async fn probe_backends_cycle(
         }
         probed_ids.insert(backend.backend_id.clone());
 
-        let api_key = backend.resolved_api_key();
-        let probe_result = tokio::time::timeout(
-            options.probe_timeout,
-            crate::backend_provider::discover_models(
-                client,
-                backend.provider_kind,
-                &backend.endpoint,
-                api_key.as_deref(),
-                None,
-            ),
-        )
-        .await;
+        let (event, error_text) = match crate::config::resolve_backend_api_key(backend) {
+            Err(error) => (ProbeEvent::ProbeFail, Some(error.to_string())),
+            Ok(api_key) => {
+                let probe_result = tokio::time::timeout(
+                    options.probe_timeout,
+                    crate::backend_provider::discover_models(
+                        client,
+                        backend.provider_kind,
+                        &backend.endpoint,
+                        api_key.as_deref(),
+                        None,
+                    ),
+                )
+                .await;
 
-        let (event, error_text) = match probe_result {
-            Ok(Ok(_models)) => (ProbeEvent::ProbeSuccess, None),
-            Ok(Err(error)) => (ProbeEvent::ProbeFail, Some(error.to_string())),
-            Err(_) => (ProbeEvent::ProbeFail, Some("probe timed out".to_string())),
+                match probe_result {
+                    Ok(Ok(_models)) => (ProbeEvent::ProbeSuccess, None),
+                    Ok(Err(error)) => (ProbeEvent::ProbeFail, Some(error.to_string())),
+                    Err(_) => (ProbeEvent::ProbeFail, Some("probe timed out".to_string())),
+                }
+            }
         };
 
         let previous = health_map.get_model(&backend.backend_id).await;

--- a/crates/gents/src/backend_registry.rs
+++ b/crates/gents/src/backend_registry.rs
@@ -14,6 +14,20 @@ pub const DEFAULT_MAX_QUEUE_DEPTH: i64 = 100;
 pub const HEALTHY_PROBE_STATUS: &str = "healthy";
 pub const UNKNOWN_PROBE_STATUS: &str = "unknown";
 
+/// An `InferenceBackend`'s contribution to an `AgentBehavior`: everything a
+/// behavior needs to know about the backend it's bound to, with
+/// `openai_wire_api` already resolved to its effective value. See
+/// [`InferenceBackend::backend_fields`].
+#[derive(Debug, Clone)]
+pub struct BackendFields {
+    pub backend_id: Option<String>,
+    pub backend_provider_kind: BackendProviderKind,
+    pub openai_wire_api: OpenAiWireApi,
+    pub backend_endpoint: String,
+    pub backend_api_key: Option<String>,
+    pub backend_api_key_env_var: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct InferenceBackend {
     pub backend_id: String,
@@ -96,15 +110,25 @@ impl InferenceBackend {
         })
     }
 
-    pub fn resolved_api_key(&self) -> Option<String> {
-        if let Some(key) = self.api_key.as_ref() {
-            return Some(key.clone());
+    /// The subset of this backend that becomes an `AgentBehavior`'s
+    /// backend-scoped fields. Single owner of that field mapping —
+    /// `agent.rs`'s document-driven assembler and `agent/builder.rs`'s
+    /// embedder assembler (`PendingAgentBehavior::into_factory`) used to
+    /// duplicate it independently, including the `openai_wire_api`
+    /// effective-value computation.
+    pub fn backend_fields(&self) -> BackendFields {
+        BackendFields {
+            backend_id: Some(self.backend_id.clone()),
+            backend_provider_kind: self.provider_kind,
+            openai_wire_api: crate::OpenAiWireApi::effective_for_provider(
+                self.provider_kind,
+                self.openai_wire_api,
+                &self.backend_id,
+            ),
+            backend_endpoint: self.endpoint.clone(),
+            backend_api_key: self.api_key.clone(),
+            backend_api_key_env_var: self.api_key_env_var.clone(),
         }
-        self.api_key_env_var
-            .as_ref()
-            .and_then(|var| std::env::var(var).ok())
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
     }
 
     pub fn display_state(&self) -> &'static str {
@@ -485,7 +509,18 @@ pub async fn probe_and_promote_enabled_backends(node: &EmbeddedNode) {
             continue;
         }
         async {
-            let api_key = backend.resolved_api_key();
+            let api_key = match crate::config::resolve_backend_api_key(&backend) {
+                Ok(api_key) => api_key,
+                Err(error) => {
+                    tracing::warn!(
+                        backend_id = %backend.backend_id,
+                        endpoint = %backend.endpoint,
+                        error = %error,
+                        "startup backend probe: could not resolve API key, leaving probe_status unchanged"
+                    );
+                    return;
+                }
+            };
             match crate::backend_provider::discover_models(
                 &client,
                 backend.provider_kind,

--- a/crates/gents/src/backend_registry/tests.rs
+++ b/crates/gents/src/backend_registry/tests.rs
@@ -188,27 +188,57 @@ fn backend_with_keys(api_key: Option<&str>, env_var: Option<&str>) -> InferenceB
 }
 
 #[test]
-fn resolved_api_key_prefers_raw_key() {
+fn resolve_backend_api_key_prefers_raw_key() {
     let backend = backend_with_keys(Some("raw-key"), Some("BACKEND_REGISTRY_TEST_KEY_UNUSED"));
-    assert_eq!(backend.resolved_api_key().as_deref(), Some("raw-key"));
+    assert_eq!(
+        crate::config::resolve_backend_api_key(&backend)
+            .expect("raw key resolves")
+            .as_deref(),
+        Some("raw-key")
+    );
 }
 
 #[test]
-fn resolved_api_key_falls_back_to_env() {
+fn resolve_backend_api_key_falls_back_to_env() {
     let var = "BACKEND_REGISTRY_TEST_KEY_FALLBACK";
     std::env::set_var(var, "env-key");
     let backend = backend_with_keys(None, Some(var));
-    assert_eq!(backend.resolved_api_key().as_deref(), Some("env-key"));
+    assert_eq!(
+        crate::config::resolve_backend_api_key(&backend)
+            .expect("env key resolves")
+            .as_deref(),
+        Some("env-key")
+    );
     std::env::remove_var(var);
 }
 
 #[test]
-fn resolved_api_key_none_when_unset() {
+fn resolve_backend_api_key_none_when_no_env_var_configured() {
     let backend = backend_with_keys(None, None);
-    assert_eq!(backend.resolved_api_key(), None);
-    // Env var named but unset in the environment.
-    let backend = backend_with_keys(None, Some("BACKEND_REGISTRY_TEST_KEY_MISSING"));
-    assert_eq!(backend.resolved_api_key(), None);
+    assert_eq!(
+        crate::config::resolve_backend_api_key(&backend)
+            .expect("no key configured is not an error"),
+        None
+    );
+}
+
+/// A backend whose `api_key_env_var` names an environment variable that
+/// isn't actually set must fail loudly, naming the backend — never silently
+/// probe or build with no key (#1338).
+#[test]
+fn resolve_backend_api_key_errors_when_env_var_named_but_unset() {
+    let backend = backend_with_keys(None, Some("BACKEND_REGISTRY_TEST_KEY_MISSING_1338"));
+    let error = crate::config::resolve_backend_api_key(&backend)
+        .expect_err("a named-but-unset env var must hard error");
+    let message = error.to_string();
+    assert!(
+        message.contains(&backend.backend_id),
+        "error must name the backend: {message}"
+    );
+    assert!(
+        message.contains("BACKEND_REGISTRY_TEST_KEY_MISSING_1338"),
+        "error must name the environment variable: {message}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/gents/src/chatgpt_codex.rs
+++ b/crates/gents/src/chatgpt_codex.rs
@@ -1,21 +1,22 @@
 use std::future::Future;
 use std::sync::Arc;
-use std::{fmt, fmt::Formatter};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use chrono::{DateTime, Duration, Utc};
 use defra_node::EmbeddedNode;
 use rig::http_client::{
-    self, HeaderMap, HeaderValue, HttpClientExt, LazyBody, MultipartForm, Request, ReqwestClient,
-    Response, StreamingResponse,
+    self, HeaderMap, HeaderValue, HttpClientExt, LazyBody, Request, ReqwestClient, Response,
 };
+#[cfg(test)]
+use rig::http_client::{MultipartForm, StreamingResponse};
 use rig::wasm_compat::WasmCompatSend;
 use serde_json::{json, Value};
 
+#[cfg(test)]
+use crate::oauth_credential::{classify_chatgpt_auth_error, BearerSource, OAuthAuthProblem};
 use crate::oauth_credential::{
-    classify_chatgpt_auth_error, lookup_oauth_credential, oauth_credential_id, shared_bearer,
-    BearerSource, DbCredentialBearer, OAuthAuthProblem, OAuthCredential, OAuthRefreshKind,
+    oauth_credential_id, DbCredentialBearer, OAuthCredential, OAuthRefreshKind,
     CHATGPT_OAUTH_PRODUCT,
 };
 
@@ -122,98 +123,20 @@ pub fn chatgpt_codex_client_version() -> String {
 const CHATGPT_CODEX_CLIENT_VERSION: &str = "0.144.4";
 const CHATGPT_CODEX_CLIENT_VERSION_ENV: &str = "GENTS_CHATGPT_CODEX_CLIENT_VERSION";
 
-fn bearer_rejection_status(error: &http_client::Error) -> Option<u16> {
-    match error {
-        http_client::Error::InvalidStatusCode(status)
-        | http_client::Error::InvalidStatusCodeWithMessage(status, _) => Some(status.as_u16()),
-        _ => None,
-    }
-}
+/// [`crate::oauth_http::IdentityHeaders`] policy for the ChatGPT Codex
+/// Responses transport: 401/403 kill the bearer, the `/responses` body needs
+/// the `instructions` hoist, and a buffered send must rewrite Codex's SSE
+/// body into the JSON `response.completed` shape rig expects. Codex's
+/// identity headers (`build_chatgpt_codex_headers`) ride as `http_headers`
+/// client-build defaults instead of a per-request merge, so this policy
+/// leaves `merge_identity_headers` at its no-op default.
+#[derive(Clone, Default)]
+pub struct ChatGptCodexPolicy;
 
-fn is_bearer_rejection(error: &http_client::Error) -> bool {
-    matches!(bearer_rejection_status(error), Some(401) | Some(403))
-}
+impl crate::oauth_http::IdentityHeaders for ChatGptCodexPolicy {
+    const REJECTION_STATUSES: &'static [u16] = &[401, 403];
 
-pub struct ChatGptCodexHttpClient<S: BearerSource, H = ReqwestClient> {
-    inner: H,
-    bearer: Option<Arc<S>>,
-}
-
-impl<S: BearerSource, H: Clone> Clone for ChatGptCodexHttpClient<S, H> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            bearer: self.bearer.clone(),
-        }
-    }
-}
-
-impl<S: BearerSource, H: fmt::Debug> fmt::Debug for ChatGptCodexHttpClient<S, H> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ChatGptCodexHttpClient")
-            .field("inner", &self.inner)
-            .field("bearer_configured", &self.bearer.is_some())
-            .finish()
-    }
-}
-
-impl<S: BearerSource, H: Default> Default for ChatGptCodexHttpClient<S, H> {
-    fn default() -> Self {
-        Self {
-            inner: H::default(),
-            bearer: None,
-        }
-    }
-}
-
-impl<S: BearerSource> ChatGptCodexHttpClient<S, ReqwestClient> {
-    pub fn new(bearer: Arc<S>) -> Self {
-        Self {
-            inner: ReqwestClient::default(),
-            bearer: Some(bearer),
-        }
-    }
-}
-
-impl<S: BearerSource, H> ChatGptCodexHttpClient<S, H> {
-    pub fn with_inner(bearer: Arc<S>, inner: H) -> Self {
-        Self {
-            inner,
-            bearer: Some(bearer),
-        }
-    }
-
-    async fn fresh_auth_header(&self) -> http_client::Result<HeaderValue> {
-        let bearer = self.bearer.as_ref().ok_or_else(|| {
-            http_client::Error::Instance(
-                anyhow::anyhow!("ChatGptCodexHttpClient used without a configured BearerSource")
-                    .into(),
-            )
-        })?;
-        let token = bearer
-            .current_bearer()
-            .await
-            .map_err(|error| http_client::Error::Instance(error.into()))?;
-        HeaderValue::from_str(&format!("Bearer {token}"))
-            .map_err(|error| http_client::Error::Instance(anyhow::Error::from(error).into()))
-    }
-
-    async fn prepare(&self, req: Request<Bytes>) -> http_client::Result<Request<Bytes>> {
-        let req = Self::inject_required_instructions(req);
-        let value = self.fresh_auth_header().await?;
-        let (mut parts, body) = req.into_parts();
-        parts.headers.insert("authorization", value);
-        Ok(Request::from_parts(parts, body))
-    }
-
-    fn bearer_to_invalidate<X>(&self, result: &http_client::Result<X>) -> Option<Arc<S>> {
-        match result {
-            Err(error) if is_bearer_rejection(error) => self.bearer.clone(),
-            _ => None,
-        }
-    }
-
-    fn inject_required_instructions(req: Request<Bytes>) -> Request<Bytes> {
+    fn patch_request_body(&self, req: Request<Bytes>) -> Request<Bytes> {
         let (parts, body) = req.into_parts();
         let mut body = body;
         if parts.uri.path().ends_with("/responses") {
@@ -224,131 +147,48 @@ impl<S: BearerSource, H> ChatGptCodexHttpClient<S, H> {
         Request::from_parts(parts, body)
     }
 
-    #[cfg(test)]
-    pub async fn prepare_for_test(
+    fn send_via<T, U>(
         &self,
+        inner: &T,
         req: Request<Bytes>,
-    ) -> http_client::Result<Request<Bytes>> {
-        self.prepare(req).await
-    }
-}
-
-impl<S, H> HttpClientExt for ChatGptCodexHttpClient<S, H>
-where
-    S: BearerSource + 'static,
-    H: Clone + HttpClientExt + fmt::Debug + 'static,
-{
-    fn send<T, U>(
-        &self,
-        req: Request<T>,
     ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
     where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes>,
-        U: WasmCompatSend + 'static,
+        T: Clone + HttpClientExt + 'static,
+        U: From<Bytes> + WasmCompatSend + 'static,
     {
-        let inner = self.inner.clone();
-        let this = self.clone();
-        let (parts, body) = req.into_parts();
-        let req = Request::from_parts(parts, body.into());
+        let inner = inner.clone();
         async move {
-            let req = this.prepare(req).await?;
-            let result = send_inner(inner, req).await;
-            if let Some(bearer) = this.bearer_to_invalidate(&result) {
-                bearer.invalidate().await;
-            }
-            result
-        }
-    }
+            let is_responses_request = req.uri().path().ends_with("/responses");
+            let request_body = req.body().clone();
+            let response = HttpClientExt::send::<Bytes, Bytes>(&inner, req).await?;
 
-    fn send_multipart<U>(
-        &self,
-        req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        U: From<Bytes>,
-        U: WasmCompatSend + 'static,
-    {
-        let inner = self.inner.clone();
-        let this = self.clone();
-        async move {
-            let value = this.fresh_auth_header().await?;
-            let (mut parts, body) = req.into_parts();
-            parts.headers.insert("authorization", value);
-            let req = Request::from_parts(parts, body);
-            let result = HttpClientExt::send_multipart(&inner, req).await;
-            if let Some(bearer) = this.bearer_to_invalidate(&result) {
-                bearer.invalidate().await;
-            }
-            result
-        }
-    }
+            let status = response.status();
+            let headers = response.headers().clone();
+            let response_body = response.into_body().await?;
+            let body = if is_responses_request {
+                let text = String::from_utf8_lossy(&response_body);
+                synthesize_completion_response(&request_body, &text)
+            } else {
+                response_body
+            };
 
-    fn send_streaming<T>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
-    where
-        T: Into<Bytes>,
-    {
-        let inner = self.inner.clone();
-        let this = self.clone();
-        let (parts, body) = req.into_parts();
-        let req = Request::from_parts(parts, body.into());
-        async move {
-            let req = this.prepare(req).await?;
-            let result = HttpClientExt::send_streaming(&inner, req).await;
-            if let Some(bearer) = this.bearer_to_invalidate(&result) {
-                bearer.invalidate().await;
+            let mut response_builder = Response::builder().status(status);
+            if let Some(response_headers) = response_builder.headers_mut() {
+                *response_headers = headers;
             }
-            let mut response = result?;
-            ensure_event_stream_content_type(response.headers_mut());
-            Ok(response)
+            let body: LazyBody<U> = Box::pin(async move { Ok(U::from(body)) });
+            response_builder
+                .body(body)
+                .map_err(http_client::Error::Protocol)
         }
     }
 }
 
-fn ensure_event_stream_content_type(headers: &mut HeaderMap) {
-    if !headers.contains_key("content-type") {
-        headers.insert(
-            "content-type",
-            HeaderValue::from_static("text/event-stream"),
-        );
-    }
-}
-
-async fn send_inner<H, U>(
-    inner: H,
-    req: Request<Bytes>,
-) -> http_client::Result<Response<LazyBody<U>>>
-where
-    H: HttpClientExt,
-    U: From<Bytes>,
-    U: WasmCompatSend + 'static,
-{
-    let is_responses_request = req.uri().path().ends_with("/responses");
-    let request_body = req.body().clone();
-    let response = HttpClientExt::send::<Bytes, Bytes>(&inner, req).await?;
-
-    let status = response.status();
-    let headers = response.headers().clone();
-    let response_body = response.into_body().await?;
-    let body = if is_responses_request {
-        let text = String::from_utf8_lossy(&response_body);
-        synthesize_completion_response(&request_body, &text)
-    } else {
-        response_body
-    };
-
-    let mut response_builder = Response::builder().status(status);
-    if let Some(response_headers) = response_builder.headers_mut() {
-        *response_headers = headers;
-    }
-    let body: LazyBody<U> = Box::pin(async move { Ok(U::from(body)) });
-    response_builder
-        .body(body)
-        .map_err(http_client::Error::Protocol)
-}
+/// Codex's Responses transport: bearer auth, the `instructions` hoist, and
+/// the SSE→JSON response rewrite, layered over `crate::oauth_http`'s shared
+/// bearer-auth wrapper.
+pub type ChatGptCodexHttpClient<S, H = ReqwestClient> =
+    crate::oauth_http::BearerAuthHttpClient<S, ChatGptCodexPolicy, H>;
 
 pub(crate) fn patch_instructions_body(body: &[u8]) -> Option<Bytes> {
     let mut value = serde_json::from_slice::<Value>(body).ok()?;
@@ -558,32 +398,17 @@ pub async fn build_responses_client(
     >,
 > {
     let provider = CHATGPT_CODEX_PROVIDER;
-    let credential = lookup_oauth_credential(node.as_ref(), agent_did, provider)
-        .await
-        .with_context(|| format!("loading OAuthCredential for agent {agent_did}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(classify_chatgpt_auth_error(
-                agent_did,
-                provider,
-                &OAuthAuthProblem::Missing,
-            ))
-        })?;
+    let (bearer, credential) = crate::oauth_http::bootstrap_oauth_client(
+        node,
+        agent_did,
+        provider,
+        OAuthRefreshKind::ChatGpt,
+        CHATGPT_OAUTH_PRODUCT,
+    )
+    .await?;
     let headers =
         build_chatgpt_codex_headers(credential.account_id.as_deref(), credential.is_fedramp)?;
     let endpoint = normalize_endpoint(endpoint);
-    let credential_id = credential.credential_id.clone();
-    let bearer = shared_bearer(&credential_id, || {
-        DbCredentialBearer::with_cache(
-            node,
-            agent_did,
-            provider,
-            credential_id.clone(),
-            true,
-            Some(credential.clone()),
-            OAuthRefreshKind::ChatGpt,
-            CHATGPT_OAUTH_PRODUCT,
-        )
-    });
     // The capture wrapper sits *below* the Codex wrapper, so it sees the body
     // after `patch_instructions_body` has hoisted `instructions`, stripped
     // system items, set `store`/`stream`, deleted the unsupported sampling
@@ -815,13 +640,16 @@ mod tests {
 
     #[test]
     fn bearer_rejection_only_for_401_and_403() {
-        assert!(is_bearer_rejection(&status_error("401")));
-        assert!(is_bearer_rejection(&status_error("403")));
-        assert!(!is_bearer_rejection(&status_error("500")));
-        assert!(!is_bearer_rejection(&status_error("429")));
-        assert!(!is_bearer_rejection(&http_client::Error::Instance(
-            anyhow::anyhow!("network down").into()
-        )));
+        use crate::oauth_http::{is_bearer_rejection, IdentityHeaders as _};
+        let statuses = ChatGptCodexPolicy::REJECTION_STATUSES;
+        assert!(is_bearer_rejection(statuses, &status_error("401")));
+        assert!(is_bearer_rejection(statuses, &status_error("403")));
+        assert!(!is_bearer_rejection(statuses, &status_error("500")));
+        assert!(!is_bearer_rejection(statuses, &status_error("429")));
+        assert!(!is_bearer_rejection(
+            statuses,
+            &http_client::Error::Instance(anyhow::anyhow!("network down").into())
+        ));
     }
 
     async fn send_through(status: u16) -> Arc<CountingBearer> {
@@ -1071,28 +899,8 @@ mod tests {
         assert_eq!(credential.id_token.as_deref(), Some(id_token.as_str()));
     }
 
-    #[test]
-    fn event_stream_content_type_is_added_only_when_missing() {
-        let mut missing = HeaderMap::new();
-        ensure_event_stream_content_type(&mut missing);
-        assert_eq!(
-            missing
-                .get("content-type")
-                .and_then(|value| value.to_str().ok()),
-            Some("text/event-stream")
-        );
-
-        let mut present = HeaderMap::new();
-        present.insert("content-type", HeaderValue::from_static("application/json"));
-        ensure_event_stream_content_type(&mut present);
-        assert_eq!(
-            present
-                .get("content-type")
-                .and_then(|value| value.to_str().ok()),
-            Some("application/json"),
-            "backend-supplied content type should not be overwritten"
-        );
-    }
+    // `ensure_event_stream_content_type` is single-owned and unit-tested in
+    // `crate::oauth_http` now (`event_stream_content_type_is_added_only_when_missing`).
 
     #[test]
     fn streamed_output_prefers_deltas_over_done_text() {

--- a/crates/gents/src/chatgpt_codex.rs
+++ b/crates/gents/src/chatgpt_codex.rs
@@ -123,7 +123,7 @@ pub fn chatgpt_codex_client_version() -> String {
 const CHATGPT_CODEX_CLIENT_VERSION: &str = "0.144.4";
 const CHATGPT_CODEX_CLIENT_VERSION_ENV: &str = "GENTS_CHATGPT_CODEX_CLIENT_VERSION";
 
-/// [`crate::oauth_http::IdentityHeaders`] policy for the ChatGPT Codex
+/// [`crate::oauth_http::OAuthHttpPolicy`] policy for the ChatGPT Codex
 /// Responses transport: 401/403 kill the bearer, the `/responses` body needs
 /// the `instructions` hoist, and a buffered send must rewrite Codex's SSE
 /// body into the JSON `response.completed` shape rig expects. Codex's
@@ -133,7 +133,7 @@ const CHATGPT_CODEX_CLIENT_VERSION_ENV: &str = "GENTS_CHATGPT_CODEX_CLIENT_VERSI
 #[derive(Clone, Default)]
 pub struct ChatGptCodexPolicy;
 
-impl crate::oauth_http::IdentityHeaders for ChatGptCodexPolicy {
+impl crate::oauth_http::OAuthHttpPolicy for ChatGptCodexPolicy {
     const REJECTION_STATUSES: &'static [u16] = &[401, 403];
 
     fn patch_request_body(&self, req: Request<Bytes>) -> Request<Bytes> {
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn bearer_rejection_only_for_401_and_403() {
-        use crate::oauth_http::{is_bearer_rejection, IdentityHeaders as _};
+        use crate::oauth_http::{is_bearer_rejection, OAuthHttpPolicy as _};
         let statuses = ChatGptCodexPolicy::REJECTION_STATUSES;
         assert!(is_bearer_rejection(statuses, &status_error("401")));
         assert!(is_bearer_rejection(statuses, &status_error("403")));

--- a/crates/gents/src/config.rs
+++ b/crates/gents/src/config.rs
@@ -267,33 +267,22 @@ impl AgentBehavior {
         &self.principal.identity
     }
 
+    /// Resolve this behavior's backend API key. Delegates to
+    /// [`resolve_api_key`], the single owner of the resolution and
+    /// hard-error-on-missing-env-var semantics; a missing or empty
+    /// `backend_api_key_env_var` names both the backend and the behavior in
+    /// the error, since a behavior's own binding (not just the backend
+    /// document) is what's unusable.
     pub fn resolve_backend_api_key(&self) -> Result<Option<String>> {
-        if let Some(api_key) = normalize_optional_secret(self.backend_api_key.as_deref()) {
-            return Ok(Some(api_key.to_string()));
-        }
-
-        if let Some(env_var) = normalize_optional_env_var(self.backend_api_key_env_var.as_deref()) {
-            let value = std::env::var(env_var).with_context(|| {
-                format!(
-                    "backend {} for behavior {} requires environment variable {}",
-                    self.backend_id.as_deref().unwrap_or("<unbound>"),
-                    self.behavior_id,
-                    env_var
-                )
-            })?;
-            let value = value.trim();
-            if value.is_empty() {
-                anyhow::bail!(
-                    "backend {} for behavior {} resolved empty API key from environment variable {}",
-                    self.backend_id.as_deref().unwrap_or("<unbound>"),
-                    self.behavior_id,
-                    env_var
-                );
-            }
-            return Ok(Some(value.to_string()));
-        }
-
-        Ok(None)
+        resolve_api_key(
+            &format!(
+                "backend {} for behavior {}",
+                self.backend_id.as_deref().unwrap_or("<unbound>"),
+                self.behavior_id
+            ),
+            self.backend_api_key.as_deref(),
+            self.backend_api_key_env_var.as_deref(),
+        )
     }
 
     pub fn completion_client_api_key(&self) -> Result<String> {
@@ -301,6 +290,54 @@ impl AgentBehavior {
             .resolve_backend_api_key()?
             .unwrap_or_else(|| "no-key".to_string()))
     }
+}
+
+/// Resolve an [`crate::backend_registry::InferenceBackend`]'s API key
+/// independent of any behavior binding — used by the startup and periodic
+/// backend probers, which check reachability before any behavior claims the
+/// backend. Delegates to [`resolve_api_key`]; a missing or empty
+/// `api_key_env_var` is a hard error naming the backend, exactly as
+/// [`AgentBehavior::resolve_backend_api_key`] errors for a bound behavior —
+/// a backend whose configured env var isn't set must fail loudly, not probe
+/// silently with no key (previously [`InferenceBackend::resolved_api_key`]
+/// swallowed this into `None`).
+pub fn resolve_backend_api_key(
+    backend: &crate::backend_registry::InferenceBackend,
+) -> Result<Option<String>> {
+    resolve_api_key(
+        &format!("backend {}", backend.backend_id),
+        backend.api_key.as_deref(),
+        backend.api_key_env_var.as_deref(),
+    )
+}
+
+/// Single owner of "resolve an API key from a raw value or an environment
+/// variable name": prefer the raw value; otherwise, if an env var name is
+/// configured, its value must be set and non-blank or this hard-errors
+/// naming `subject` — a configured-but-unusable credential is a
+/// misconfiguration, not a silent no-key fallback. No env var configured at
+/// all is a legitimate no-key backend (e.g. an unauthenticated local
+/// endpoint) and resolves to `None`.
+fn resolve_api_key(
+    subject: &str,
+    api_key: Option<&str>,
+    api_key_env_var: Option<&str>,
+) -> Result<Option<String>> {
+    if let Some(api_key) = normalize_optional_secret(api_key) {
+        return Ok(Some(api_key.to_string()));
+    }
+
+    if let Some(env_var) = normalize_optional_env_var(api_key_env_var) {
+        let value = std::env::var(env_var)
+            .with_context(|| format!("{subject} requires environment variable {env_var}"))?;
+        let value = value.trim();
+        if value.is_empty() {
+            anyhow::bail!("{subject} resolved empty API key from environment variable {env_var}");
+        }
+        return Ok(Some(value.to_string()));
+    }
+
+    Ok(None)
 }
 
 fn normalize_optional_env_var(value: Option<&str>) -> Option<&str> {
@@ -365,6 +402,45 @@ mod tests {
             sampling: SamplingConfig::default(),
             skills: Vec::new(),
         }
+    }
+
+    /// A behavior bound to a backend whose `backend_api_key_env_var` names an
+    /// environment variable that isn't actually set in the process must fail
+    /// loudly, naming both the backend and the behavior — never silently
+    /// build/run with no key (#1338).
+    #[test]
+    fn resolve_backend_api_key_errors_when_env_var_named_but_unset() {
+        let mut behavior = behavior_with_wire(OpenAiWireApi::ChatCompletions);
+        behavior.backend_api_key_env_var =
+            Some("GENTS_CONFIG_TEST_KEY_MISSING_1338_NEVER_SET".to_string());
+
+        let error = behavior
+            .resolve_backend_api_key()
+            .expect_err("a named-but-unset env var must hard error");
+        let message = error.to_string();
+        assert!(
+            message.contains("backend-general"),
+            "error must name the backend: {message}"
+        );
+        assert!(
+            message.contains("general"),
+            "error must name the behavior: {message}"
+        );
+        assert!(
+            message.contains("GENTS_CONFIG_TEST_KEY_MISSING_1338_NEVER_SET"),
+            "error must name the environment variable: {message}"
+        );
+    }
+
+    #[test]
+    fn resolve_backend_api_key_none_when_no_env_var_configured() {
+        let behavior = behavior_with_wire(OpenAiWireApi::ChatCompletions);
+        assert_eq!(
+            behavior
+                .resolve_backend_api_key()
+                .expect("no key configured is not an error"),
+            None
+        );
     }
 
     #[test]

--- a/crates/gents/src/config.rs
+++ b/crates/gents/src/config.rs
@@ -411,6 +411,10 @@ mod tests {
     #[test]
     fn resolve_backend_api_key_errors_when_env_var_named_but_unset() {
         let mut behavior = behavior_with_wire(OpenAiWireApi::ChatCompletions);
+        // Deliberately not a substring of `backend-general` (the fixture's
+        // backend id) so the two assertions below can't pass vacuously off
+        // one shared match.
+        behavior.behavior_id = "behavior-alpha".to_string();
         behavior.backend_api_key_env_var =
             Some("GENTS_CONFIG_TEST_KEY_MISSING_1338_NEVER_SET".to_string());
 
@@ -423,7 +427,7 @@ mod tests {
             "error must name the backend: {message}"
         );
         assert!(
-            message.contains("general"),
+            message.contains("behavior-alpha"),
             "error must name the behavior: {message}"
         );
         assert!(

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -47,6 +47,7 @@ pub mod interrupt;
 #[cfg(test)]
 pub(crate) mod lean_vocab_test;
 pub mod oauth_credential;
+pub(crate) mod oauth_http;
 pub mod openai_wire;
 pub mod p2p_observability;
 pub(crate) mod provider_input;

--- a/crates/gents/src/llm/backend_client.rs
+++ b/crates/gents/src/llm/backend_client.rs
@@ -191,6 +191,28 @@ pub(crate) async fn build_backend_client(
     }
 }
 
+/// Dispatch a built `BackendClient` to `$body`, binding the unwrapped
+/// concrete client to `$c`. Single owner of the six-arm match every caller
+/// otherwise has to repeat: each `BackendProviderKind` × wire-API
+/// combination produces a distinct concrete `rig` client type, and `$body`
+/// is typically a call into a `CompletionClient`-generic continuation
+/// (`run_behavior_with_client` / `run_oneshot_with_completion_client`) that
+/// Rust monomorphizes once per concrete type it's invoked with — so the
+/// match itself can't become a plain function, only written once.
+macro_rules! with_backend_client {
+    ($client:expr, |$c:ident| $body:expr) => {
+        match $client {
+            $crate::llm::backend_client::BackendClient::OpenAiChatCompletions($c) => $body,
+            $crate::llm::backend_client::BackendClient::OpenAiResponses($c) => $body,
+            $crate::llm::backend_client::BackendClient::OpenRouter($c) => $body,
+            $crate::llm::backend_client::BackendClient::ChatGptCodex($c) => $body,
+            $crate::llm::backend_client::BackendClient::XaiGrokChatCompletions($c) => $body,
+            $crate::llm::backend_client::BackendClient::XaiGrokResponses($c) => $body,
+        }
+    };
+}
+pub(crate) use with_backend_client;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/gents/src/llm/backend_client.rs
+++ b/crates/gents/src/llm/backend_client.rs
@@ -1,0 +1,314 @@
+//! Single owner of "build the provider completion client for a behavior's
+//! `BackendProviderKind`" — the daemon (`agent/runtime/context.rs`) and
+//! one-shot (`oneshot.rs`) used to carry independent copies of this
+//! four-way match, and only the daemon wrapped OAuth-branch client
+//! construction in a build timeout. Both callers now go through
+//! [`build_backend_client`], which applies that timeout to every OAuth build
+//! regardless of caller.
+//!
+//! Each `BackendProviderKind` × wire-API combination produces a distinct
+//! concrete `rig` client type, so the result is a small closed enum
+//! ([`BackendClient`]) rather than a `dyn` client: callers match on it once to
+//! hand the concrete value to their own generic completion-loop entry point
+//! (`run_behavior_with_client` / `run_oneshot_with_completion_client`), which
+//! is the only place left that needs to be generic over the client type.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use defra_node::EmbeddedNode;
+
+use crate::backend_provider::BackendProviderKind;
+use crate::config::AgentBehavior;
+
+/// A built provider completion client, tagged by which
+/// `BackendProviderKind` × wire-API combination produced it.
+pub(crate) enum BackendClient {
+    OpenAiChatCompletions(
+        rig::providers::openai::CompletionsClient<
+            crate::inference_http::SessionTaggingHttpClient<
+                crate::rendered_request::RenderedRequestCapturingHttpClient,
+            >,
+        >,
+    ),
+    OpenAiResponses(
+        rig::providers::openai::Client<
+            crate::inference_http::SessionTaggingHttpClient<
+                crate::inference_http::ResponsesNormalizingHttpClient<
+                    crate::rendered_request::RenderedRequestCapturingHttpClient,
+                >,
+            >,
+        >,
+    ),
+    OpenRouter(
+        rig::providers::openrouter::Client<
+            crate::rendered_request::RenderedRequestCapturingHttpClient,
+        >,
+    ),
+    ChatGptCodex(
+        rig::providers::openai::Client<
+            crate::chatgpt_codex::ChatGptCodexHttpClient<
+                crate::oauth_credential::DbCredentialBearer,
+                crate::rendered_request::RenderedRequestCapturingHttpClient,
+            >,
+        >,
+    ),
+    XaiGrokChatCompletions(
+        rig::providers::openai::CompletionsClient<
+            crate::xai_grok_oauth::CapturingXaiGrokOAuthHttpClient,
+        >,
+    ),
+    XaiGrokResponses(
+        rig::providers::openai::Client<crate::xai_grok_oauth::CapturingXaiGrokOAuthHttpClient>,
+    ),
+}
+
+/// Build the provider completion client for `behavior`'s
+/// `backend_provider_kind` (and, where the provider has one, its configured
+/// `openai_wire_api`).
+///
+/// OAuth-branch construction (ChatGPT Codex, Grok/xAI OAuth) hits DefraDB for
+/// the agent's `OAuthCredential` and is bounded by `build_timeout` so a wedged
+/// lookup cannot hang startup forever — the same protection the daemon has
+/// always applied, now shared by one-shot too (#1338).
+pub(crate) async fn build_backend_client(
+    node: Arc<EmbeddedNode>,
+    behavior: &AgentBehavior,
+    api_key: &str,
+    build_timeout: Duration,
+) -> Result<BackendClient> {
+    match behavior.backend_provider_kind {
+        BackendProviderKind::OpenAiCompatible => {
+            let build_context = format!(
+                "building OpenAI-compatible completion client for behavior {} against {}",
+                behavior.behavior_id, behavior.backend_endpoint
+            );
+            if behavior.openai_wire_api == crate::OpenAiWireApi::ChatCompletions {
+                let client = crate::inference_http::build_openai_chat_completions_client(
+                    api_key,
+                    &behavior.backend_endpoint,
+                    crate::inference_http::SessionTaggingHttpClient::new(
+                        crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
+                    ),
+                )
+                .with_context(|| build_context.clone())?;
+                Ok(BackendClient::OpenAiChatCompletions(client))
+            } else {
+                let client = crate::inference_http::build_openai_responses_client(
+                    api_key,
+                    &behavior.backend_endpoint,
+                    crate::inference_http::SessionTaggingHttpClient::new(
+                        crate::inference_http::ResponsesNormalizingHttpClient::new(
+                            crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
+                        ),
+                    ),
+                    Default::default(),
+                )
+                .with_context(|| build_context.clone())?;
+                Ok(BackendClient::OpenAiResponses(client))
+            }
+        }
+        BackendProviderKind::OpenRouter => {
+            let build_context = format!(
+                "building OpenRouter completion client for behavior {} against {}",
+                behavior.behavior_id, behavior.backend_endpoint
+            );
+            let client: rig::providers::openrouter::Client<
+                crate::rendered_request::RenderedRequestCapturingHttpClient,
+            > = rig::providers::openrouter::Client::builder()
+                .api_key(api_key)
+                .base_url(&behavior.backend_endpoint)
+                .http_client(crate::rendered_request::RenderedRequestCapturingHttpClient::default())
+                .build()
+                .with_context(|| build_context.clone())?;
+            Ok(BackendClient::OpenRouter(client))
+        }
+        BackendProviderKind::ChatGptCodex => {
+            let client = tokio::time::timeout(
+                build_timeout,
+                crate::chatgpt_codex::build_responses_client(
+                    node,
+                    behavior.agent_did(),
+                    &behavior.backend_endpoint,
+                ),
+            )
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "timed out after {build_timeout:?} building the ChatGPT Codex completion client"
+                )
+            })
+            .and_then(|result| result)
+            .with_context(|| {
+                format!(
+                    "building ChatGPT Codex completion client for behavior {} against {}",
+                    behavior.behavior_id, behavior.backend_endpoint
+                )
+            })?;
+            Ok(BackendClient::ChatGptCodex(client))
+        }
+        BackendProviderKind::XaiGrokOAuth => {
+            let build_context = format!(
+                "building Grok OAuth completion client for behavior {} against {}",
+                behavior.behavior_id, behavior.backend_endpoint
+            );
+            let timeout_error = || {
+                anyhow::anyhow!(
+                    "timed out after {build_timeout:?} building the Grok OAuth completion client"
+                )
+            };
+            if behavior.openai_wire_api == crate::OpenAiWireApi::ChatCompletions {
+                let client = tokio::time::timeout(
+                    build_timeout,
+                    crate::xai_grok_oauth::build_chat_completions_client(
+                        node,
+                        behavior.agent_did(),
+                        &behavior.backend_endpoint,
+                    ),
+                )
+                .await
+                .map_err(|_| timeout_error())
+                .and_then(|result| result)
+                .with_context(|| build_context.clone())?;
+                Ok(BackendClient::XaiGrokChatCompletions(client))
+            } else {
+                let client = tokio::time::timeout(
+                    build_timeout,
+                    crate::xai_grok_oauth::build_responses_client(
+                        node,
+                        behavior.agent_did(),
+                        &behavior.backend_endpoint,
+                    ),
+                )
+                .await
+                .map_err(|_| timeout_error())
+                .and_then(|result| result)
+                .with_context(|| build_context.clone())?;
+                Ok(BackendClient::XaiGrokResponses(client))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::PendingAgentBehavior;
+    use crate::identity::KeyIdentity;
+
+    async fn test_node() -> Arc<EmbeddedNode> {
+        Arc::new(EmbeddedNode::builder().build().await.unwrap())
+    }
+
+    /// `BackendClient` intentionally holds no `Debug` bound (every variant's
+    /// rig client type would need one for no reason a caller needs) so
+    /// `Result::expect_err` doesn't apply here; unwrap the error by hand.
+    fn expect_err(result: Result<BackendClient>, msg: &str) -> anyhow::Error {
+        match result {
+            Ok(_) => panic!("{msg}"),
+            Err(error) => error,
+        }
+    }
+
+    fn test_behavior(kind: BackendProviderKind, wire_api: crate::OpenAiWireApi) -> AgentBehavior {
+        let identity = KeyIdentity::load_or_create(
+            std::env::temp_dir().join(format!("backend-client-table-{}.key", uuid::Uuid::new_v4())),
+            None,
+        )
+        .unwrap();
+        let mut behavior = PendingAgentBehavior::new("backend-client-table")
+            .build_with_identity_for_test(identity);
+        behavior.backend_provider_kind = kind;
+        behavior.openai_wire_api = wire_api;
+        behavior.backend_endpoint = "http://127.0.0.1:1/v1".to_string();
+        behavior
+    }
+
+    /// OpenAI-compatible and OpenRouter clients are built synchronously from
+    /// strings (api key/endpoint) with no I/O, so the table test can assert
+    /// on the exact concrete variant the shared constructor returns for every
+    /// `BackendProviderKind` that doesn't need a live OAuthCredential.
+    #[tokio::test]
+    async fn each_openai_shaped_provider_kind_yields_the_expected_client_variant() {
+        let node = test_node().await;
+
+        let chat = test_behavior(
+            BackendProviderKind::OpenAiCompatible,
+            crate::OpenAiWireApi::ChatCompletions,
+        );
+        let client = build_backend_client(node.clone(), &chat, "key", Duration::from_secs(1))
+            .await
+            .expect("chat completions client builds without I/O");
+        assert!(matches!(client, BackendClient::OpenAiChatCompletions(_)));
+
+        let responses = test_behavior(
+            BackendProviderKind::OpenAiCompatible,
+            crate::OpenAiWireApi::Responses,
+        );
+        let client = build_backend_client(node.clone(), &responses, "key", Duration::from_secs(1))
+            .await
+            .expect("responses client builds without I/O");
+        assert!(matches!(client, BackendClient::OpenAiResponses(_)));
+
+        let mut openrouter = test_behavior(
+            BackendProviderKind::OpenRouter,
+            crate::OpenAiWireApi::ChatCompletions,
+        );
+        openrouter.backend_endpoint = "https://openrouter.ai/api/v1".to_string();
+        let client = build_backend_client(node.clone(), &openrouter, "key", Duration::from_secs(1))
+            .await
+            .expect("openrouter client builds without I/O");
+        assert!(matches!(client, BackendClient::OpenRouter(_)));
+    }
+
+    /// The OAuth branches (ChatGPT Codex, Grok/xAI OAuth) hit DefraDB for a
+    /// credential that doesn't exist in this bare test node, so they cannot
+    /// reach a concrete client — but the shared constructor must still route
+    /// each `BackendProviderKind`/wire-API combination to the *correct*
+    /// provider's builder, which a provider-specific "missing OAuthCredential"
+    /// error proves (Codex names ChatGPT, xAI names Grok).
+    #[tokio::test]
+    async fn each_oauth_provider_kind_dispatches_to_its_own_builder() {
+        let node = test_node().await;
+        crate::migration::ensure_all_runtime_migrations(node.clone())
+            .await
+            .unwrap();
+
+        let codex = test_behavior(
+            BackendProviderKind::ChatGptCodex,
+            crate::OpenAiWireApi::Responses,
+        );
+        let result =
+            build_backend_client(node.clone(), &codex, "key", Duration::from_secs(5)).await;
+        let error = expect_err(result, "no OAuthCredential exists for this agent");
+        assert!(
+            format!("{error:#}").contains("ChatGPT"),
+            "must route to the Codex builder: {error:#}"
+        );
+
+        let xai_chat = test_behavior(
+            BackendProviderKind::XaiGrokOAuth,
+            crate::OpenAiWireApi::ChatCompletions,
+        );
+        let result =
+            build_backend_client(node.clone(), &xai_chat, "key", Duration::from_secs(5)).await;
+        let error = expect_err(result, "no OAuthCredential exists for this agent");
+        assert!(
+            format!("{error:#}").contains("Grok"),
+            "must route to the Grok Chat Completions builder: {error:#}"
+        );
+
+        let xai_responses = test_behavior(
+            BackendProviderKind::XaiGrokOAuth,
+            crate::OpenAiWireApi::Responses,
+        );
+        let result =
+            build_backend_client(node.clone(), &xai_responses, "key", Duration::from_secs(5)).await;
+        let error = expect_err(result, "no OAuthCredential exists for this agent");
+        assert!(
+            format!("{error:#}").contains("Grok"),
+            "must route to the Grok Responses builder: {error:#}"
+        );
+    }
+}

--- a/crates/gents/src/llm/backend_client.rs
+++ b/crates/gents/src/llm/backend_client.rs
@@ -223,16 +223,6 @@ mod tests {
         Arc::new(EmbeddedNode::builder().build().await.unwrap())
     }
 
-    /// `BackendClient` intentionally holds no `Debug` bound (every variant's
-    /// rig client type would need one for no reason a caller needs) so
-    /// `Result::expect_err` doesn't apply here; unwrap the error by hand.
-    fn expect_err(result: Result<BackendClient>, msg: &str) -> anyhow::Error {
-        match result {
-            Ok(_) => panic!("{msg}"),
-            Err(error) => error,
-        }
-    }
-
     fn test_behavior(kind: BackendProviderKind, wire_api: crate::OpenAiWireApi) -> AgentBehavior {
         let identity = KeyIdentity::load_or_create(
             std::env::temp_dir().join(format!("backend-client-table-{}.key", uuid::Uuid::new_v4())),
@@ -284,14 +274,33 @@ mod tests {
         assert!(matches!(client, BackendClient::OpenRouter(_)));
     }
 
-    /// The OAuth branches (ChatGPT Codex, Grok/xAI OAuth) hit DefraDB for a
-    /// credential that doesn't exist in this bare test node, so they cannot
-    /// reach a concrete client — but the shared constructor must still route
-    /// each `BackendProviderKind`/wire-API combination to the *correct*
-    /// provider's builder, which a provider-specific "missing OAuthCredential"
-    /// error proves (Codex names ChatGPT, xAI names Grok).
+    async fn seed_oauth_credential(node: &EmbeddedNode, behavior: &AgentBehavior, provider: &str) {
+        let agent_did = behavior.agent_did();
+        let credential = crate::oauth_credential::OAuthCredential {
+            doc_id: None,
+            credential_id: crate::oauth_credential::oauth_credential_id(agent_did, provider),
+            agent_did: agent_did.to_string(),
+            provider: provider.to_string(),
+            access_token: "access-token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            id_token: None,
+            account_id: None,
+            chatgpt_plan_type: None,
+            is_fedramp: false,
+            access_token_expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            last_refresh: None,
+            enabled: true,
+        };
+        crate::oauth_credential::upsert_oauth_credential(node, &credential)
+            .await
+            .expect("test OAuthCredential must persist");
+    }
+
+    /// Seed credentials so every OAuth route reaches a concrete client. A
+    /// missing-credential assertion cannot distinguish xAI Chat Completions
+    /// from Responses because both fail in their shared bootstrap preamble.
     #[tokio::test]
-    async fn each_oauth_provider_kind_dispatches_to_its_own_builder() {
+    async fn each_oauth_provider_kind_yields_the_expected_client_variant() {
         let node = test_node().await;
         crate::migration::ensure_all_runtime_migrations(node.clone())
             .await
@@ -301,36 +310,46 @@ mod tests {
             BackendProviderKind::ChatGptCodex,
             crate::OpenAiWireApi::Responses,
         );
-        let result =
-            build_backend_client(node.clone(), &codex, "key", Duration::from_secs(5)).await;
-        let error = expect_err(result, "no OAuthCredential exists for this agent");
-        assert!(
-            format!("{error:#}").contains("ChatGPT"),
-            "must route to the Codex builder: {error:#}"
-        );
+        seed_oauth_credential(
+            node.as_ref(),
+            &codex,
+            crate::chatgpt_codex::CHATGPT_CODEX_PROVIDER,
+        )
+        .await;
+        let client = build_backend_client(node.clone(), &codex, "key", Duration::from_secs(5))
+            .await
+            .expect("Codex client builds from the seeded credential without network I/O");
+        assert!(matches!(client, BackendClient::ChatGptCodex(_)));
 
         let xai_chat = test_behavior(
             BackendProviderKind::XaiGrokOAuth,
             crate::OpenAiWireApi::ChatCompletions,
         );
-        let result =
-            build_backend_client(node.clone(), &xai_chat, "key", Duration::from_secs(5)).await;
-        let error = expect_err(result, "no OAuthCredential exists for this agent");
-        assert!(
-            format!("{error:#}").contains("Grok"),
-            "must route to the Grok Chat Completions builder: {error:#}"
-        );
+        seed_oauth_credential(
+            node.as_ref(),
+            &xai_chat,
+            crate::xai_grok_oauth::XAI_OAUTH_PROVIDER,
+        )
+        .await;
+        let client = build_backend_client(node.clone(), &xai_chat, "key", Duration::from_secs(5))
+            .await
+            .expect("Grok Chat Completions client builds without network I/O");
+        assert!(matches!(client, BackendClient::XaiGrokChatCompletions(_)));
 
         let xai_responses = test_behavior(
             BackendProviderKind::XaiGrokOAuth,
             crate::OpenAiWireApi::Responses,
         );
-        let result =
-            build_backend_client(node.clone(), &xai_responses, "key", Duration::from_secs(5)).await;
-        let error = expect_err(result, "no OAuthCredential exists for this agent");
-        assert!(
-            format!("{error:#}").contains("Grok"),
-            "must route to the Grok Responses builder: {error:#}"
-        );
+        seed_oauth_credential(
+            node.as_ref(),
+            &xai_responses,
+            crate::xai_grok_oauth::XAI_OAUTH_PROVIDER,
+        )
+        .await;
+        let client =
+            build_backend_client(node.clone(), &xai_responses, "key", Duration::from_secs(5))
+                .await
+                .expect("Grok Responses client builds without network I/O");
+        assert!(matches!(client, BackendClient::XaiGrokResponses(_)));
     }
 }

--- a/crates/gents/src/llm/mod.rs
+++ b/crates/gents/src/llm/mod.rs
@@ -14,6 +14,7 @@
 /// format is protocol vocabulary shared by every peer); re-exported here so
 /// crate paths read `crate::llm::message::Message`.
 pub use gents_protocol::message;
+pub(crate) mod backend_client;
 pub(crate) mod responses_normalize;
 pub mod rig_compat;
 pub mod tool;

--- a/crates/gents/src/oauth_credential.rs
+++ b/crates/gents/src/oauth_credential.rs
@@ -115,6 +115,25 @@ pub fn classify_chatgpt_auth_error(
     classify_oauth_auth_error(&CHATGPT_OAUTH_PRODUCT, agent_did, provider, problem)
 }
 
+/// Single owner of the OAuth access-token expiry fallback chain xAI's
+/// device-code login and refresh both used to duplicate: prefer the JWT's own
+/// `exp` claim (authoritative when present), fall back to a positive
+/// `expires_in` (seconds) added to `now`, and default to a conservative
+/// 15-minute window when neither is present or valid.
+pub fn resolve_access_token_expiry(
+    access_token: &str,
+    expires_in: Option<i64>,
+    now: DateTime<Utc>,
+) -> DateTime<Utc> {
+    crate::chatgpt_oauth_refresh::jwt_expiration(access_token)
+        .or_else(|| {
+            expires_in
+                .filter(|seconds| *seconds > 0)
+                .map(|seconds| now + Duration::seconds(seconds))
+        })
+        .unwrap_or_else(|| now + Duration::minutes(15))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefreshedTokens {
     pub access_token: String,

--- a/crates/gents/src/oauth_http.rs
+++ b/crates/gents/src/oauth_http.rs
@@ -1,0 +1,526 @@
+//! Shared bearer-auth HTTP transport for OAuth-backed inference providers.
+//!
+//! ChatGPT Codex and Grok/xAI OAuth both wrap a raw HTTP client with the same
+//! shape: inject a fresh bearer on every request, invalidate it when the
+//! provider rejects it, and normalize the streaming content-type. Before this
+//! module the two providers carried ~150-line copies of that wrapper apiece,
+//! differing only in which HTTP statuses count as a bearer rejection, what
+//! provider-specific shaping the request body and response need, and whether
+//! identity headers ride per-request or as client-build defaults.
+//!
+//! [`BearerAuthHttpClient`] is the single wrapper; [`IdentityHeaders`] is the
+//! per-provider policy (a small `Default` marker type) that supplies those
+//! differences. `chatgpt_codex` and `xai_grok_oauth` each keep their own
+//! provider-specific body-patch/response-shaping free functions and instantiate
+//! this wrapper through a policy type and a type alias so their existing call
+//! sites (`ChatGptCodexHttpClient::new`, `.with_inner`, `.prepare_for_test`)
+//! are unchanged.
+
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use defra_node::EmbeddedNode;
+use rig::http_client::{
+    self, HeaderMap, HttpClientExt, LazyBody, MultipartForm, Request, ReqwestClient, Response,
+    StreamingResponse,
+};
+use rig::wasm_compat::WasmCompatSend;
+
+use crate::oauth_credential::{
+    classify_oauth_auth_error, lookup_oauth_credential, shared_bearer, BearerSource,
+    DbCredentialBearer, OAuthAuthProblem, OAuthCredential, OAuthProduct, OAuthRefreshKind,
+};
+
+/// Per-provider policy for [`BearerAuthHttpClient`]: which HTTP statuses mean
+/// "the bearer is dead", plus the request/response shaping hooks each
+/// provider needs. Every method has a passthrough default so a provider only
+/// overrides what it actually differs on.
+pub trait IdentityHeaders: Clone + Default + Send + Sync + 'static {
+    /// HTTP status codes on which the current bearer must be invalidated and
+    /// refreshed on the next request. Codex: 401 and 403. xAI: 401 only — its
+    /// proxy uses 403 as a NotEntitled tier gate that no refresh fixes, and
+    /// with rotating refresh tokens a force-refresh loop would burn a
+    /// rotation per request.
+    const REJECTION_STATUSES: &'static [u16];
+
+    /// Merge provider identity headers into an outbound request, without
+    /// overwriting anything already present. Default: none — a provider whose
+    /// identity headers ride as client-build defaults (Codex, via
+    /// `http_headers` on the rig client builder) never needs this.
+    fn merge_identity_headers(&self, headers: &mut HeaderMap) -> http_client::Result<()> {
+        let _ = headers;
+        Ok(())
+    }
+
+    /// Provider-specific request-body shaping applied before auth/identity
+    /// headers (Codex's `instructions` hoist, xAI's `store:false`). Default:
+    /// unchanged.
+    fn patch_request_body(&self, req: Request<Bytes>) -> Request<Bytes> {
+        req
+    }
+
+    /// Buffered (non-streaming) send. Default: pass the response straight
+    /// through. Codex overrides this to rewrite the SSE `/responses` body it
+    /// receives into the buffered `response.completed` JSON rig expects.
+    fn send_via<T, U>(
+        &self,
+        inner: &T,
+        req: Request<Bytes>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        T: Clone + HttpClientExt + 'static,
+        U: From<Bytes> + WasmCompatSend + 'static,
+    {
+        let inner = inner.clone();
+        async move { HttpClientExt::send::<Bytes, U>(&inner, req).await }
+    }
+
+    /// Streaming-response post-process beyond the shared content-type fixup
+    /// (xAI folds `usage` into the final SSE chunk). Default: unchanged.
+    fn patch_streaming(&self, response: StreamingResponse) -> StreamingResponse {
+        response
+    }
+}
+
+fn bearer_rejection_status(error: &http_client::Error) -> Option<u16> {
+    match error {
+        http_client::Error::InvalidStatusCode(status)
+        | http_client::Error::InvalidStatusCodeWithMessage(status, _) => Some(status.as_u16()),
+        _ => None,
+    }
+}
+
+/// Single owner of "does this HTTP error mean the bearer is dead" for every
+/// OAuth-backed provider. `rejection_statuses` is the provider's
+/// [`IdentityHeaders::REJECTION_STATUSES`].
+pub fn is_bearer_rejection(rejection_statuses: &[u16], error: &http_client::Error) -> bool {
+    bearer_rejection_status(error).is_some_and(|status| rejection_statuses.contains(&status))
+}
+
+/// Single owner of "the streaming response must be SSE" across OAuth
+/// providers: only fills in `content-type` when the backend omitted it.
+pub fn ensure_event_stream_content_type(headers: &mut HeaderMap) {
+    if !headers.contains_key("content-type") {
+        headers.insert(
+            "content-type",
+            http_client::HeaderValue::from_static("text/event-stream"),
+        );
+    }
+}
+
+/// HTTP client that injects a fresh OAuth bearer on every request, applies a
+/// provider's [`IdentityHeaders`] policy, and invalidates the bearer when the
+/// provider rejects it.
+pub struct BearerAuthHttpClient<S: BearerSource, P: IdentityHeaders, T = ReqwestClient> {
+    inner: T,
+    bearer: Option<Arc<S>>,
+    policy: P,
+}
+
+impl<S: BearerSource, P: IdentityHeaders, T: Clone> Clone for BearerAuthHttpClient<S, P, T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            bearer: self.bearer.clone(),
+            policy: self.policy.clone(),
+        }
+    }
+}
+
+impl<S: BearerSource, P: IdentityHeaders, T: fmt::Debug> fmt::Debug
+    for BearerAuthHttpClient<S, P, T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BearerAuthHttpClient")
+            .field("inner", &self.inner)
+            .field("bearer_configured", &self.bearer.is_some())
+            .finish()
+    }
+}
+
+impl<S: BearerSource, P: IdentityHeaders, T: Default> Default for BearerAuthHttpClient<S, P, T> {
+    fn default() -> Self {
+        Self {
+            inner: T::default(),
+            bearer: None,
+            policy: P::default(),
+        }
+    }
+}
+
+impl<S: BearerSource, P: IdentityHeaders> BearerAuthHttpClient<S, P, ReqwestClient> {
+    pub fn new(bearer: Arc<S>) -> Self {
+        Self {
+            inner: ReqwestClient::default(),
+            bearer: Some(bearer),
+            policy: P::default(),
+        }
+    }
+}
+
+impl<S: BearerSource, P: IdentityHeaders, T> BearerAuthHttpClient<S, P, T> {
+    pub fn with_inner(bearer: Arc<S>, inner: T) -> Self {
+        Self {
+            inner,
+            bearer: Some(bearer),
+            policy: P::default(),
+        }
+    }
+
+    async fn fresh_auth_header(&self) -> http_client::Result<http_client::HeaderValue> {
+        let bearer = self.bearer.as_ref().ok_or_else(|| {
+            http_client::Error::Instance(
+                anyhow::anyhow!("BearerAuthHttpClient used without a configured BearerSource")
+                    .into(),
+            )
+        })?;
+        let token = bearer
+            .current_bearer()
+            .await
+            .map_err(|error| http_client::Error::Instance(error.into()))?;
+        http_client::HeaderValue::from_str(&format!("Bearer {token}"))
+            .map_err(|error| http_client::Error::Instance(anyhow::Error::from(error).into()))
+    }
+
+    async fn prepare(&self, req: Request<Bytes>) -> http_client::Result<Request<Bytes>> {
+        let req = self.policy.patch_request_body(req);
+        let value = self.fresh_auth_header().await?;
+        let (mut parts, body) = req.into_parts();
+        parts.headers.insert("authorization", value);
+        self.policy.merge_identity_headers(&mut parts.headers)?;
+        Ok(Request::from_parts(parts, body))
+    }
+
+    fn bearer_to_invalidate<X>(&self, result: &http_client::Result<X>) -> Option<Arc<S>> {
+        match result {
+            Err(error) if is_bearer_rejection(P::REJECTION_STATUSES, error) => self.bearer.clone(),
+            _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub async fn prepare_for_test(
+        &self,
+        req: Request<Bytes>,
+    ) -> http_client::Result<Request<Bytes>> {
+        self.prepare(req).await
+    }
+}
+
+impl<S, P, T> HttpClientExt for BearerAuthHttpClient<S, P, T>
+where
+    S: BearerSource + 'static,
+    P: IdentityHeaders,
+    T: Clone + HttpClientExt + fmt::Debug + 'static,
+{
+    fn send<A, U>(
+        &self,
+        req: Request<A>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        A: Into<Bytes> + WasmCompatSend,
+        U: From<Bytes>,
+        U: WasmCompatSend + 'static,
+    {
+        let inner = self.inner.clone();
+        let this = self.clone();
+        let (parts, body) = req.into_parts();
+        let req = Request::from_parts(parts, body.into());
+        async move {
+            let req = this.prepare(req).await?;
+            let result = this.policy.send_via(&inner, req).await;
+            if let Some(bearer) = this.bearer_to_invalidate(&result) {
+                bearer.invalidate().await;
+            }
+            result
+        }
+    }
+
+    fn send_multipart<U>(
+        &self,
+        req: Request<MultipartForm>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        U: From<Bytes>,
+        U: WasmCompatSend + 'static,
+    {
+        let inner = self.inner.clone();
+        let this = self.clone();
+        async move {
+            let value = this.fresh_auth_header().await?;
+            let (mut parts, body) = req.into_parts();
+            parts.headers.insert("authorization", value);
+            this.policy.merge_identity_headers(&mut parts.headers)?;
+            let req = Request::from_parts(parts, body);
+            let result = HttpClientExt::send_multipart(&inner, req).await;
+            if let Some(bearer) = this.bearer_to_invalidate(&result) {
+                bearer.invalidate().await;
+            }
+            result
+        }
+    }
+
+    fn send_streaming<A>(
+        &self,
+        req: Request<A>,
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    where
+        A: Into<Bytes>,
+    {
+        let inner = self.inner.clone();
+        let this = self.clone();
+        let (parts, body) = req.into_parts();
+        let req = Request::from_parts(parts, body.into());
+        async move {
+            let req = this.prepare(req).await?;
+            let result = HttpClientExt::send_streaming(&inner, req).await;
+            if let Some(bearer) = this.bearer_to_invalidate(&result) {
+                bearer.invalidate().await;
+            }
+            let mut response = result?;
+            ensure_event_stream_content_type(response.headers_mut());
+            Ok(this.policy.patch_streaming(response))
+        }
+    }
+}
+
+/// Look up the `OAuthCredential` for `(agent_did, provider)` and mint a
+/// shared, cached [`DbCredentialBearer`] against it. Single owner of the
+/// lookup-or-missing-error-then-cache-bearer preamble both `chatgpt_codex`'s
+/// and `xai_grok_oauth`'s client builders used to duplicate.
+pub async fn bootstrap_oauth_client(
+    node: Arc<EmbeddedNode>,
+    agent_did: &str,
+    provider: &str,
+    refresh_kind: OAuthRefreshKind,
+    product: OAuthProduct,
+) -> Result<(Arc<DbCredentialBearer>, OAuthCredential)> {
+    let credential = lookup_oauth_credential(node.as_ref(), agent_did, provider)
+        .await
+        .with_context(|| format!("loading OAuthCredential for agent {agent_did}"))?
+        .ok_or_else(|| {
+            anyhow::anyhow!(classify_oauth_auth_error(
+                &product,
+                agent_did,
+                provider,
+                &OAuthAuthProblem::Missing,
+            ))
+        })?;
+    let credential_id = credential.credential_id.clone();
+    let provider = provider.to_string();
+    let bearer = shared_bearer(&credential_id, || {
+        DbCredentialBearer::with_cache(
+            node,
+            agent_did,
+            provider,
+            credential_id.clone(),
+            true,
+            Some(credential.clone()),
+            refresh_kind,
+            product,
+        )
+    });
+    Ok((bearer, credential))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, Default)]
+    struct TestPolicy;
+
+    impl IdentityHeaders for TestPolicy {
+        const REJECTION_STATUSES: &'static [u16] = &[401, 403];
+    }
+
+    struct CountingBearer {
+        token: String,
+        calls: AtomicUsize,
+        invalidations: AtomicUsize,
+    }
+
+    impl CountingBearer {
+        fn new(token: &str) -> Arc<Self> {
+            Arc::new(Self {
+                token: token.to_string(),
+                calls: AtomicUsize::new(0),
+                invalidations: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    impl BearerSource for CountingBearer {
+        async fn current_bearer(&self) -> Result<String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.token.clone())
+        }
+
+        async fn invalidate(&self) {
+            self.invalidations.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct StatusInjectingClient {
+        status: u16,
+    }
+
+    impl HttpClientExt for StatusInjectingClient {
+        fn send<T, U>(
+            &self,
+            _req: Request<T>,
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        where
+            T: Into<Bytes> + WasmCompatSend,
+            U: From<Bytes> + WasmCompatSend + 'static,
+        {
+            let status = self.status;
+            async move {
+                if status >= 400 {
+                    return Err(http_client::Error::InvalidStatusCodeWithMessage(
+                        status.to_string().parse().expect("valid status"),
+                        "injected".to_string(),
+                    ));
+                }
+                let body: LazyBody<U> = Box::pin(async { Ok(U::from(Bytes::new())) });
+                Response::builder()
+                    .status(status)
+                    .body(body)
+                    .map_err(http_client::Error::Protocol)
+            }
+        }
+
+        fn send_multipart<U>(
+            &self,
+            _req: Request<MultipartForm>,
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        where
+            U: From<Bytes> + WasmCompatSend + 'static,
+        {
+            std::future::ready(Err(http_client::Error::InvalidStatusCode(
+                "501".parse().expect("valid status"),
+            )))
+        }
+
+        fn send_streaming<T>(
+            &self,
+            _req: Request<T>,
+        ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+        where
+            T: Into<Bytes>,
+        {
+            std::future::ready(Err(http_client::Error::InvalidStatusCode(
+                "501".parse().expect("valid status"),
+            )))
+        }
+    }
+
+    fn status_error(status: &str) -> http_client::Error {
+        http_client::Error::InvalidStatusCodeWithMessage(
+            status.parse().expect("valid status"),
+            String::new(),
+        )
+    }
+
+    #[test]
+    fn rejection_statuses_are_provider_scoped() {
+        assert!(is_bearer_rejection(&[401, 403], &status_error("401")));
+        assert!(is_bearer_rejection(&[401, 403], &status_error("403")));
+        assert!(!is_bearer_rejection(&[401], &status_error("403")));
+        assert!(!is_bearer_rejection(&[401, 403], &status_error("500")));
+    }
+
+    #[test]
+    fn event_stream_content_type_is_added_only_when_missing() {
+        let mut missing = HeaderMap::new();
+        ensure_event_stream_content_type(&mut missing);
+        assert_eq!(
+            missing
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+
+        let mut present = HeaderMap::new();
+        present.insert(
+            "content-type",
+            http_client::HeaderValue::from_static("application/json"),
+        );
+        ensure_event_stream_content_type(&mut present);
+        assert_eq!(
+            present
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json"),
+            "backend-supplied content type should not be overwritten"
+        );
+    }
+
+    async fn send_through(status: u16) -> Arc<CountingBearer> {
+        let bearer = CountingBearer::new("tok");
+        let client = BearerAuthHttpClient::<CountingBearer, TestPolicy, _>::with_inner(
+            bearer.clone(),
+            StatusInjectingClient { status },
+        );
+        let req = Request::builder()
+            .method("POST")
+            .uri("https://example.com/v1/models")
+            .body(Bytes::from_static(b"{}"))
+            .unwrap();
+        let _ = HttpClientExt::send::<Bytes, Bytes>(&client, req).await;
+        bearer
+    }
+
+    #[tokio::test]
+    async fn rejection_status_invalidates_the_bearer() {
+        let bearer = send_through(401).await;
+        assert_eq!(
+            bearer.invalidations.load(Ordering::SeqCst),
+            1,
+            "a rejection status from the provider must invalidate the bearer"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_rejection_status_leaves_the_bearer_intact() {
+        let bearer = send_through(200).await;
+        assert_eq!(
+            bearer.invalidations.load(Ordering::SeqCst),
+            0,
+            "a successful response must not invalidate the bearer"
+        );
+    }
+
+    #[tokio::test]
+    async fn injects_fresh_bearer_on_each_request() {
+        let bearer = CountingBearer::new("tok-123");
+        let client = BearerAuthHttpClient::<_, TestPolicy>::new(bearer.clone());
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("https://example.com/v1/responses")
+            .header("authorization", "Bearer STALE")
+            .body(Bytes::from_static(b"{}"))
+            .unwrap();
+
+        let prepared = client.prepare_for_test(req).await.unwrap();
+        let auth = prepared
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        assert_eq!(auth, "Bearer tok-123", "stale bearer was replaced");
+        assert_eq!(
+            bearer.calls.load(Ordering::SeqCst),
+            1,
+            "refreshed once per request"
+        );
+    }
+}

--- a/crates/gents/src/oauth_http.rs
+++ b/crates/gents/src/oauth_http.rs
@@ -8,7 +8,7 @@
 //! provider-specific shaping the request body and response need, and whether
 //! identity headers ride per-request or as client-build defaults.
 //!
-//! [`BearerAuthHttpClient`] is the single wrapper; [`IdentityHeaders`] is the
+//! [`BearerAuthHttpClient`] is the single wrapper; [`OAuthHttpPolicy`] is the
 //! per-provider policy (a small `Default` marker type) that supplies those
 //! differences. `chatgpt_codex` and `xai_grok_oauth` each keep their own
 //! provider-specific body-patch/response-shaping free functions and instantiate
@@ -38,7 +38,7 @@ use crate::oauth_credential::{
 /// "the bearer is dead", plus the request/response shaping hooks each
 /// provider needs. Every method has a passthrough default so a provider only
 /// overrides what it actually differs on.
-pub trait IdentityHeaders: Clone + Default + Send + Sync + 'static {
+pub trait OAuthHttpPolicy: Clone + Default + Send + Sync + 'static {
     /// HTTP status codes on which the current bearer must be invalidated and
     /// refreshed on the next request. Codex: 401 and 403. xAI: 401 only — its
     /// proxy uses 403 as a NotEntitled tier gate that no refresh fixes, and
@@ -95,7 +95,7 @@ fn bearer_rejection_status(error: &http_client::Error) -> Option<u16> {
 
 /// Single owner of "does this HTTP error mean the bearer is dead" for every
 /// OAuth-backed provider. `rejection_statuses` is the provider's
-/// [`IdentityHeaders::REJECTION_STATUSES`].
+/// [`OAuthHttpPolicy::REJECTION_STATUSES`].
 pub fn is_bearer_rejection(rejection_statuses: &[u16], error: &http_client::Error) -> bool {
     bearer_rejection_status(error).is_some_and(|status| rejection_statuses.contains(&status))
 }
@@ -112,15 +112,15 @@ pub fn ensure_event_stream_content_type(headers: &mut HeaderMap) {
 }
 
 /// HTTP client that injects a fresh OAuth bearer on every request, applies a
-/// provider's [`IdentityHeaders`] policy, and invalidates the bearer when the
+/// provider's [`OAuthHttpPolicy`], and invalidates the bearer when the
 /// provider rejects it.
-pub struct BearerAuthHttpClient<S: BearerSource, P: IdentityHeaders, T = ReqwestClient> {
+pub struct BearerAuthHttpClient<S: BearerSource, P: OAuthHttpPolicy, T = ReqwestClient> {
     inner: T,
     bearer: Option<Arc<S>>,
     policy: P,
 }
 
-impl<S: BearerSource, P: IdentityHeaders, T: Clone> Clone for BearerAuthHttpClient<S, P, T> {
+impl<S: BearerSource, P: OAuthHttpPolicy, T: Clone> Clone for BearerAuthHttpClient<S, P, T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -130,7 +130,7 @@ impl<S: BearerSource, P: IdentityHeaders, T: Clone> Clone for BearerAuthHttpClie
     }
 }
 
-impl<S: BearerSource, P: IdentityHeaders, T: fmt::Debug> fmt::Debug
+impl<S: BearerSource, P: OAuthHttpPolicy, T: fmt::Debug> fmt::Debug
     for BearerAuthHttpClient<S, P, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -141,7 +141,7 @@ impl<S: BearerSource, P: IdentityHeaders, T: fmt::Debug> fmt::Debug
     }
 }
 
-impl<S: BearerSource, P: IdentityHeaders, T: Default> Default for BearerAuthHttpClient<S, P, T> {
+impl<S: BearerSource, P: OAuthHttpPolicy, T: Default> Default for BearerAuthHttpClient<S, P, T> {
     fn default() -> Self {
         Self {
             inner: T::default(),
@@ -151,7 +151,7 @@ impl<S: BearerSource, P: IdentityHeaders, T: Default> Default for BearerAuthHttp
     }
 }
 
-impl<S: BearerSource, P: IdentityHeaders> BearerAuthHttpClient<S, P, ReqwestClient> {
+impl<S: BearerSource, P: OAuthHttpPolicy> BearerAuthHttpClient<S, P, ReqwestClient> {
     pub fn new(bearer: Arc<S>) -> Self {
         Self {
             inner: ReqwestClient::default(),
@@ -161,7 +161,7 @@ impl<S: BearerSource, P: IdentityHeaders> BearerAuthHttpClient<S, P, ReqwestClie
     }
 }
 
-impl<S: BearerSource, P: IdentityHeaders, T> BearerAuthHttpClient<S, P, T> {
+impl<S: BearerSource, P: OAuthHttpPolicy, T> BearerAuthHttpClient<S, P, T> {
     pub fn with_inner(bearer: Arc<S>, inner: T) -> Self {
         Self {
             inner,
@@ -213,7 +213,7 @@ impl<S: BearerSource, P: IdentityHeaders, T> BearerAuthHttpClient<S, P, T> {
 impl<S, P, T> HttpClientExt for BearerAuthHttpClient<S, P, T>
 where
     S: BearerSource + 'static,
-    P: IdentityHeaders,
+    P: OAuthHttpPolicy,
     T: Clone + HttpClientExt + fmt::Debug + 'static,
 {
     fn send<A, U>(
@@ -334,7 +334,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct TestPolicy;
 
-    impl IdentityHeaders for TestPolicy {
+    impl OAuthHttpPolicy for TestPolicy {
         const REJECTION_STATUSES: &'static [u16] = &[401, 403];
     }
 

--- a/crates/gents/src/oneshot.rs
+++ b/crates/gents/src/oneshot.rs
@@ -7,7 +7,6 @@ use defra_node::EmbeddedNode;
 use rig::client::CompletionClient;
 use rig::completion::CompletionModel;
 
-use crate::backend_provider::BackendProviderKind;
 use crate::completion_factory::loop_config;
 use crate::config::AgentBehavior;
 use crate::hook::{BackgroundToolRegistry, DefraSessionHook, FailurePolicy};
@@ -57,82 +56,16 @@ pub async fn run_openai_oneshot_with_tools(
         &tool_surface.background_tools().allowlist,
     );
 
-    match behavior.backend_provider_kind {
-        BackendProviderKind::OpenAiCompatible => {
-            let build_context = format!(
-                "building OpenAI-compatible completion client for behavior {} against {}",
-                behavior.behavior_id, behavior.backend_endpoint
-            );
-            if behavior.openai_wire_api == crate::OpenAiWireApi::ChatCompletions {
-                let client: rig::providers::openai::CompletionsClient<
-                    crate::inference_http::SessionTaggingHttpClient<
-                        crate::rendered_request::RenderedRequestCapturingHttpClient,
-                    >,
-                > = crate::inference_http::build_openai_chat_completions_client(
-                    &api_key,
-                    &behavior.backend_endpoint,
-                    crate::inference_http::SessionTaggingHttpClient::new(
-                        crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
-                    ),
-                )
-                .with_context(|| build_context.clone())?;
-                run_oneshot_with_completion_client(
-                    node,
-                    behavior,
-                    prompt,
-                    prompt_builder,
-                    preamble,
-                    tools,
-                    background_tool_registry,
-                    lsp_pool.clone(),
-                    client,
-                )
-                .await
-            } else {
-                let client: rig::providers::openai::Client<
-                    crate::inference_http::SessionTaggingHttpClient<
-                        crate::inference_http::ResponsesNormalizingHttpClient<
-                            crate::rendered_request::RenderedRequestCapturingHttpClient,
-                        >,
-                    >,
-                > = crate::inference_http::build_openai_responses_client(
-                    &api_key,
-                    &behavior.backend_endpoint,
-                    crate::inference_http::SessionTaggingHttpClient::new(
-                        crate::inference_http::ResponsesNormalizingHttpClient::new(
-                            crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
-                        ),
-                    ),
-                    Default::default(),
-                )
-                .with_context(|| build_context.clone())?;
-                run_oneshot_with_completion_client(
-                    node,
-                    behavior,
-                    prompt,
-                    prompt_builder,
-                    preamble,
-                    tools,
-                    background_tool_registry,
-                    lsp_pool.clone(),
-                    client,
-                )
-                .await
-            }
-        }
-        BackendProviderKind::OpenRouter => {
-            let build_context = format!(
-                "building OpenRouter completion client for behavior {} against {}",
-                behavior.behavior_id, behavior.backend_endpoint
-            );
-            let client: rig::providers::openrouter::Client<
-                crate::rendered_request::RenderedRequestCapturingHttpClient,
-            > = rig::providers::openrouter::Client::builder()
-                .api_key(&api_key)
-                .base_url(&behavior.backend_endpoint)
-                .http_client(crate::rendered_request::RenderedRequestCapturingHttpClient::default())
-                .build()
-                .with_context(|| build_context.clone())?;
+    let client = crate::llm::backend_client::build_backend_client(
+        node.clone(),
+        behavior,
+        &api_key,
+        crate::startup_readiness::StartupReadinessOptions::default().build_timeout,
+    )
+    .await?;
+
+    match client {
+        crate::llm::backend_client::BackendClient::OpenAiChatCompletions(client) => {
             run_oneshot_with_completion_client(
                 node,
                 behavior,
@@ -146,19 +79,7 @@ pub async fn run_openai_oneshot_with_tools(
             )
             .await
         }
-        BackendProviderKind::ChatGptCodex => {
-            let client = crate::chatgpt_codex::build_responses_client(
-                node.clone(),
-                behavior.agent_did(),
-                &behavior.backend_endpoint,
-            )
-            .await
-            .with_context(|| {
-                format!(
-                    "building ChatGPT Codex completion client for behavior {} against {}",
-                    behavior.behavior_id, behavior.backend_endpoint
-                )
-            })?;
+        crate::llm::backend_client::BackendClient::OpenAiResponses(client) => {
             run_oneshot_with_completion_client(
                 node,
                 behavior,
@@ -172,52 +93,61 @@ pub async fn run_openai_oneshot_with_tools(
             )
             .await
         }
-        BackendProviderKind::XaiGrokOAuth => {
-            let build_context = format!(
-                "building Grok OAuth completion client for behavior {} against {}",
-                behavior.behavior_id, behavior.backend_endpoint
-            );
-            if behavior.openai_wire_api == crate::OpenAiWireApi::ChatCompletions {
-                let client = crate::xai_grok_oauth::build_chat_completions_client(
-                    node.clone(),
-                    behavior.agent_did(),
-                    &behavior.backend_endpoint,
-                )
-                .await
-                .with_context(|| build_context.clone())?;
-                run_oneshot_with_completion_client(
-                    node,
-                    behavior,
-                    prompt,
-                    prompt_builder,
-                    preamble,
-                    tools,
-                    background_tool_registry,
-                    lsp_pool.clone(),
-                    client,
-                )
-                .await
-            } else {
-                let client = crate::xai_grok_oauth::build_responses_client(
-                    node.clone(),
-                    behavior.agent_did(),
-                    &behavior.backend_endpoint,
-                )
-                .await
-                .with_context(|| build_context.clone())?;
-                run_oneshot_with_completion_client(
-                    node,
-                    behavior,
-                    prompt,
-                    prompt_builder,
-                    preamble,
-                    tools,
-                    background_tool_registry,
-                    lsp_pool.clone(),
-                    client,
-                )
-                .await
-            }
+        crate::llm::backend_client::BackendClient::OpenRouter(client) => {
+            run_oneshot_with_completion_client(
+                node,
+                behavior,
+                prompt,
+                prompt_builder,
+                preamble,
+                tools,
+                background_tool_registry,
+                lsp_pool.clone(),
+                client,
+            )
+            .await
+        }
+        crate::llm::backend_client::BackendClient::ChatGptCodex(client) => {
+            run_oneshot_with_completion_client(
+                node,
+                behavior,
+                prompt,
+                prompt_builder,
+                preamble,
+                tools,
+                background_tool_registry,
+                lsp_pool.clone(),
+                client,
+            )
+            .await
+        }
+        crate::llm::backend_client::BackendClient::XaiGrokChatCompletions(client) => {
+            run_oneshot_with_completion_client(
+                node,
+                behavior,
+                prompt,
+                prompt_builder,
+                preamble,
+                tools,
+                background_tool_registry,
+                lsp_pool.clone(),
+                client,
+            )
+            .await
+        }
+        crate::llm::backend_client::BackendClient::XaiGrokResponses(client) => {
+            run_oneshot_with_completion_client(
+                node,
+                behavior,
+                prompt,
+                prompt_builder,
+                preamble,
+                tools,
+                background_tool_registry,
+                lsp_pool.clone(),
+                client,
+            )
+            .await
         }
     }
 }
@@ -238,6 +168,19 @@ where
     C::CompletionModel: 'static,
     <C::CompletionModel as CompletionModel>::StreamingResponse: 'static,
 {
+    // exemption: one-shot does not wrap `model` in the daemon's
+    // `AdmissionRegistry`. Admission enforces a per-backend concurrency
+    // ceiling (`BackendAdmissionConfig`, built from the backend document's
+    // `max_concurrent`/`max_queue_depth`/`probe_status`) so multiple daemon
+    // slots sharing one backend stay bounded; it requires a registry that has
+    // been `reconcile()`-d with that config, which only the daemon's runtime
+    // reconciler drives. `AgentBehavior` here carries no such fields (by
+    // design — one-shot is a single ad hoc call, not a slot pool with
+    // contention to bound), so plugging in a fresh, never-reconciled registry
+    // would make every completion fail immediately with "BackendGone: backend
+    // admission controller is not active" rather than skip the ceiling.
+    // Pinned by `oneshot_completes_without_backend_admission_reconciliation`
+    // in `tests/misc/oneshot_admission_exemption.rs`.
     let model = client.completion_model(&behavior.model_name);
     let config = loop_config(
         behavior,

--- a/crates/gents/src/oneshot.rs
+++ b/crates/gents/src/oneshot.rs
@@ -64,92 +64,20 @@ pub async fn run_openai_oneshot_with_tools(
     )
     .await?;
 
-    match client {
-        crate::llm::backend_client::BackendClient::OpenAiChatCompletions(client) => {
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                lsp_pool.clone(),
-                client,
-            )
-            .await
-        }
-        crate::llm::backend_client::BackendClient::OpenAiResponses(client) => {
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                lsp_pool.clone(),
-                client,
-            )
-            .await
-        }
-        crate::llm::backend_client::BackendClient::OpenRouter(client) => {
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                lsp_pool.clone(),
-                client,
-            )
-            .await
-        }
-        crate::llm::backend_client::BackendClient::ChatGptCodex(client) => {
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                lsp_pool.clone(),
-                client,
-            )
-            .await
-        }
-        crate::llm::backend_client::BackendClient::XaiGrokChatCompletions(client) => {
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                lsp_pool.clone(),
-                client,
-            )
-            .await
-        }
-        crate::llm::backend_client::BackendClient::XaiGrokResponses(client) => {
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                lsp_pool.clone(),
-                client,
-            )
-            .await
-        }
-    }
+    crate::llm::backend_client::with_backend_client!(client, |client| {
+        run_oneshot_with_completion_client(
+            node,
+            behavior,
+            prompt,
+            prompt_builder,
+            preamble,
+            tools,
+            background_tool_registry,
+            lsp_pool.clone(),
+            client,
+        )
+        .await
+    })
 }
 
 async fn run_oneshot_with_completion_client<C>(

--- a/crates/gents/src/rendered_request/transport.rs
+++ b/crates/gents/src/rendered_request/transport.rs
@@ -7,8 +7,8 @@
 //!
 //! | stack (outermost → innermost) | rewrite below the assembled request |
 //! |---|---|
-//! | `ChatGptCodexHttpClient` → *capture* → reqwest | hoists the first system text into `instructions` and strips system items from `input`, sets `store:false`/`stream:true`, deletes `max_output_tokens`/`temperature`/`top_p`, forces `strict:false` on every tool |
-//! | `XaiGrokOAuthHttpClient` → *capture* → reqwest | injects `store:false` |
+//! | `BearerAuthHttpClient<_, ChatGptCodexPolicy>` (aka `ChatGptCodexHttpClient`) → *capture* → reqwest | hoists the first system text into `instructions` and strips system items from `input`, sets `store:false`/`stream:true`, deletes `max_output_tokens`/`temperature`/`top_p`, forces `strict:false` on every tool |
+//! | `BearerAuthHttpClient<_, XaiGrokOAuthPolicy>` (aka `XaiGrokOAuthHttpClient`) → *capture* → reqwest | injects `store:false` |
 //! | `SessionTaggingHttpClient` → `ResponsesNormalizingHttpClient` → *capture* → reqwest | rewrites prior assistant items into typed, id-bearing, annotated Responses items |
 //! | `SessionTaggingHttpClient` → *capture* → reqwest (Chat Completions), openrouter → *capture* → reqwest | none |
 //!

--- a/crates/gents/src/xai_grok_oauth.rs
+++ b/crates/gents/src/xai_grok_oauth.rs
@@ -99,7 +99,7 @@ pub fn build_xai_grok_oauth_headers() -> Result<HeaderMap> {
     Ok(headers)
 }
 
-/// [`crate::oauth_http::IdentityHeaders`] policy for the Grok/xAI OAuth
+/// [`crate::oauth_http::OAuthHttpPolicy`] policy for the Grok/xAI OAuth
 /// transport: only 401 kills the bearer (403 is the NotEntitled tier gate,
 /// which no refresh fixes — and with rotating refresh tokens a force-refresh
 /// loop would burn a rotation per request), identity headers ride
@@ -109,7 +109,7 @@ pub fn build_xai_grok_oauth_headers() -> Result<HeaderMap> {
 #[derive(Clone, Default)]
 pub struct XaiGrokOAuthPolicy;
 
-impl crate::oauth_http::IdentityHeaders for XaiGrokOAuthPolicy {
+impl crate::oauth_http::OAuthHttpPolicy for XaiGrokOAuthPolicy {
     const REJECTION_STATUSES: &'static [u16] = &[401];
 
     /// Inject the Grok-CLI identity headers the proxy's auth middleware and
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn only_401_invalidates_bearer_403_is_a_tier_gate() {
-        use crate::oauth_http::{is_bearer_rejection, IdentityHeaders as _};
+        use crate::oauth_http::{is_bearer_rejection, OAuthHttpPolicy as _};
         // 401 = expired/revoked grant: refresh may fix it. 403 = NotEntitled
         // tier gate: refresh never fixes it, and with rotating refresh tokens
         // a force-refresh loop would burn a rotation per request.

--- a/crates/gents/src/xai_grok_oauth.rs
+++ b/crates/gents/src/xai_grok_oauth.rs
@@ -1,24 +1,28 @@
 //! Grok / xAI SuperGrok subscription OAuth provider (subscription proxy path).
 
-use std::future::Future;
 use std::sync::Arc;
-use std::{fmt, fmt::Formatter};
 
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use defra_node::EmbeddedNode;
 use futures::StreamExt as _;
 use rig::http_client::{
-    self, HeaderMap, HeaderValue, HttpClientExt, LazyBody, MultipartForm, Request, ReqwestClient,
-    Response, StreamingResponse,
+    self, HeaderMap, HeaderValue, Request, ReqwestClient, Response, StreamingResponse,
 };
+#[cfg(test)]
+use rig::http_client::{HttpClientExt, LazyBody, MultipartForm};
+#[cfg(test)]
 use rig::wasm_compat::WasmCompatSend;
 use serde_json::Value;
 
+#[cfg(test)]
+use crate::oauth_credential::BearerSource;
 use crate::oauth_credential::{
-    classify_oauth_auth_error, lookup_oauth_credential, shared_bearer, BearerSource,
-    DbCredentialBearer, OAuthAuthProblem, OAuthRefreshKind, XAI_OAUTH_PRODUCT,
+    classify_oauth_auth_error, DbCredentialBearer, OAuthAuthProblem, OAuthRefreshKind,
+    XAI_OAUTH_PRODUCT,
 };
+#[cfg(test)]
+use std::future::Future;
 
 pub const XAI_OAUTH_PROVIDER: &str = "xai-oauth";
 
@@ -95,94 +99,24 @@ pub fn build_xai_grok_oauth_headers() -> Result<HeaderMap> {
     Ok(headers)
 }
 
-fn bearer_rejection_status(error: &http_client::Error) -> Option<u16> {
-    match error {
-        http_client::Error::InvalidStatusCode(status)
-        | http_client::Error::InvalidStatusCodeWithMessage(status, _) => Some(status.as_u16()),
-        _ => None,
-    }
-}
+/// [`crate::oauth_http::IdentityHeaders`] policy for the Grok/xAI OAuth
+/// transport: only 401 kills the bearer (403 is the NotEntitled tier gate,
+/// which no refresh fixes — and with rotating refresh tokens a force-refresh
+/// loop would burn a rotation per request), identity headers ride
+/// per-request (the Chat Completions client builder has no default-header
+/// hook, unlike Responses), the `/responses` body needs `store:false`, and a
+/// streaming response needs its `usage` folded from `context_details`.
+#[derive(Clone, Default)]
+pub struct XaiGrokOAuthPolicy;
 
-// 403 is deliberately NOT a bearer rejection here (unlike Codex): the proxy
-// uses it for the NotEntitled tier gate, which no refresh fixes — and with
-// rotating refresh tokens a force-refresh loop would burn a rotation per
-// request.
-fn is_bearer_rejection(error: &http_client::Error) -> bool {
-    matches!(bearer_rejection_status(error), Some(401))
-}
+impl crate::oauth_http::IdentityHeaders for XaiGrokOAuthPolicy {
+    const REJECTION_STATUSES: &'static [u16] = &[401];
 
-/// HTTP client that injects a fresh OAuth bearer and lightly shapes Responses bodies.
-pub struct XaiGrokOAuthHttpClient<S: BearerSource, H = ReqwestClient> {
-    inner: H,
-    bearer: Option<Arc<S>>,
-}
-
-impl<S: BearerSource, H: Clone> Clone for XaiGrokOAuthHttpClient<S, H> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            bearer: self.bearer.clone(),
-        }
-    }
-}
-
-impl<S: BearerSource, H: fmt::Debug> fmt::Debug for XaiGrokOAuthHttpClient<S, H> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.debug_struct("XaiGrokOAuthHttpClient")
-            .field("inner", &self.inner)
-            .field("bearer_configured", &self.bearer.is_some())
-            .finish()
-    }
-}
-
-impl<S: BearerSource, H: Default> Default for XaiGrokOAuthHttpClient<S, H> {
-    fn default() -> Self {
-        Self {
-            inner: H::default(),
-            bearer: None,
-        }
-    }
-}
-
-impl<S: BearerSource> XaiGrokOAuthHttpClient<S, ReqwestClient> {
-    pub fn new(bearer: Arc<S>) -> Self {
-        Self {
-            inner: ReqwestClient::default(),
-            bearer: Some(bearer),
-        }
-    }
-}
-
-impl<S: BearerSource, H> XaiGrokOAuthHttpClient<S, H> {
-    pub fn with_inner(bearer: Arc<S>, inner: H) -> Self {
-        Self {
-            inner,
-            bearer: Some(bearer),
-        }
-    }
-
-    async fn fresh_auth_header(&self) -> http_client::Result<HeaderValue> {
-        let bearer = self.bearer.as_ref().ok_or_else(|| {
-            http_client::Error::Instance(
-                anyhow::anyhow!("XaiGrokOAuthHttpClient used without a configured BearerSource")
-                    .into(),
-            )
-        })?;
-        let token = bearer
-            .current_bearer()
-            .await
-            .map_err(|error| http_client::Error::Instance(error.into()))?;
-        HeaderValue::from_str(&format!("Bearer {token}"))
-            .map_err(|error| http_client::Error::Instance(anyhow::Error::from(error).into()))
-    }
-
-    /// Inject the bearer plus the Grok-CLI identity headers the proxy's auth
-    /// middleware and version gate expect on every request, regardless of wire
-    /// API or body shape. Callers (e.g. the Responses client builder) may
-    /// pre-set identity headers; those are never overwritten.
-    async fn apply_auth_and_identity(&self, headers: &mut HeaderMap) -> http_client::Result<()> {
-        let value = self.fresh_auth_header().await?;
-        headers.insert("authorization", value);
+    /// Inject the Grok-CLI identity headers the proxy's auth middleware and
+    /// version gate expect on every request, regardless of wire API or body
+    /// shape. Callers (e.g. the Responses client builder) may pre-set
+    /// identity headers; those are never overwritten.
+    fn merge_identity_headers(&self, headers: &mut HeaderMap) -> http_client::Result<()> {
         let identity = build_xai_grok_oauth_headers()
             .map_err(|error| http_client::Error::Instance(error.into()))?;
         for (name, header_value) in identity.iter() {
@@ -193,21 +127,7 @@ impl<S: BearerSource, H> XaiGrokOAuthHttpClient<S, H> {
         Ok(())
     }
 
-    async fn prepare(&self, req: Request<Bytes>) -> http_client::Result<Request<Bytes>> {
-        let req = Self::patch_responses_body(req);
-        let (mut parts, body) = req.into_parts();
-        self.apply_auth_and_identity(&mut parts.headers).await?;
-        Ok(Request::from_parts(parts, body))
-    }
-
-    fn bearer_to_invalidate<X>(&self, result: &http_client::Result<X>) -> Option<Arc<S>> {
-        match result {
-            Err(error) if is_bearer_rejection(error) => self.bearer.clone(),
-            _ => None,
-        }
-    }
-
-    fn patch_responses_body(req: Request<Bytes>) -> Request<Bytes> {
+    fn patch_request_body(&self, req: Request<Bytes>) -> Request<Bytes> {
         let (parts, body) = req.into_parts();
         let mut body = body;
         if parts.uri.path().ends_with("/responses") {
@@ -218,97 +138,16 @@ impl<S: BearerSource, H> XaiGrokOAuthHttpClient<S, H> {
         Request::from_parts(parts, body)
     }
 
-    #[cfg(test)]
-    pub async fn prepare_for_test(
-        &self,
-        req: Request<Bytes>,
-    ) -> http_client::Result<Request<Bytes>> {
-        self.prepare(req).await
+    fn patch_streaming(&self, response: StreamingResponse) -> StreamingResponse {
+        normalize_xai_usage_stream(response)
     }
 }
 
-impl<S, H> HttpClientExt for XaiGrokOAuthHttpClient<S, H>
-where
-    S: BearerSource + 'static,
-    H: Clone + HttpClientExt + fmt::Debug + 'static,
-{
-    fn send<T, U>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        T: Into<Bytes> + WasmCompatSend,
-        U: From<Bytes>,
-        U: WasmCompatSend + 'static,
-    {
-        let inner = self.inner.clone();
-        let this = self.clone();
-        let (parts, body) = req.into_parts();
-        let req = Request::from_parts(parts, body.into());
-        async move {
-            let req = this.prepare(req).await?;
-            let result = HttpClientExt::send::<Bytes, U>(&inner, req).await;
-            if let Some(bearer) = this.bearer_to_invalidate(&result) {
-                bearer.invalidate().await;
-            }
-            result
-        }
-    }
-
-    fn send_multipart<U>(
-        &self,
-        req: Request<MultipartForm>,
-    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        U: From<Bytes>,
-        U: WasmCompatSend + 'static,
-    {
-        let inner = self.inner.clone();
-        let this = self.clone();
-        async move {
-            let (mut parts, body) = req.into_parts();
-            this.apply_auth_and_identity(&mut parts.headers).await?;
-            let req = Request::from_parts(parts, body);
-            let result = HttpClientExt::send_multipart(&inner, req).await;
-            if let Some(bearer) = this.bearer_to_invalidate(&result) {
-                bearer.invalidate().await;
-            }
-            result
-        }
-    }
-
-    fn send_streaming<T>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
-    where
-        T: Into<Bytes>,
-    {
-        let inner = self.inner.clone();
-        let this = self.clone();
-        let (parts, body) = req.into_parts();
-        let req = Request::from_parts(parts, body.into());
-        async move {
-            let req = this.prepare(req).await?;
-            let result = HttpClientExt::send_streaming(&inner, req).await;
-            if let Some(bearer) = this.bearer_to_invalidate(&result) {
-                bearer.invalidate().await;
-            }
-            let mut response = result?;
-            ensure_event_stream_content_type(response.headers_mut());
-            Ok(normalize_xai_usage_stream(response))
-        }
-    }
-}
-
-fn ensure_event_stream_content_type(headers: &mut HeaderMap) {
-    if !headers.contains_key("content-type") {
-        headers.insert(
-            "content-type",
-            HeaderValue::from_static("text/event-stream"),
-        );
-    }
-}
+/// Grok's OAuth transport: bearer auth, per-request identity headers,
+/// `store:false` shaping, and streaming usage normalization, layered over
+/// `crate::oauth_http`'s shared bearer-auth wrapper.
+pub type XaiGrokOAuthHttpClient<S, H = ReqwestClient> =
+    crate::oauth_http::BearerAuthHttpClient<S, XaiGrokOAuthPolicy, H>;
 
 fn normalize_xai_usage_stream(response: StreamingResponse) -> StreamingResponse {
     let (parts, mut body) = response.into_parts();
@@ -465,29 +304,14 @@ async fn build_authenticated_http(
     agent_did: &str,
 ) -> Result<CapturingXaiGrokOAuthHttpClient> {
     let provider = XAI_OAUTH_PROVIDER;
-    let credential = lookup_oauth_credential(node.as_ref(), agent_did, provider)
-        .await
-        .with_context(|| format!("loading OAuthCredential for agent {agent_did}"))?
-        .ok_or_else(|| {
-            anyhow::anyhow!(classify_xai_auth_error(
-                agent_did,
-                provider,
-                &OAuthAuthProblem::Missing,
-            ))
-        })?;
-    let credential_id = credential.credential_id.clone();
-    let bearer = shared_bearer(&credential_id, || {
-        DbCredentialBearer::with_cache(
-            node,
-            agent_did,
-            provider,
-            credential_id.clone(),
-            true,
-            Some(credential.clone()),
-            OAuthRefreshKind::Xai,
-            XAI_OAUTH_PRODUCT,
-        )
-    });
+    let (bearer, _credential) = crate::oauth_http::bootstrap_oauth_client(
+        node,
+        agent_did,
+        provider,
+        OAuthRefreshKind::Xai,
+        XAI_OAUTH_PRODUCT,
+    )
+    .await?;
     Ok(XaiGrokOAuthHttpClient::with_inner(
         bearer,
         crate::rendered_request::RenderedRequestCapturingHttpClient::default(),
@@ -613,14 +437,16 @@ mod tests {
 
     #[test]
     fn only_401_invalidates_bearer_403_is_a_tier_gate() {
+        use crate::oauth_http::{is_bearer_rejection, IdentityHeaders as _};
         // 401 = expired/revoked grant: refresh may fix it. 403 = NotEntitled
         // tier gate: refresh never fixes it, and with rotating refresh tokens
         // a force-refresh loop would burn a rotation per request.
+        let statuses = XaiGrokOAuthPolicy::REJECTION_STATUSES;
         let unauthorized =
             http_client::Error::InvalidStatusCode("401".parse().expect("valid status"));
         let forbidden = http_client::Error::InvalidStatusCode("403".parse().expect("valid status"));
-        assert!(is_bearer_rejection(&unauthorized));
-        assert!(!is_bearer_rejection(&forbidden));
+        assert!(is_bearer_rejection(statuses, &unauthorized));
+        assert!(!is_bearer_rejection(statuses, &forbidden));
     }
 
     #[test]

--- a/crates/gents/src/xai_oauth_login.rs
+++ b/crates/gents/src/xai_oauth_login.rs
@@ -253,15 +253,11 @@ pub fn credential_from_login_tokens(
 ) -> OAuthCredential {
     let agent_did = agent_did.into();
     let provider = provider.into();
-    let access_token_expires_at =
-        crate::chatgpt_oauth_refresh::jwt_expiration(&tokens.access_token)
-            .or_else(|| {
-                tokens
-                    .expires_in
-                    .filter(|seconds| *seconds > 0)
-                    .map(|seconds| now + chrono::Duration::seconds(seconds))
-            })
-            .unwrap_or_else(|| now + chrono::Duration::minutes(15));
+    let access_token_expires_at = crate::oauth_credential::resolve_access_token_expiry(
+        &tokens.access_token,
+        tokens.expires_in,
+        now,
+    );
 
     OAuthCredential {
         doc_id: None,

--- a/crates/gents/src/xai_oauth_refresh.rs
+++ b/crates/gents/src/xai_oauth_refresh.rs
@@ -1,6 +1,6 @@
 //! xAI OAuth refresh against `auth.x.ai` (public Grok CLI client).
 
-use chrono::{Duration, Utc};
+use chrono::Utc;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -82,14 +82,11 @@ pub async fn refresh_xai_token(
         )
     })?;
 
-    let access_token_expires_at = crate::chatgpt_oauth_refresh::jwt_expiration(&access_token)
-        .or_else(|| {
-            refreshed
-                .expires_in
-                .filter(|seconds| *seconds > 0)
-                .map(|seconds| Utc::now() + Duration::seconds(seconds))
-        })
-        .unwrap_or_else(|| Utc::now() + Duration::minutes(15));
+    let access_token_expires_at = crate::oauth_credential::resolve_access_token_expiry(
+        &access_token,
+        refreshed.expires_in,
+        Utc::now(),
+    );
 
     Ok(RefreshedTokens {
         access_token,

--- a/crates/gents/tests/misc.rs
+++ b/crates/gents/tests/misc.rs
@@ -24,5 +24,7 @@ mod goal_controller;
 mod legacy_authority_absence;
 #[path = "misc/log_rate_filter.rs"]
 mod log_rate_filter;
+#[path = "misc/oneshot_admission_exemption.rs"]
+mod oneshot_admission_exemption;
 #[path = "misc/startup_readiness_barrier.rs"]
 mod startup_readiness_barrier;

--- a/crates/gents/tests/misc/oneshot_admission_exemption.rs
+++ b/crates/gents/tests/misc/oneshot_admission_exemption.rs
@@ -1,0 +1,45 @@
+//! Pins the `// exemption:` decision in `gents::oneshot`: one-shot completion
+//! calls do not route through the daemon's `AdmissionRegistry`.
+//!
+//! Admission enforces a per-backend concurrency ceiling built from the
+//! backend document's `max_concurrent`/`max_queue_depth`/`probe_status`
+//! (`BackendAdmissionConfig`) and requires a registry that has been
+//! `reconcile()`-d with that config — only the daemon's runtime reconciler
+//! ever drives that. If a future change plugged one-shot's model into an
+//! `AdmissionRegistry` without also reconciling it, every completion call
+//! would fail immediately with "BackendGone: backend admission controller is
+//! not active" instead of running — which is exactly what this test would
+//! catch: it runs a real one-shot call against a mock backend with nothing in
+//! the process ever calling `AdmissionRegistry::reconcile`, and asserts it
+//! still succeeds.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use gents::defra_node::EmbeddedNode;
+use gents::{ensure_runtime_schemas, run_openai_oneshot};
+
+use crate::support::fixtures::test_behavior;
+use crate::support::mock_endpoint::MockModelEndpoint;
+
+#[tokio::test]
+async fn oneshot_completes_without_backend_admission_reconciliation() -> Result<()> {
+    let node = Arc::new(EmbeddedNode::builder().build().await?);
+    ensure_runtime_schemas(node.as_ref()).await?;
+
+    let mock_endpoint = MockModelEndpoint::start("default")?;
+    let mut behavior = test_behavior(
+        "oneshot-admission-exemption",
+        "backend-oneshot-exempt",
+        None,
+    );
+    behavior.backend_endpoint = mock_endpoint.endpoint().to_string();
+
+    let result = run_openai_oneshot(node, &behavior, "ping").await?;
+
+    assert!(
+        !result.response_text.trim().is_empty(),
+        "one-shot must complete without any AdmissionRegistry ever being reconciled for this backend"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Closes #1338. Stacked on #1360 (base branch `so/1331-config-validators`).

## What changed

Backend client construction, credential resolution, and OAuth bearer handling each have one owner.

- One `build_backend_client` owns the provider/wire-API construction match shared by daemon and one-shot. One `with_backend_client!` dispatch owns the unavoidable concrete-client fan-out. OAuth construction now has the same timeout in one-shot; its admission bypass remains an explicit, tested exemption.
- One `InferenceBackend::backend_fields` mapping feeds both behavior assembly paths. One API-key resolver preserves raw-key precedence and makes a configured but missing/blank environment variable a contextual hard error. Startup and periodic probers no longer silently attempt unauthenticated calls.
- One `BearerAuthHttpClient` plus an accurately named `OAuthHttpPolicy` owns fresh bearer injection, provider-specific rejection statuses, request/response shaping, and streaming content-type normalization. Codex retains 401/403 invalidation; xAI retains 401-only invalidation. OAuth credential bootstrap and xAI access-token expiry fallback each have one owner.

## Behavior

Existing provider behavior is preserved except for the intentional credential-resolution correction above. One-shot remains outside daemon admission because it has no reconciled backend admission controller; the exemption is documented and pinned by an integration test.

## Net code

Production code is net deleting (about 50 lines when in-file test modules are excluded), while adding direct table coverage for every provider/wire-API client variant.

## Verification

After rebasing onto #1360:

- `cargo test -p gents --lib llm::backend_client::`
- `cargo test -p gents --lib oauth_http::tests::`
- `cargo test -p gents --lib config::tests::`
- `cargo test -p gents --lib backend_registry::`
- `cargo test -p gents --lib chatgpt_codex::tests::`
- `cargo test -p gents --lib xai_grok_oauth::tests::`
- `cargo test -p gents --lib oauth_credential::tests::`
- `cargo test -p gents --lib xai_oauth_login::tests::`
- `cargo test -p gents --test misc oneshot_completes_without_backend_admission_reconciliation`
- `cargo check -p gents --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check so/1331-config-validators...HEAD`

The workspace-wide `clippy -D warnings` gate remains red on the pre-existing main-branch lint backlog; this PR does not broaden or suppress that backlog.