### PR TITLE
Small single-owner consolidations (#1339)

### DIFF
--- a/.github/scripts/compile-rust-ci-suite.sh
+++ b/.github/scripts/compile-rust-ci-suite.sh
@@ -67,12 +67,12 @@ if [[ "${mode}" != "build" ]]; then
   exit 2
 fi
 
-# The support shard deliberately reuses a non-incremental target directory
-# across checkouts. Cargo's mtime fast path can otherwise accept a stale local
-# crate when a checkout adds a new module, as happened when gents-protocol
-# became the ChatGPT OAuth vocabulary owner. Preserve downloaded dependencies
-# and sccache entries, but always rebuild workspace members in this shard.
-if [[ "${CARGO_INCREMENTAL:-}" == "0" ]]; then
+# The support shard deliberately reuses a target directory across checkouts.
+# Cargo's mtime fast path can otherwise accept a stale local crate when a
+# checkout adds a new module, as happened when gents-protocol became the
+# ChatGPT OAuth vocabulary owner. Preserve dependency artifacts, but always
+# rebuild workspace members in this shard with its direct rustc wrapper.
+if [[ "${suite}" == "support" ]]; then
   cargo clean --workspace
 fi
 

--- a/.github/scripts/compile-rust-ci-suite.sh
+++ b/.github/scripts/compile-rust-ci-suite.sh
@@ -67,6 +67,15 @@ if [[ "${mode}" != "build" ]]; then
   exit 2
 fi
 
+# The support shard deliberately reuses a non-incremental target directory
+# across checkouts. Cargo's mtime fast path can otherwise accept a stale local
+# crate when a checkout adds a new module, as happened when gents-protocol
+# became the ChatGPT OAuth vocabulary owner. Preserve downloaded dependencies
+# and sccache entries, but always rebuild workspace members in this shard.
+if [[ "${CARGO_INCREMENTAL:-}" == "0" ]]; then
+  cargo clean --workspace
+fi
+
 cargo_args=()
 for package in "${packages[@]}"; do
   cargo_args+=(-p "${package}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,14 @@ jobs:
       github.event.pull_request.stack.position == github.event.pull_request.stack.size
     needs: rename-guard
     runs-on:
-      [self-hosted, macOS, ARM64, studio, "${{ matrix.host }}", "${{ matrix.slot }}"]
+      [
+        self-hosted,
+        macOS,
+        ARM64,
+        studio,
+        "${{ matrix.host }}",
+        "${{ matrix.slot }}",
+      ]
     strategy:
       fail-fast: false
       matrix:
@@ -120,8 +127,12 @@ jobs:
           - suite: support
             host: studio-1
             slot: ci-support
-            cargo_incremental: "0"
-            rustc_wrapper: sccache
+            cargo_incremental: "1"
+            # Shared sccache can return a stale module graph when a checkout
+            # adds a Rust module. The persistent target still keeps external
+            # dependencies warm after the support script cleans workspace
+            # members, so compile local crates directly for correctness.
+            rustc_wrapper: .github/scripts/rustc-direct.sh
           - suite: desktop
             host: studio-2
             slot: ci-desktop
@@ -338,8 +349,7 @@ jobs:
       github.event.pull_request.stack.position == github.event.pull_request.stack.size
     # Reuse the warm proof cache on studio-1's light support slot. This keeps
     # the runtime slot free once rename-guard releases the Rust matrix.
-    runs-on:
-      [self-hosted, macOS, ARM64, studio, studio-1, ci-support]
+    runs-on: [self-hosted, macOS, ARM64, studio, studio-1, ci-support]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,7 +3750,6 @@ dependencies = [
  "events",
  "futures",
  "gents-callback-fixture-create-workspace",
- "gents-chatgpt-login",
  "gents-fs-runner",
  "gents-lean-contract",
  "gents-migration",
@@ -3806,6 +3805,7 @@ name = "gents-chatgpt-login"
 version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
+ "gents-protocol",
  "rand 0.9.2",
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
  "events",
  "futures",
  "gents-callback-fixture-create-workspace",
+ "gents-chatgpt-login",
  "gents-fs-runner",
  "gents-lean-contract",
  "gents-migration",

--- a/apps/gents-desktop/src/hooks/desktopProjectionController.ts
+++ b/apps/gents-desktop/src/hooks/desktopProjectionController.ts
@@ -1,5 +1,7 @@
-import { isTerminalTurnState } from "@source-inc/gents-desktop-chat";
-import type { DesktopSessionSnapshot } from "@source-inc/gents-desktop-client";
+import {
+  isTerminalTurnState,
+  type DesktopSessionSnapshot,
+} from "@source-inc/gents-desktop-client";
 
 import type { DesktopUpdateRefreshScope } from "./desktopShellRuntime";
 

--- a/apps/gents-desktop/src/hooks/useDesktopChatProjectionState.ts
+++ b/apps/gents-desktop/src/hooks/useDesktopChatProjectionState.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type SetStateAction } from "react";
 
 import {
-  isTerminalTurnState,
   projectChatShell,
   reconcileProjectedWorkflow,
   type ChatWorkflowState,
@@ -14,6 +13,7 @@ import type {
   SyncHealthView,
 } from "@source-inc/gents-desktop-client";
 import {
+  isTerminalTurnState,
   projectDeploymentOperationalState,
   selectedBehaviorReadinessDecision,
 } from "@source-inc/gents-desktop-client";

--- a/apps/gents-desktop/tests/fleet-dashboard.test.tsx
+++ b/apps/gents-desktop/tests/fleet-dashboard.test.tsx
@@ -446,7 +446,22 @@ describe("FleetHostDashboard per-deployment inference status", () => {
   });
 
   it("places setup status on the affected deployment and opens its wizard", () => {
-    renderFleet([{ ...deployment, inferenceBackends: [] }]);
+    const missingInference: DeploymentView = {
+      ...deployment,
+      inferenceBackends: [],
+      behaviorReadiness: {
+        ...deployment.behaviorReadiness,
+        behaviors: [
+          {
+            state: "unavailable",
+            behaviorId: "default",
+            reason: "backend_not_configured",
+          },
+          { state: "ready", behaviorId: "ops" },
+        ],
+      },
+    };
+    renderFleet([missingInference]);
     expect(screen.queryByText("Finish setting up")).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId("fleet-inference-setup-peer-1"));
     expect(screen.getByTestId("inference-wizard")).toBeInTheDocument();

--- a/apps/gents-desktop/tests/fleet-row.test.tsx
+++ b/apps/gents-desktop/tests/fleet-row.test.tsx
@@ -133,9 +133,24 @@ describe("FleetRow", () => {
 
   it("does not infer missing backend setup from redacted enrolled-agent config", () => {
     const onSetupInference = vi.fn();
+    const hostManagedMissingCredentials: DeploymentView = {
+      ...deployment,
+      source: "enrollment",
+      inferenceBackends: [],
+      behaviorReadiness: {
+        ...deployment.behaviorReadiness,
+        behaviors: [
+          {
+            state: "unavailable",
+            behaviorId: "default",
+            reason: "credentials_required",
+          },
+        ],
+      },
+    };
     renderRow(
       { onSetupInference },
-      { ...deployment, source: "enrollment", inferenceBackends: [] },
+      hostManagedMissingCredentials,
     );
 
     expect(

--- a/apps/gents-desktop/tests/fleet-row.test.tsx
+++ b/apps/gents-desktop/tests/fleet-row.test.tsx
@@ -148,10 +148,7 @@ describe("FleetRow", () => {
         ],
       },
     };
-    renderRow(
-      { onSetupInference },
-      hostManagedMissingCredentials,
-    );
+    renderRow({ onSetupInference }, hostManagedMissingCredentials);
 
     expect(
       screen.queryByTestId("fleet-inference-setup-peer-1"),

--- a/apps/gents-desktop/tests/fleet-row.test.tsx
+++ b/apps/gents-desktop/tests/fleet-row.test.tsx
@@ -110,7 +110,21 @@ describe("FleetRow", () => {
 
   it("shows inference setup status only on the affected deployment row", () => {
     const onSetupInference = vi.fn();
-    const missingInference = { ...deployment, inferenceBackends: [] };
+    const missingInference: DeploymentView = {
+      ...deployment,
+      inferenceBackends: [],
+      behaviorReadiness: {
+        ...deployment.behaviorReadiness,
+        behaviors: [
+          {
+            state: "unavailable",
+            behaviorId: "default",
+            reason: "backend_not_configured",
+          },
+          { state: "ready", behaviorId: "ops" },
+        ],
+      },
+    };
     renderRow({ onSetupInference }, missingInference);
 
     fireEvent.click(screen.getByTestId("fleet-inference-setup-peer-1"));

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -281,7 +281,7 @@
       "permissionSet": "native-e2e"
     }
   ],
-  "contractVersion": "6.2",
+  "contractVersion": "6.3",
   "errorCodes": [
     "clientNotRunning",
     "clientStartFailed",
@@ -416,5 +416,5 @@
       "name": "full"
     }
   ],
-  "wireSchemaHash": "df5cd8234a352627975cc23f8b8f258d7d0675a4c544d4a8f8b02b930f35010e"
+  "wireSchemaHash": "56091dd558796e1dd812bb794a134de193fee7706e81aa33082f53142232f47e"
 }

--- a/crates/gents-chatgpt-login/Cargo.toml
+++ b/crates/gents-chatgpt-login/Cargo.toml
@@ -8,6 +8,7 @@ description = "Minimal ChatGPT OAuth login flows for Gents"
 
 [dependencies]
 base64.workspace = true
+gents-protocol.workspace = true
 rand.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/crates/gents-chatgpt-login/src/lib.rs
+++ b/crates/gents-chatgpt-login/src/lib.rs
@@ -12,6 +12,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
+pub use gents_protocol::chatgpt_oauth::{
+    CLIENT_ID, DEFAULT_ISSUER, REFRESH_TOKEN_URL, REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
+};
 use rand::RngCore;
 use reqwest::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -19,18 +22,6 @@ use sha2::{Digest, Sha256};
 use tiny_http::{Header, Response, Server, StatusCode as TinyStatusCode};
 use tokio::sync::{mpsc, Notify};
 use url::Url;
-
-pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
-pub const DEFAULT_ISSUER: &str = "https://auth.openai.com";
-pub const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
-/// The refresh-token endpoint under [`DEFAULT_ISSUER`]. Kept as its own
-/// constant (rather than formatted at each call site) for callers — like
-/// `gents::chatgpt_oauth_refresh` — that only ever refresh against the
-/// default issuer; `refresh_tokens` in this crate still formats
-/// `{issuer}/oauth/token` directly since it supports a caller-supplied
-/// issuer. `refresh_token_url_matches_default_issuer` guards the two
-/// against drift.
-pub const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 
 const DEFAULT_PORT: u16 = 1455;
 const FALLBACK_PORT: u16 = 1457;
@@ -614,11 +605,6 @@ pub async fn complete_device_code_login(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn refresh_token_url_matches_default_issuer() {
-        assert_eq!(REFRESH_TOKEN_URL, format!("{DEFAULT_ISSUER}/oauth/token"));
-    }
 
     #[test]
     fn authorize_url_preserves_the_codex_compatible_contract() {

--- a/crates/gents-chatgpt-login/src/lib.rs
+++ b/crates/gents-chatgpt-login/src/lib.rs
@@ -23,6 +23,14 @@ use url::Url;
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 pub const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+/// The refresh-token endpoint under [`DEFAULT_ISSUER`]. Kept as its own
+/// constant (rather than formatted at each call site) for callers — like
+/// `gents::chatgpt_oauth_refresh` — that only ever refresh against the
+/// default issuer; `refresh_tokens` in this crate still formats
+/// `{issuer}/oauth/token` directly since it supports a caller-supplied
+/// issuer. `refresh_token_url_matches_default_issuer` guards the two
+/// against drift.
+pub const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 
 const DEFAULT_PORT: u16 = 1455;
 const FALLBACK_PORT: u16 = 1457;
@@ -606,6 +614,11 @@ pub async fn complete_device_code_login(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn refresh_token_url_matches_default_issuer() {
+        assert_eq!(REFRESH_TOKEN_URL, format!("{DEFAULT_ISSUER}/oauth/token"));
+    }
 
     #[test]
     fn authorize_url_preserves_the_codex_compatible_contract() {

--- a/crates/gents-chatgpt-login/src/lib.rs
+++ b/crates/gents-chatgpt-login/src/lib.rs
@@ -12,9 +12,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
-pub use gents_protocol::chatgpt_oauth::{
-    CLIENT_ID, DEFAULT_ISSUER, REFRESH_TOKEN_URL, REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
-};
+use gents_protocol::chatgpt_oauth::{token_endpoint, CLIENT_ID, DEFAULT_ISSUER};
 use rand::RngCore;
 use reqwest::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -354,7 +352,7 @@ async fn exchange_code_for_tokens(
     pkce: &PkceCodes,
     code: &str,
 ) -> io::Result<LoginTokens> {
-    let endpoint = format!("{}/oauth/token", options.issuer.trim_end_matches('/'));
+    let endpoint = token_endpoint(&options.issuer);
     let response = build_http_client()?
         .post(endpoint)
         .form(&[

--- a/crates/gents-cli/src/commands/codex_login.rs
+++ b/crates/gents-cli/src/commands/codex_login.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use gents_chatgpt_login::{
-    complete_device_code_login, request_device_code, run_login_server, LoginOptions, CLIENT_ID,
+    complete_device_code_login, request_device_code, run_login_server, LoginOptions,
 };
+use gents_protocol::chatgpt_oauth::CLIENT_ID;
 use serde_json::{json, Value};
 
 use crate::cli::args::CodexLoginArgs;

--- a/crates/gents-cli/src/config_import.rs
+++ b/crates/gents-cli/src/config_import.rs
@@ -28,7 +28,7 @@ const CONFIG_APPLY_ORDER: [Collection; 14] = gents::DESIRED_STATE_APPLY_ORDER;
 /// Reverses a fixed-size `Collection` array at compile time. Pulled out so
 /// `CONFIG_PRUNE_ORDER` derives from `CONFIG_APPLY_ORDER` instead of
 /// maintaining its own hand-reversed literal.
-const fn reversed(order: [Collection; 14]) -> [Collection; 14] {
+const fn reversed<const N: usize>(order: [Collection; N]) -> [Collection; N] {
     let mut reversed = order;
     let mut i = 0;
     while i < reversed.len() / 2 {
@@ -44,7 +44,7 @@ const fn reversed(order: [Collection; 14]) -> [Collection; 14] {
 /// Delete order must undo create order: children before the parents they
 /// reference. Derived from `CONFIG_APPLY_ORDER` reversed rather than a
 /// second hand-maintained literal (#1339).
-const CONFIG_PRUNE_ORDER: [Collection; 14] = reversed(CONFIG_APPLY_ORDER);
+const CONFIG_PRUNE_ORDER: [Collection; CONFIG_APPLY_ORDER.len()] = reversed(CONFIG_APPLY_ORDER);
 
 #[cfg(test)]
 pub(crate) const CONFIG_APPLY_ORDER_FOR_TESTS: &[Collection] = &CONFIG_APPLY_ORDER;

--- a/crates/gents-cli/src/config_import.rs
+++ b/crates/gents-cli/src/config_import.rs
@@ -25,22 +25,26 @@ const CONFIG_IMPORT_BATCH_SIZE: usize = 50;
 
 const CONFIG_APPLY_ORDER: [Collection; 14] = gents::DESIRED_STATE_APPLY_ORDER;
 
-const CONFIG_PRUNE_ORDER: [Collection; 14] = [
-    Collection::AgentPrincipal,
-    Collection::EventTrigger,
-    Collection::Schedule,
-    Collection::Task,
-    Collection::ProjectionAcpBinding,
-    Collection::AgentBehavior,
-    Collection::Skill,
-    Collection::ToolSelection,
-    Collection::EthTool,
-    Collection::ChainKeyBinding,
-    Collection::DatastoreToolSurface,
-    Collection::ToolServiceRegistry,
-    Collection::InferenceProfile,
-    Collection::InferenceBackend,
-];
+/// Reverses a fixed-size `Collection` array at compile time. Pulled out so
+/// `CONFIG_PRUNE_ORDER` derives from `CONFIG_APPLY_ORDER` instead of
+/// maintaining its own hand-reversed literal.
+const fn reversed(order: [Collection; 14]) -> [Collection; 14] {
+    let mut reversed = order;
+    let mut i = 0;
+    while i < reversed.len() / 2 {
+        let j = reversed.len() - 1 - i;
+        let tmp = reversed[i];
+        reversed[i] = reversed[j];
+        reversed[j] = tmp;
+        i += 1;
+    }
+    reversed
+}
+
+/// Delete order must undo create order: children before the parents they
+/// reference. Derived from `CONFIG_APPLY_ORDER` reversed rather than a
+/// second hand-maintained literal (#1339).
+const CONFIG_PRUNE_ORDER: [Collection; 14] = reversed(CONFIG_APPLY_ORDER);
 
 #[cfg(test)]
 pub(crate) const CONFIG_APPLY_ORDER_FOR_TESTS: &[Collection] = &CONFIG_APPLY_ORDER;

--- a/crates/gents-desktop-bridge/src/commands/chat.rs
+++ b/crates/gents-desktop-bridge/src/commands/chat.rs
@@ -2,7 +2,9 @@ use anyhow::{bail, Result};
 use gents_desktop_core::client::{ClientCore, SubmitRequestOptions};
 use uuid::Uuid;
 
-use super::super::types::{ChatSendRequest, ChatSendResult, ConversationRenameRequest};
+use super::super::types::{
+    turn_state_label, ChatSendRequest, ChatSendResult, ConversationRenameRequest,
+};
 
 pub async fn send_chat_message(
     core: &ClientCore,
@@ -37,7 +39,10 @@ pub async fn send_chat_message(
     let store = core.store().snapshot();
     if let Some(turn_state) = store.derive_turn_for_agent(&session_id, &agent_did) {
         if !turn_state.is_terminal() {
-            bail!("cannot send while current turn is {turn_state:?}");
+            bail!(
+                "cannot send while current turn is {}",
+                turn_state_label(turn_state)
+            );
         }
     }
 

--- a/crates/gents-desktop-bridge/src/commands/chat.rs
+++ b/crates/gents-desktop-bridge/src/commands/chat.rs
@@ -1,30 +1,8 @@
 use anyhow::{bail, Result};
 use gents_desktop_core::client::{ClientCore, SubmitRequestOptions};
-use gents_protocol::client_protocol::ClientTurnState;
 use uuid::Uuid;
 
 use super::super::types::{ChatSendRequest, ChatSendResult, ConversationRenameRequest};
-
-fn can_send_in_turn(state: ClientTurnState) -> bool {
-    matches!(
-        state,
-        ClientTurnState::Completed
-            | ClientTurnState::Failed
-            | ClientTurnState::Superseded
-            | ClientTurnState::Interrupted
-    )
-}
-
-fn turn_state_label(state: ClientTurnState) -> &'static str {
-    match state {
-        ClientTurnState::WaitingForClaim => "waitingForClaim",
-        ClientTurnState::Streaming => "streaming",
-        ClientTurnState::Completed => "completed",
-        ClientTurnState::Failed => "failed",
-        ClientTurnState::Superseded => "superseded",
-        ClientTurnState::Interrupted => "interrupted",
-    }
-}
 
 pub async fn send_chat_message(
     core: &ClientCore,
@@ -58,11 +36,8 @@ pub async fn send_chat_message(
 
     let store = core.store().snapshot();
     if let Some(turn_state) = store.derive_turn_for_agent(&session_id, &agent_did) {
-        if !can_send_in_turn(turn_state) {
-            bail!(
-                "cannot send while current turn is {}",
-                turn_state_label(turn_state)
-            );
+        if !turn_state.is_terminal() {
+            bail!("cannot send while current turn is {turn_state:?}");
         }
     }
 

--- a/crates/gents-desktop-bridge/src/contract.rs
+++ b/crates/gents-desktop-bridge/src/contract.rs
@@ -7,6 +7,9 @@ use ts_rs::TS;
 use crate::error::BridgeErrorCode;
 
 /// Exact `MAJOR.MINOR` contract version. The client accepts no version range.
+// 6.3: additive — BridgeError.endpoint carries the unreachable endpoint as a
+//      structured field for EndpointUnreachable errors, so callers stop
+//      regexing it back out of `message` (#1339).
 // 6.2: additive — MCPServiceHealthView.displayState is the projected
 //      three-state MCP health classification (ToolServiceHealthState::project);
 //      the desktop no longer re-derives a synthetic "stuck" state from status.
@@ -48,13 +51,13 @@ use crate::error::BridgeErrorCode;
 // grantable [[set]] entries + default (core/client-lifecycle).
 // 0.3: BridgeError on command Err paths; SnapshotGrants projection; native-e2e.
 // 0.2: desktop_bridge_contract, desktop_peer_probe_address; peer_status by id.
-pub const CONTRACT_VERSION: &str = "6.2";
+pub const CONTRACT_VERSION: &str = "6.3";
 
 /// Exact digest of the committed generated TypeScript wire tree. The client
 /// checks this in addition to semantic versioning, so a DTO shape change
 /// cannot silently ship under an unchanged contract version.
 pub const WIRE_SCHEMA_HASH: &str =
-    "df5cd8234a352627975cc23f8b8f258d7d0675a4c544d4a8f8b02b930f35010e";
+    "56091dd558796e1dd812bb794a134de193fee7706e81aa33082f53142232f47e";
 
 /// Package version string shared with workspace release train.
 pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/gents-desktop-bridge/src/error.rs
+++ b/crates/gents-desktop-bridge/src/error.rs
@@ -91,71 +91,39 @@ impl BridgeError {
 
     /// An `EndpointUnreachable` error carrying the endpoint that could not be
     /// reached as a structured field.
-    pub fn endpoint_unreachable(endpoint: impl Into<String>, message: impl Into<String>) -> Self {
+    pub(crate) fn endpoint_unreachable(
+        endpoint: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             endpoint: Some(endpoint.into()),
             ..Self::new(BridgeErrorCode::EndpointUnreachable, message)
         }
     }
 
-    /// Classify a lower-level transport failure message. Connection
-    /// failures (refused, timed out, DNS, or a failed send/read) become
-    /// `EndpointUnreachable` with the endpoint recovered from the message
-    /// when one is present; anything else (a non-2xx response, a JSON
-    /// decode failure, …) stays untyped, exactly as before. Single owner
-    /// for the classification shared by
+    /// Classify a lower-level transport failure from its typed error chain.
+    /// Connection, timeout, and response-body transport failures become
+    /// `EndpointUnreachable`, with the endpoint taken from the underlying
+    /// `reqwest::Error`; anything else (a non-2xx response, a JSON decode
+    /// failure, or unrelated prose containing words such as "timeout") stays
+    /// untyped. Single owner for the classification shared by
     /// `tauri_commands::peers::desktop_peer_status_fetch` and the
     /// local-runtime discovery path in `tauri_commands::lifecycle`, so
     /// neither call site — nor the TS client — needs its own copy (#1339).
-    pub fn classify_transport_error(message: impl Into<String>) -> Self {
-        let message = message.into();
-        if !looks_like_unreachable_endpoint(&message) {
+    pub(crate) fn classify_transport_error(error: anyhow::Error) -> Self {
+        let transport = error
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<reqwest::Error>())
+            .filter(|error| error.is_connect() || error.is_timeout() || error.is_body());
+        let message = error.to_string();
+        let Some(transport) = transport else {
             return Self::untyped(message);
-        }
-        match transport_endpoint_from_message(&message) {
-            Some(endpoint) => Self::endpoint_unreachable(endpoint, message),
+        };
+        match transport.url() {
+            Some(url) => Self::endpoint_unreachable(url.origin().ascii_serialization(), message),
             None => Self::new(BridgeErrorCode::EndpointUnreachable, message),
         }
     }
-}
-
-/// True when `message` describes a connection-level transport failure
-/// (refused, timed out, DNS, or a failed send/read) rather than an
-/// application-level failure (a non-2xx response, a JSON decode error, …)
-/// from an endpoint that was in fact reachable.
-fn looks_like_unreachable_endpoint(message: &str) -> bool {
-    let lower = message.to_ascii_lowercase();
-    lower.contains("connection refused")
-        || lower.contains("refused")
-        || lower.contains("timed out")
-        || lower.contains("timeout")
-        || lower.contains("no gents server found at")
-        || lower.contains("sending get request to")
-        || lower.contains("sending post request to")
-        || lower.contains("sending delete request to")
-        || lower.contains("reading get response body from")
-        || lower.contains("error trying to connect")
-        || lower.contains("dns error")
-}
-
-/// Best-effort recovery of the origin a transport-failure message names
-/// (e.g. "...sending GET request to http://127.0.0.1:9181/status" ->
-/// "http://127.0.0.1:9181"). `None` when the message names no URL.
-fn transport_endpoint_from_message(message: &str) -> Option<String> {
-    let start = message
-        .find("http://")
-        .or_else(|| message.find("https://"))?;
-    let candidate = &message[start..];
-    // Capture the whole non-whitespace token first (a host/IP legitimately
-    // contains '.'), then trim only trailing punctuation the token picked up
-    // from surrounding prose (e.g. a sentence-ending period).
-    let end = candidate
-        .find(char::is_whitespace)
-        .unwrap_or(candidate.len());
-    let token = candidate[..end].trim_end_matches(['.', ',', ';', ')', ']']);
-    reqwest::Url::parse(token)
-        .ok()
-        .map(|parsed| parsed.origin().ascii_serialization())
 }
 
 impl std::fmt::Display for BridgeError {
@@ -212,67 +180,45 @@ mod tests {
         assert_eq!(json["endpoint"], "http://127.0.0.1:9181");
     }
 
-    #[test]
-    fn classify_transport_error_flags_connection_failures_with_endpoint() {
-        let err = BridgeError::classify_transport_error(
-            "sending GET request to http://127.0.0.1:9181/api/v0/p2p/shareable-address",
-        );
-        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
-        assert_eq!(err.endpoint.as_deref(), Some("http://127.0.0.1:9181"));
+    #[tokio::test]
+    async fn classify_transport_error_uses_reqwest_source_and_url() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind temporary port");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local address"));
+        drop(listener);
 
-        let err = BridgeError::classify_transport_error(
-            "no gents server found at http://127.0.0.1:9191/status. Start one first with              `gents server` or `gents demo`.",
-        );
+        let error = gents_desktop_core::local_runtime::fetch_runtime_connection_payload(&endpoint)
+            .await
+            .expect_err("closed temporary port must refuse the request");
+        let err = BridgeError::classify_transport_error(error);
         assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
-        assert_eq!(err.endpoint.as_deref(), Some("http://127.0.0.1:9191"));
-
-        let err = BridgeError::classify_transport_error("connection refused (os error 61)");
-        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
-        assert_eq!(err.endpoint, None);
-
-        let err = BridgeError::classify_transport_error("request timed out after 5s");
-        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
+        assert_eq!(err.endpoint.as_deref(), Some(endpoint.as_str()));
     }
 
     #[test]
     fn classify_transport_error_leaves_application_level_failures_untyped() {
-        let err = BridgeError::classify_transport_error(
-            "GET http://127.0.0.1:9181/status failed with 500 Internal Server Error: boom",
-        );
+        let err = BridgeError::classify_transport_error(anyhow::anyhow!(
+            "GET http://127.0.0.1:9181/status failed with 504 Gateway Timeout: request refused"
+        ));
         assert_eq!(err.code, BridgeErrorCode::Unknown);
         assert_eq!(err.endpoint, None);
 
-        let err = BridgeError::classify_transport_error(
-            "decoding JSON response from http://127.0.0.1:9181/status",
-        );
+        let err = BridgeError::classify_transport_error(anyhow::anyhow!(
+            "decoding JSON response from http://127.0.0.1:9181/status"
+        ));
         assert_eq!(err.code, BridgeErrorCode::Unknown);
         assert_eq!(err.endpoint, None);
     }
 
     /// `tauri_commands::peers::desktop_peer_enroll_status` and
     /// `desktop_peer_status_fetch` both map a `fetch_runtime_connection_payload`
-    /// failure through `classify_transport_error(error.to_string())` — the
-    /// exact message shapes `gents_desktop_core::local_runtime::http_get_json`
-    /// produces for a connection-refused failure and a JSON decode failure
-    /// against the status-enrollment server address (#1339 review round 2).
+    /// failure through `classify_transport_error`. A display string alone is
+    /// never sufficient evidence of an unreachable endpoint (#1339).
     #[test]
-    fn classify_transport_error_covers_enroll_status_connection_and_json_failures() {
-        let connection_refused = BridgeError::classify_transport_error(
-            "no gents server found at http://198.51.100.7:9191/status. Start one first with              `gents server` or `gents demo`. Remote runtimes must be added through              authenticated status enrollment in the desktop app.",
-        );
-        assert_eq!(
-            connection_refused.code,
-            BridgeErrorCode::EndpointUnreachable
-        );
-        assert_eq!(
-            connection_refused.endpoint.as_deref(),
-            Some("http://198.51.100.7:9191")
-        );
-
-        let json_failure = BridgeError::classify_transport_error(
-            "decoding JSON response from http://198.51.100.7:9191/status",
-        );
-        assert_eq!(json_failure.code, BridgeErrorCode::Unknown);
-        assert_eq!(json_failure.endpoint, None);
+    fn classify_transport_error_rejects_message_only_transport_lookalikes() {
+        let lookalike = BridgeError::classify_transport_error(anyhow::anyhow!(
+            "no gents server found at http://198.51.100.7:9191/status: connection refused"
+        ));
+        assert_eq!(lookalike.code, BridgeErrorCode::Unknown);
+        assert_eq!(lookalike.endpoint, None);
     }
 }

--- a/crates/gents-desktop-bridge/src/error.rs
+++ b/crates/gents-desktop-bridge/src/error.rs
@@ -69,6 +69,10 @@ pub struct BridgeError {
     pub code: BridgeErrorCode,
     pub message: String,
     pub retryable: bool,
+    /// The origin/address that could not be reached, for
+    /// `EndpointUnreachable` errors. `None` for every other code. Structured
+    /// so callers don't need to regex it back out of `message` (#1339).
+    pub endpoint: Option<String>,
 }
 
 impl BridgeError {
@@ -77,11 +81,21 @@ impl BridgeError {
             code,
             message: message.into(),
             retryable: code.retryable(),
+            endpoint: None,
         }
     }
 
     pub fn untyped(message: impl Into<String>) -> Self {
         Self::new(BridgeErrorCode::Unknown, message)
+    }
+
+    /// An `EndpointUnreachable` error carrying the endpoint that could not be
+    /// reached as a structured field.
+    pub fn endpoint_unreachable(endpoint: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            endpoint: Some(endpoint.into()),
+            ..Self::new(BridgeErrorCode::EndpointUnreachable, message)
+        }
     }
 }
 
@@ -122,5 +136,20 @@ mod tests {
         assert_eq!(json["code"], "stalePreview");
         assert_eq!(json["retryable"], true);
         assert_eq!(json["message"], "preview drifted");
+        assert!(json["endpoint"].is_null());
+    }
+
+    #[test]
+    fn endpoint_unreachable_carries_the_endpoint_as_a_structured_field() {
+        let err = BridgeError::endpoint_unreachable(
+            "http://127.0.0.1:9181",
+            "sending GET request to http://127.0.0.1:9181/api/v0/p2p/shareable-address",
+        );
+        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
+        assert!(err.retryable);
+        assert_eq!(err.endpoint.as_deref(), Some("http://127.0.0.1:9181"));
+        let json = serde_json::to_value(&err).expect("serialize");
+        assert_eq!(json["code"], "endpointUnreachable");
+        assert_eq!(json["endpoint"], "http://127.0.0.1:9181");
     }
 }

--- a/crates/gents-desktop-bridge/src/error.rs
+++ b/crates/gents-desktop-bridge/src/error.rs
@@ -248,4 +248,31 @@ mod tests {
         assert_eq!(err.code, BridgeErrorCode::Unknown);
         assert_eq!(err.endpoint, None);
     }
+
+    /// `tauri_commands::peers::desktop_peer_enroll_status` and
+    /// `desktop_peer_status_fetch` both map a `fetch_runtime_connection_payload`
+    /// failure through `classify_transport_error(error.to_string())` — the
+    /// exact message shapes `gents_desktop_core::local_runtime::http_get_json`
+    /// produces for a connection-refused failure and a JSON decode failure
+    /// against the status-enrollment server address (#1339 review round 2).
+    #[test]
+    fn classify_transport_error_covers_enroll_status_connection_and_json_failures() {
+        let connection_refused = BridgeError::classify_transport_error(
+            "no gents server found at http://198.51.100.7:9191/status. Start one first with              `gents server` or `gents demo`. Remote runtimes must be added through              authenticated status enrollment in the desktop app.",
+        );
+        assert_eq!(
+            connection_refused.code,
+            BridgeErrorCode::EndpointUnreachable
+        );
+        assert_eq!(
+            connection_refused.endpoint.as_deref(),
+            Some("http://198.51.100.7:9191")
+        );
+
+        let json_failure = BridgeError::classify_transport_error(
+            "decoding JSON response from http://198.51.100.7:9191/status",
+        );
+        assert_eq!(json_failure.code, BridgeErrorCode::Unknown);
+        assert_eq!(json_failure.endpoint, None);
+    }
 }

--- a/crates/gents-desktop-bridge/src/error.rs
+++ b/crates/gents-desktop-bridge/src/error.rs
@@ -97,6 +97,65 @@ impl BridgeError {
             ..Self::new(BridgeErrorCode::EndpointUnreachable, message)
         }
     }
+
+    /// Classify a lower-level transport failure message. Connection
+    /// failures (refused, timed out, DNS, or a failed send/read) become
+    /// `EndpointUnreachable` with the endpoint recovered from the message
+    /// when one is present; anything else (a non-2xx response, a JSON
+    /// decode failure, …) stays untyped, exactly as before. Single owner
+    /// for the classification shared by
+    /// `tauri_commands::peers::desktop_peer_status_fetch` and the
+    /// local-runtime discovery path in `tauri_commands::lifecycle`, so
+    /// neither call site — nor the TS client — needs its own copy (#1339).
+    pub fn classify_transport_error(message: impl Into<String>) -> Self {
+        let message = message.into();
+        if !looks_like_unreachable_endpoint(&message) {
+            return Self::untyped(message);
+        }
+        match transport_endpoint_from_message(&message) {
+            Some(endpoint) => Self::endpoint_unreachable(endpoint, message),
+            None => Self::new(BridgeErrorCode::EndpointUnreachable, message),
+        }
+    }
+}
+
+/// True when `message` describes a connection-level transport failure
+/// (refused, timed out, DNS, or a failed send/read) rather than an
+/// application-level failure (a non-2xx response, a JSON decode error, …)
+/// from an endpoint that was in fact reachable.
+fn looks_like_unreachable_endpoint(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("connection refused")
+        || lower.contains("refused")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("no gents server found at")
+        || lower.contains("sending get request to")
+        || lower.contains("sending post request to")
+        || lower.contains("sending delete request to")
+        || lower.contains("reading get response body from")
+        || lower.contains("error trying to connect")
+        || lower.contains("dns error")
+}
+
+/// Best-effort recovery of the origin a transport-failure message names
+/// (e.g. "...sending GET request to http://127.0.0.1:9181/status" ->
+/// "http://127.0.0.1:9181"). `None` when the message names no URL.
+fn transport_endpoint_from_message(message: &str) -> Option<String> {
+    let start = message
+        .find("http://")
+        .or_else(|| message.find("https://"))?;
+    let candidate = &message[start..];
+    // Capture the whole non-whitespace token first (a host/IP legitimately
+    // contains '.'), then trim only trailing punctuation the token picked up
+    // from surrounding prose (e.g. a sentence-ending period).
+    let end = candidate
+        .find(char::is_whitespace)
+        .unwrap_or(candidate.len());
+    let token = candidate[..end].trim_end_matches(['.', ',', ';', ')', ']']);
+    reqwest::Url::parse(token)
+        .ok()
+        .map(|parsed| parsed.origin().ascii_serialization())
 }
 
 impl std::fmt::Display for BridgeError {
@@ -151,5 +210,42 @@ mod tests {
         let json = serde_json::to_value(&err).expect("serialize");
         assert_eq!(json["code"], "endpointUnreachable");
         assert_eq!(json["endpoint"], "http://127.0.0.1:9181");
+    }
+
+    #[test]
+    fn classify_transport_error_flags_connection_failures_with_endpoint() {
+        let err = BridgeError::classify_transport_error(
+            "sending GET request to http://127.0.0.1:9181/api/v0/p2p/shareable-address",
+        );
+        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
+        assert_eq!(err.endpoint.as_deref(), Some("http://127.0.0.1:9181"));
+
+        let err = BridgeError::classify_transport_error(
+            "no gents server found at http://127.0.0.1:9191/status. Start one first with              `gents server` or `gents demo`.",
+        );
+        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
+        assert_eq!(err.endpoint.as_deref(), Some("http://127.0.0.1:9191"));
+
+        let err = BridgeError::classify_transport_error("connection refused (os error 61)");
+        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
+        assert_eq!(err.endpoint, None);
+
+        let err = BridgeError::classify_transport_error("request timed out after 5s");
+        assert_eq!(err.code, BridgeErrorCode::EndpointUnreachable);
+    }
+
+    #[test]
+    fn classify_transport_error_leaves_application_level_failures_untyped() {
+        let err = BridgeError::classify_transport_error(
+            "GET http://127.0.0.1:9181/status failed with 500 Internal Server Error: boom",
+        );
+        assert_eq!(err.code, BridgeErrorCode::Unknown);
+        assert_eq!(err.endpoint, None);
+
+        let err = BridgeError::classify_transport_error(
+            "decoding JSON response from http://127.0.0.1:9181/status",
+        );
+        assert_eq!(err.code, BridgeErrorCode::Unknown);
+        assert_eq!(err.endpoint, None);
     }
 }

--- a/crates/gents-desktop-bridge/src/snapshot/session.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/session.rs
@@ -14,11 +14,11 @@ use super::super::cause_derivation::{
     ToolCallEvidence,
 };
 use super::super::types::{
-    normalize_optional, turn_state_label, CommandDenialView, DerivedCancelCauseView,
-    DesktopSessionSnapshot, GoalView, MessageView, PendingTurnView, ResponseView,
-    RetryEligibilityView, SessionCompactionView, SessionContextView, SessionHydrationView,
-    SessionLiveDeltaView, SessionLiveTextPatchView, SessionProjectionRevisionView,
-    SessionTimelinePageView, ToolCallView, ToolResultView,
+    is_live_turn_state, normalize_optional, turn_state_label, CommandDenialView,
+    DerivedCancelCauseView, DesktopSessionSnapshot, GoalView, MessageView, PendingTurnView,
+    ResponseView, RetryEligibilityView, SessionCompactionView, SessionContextView,
+    SessionHydrationView, SessionLiveDeltaView, SessionLiveTextPatchView,
+    SessionProjectionRevisionView, SessionTimelinePageView, ToolCallView, ToolResultView,
 };
 use super::timeline::{build_rendered_timeline, has_materialized_user_owner};
 use super::{request_matches_agent, source_matches_agent};

--- a/crates/gents-desktop-bridge/src/snapshot/session/live_delta.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/session/live_delta.rs
@@ -114,11 +114,7 @@ pub(crate) fn build_session_live_delta_from_store(
         |agent_did| store.derive_turn_for_request_for_agent(request_id, agent_did),
     );
     let turn_state_label = turn_state.map(turn_state_label).map(str::to_owned);
-    if !matches!(
-        turn_state,
-        Some(gents_protocol::client_protocol::ClientTurnState::WaitingForClaim)
-            | Some(gents_protocol::client_protocol::ClientTurnState::Streaming)
-    ) {
+    if !is_live_turn_state(turn_state) {
         return snapshot_required(turn_state_label, None);
     }
 

--- a/crates/gents-desktop-bridge/src/snapshot/session/projection.rs
+++ b/crates/gents-desktop-bridge/src/snapshot/session/projection.rs
@@ -170,11 +170,7 @@ pub(super) fn build_session_snapshot_from_store_for_agent_with_transcript(
             .unwrap_or_default()
             .to_ascii_lowercase();
         include_live_tail
-            && matches!(
-                turn_state,
-                Some(gents_protocol::client_protocol::ClientTurnState::WaitingForClaim)
-                    | Some(gents_protocol::client_protocol::ClientTurnState::Streaming)
-            )
+            && is_live_turn_state(turn_state)
             && response.materialized_message_sequence.is_none()
             && response.interrupted_at.is_none()
             && !matches!(

--- a/crates/gents-desktop-bridge/src/tauri_commands/lifecycle.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/lifecycle.rs
@@ -89,7 +89,7 @@ pub async fn desktop_init_local_standard(
             .unwrap_or_else(|| "Local Agent".to_string()),
     })
     .await
-    .map_err(|error| BridgeError::untyped(error.to_string()))
+    .map_err(|error| BridgeError::classify_transport_error(error.to_string()))
 }
 
 fn ensure_client_stopped_for_init(client_is_running: bool) -> Result<(), BridgeError> {
@@ -368,7 +368,7 @@ async fn start_client_core_async(
 
     match rx.await {
         Ok(Ok(core)) => Ok(core),
-        Ok(Err(error)) => Err(BridgeError::untyped(error.to_string())),
+        Ok(Err(error)) => Err(BridgeError::classify_transport_error(error.to_string())),
         Err(_) => Err(BridgeError::new(
             BridgeErrorCode::ClientStartFailed,
             "desktop client startup thread panicked or dropped its result",

--- a/crates/gents-desktop-bridge/src/tauri_commands/lifecycle.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/lifecycle.rs
@@ -89,7 +89,7 @@ pub async fn desktop_init_local_standard(
             .unwrap_or_else(|| "Local Agent".to_string()),
     })
     .await
-    .map_err(|error| BridgeError::classify_transport_error(error.to_string()))
+    .map_err(BridgeError::classify_transport_error)
 }
 
 fn ensure_client_stopped_for_init(client_is_running: bool) -> Result<(), BridgeError> {
@@ -368,7 +368,7 @@ async fn start_client_core_async(
 
     match rx.await {
         Ok(Ok(core)) => Ok(core),
-        Ok(Err(error)) => Err(BridgeError::classify_transport_error(error.to_string())),
+        Ok(Err(error)) => Err(BridgeError::untyped(error.to_string())),
         Err(_) => Err(BridgeError::new(
             BridgeErrorCode::ClientStartFailed,
             "desktop client startup thread panicked or dropped its result",

--- a/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use gents_desktop_core::local_runtime::fetch_runtime_connection_payload;
+use gents_desktop_core::local_runtime::{fetch_runtime_connection_payload, runtime_status_url};
 use tauri::{AppHandle, Runtime, State};
 
 use crate::error::BridgeError;
@@ -34,7 +34,16 @@ pub async fn desktop_peer_status_fetch(
         .ok_or_else(|| format!("saved peer {peer_id} was not found"))?;
     fetch_runtime_connection_payload(&addr)
         .await
-        .map_err(|error| BridgeError::untyped(error.to_string()))
+        .map_err(|error| {
+            // The endpoint is known structurally from the saved peer record, so
+            // it's attached directly rather than regexed back out of `error`.
+            let endpoint = runtime_status_url(&addr)
+                .ok()
+                .and_then(|url| reqwest::Url::parse(&url).ok())
+                .map(|url| url.origin().ascii_serialization())
+                .unwrap_or_else(|| addr.clone());
+            BridgeError::endpoint_unreachable(endpoint, error.to_string())
+        })
 }
 
 #[tauri::command]

--- a/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use gents_desktop_core::local_runtime::{fetch_runtime_connection_payload, runtime_status_url};
+use gents_desktop_core::local_runtime::fetch_runtime_connection_payload;
 use tauri::{AppHandle, Runtime, State};
 
 use crate::error::BridgeError;
@@ -34,16 +34,7 @@ pub async fn desktop_peer_status_fetch(
         .ok_or_else(|| format!("saved peer {peer_id} was not found"))?;
     fetch_runtime_connection_payload(&addr)
         .await
-        .map_err(|error| {
-            // The endpoint is known structurally from the saved peer record, so
-            // it's attached directly rather than regexed back out of `error`.
-            let endpoint = runtime_status_url(&addr)
-                .ok()
-                .and_then(|url| reqwest::Url::parse(&url).ok())
-                .map(|url| url.origin().ascii_serialization())
-                .unwrap_or_else(|| addr.clone());
-            BridgeError::endpoint_unreachable(endpoint, error.to_string())
-        })
+        .map_err(|error| BridgeError::classify_transport_error(error.to_string()))
 }
 
 #[tauri::command]

--- a/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
@@ -34,7 +34,7 @@ pub async fn desktop_peer_status_fetch(
         .ok_or_else(|| format!("saved peer {peer_id} was not found"))?;
     fetch_runtime_connection_payload(&addr)
         .await
-        .map_err(|error| BridgeError::classify_transport_error(error.to_string()))
+        .map_err(BridgeError::classify_transport_error)
 }
 
 #[tauri::command]
@@ -51,7 +51,7 @@ pub async fn desktop_peer_enroll_status(
     }
     let status = fetch_runtime_connection_payload(address)
         .await
-        .map_err(|error| BridgeError::classify_transport_error(error.to_string()))?;
+        .map_err(BridgeError::classify_transport_error)?;
     let server_label = status
         .get("agent_name")
         .and_then(serde_json::Value::as_str)

--- a/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
+++ b/crates/gents-desktop-bridge/src/tauri_commands/peers.rs
@@ -51,7 +51,7 @@ pub async fn desktop_peer_enroll_status(
     }
     let status = fetch_runtime_connection_payload(address)
         .await
-        .map_err(|error| BridgeError::untyped(error.to_string()))?;
+        .map_err(|error| BridgeError::classify_transport_error(error.to_string()))?;
     let server_label = status
         .get("agent_name")
         .and_then(serde_json::Value::as_str)

--- a/crates/gents-desktop-bridge/src/types.rs
+++ b/crates/gents-desktop-bridge/src/types.rs
@@ -6,5 +6,5 @@ mod util;
 mod views;
 
 pub use requests::*;
-pub use util::{normalize_optional, turn_state_label};
+pub use util::{is_live_turn_state, normalize_optional, turn_state_label};
 pub use views::*;

--- a/crates/gents-desktop-bridge/src/types.rs
+++ b/crates/gents-desktop-bridge/src/types.rs
@@ -6,5 +6,6 @@ mod util;
 mod views;
 
 pub use requests::*;
-pub use util::{is_live_turn_state, normalize_optional, turn_state_label};
+pub(crate) use util::is_live_turn_state;
+pub use util::{normalize_optional, turn_state_label};
 pub use views::*;

--- a/crates/gents-desktop-bridge/src/types/util.rs
+++ b/crates/gents-desktop-bridge/src/types/util.rs
@@ -17,3 +17,15 @@ pub fn turn_state_label(state: ClientTurnState) -> &'static str {
         ClientTurnState::Interrupted => "interrupted",
     }
 }
+
+/// True for the two non-terminal turn states (`WaitingForClaim`,
+/// `Streaming`) that still have a live tail worth overlaying onto a
+/// snapshot. Single owner for the `Some(WaitingForClaim) | Some(Streaming)`
+/// check shared by `snapshot::session::projection` and
+/// `snapshot::session::live_delta`.
+pub fn is_live_turn_state(state: Option<ClientTurnState>) -> bool {
+    matches!(
+        state,
+        Some(ClientTurnState::WaitingForClaim) | Some(ClientTurnState::Streaming)
+    )
+}

--- a/crates/gents-desktop-bridge/src/types/util.rs
+++ b/crates/gents-desktop-bridge/src/types/util.rs
@@ -23,9 +23,6 @@ pub fn turn_state_label(state: ClientTurnState) -> &'static str {
 /// snapshot. Single owner for the `Some(WaitingForClaim) | Some(Streaming)`
 /// check shared by `snapshot::session::projection` and
 /// `snapshot::session::live_delta`.
-pub fn is_live_turn_state(state: Option<ClientTurnState>) -> bool {
-    matches!(
-        state,
-        Some(ClientTurnState::WaitingForClaim) | Some(ClientTurnState::Streaming)
-    )
+pub(crate) fn is_live_turn_state(state: Option<ClientTurnState>) -> bool {
+    state.is_some_and(|state| !state.is_terminal())
 }

--- a/crates/gents-desktop-core/src/local_runtime/http.rs
+++ b/crates/gents-desktop-core/src/local_runtime/http.rs
@@ -22,11 +22,11 @@ pub(super) async fn http_get_json<T: for<'de> Deserialize<'de>>(
 ) -> Result<T> {
     let response = client.get(url).send().await.map_err(|error| {
         if error.is_connect() {
-            anyhow::anyhow!(
+            anyhow::Error::from(error).context(format!(
                 "no gents server found at {url}. Start one first with \
                  `gents server` or `gents demo`. Remote runtimes must be added \
                  through authenticated status enrollment in the desktop app."
-            )
+            ))
         } else {
             anyhow::Error::from(error).context(format!("sending GET request to {url}"))
         }

--- a/crates/gents-protocol/src/chatgpt_oauth.rs
+++ b/crates/gents-protocol/src/chatgpt_oauth.rs
@@ -1,0 +1,32 @@
+//! ChatGPT OAuth constants shared by `gents-chatgpt-login` (the login/token
+//! flows) and `gents::chatgpt_oauth_refresh` (the runtime refresh path).
+//! Single owner (#1339) — both previously held their own copies of the
+//! client id and refresh endpoint.
+
+/// Codex-compatible OAuth client id.
+pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+/// Default OAuth issuer for ChatGPT/Codex accounts.
+pub const DEFAULT_ISSUER: &str = "https://auth.openai.com";
+
+/// Environment variable that, when set to a non-empty value, overrides the
+/// refresh-token endpoint (used in tests and self-hosted issuer setups).
+pub const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+
+/// The refresh-token endpoint under [`DEFAULT_ISSUER`]. Kept as its own
+/// constant (rather than formatted at each call site) for callers that only
+/// ever refresh against the default issuer; `gents-chatgpt-login`'s own
+/// `refresh_tokens` still formats `{issuer}/oauth/token` directly since it
+/// supports a caller-supplied issuer. `refresh_token_url_matches_default_issuer`
+/// guards the two against drift.
+pub const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refresh_token_url_matches_default_issuer() {
+        assert_eq!(REFRESH_TOKEN_URL, format!("{DEFAULT_ISSUER}/oauth/token"));
+    }
+}

--- a/crates/gents-protocol/src/chatgpt_oauth.rs
+++ b/crates/gents-protocol/src/chatgpt_oauth.rs
@@ -1,7 +1,7 @@
-//! ChatGPT OAuth constants shared by `gents-chatgpt-login` (the login/token
+//! ChatGPT OAuth vocabulary shared by `gents-chatgpt-login` (the login/token
 //! flows) and `gents::chatgpt_oauth_refresh` (the runtime refresh path).
-//! Single owner (#1339) — both previously held their own copies of the
-//! client id and refresh endpoint.
+//! Single owner (#1339) for the duplicated client id, refresh-endpoint
+//! override variable, and token-endpoint construction rule.
 
 /// Codex-compatible OAuth client id.
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -13,20 +13,26 @@ pub const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 /// refresh-token endpoint (used in tests and self-hosted issuer setups).
 pub const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
 
-/// The refresh-token endpoint under [`DEFAULT_ISSUER`]. Kept as its own
-/// constant (rather than formatted at each call site) for callers that only
-/// ever refresh against the default issuer; `gents-chatgpt-login`'s own
-/// `refresh_tokens` still formats `{issuer}/oauth/token` directly since it
-/// supports a caller-supplied issuer. `refresh_token_url_matches_default_issuer`
-/// guards the two against drift.
-pub const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+/// Build the token endpoint for an OAuth issuer. Single owner of the
+/// trailing-slash normalization and `/oauth/token` suffix shared by login
+/// and runtime refresh flows.
+pub fn token_endpoint(issuer: &str) -> String {
+    format!("{}/oauth/token", issuer.trim_end_matches('/'))
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn refresh_token_url_matches_default_issuer() {
-        assert_eq!(REFRESH_TOKEN_URL, format!("{DEFAULT_ISSUER}/oauth/token"));
+    fn token_endpoint_normalizes_the_issuer_once() {
+        assert_eq!(
+            token_endpoint(DEFAULT_ISSUER),
+            "https://auth.openai.com/oauth/token"
+        );
+        assert_eq!(
+            token_endpoint("https://issuer.example/"),
+            "https://issuer.example/oauth/token"
+        );
     }
 }

--- a/crates/gents-protocol/src/lib.rs
+++ b/crates/gents-protocol/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod behavior_readiness;
 pub mod canonical;
+pub mod chatgpt_oauth;
 pub mod client_protocol;
 pub mod enrollment;
 pub mod graphql;

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -40,6 +40,7 @@ chrono-tz.workspace = true
 crypto.workspace = true
 defra-core.workspace = true
 defra-p2p-adapter.workspace = true
+gents-chatgpt-login.workspace = true
 gents-fs-runner = { path = "../gents-fs-runner" }
 gents-protocol.workspace = true
 gents-migration = { path = "../gents-migration" }

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -40,7 +40,6 @@ chrono-tz.workspace = true
 crypto.workspace = true
 defra-core.workspace = true
 defra-p2p-adapter.workspace = true
-gents-chatgpt-login.workspace = true
 gents-fs-runner = { path = "../gents-fs-runner" }
 gents-protocol.workspace = true
 gents-migration = { path = "../gents-migration" }

--- a/crates/gents/src/background_completion.rs
+++ b/crates/gents/src/background_completion.rs
@@ -18,9 +18,10 @@ use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 
 use crate::background_tools::{
-    child_request_completed, fail_running_subagent_tool_call, load_authorized_child_edge,
-    load_child_final_response, load_child_terminal_row, load_parent_subagent_context,
-    project_child_terminal, subagent_tool_not_allowed_payload, ChildEdge,
+    child_request_completed, child_terminal_reason, child_terminal_status,
+    fail_running_subagent_tool_call, load_authorized_child_edge, load_child_final_response,
+    load_child_terminal_row, load_parent_subagent_context, project_child_terminal,
+    subagent_tool_not_allowed_payload, ChildEdge,
 };
 use crate::graphql::escape_graphql_string;
 use crate::lifecycle::queue::{
@@ -29,7 +30,7 @@ use crate::lifecycle::queue::{
 };
 use crate::lifecycle::ExecutionOrigin;
 use crate::session;
-use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass, ToolCallLifecycle};
+use crate::tool_call_lifecycle::{AwaitMode, FailureClass, ToolCallLifecycle};
 
 const AGENT_REQUEST_COLLECTION: &str = "AgentRequest";
 pub const BACKGROUND_COMPLETION_WAKE_PROMPT: &str =
@@ -115,8 +116,8 @@ use notification_delivery::SideEffects;
 use queries::{load_child_linkage, load_request_id_by_doc_id, load_terminal_child_request_ids};
 use reconciliation::request_is_locally_owned;
 use rendering::{
-    child_terminal_status, child_terminal_summary, compact_summary, first_row, non_empty,
-    render_notification, render_tool_completion, xml_escape_attr,
+    compact_summary, first_row, non_empty, render_notification, render_tool_completion,
+    xml_escape_attr,
 };
 use side_effects::{
     bound_background_wake_request, bridge_state_is_terminal, ensure_projection_side_effects,

--- a/crates/gents/src/background_completion/projection.rs
+++ b/crates/gents/src/background_completion/projection.rs
@@ -77,7 +77,8 @@ async fn project_background_subagent_completion_inner(
     } else {
         let terminal = terminal.expect("non-completed child terminal checked above");
         let status = child_terminal_status(&terminal).to_string();
-        let summary = child_terminal_summary(&terminal);
+        let (reason, _failure_class) = child_terminal_reason(&terminal);
+        let summary = compact_summary(&reason);
         (status, summary, None, Some(terminal))
     };
 

--- a/crates/gents/src/background_completion/rendering.rs
+++ b/crates/gents/src/background_completion/rendering.rs
@@ -36,24 +36,6 @@ pub(super) fn render_tool_completion(
     )
 }
 
-pub(super) fn child_terminal_status(terminal: &ChildTerminal) -> &'static str {
-    match terminal {
-        ChildTerminal::Failed { .. } => "failed",
-        ChildTerminal::Dead => "dead",
-        ChildTerminal::Interrupted => "interrupted",
-        ChildTerminal::Superseded => "superseded",
-    }
-}
-
-pub(super) fn child_terminal_summary(terminal: &ChildTerminal) -> String {
-    match terminal {
-        ChildTerminal::Failed { reason, .. } => compact_summary(reason),
-        ChildTerminal::Dead => "child request reached the dead terminal state".to_string(),
-        ChildTerminal::Interrupted => "child request was interrupted".to_string(),
-        ChildTerminal::Superseded => "child request was superseded".to_string(),
-    }
-}
-
 pub(super) fn compact_summary(value: &str) -> String {
     let normalized = value.split_whitespace().collect::<Vec<_>>().join(" ");
     const LIMIT: usize = 4000;

--- a/crates/gents/src/background_tools.rs
+++ b/crates/gents/src/background_tools.rs
@@ -2173,6 +2173,41 @@ pub(crate) fn project_child_terminal(row: &ChildRequestTerminalRow) -> Option<Ch
     }
 }
 
+/// Persisted status word for a [`ChildTerminal`], shared by the background
+/// completion notification path and the subagent-bridge failure path.
+pub(crate) fn child_terminal_status(terminal: &ChildTerminal) -> &'static str {
+    match terminal {
+        ChildTerminal::Failed { .. } => "failed",
+        ChildTerminal::Dead => "dead",
+        ChildTerminal::Interrupted => "interrupted",
+        ChildTerminal::Superseded => "superseded",
+    }
+}
+
+/// Human-readable reason for a [`ChildTerminal`], shared by the notification
+/// summary and the bridge failure payload; the failure path additionally
+/// needs the [`FailureClass`] to persist alongside the reason.
+pub(crate) fn child_terminal_reason(terminal: &ChildTerminal) -> (String, FailureClass) {
+    match terminal {
+        ChildTerminal::Failed {
+            reason,
+            failure_class,
+        } => (reason.clone(), *failure_class),
+        ChildTerminal::Dead => (
+            "child request reached the dead terminal state".to_string(),
+            FailureClass::External,
+        ),
+        ChildTerminal::Interrupted => (
+            "child request was interrupted".to_string(),
+            FailureClass::External,
+        ),
+        ChildTerminal::Superseded => (
+            "child request was superseded".to_string(),
+            FailureClass::External,
+        ),
+    }
+}
+
 pub(crate) fn child_request_completed(row: &ChildRequestTerminalRow) -> bool {
     RequestLifecycleState::parse_opt(row.lifecycle_state.as_deref())
         == Some(RequestLifecycleState::Completed)

--- a/crates/gents/src/chatgpt_oauth_refresh.rs
+++ b/crates/gents/src/chatgpt_oauth_refresh.rs
@@ -1,13 +1,12 @@
 use base64::Engine;
 use chrono::{DateTime, Duration, Utc};
+use gents_chatgpt_login::{
+    CLIENT_ID as CHATGPT_OAUTH_CLIENT_ID, REFRESH_TOKEN_URL, REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::oauth_credential::{OAuthAuthProblem, RefreshedTokens};
-
-const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
-const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
-const CHATGPT_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct IdTokenClaims {

--- a/crates/gents/src/chatgpt_oauth_refresh.rs
+++ b/crates/gents/src/chatgpt_oauth_refresh.rs
@@ -1,7 +1,8 @@
 use base64::Engine;
 use chrono::{DateTime, Duration, Utc};
 use gents_protocol::chatgpt_oauth::{
-    CLIENT_ID as CHATGPT_OAUTH_CLIENT_ID, REFRESH_TOKEN_URL, REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
+    token_endpoint, CLIENT_ID as CHATGPT_OAUTH_CLIENT_ID, DEFAULT_ISSUER,
+    REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -40,7 +41,7 @@ pub async fn refresh_chatgpt_token(
     let endpoint = std::env::var(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR)
         .ok()
         .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| REFRESH_TOKEN_URL.to_string());
+        .unwrap_or_else(|| token_endpoint(DEFAULT_ISSUER));
     let request = RefreshRequest {
         client_id: CHATGPT_OAUTH_CLIENT_ID,
         grant_type: "refresh_token",

--- a/crates/gents/src/chatgpt_oauth_refresh.rs
+++ b/crates/gents/src/chatgpt_oauth_refresh.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use chrono::{DateTime, Duration, Utc};
-use gents_chatgpt_login::{
+use gents_protocol::chatgpt_oauth::{
     CLIENT_ID as CHATGPT_OAUTH_CLIENT_ID, REFRESH_TOKEN_URL, REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/gents/src/document_config/tests.rs
+++ b/crates/gents/src/document_config/tests.rs
@@ -517,8 +517,10 @@ fn validate_rejects_duplicate_field_names_within_decl() {
 fn reserved_names_cover_native_and_meta_tools() {
     use crate::toolset::NativeTool;
 
-    // Every native tool name must be reserved (guards the hardcoded native
-    // literal list in `is_reserved_builtin_tool_name` against drift).
+    // Every constructible native tool's `tool_name()` must appear in the
+    // `NativeTool::ALL_NAMES` registry (guards it against drifting from
+    // `tool_name` as variants are added), and every registry entry must be
+    // reserved.
     let native = [
         NativeTool::ListFiles { max_entries: 1 },
         NativeTool::ReadFile { max_chars: 1 },
@@ -533,9 +535,20 @@ fn reserved_names_cover_native_and_meta_tools() {
     ];
     for tool in &native {
         assert!(
+            NativeTool::ALL_NAMES.contains(&tool.tool_name().as_str()),
+            "native tool {:?} missing from NativeTool::ALL_NAMES",
+            tool.tool_name()
+        );
+        assert!(
             is_reserved_builtin_tool_name(&tool.tool_name()),
             "native tool {:?} must be reserved",
             tool.tool_name()
+        );
+    }
+    for name in NativeTool::ALL_NAMES {
+        assert!(
+            is_reserved_builtin_tool_name(name),
+            "registry name {name:?} must be reserved"
         );
     }
     assert!(is_reserved_builtin_tool_name("bash"));

--- a/crates/gents/src/document_config/tool_selection.rs
+++ b/crates/gents/src/document_config/tool_selection.rs
@@ -407,20 +407,6 @@ pub(crate) fn validate_write_tool_declarations(
 pub fn is_reserved_builtin_tool_name(name: &str) -> bool {
     let name = name.trim();
 
-    // Native tools have no shared name constants; these literals must stay in
-    // sync with `crate::toolset::NativeTool::tool_name`. The
-    // `reserved_names_cover_native_and_meta_tools` test guards against drift.
-    const NATIVE_TOOL_NAMES: &[&str] = &[
-        "list_files",
-        "read_file",
-        "glob",
-        "grep",
-        "write_file",
-        "edit_file",
-        "bash",
-        "bash_unrestricted",
-        "lsp",
-    ];
     const SUBAGENT_TOOL_NAMES: &[&str] = &[
         SPAWN_SUBAGENT_TOOL_NAME,
         WAIT_SUBAGENT_TOOL_NAME,
@@ -446,7 +432,8 @@ pub fn is_reserved_builtin_tool_name(name: &str) -> bool {
         "memory",
     ];
 
-    NATIVE_TOOL_NAMES.contains(&name)
+    crate::toolset::NativeTool::ALL_NAMES.contains(&name)
+        || name == crate::toolset::lsp::LSP_TOOL_NAME
         || META_TOOL_NAMES.contains(&name)
         || SUBAGENT_TOOL_NAMES.contains(&name)
         || SINGLETON_TOOL_NAMES.contains(&name)

--- a/crates/gents/src/hook.rs
+++ b/crates/gents/src/hook.rs
@@ -936,7 +936,9 @@ impl DefraSessionHook {
             let mut map = self.in_flight_lifecycles.lock().await;
             let expired_ids = map
                 .iter()
-                .filter_map(|(id, lifecycle)| (lifecycle.deadline_at() <= now).then(|| id.clone()))
+                .filter_map(|(id, lifecycle)| {
+                    lifecycle.is_deadline_expired(now).then(|| id.clone())
+                })
                 .collect::<Vec<_>>();
 
             expired_ids

--- a/crates/gents/src/hook/persistence/approval.rs
+++ b/crates/gents/src/hook/persistence/approval.rs
@@ -119,16 +119,17 @@ impl DefraSessionHook {
     ) -> anyhow::Result<ToolCallHookAction> {
         loop {
             let observed = {
+                let now = Utc::now();
                 let map = self.in_flight_lifecycles.lock().await;
                 map.get(internal_call_id).map(|lifecycle| {
                     (
                         lifecycle.state(),
-                        lifecycle.deadline_at(),
+                        lifecycle.is_deadline_expired(now),
                         lifecycle.doc_id().map(str::to_string),
                     )
                 })
             };
-            let (state, deadline_at, tool_call_doc_id) = match observed {
+            let (state, deadline_expired, tool_call_doc_id) = match observed {
                 Some(entry) => entry,
                 None => {
                     return Ok(ToolCallHookAction::skip(format!(
@@ -170,7 +171,7 @@ impl DefraSessionHook {
 
             // Held calls keep aging against deadline_at: an unanswered
             // approval must not become a zombie.
-            if Utc::now() >= deadline_at {
+            if deadline_expired {
                 let mut map = self.in_flight_lifecycles.lock().await;
                 if let Some(lifecycle) = map.get_mut(internal_call_id) {
                     lifecycle.timeout_while_held().await?;

--- a/crates/gents/src/hook/persistence/approval.rs
+++ b/crates/gents/src/hook/persistence/approval.rs
@@ -119,12 +119,11 @@ impl DefraSessionHook {
     ) -> anyhow::Result<ToolCallHookAction> {
         loop {
             let observed = {
-                let now = Utc::now();
                 let map = self.in_flight_lifecycles.lock().await;
                 map.get(internal_call_id).map(|lifecycle| {
                     (
                         lifecycle.state(),
-                        lifecycle.is_deadline_expired(now),
+                        lifecycle.is_deadline_expired(Utc::now()),
                         lifecycle.doc_id().map(str::to_string),
                     )
                 })

--- a/crates/gents/src/hook/persistence/helpers.rs
+++ b/crates/gents/src/hook/persistence/helpers.rs
@@ -412,36 +412,6 @@ pub(super) fn json_envelope_with_bounded_result(
     json_string(envelope)
 }
 
-pub(super) fn child_terminal_status(terminal: &ChildTerminal) -> &'static str {
-    match terminal {
-        ChildTerminal::Failed { .. } => "failed",
-        ChildTerminal::Dead => "dead",
-        ChildTerminal::Interrupted => "interrupted",
-        ChildTerminal::Superseded => "superseded",
-    }
-}
-
-pub(super) fn child_terminal_error(terminal: &ChildTerminal) -> (String, FailureClass) {
-    match terminal {
-        ChildTerminal::Failed {
-            reason,
-            failure_class,
-        } => (reason.clone(), *failure_class),
-        ChildTerminal::Dead => (
-            "child request reached terminal state dead".to_string(),
-            FailureClass::External,
-        ),
-        ChildTerminal::Interrupted => (
-            "child request was interrupted".to_string(),
-            FailureClass::External,
-        ),
-        ChildTerminal::Superseded => (
-            "child request was superseded".to_string(),
-            FailureClass::External,
-        ),
-    }
-}
-
 pub(super) fn foreground_terminal_failure_payload(
     child_request_id: &str,
     child_session_id: &str,

--- a/crates/gents/src/hook/persistence/mod.rs
+++ b/crates/gents/src/hook/persistence/mod.rs
@@ -12,7 +12,8 @@ use crate::background_tools::r4c_args::{
 };
 use crate::background_tools::{
     active_session_request_id, append_steering_request, child_request_completed,
-    context_allowed_target_names, drain_automated_wakeups_returning_ids,
+    child_terminal_reason, child_terminal_status, context_allowed_target_names,
+    drain_automated_wakeups_returning_ids,
     effective_context_cross_deployment_spawn_timeout_seconds, handle_list_background_tools,
     handle_list_subagents, handle_read_subagent, handle_read_tool_output,
     load_authorized_child_edge, load_child_final_response, load_child_terminal_row,

--- a/crates/gents/src/hook/persistence/subagent_bridge.rs
+++ b/crates/gents/src/hook/persistence/subagent_bridge.rs
@@ -295,7 +295,7 @@ impl DefraSessionHook {
 
                 if let Some(terminal) = project_child_terminal(&row) {
                     let status = child_terminal_status(&terminal);
-                    let (reason, failure_class) = child_terminal_error(&terminal);
+                    let (reason, failure_class) = child_terminal_reason(&terminal);
                     if edge.lifecycle_state == "running" {
                         let Some(mut lifecycle) =
                             self.take_owned_in_flight_lifecycle(internal_call_id).await
@@ -594,7 +594,7 @@ impl DefraSessionHook {
 
                 if let Some(terminal) = project_child_terminal(&row) {
                     let status = child_terminal_status(&terminal);
-                    let (reason, failure_class) = child_terminal_error(&terminal);
+                    let (reason, failure_class) = child_terminal_reason(&terminal);
                     if edge.lifecycle_state == "running" {
                         if let Some(mut lifecycle) = self
                             .take_or_load_in_flight_lifecycle(

--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -38,6 +38,45 @@ pub use task_title::task_run_conversation_title;
 
 pub const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 
+/// Outcome of interpreting a persisted `valid_until` TTL against `now`.
+/// Single owner for the parse, shared by the claim path
+/// (`lifecycle::claim::claim_inner`, which errors the claim attempt on
+/// `Malformed`) and the watcher's pre-claim scans (`watcher::query`), which
+/// must fail closed on `Malformed` too — a request whose TTL cannot be
+/// interpreted is not evidence it is still live, so it must not be silently
+/// claimed as if `valid_until` were unset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TtlOutcome {
+    /// No `valid_until` was persisted (or it was empty/whitespace).
+    NotSet,
+    /// `valid_until` parsed and has not yet passed.
+    Live,
+    /// `valid_until` parsed and has passed.
+    Expired,
+    /// `valid_until` was present but did not parse as RFC3339.
+    Malformed,
+}
+
+/// Parse a persisted `valid_until` value against `now`. See [`TtlOutcome`].
+pub(crate) fn parse_valid_until(
+    value: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> TtlOutcome {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return TtlOutcome::NotSet;
+    };
+    match chrono::DateTime::parse_from_rfc3339(value) {
+        Ok(parsed) => {
+            if now > parsed.with_timezone(&chrono::Utc) {
+                TtlOutcome::Expired
+            } else {
+                TtlOutcome::Live
+            }
+        }
+        Err(_) => TtlOutcome::Malformed,
+    }
+}
+
 pub fn is_background_completion_request(metadata: Option<&str>) -> bool {
     queue::is_automated_wakeup(metadata)
 }
@@ -483,6 +522,24 @@ mod tests {
 
     fn materialization_identity() -> Arc<dyn crate::identity::AgentIdentity> {
         Arc::new(MaterializationTestIdentity)
+    }
+
+    #[test]
+    fn parse_valid_until_covers_not_set_live_expired_and_malformed() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-08-12T22:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let future = "2026-08-12T23:00:00Z";
+        let past = "2026-08-12T21:00:00Z";
+
+        assert_eq!(parse_valid_until(None, now), TtlOutcome::NotSet);
+        assert_eq!(parse_valid_until(Some("   "), now), TtlOutcome::NotSet);
+        assert_eq!(parse_valid_until(Some(future), now), TtlOutcome::Live);
+        assert_eq!(parse_valid_until(Some(past), now), TtlOutcome::Expired);
+        assert_eq!(
+            parse_valid_until(Some("not-a-timestamp"), now),
+            TtlOutcome::Malformed
+        );
     }
 
     #[test]

--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -49,10 +49,13 @@ pub const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 pub(crate) enum TtlOutcome {
     /// No `valid_until` was persisted (or it was empty/whitespace).
     NotSet,
-    /// `valid_until` parsed and has not yet passed.
-    Live,
-    /// `valid_until` parsed and has passed.
-    Expired,
+    /// `valid_until` parsed and has not yet passed; carries the parsed
+    /// value so callers that need it (e.g. to persist alongside a claim)
+    /// don't have to re-parse the original string.
+    Live(chrono::DateTime<chrono::Utc>),
+    /// `valid_until` parsed and has passed; carries the parsed value for
+    /// the same reason.
+    Expired(chrono::DateTime<chrono::Utc>),
     /// `valid_until` was present but did not parse as RFC3339.
     Malformed,
 }
@@ -67,10 +70,11 @@ pub(crate) fn parse_valid_until(
     };
     match chrono::DateTime::parse_from_rfc3339(value) {
         Ok(parsed) => {
-            if now > parsed.with_timezone(&chrono::Utc) {
-                TtlOutcome::Expired
+            let parsed = parsed.with_timezone(&chrono::Utc);
+            if now > parsed {
+                TtlOutcome::Expired(parsed)
             } else {
-                TtlOutcome::Live
+                TtlOutcome::Live(parsed)
             }
         }
         Err(_) => TtlOutcome::Malformed,
@@ -531,11 +535,23 @@ mod tests {
             .with_timezone(&chrono::Utc);
         let future = "2026-08-12T23:00:00Z";
         let past = "2026-08-12T21:00:00Z";
+        let future_at = chrono::DateTime::parse_from_rfc3339(future)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let past_at = chrono::DateTime::parse_from_rfc3339(past)
+            .unwrap()
+            .with_timezone(&chrono::Utc);
 
         assert_eq!(parse_valid_until(None, now), TtlOutcome::NotSet);
         assert_eq!(parse_valid_until(Some("   "), now), TtlOutcome::NotSet);
-        assert_eq!(parse_valid_until(Some(future), now), TtlOutcome::Live);
-        assert_eq!(parse_valid_until(Some(past), now), TtlOutcome::Expired);
+        assert_eq!(
+            parse_valid_until(Some(future), now),
+            TtlOutcome::Live(future_at)
+        );
+        assert_eq!(
+            parse_valid_until(Some(past), now),
+            TtlOutcome::Expired(past_at)
+        );
         assert_eq!(
             parse_valid_until(Some("not-a-timestamp"), now),
             TtlOutcome::Malformed

--- a/crates/gents/src/lifecycle.rs
+++ b/crates/gents/src/lifecycle.rs
@@ -47,7 +47,7 @@ pub const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 /// claimed as if `valid_until` were unset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TtlOutcome {
-    /// No `valid_until` was persisted (or it was empty/whitespace).
+    /// No `valid_until` was persisted.
     NotSet,
     /// `valid_until` parsed and has not yet passed; carries the parsed
     /// value so callers that need it (e.g. to persist alongside a claim)
@@ -57,7 +57,7 @@ pub(crate) enum TtlOutcome {
     /// the same reason.
     Expired(chrono::DateTime<chrono::Utc>),
     /// `valid_until` was present but did not parse as RFC3339.
-    Malformed,
+    Malformed(chrono::ParseError),
 }
 
 /// Parse a persisted `valid_until` value against `now`. See [`TtlOutcome`].
@@ -65,7 +65,7 @@ pub(crate) fn parse_valid_until(
     value: Option<&str>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> TtlOutcome {
-    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+    let Some(value) = value else {
         return TtlOutcome::NotSet;
     };
     match chrono::DateTime::parse_from_rfc3339(value) {
@@ -77,7 +77,7 @@ pub(crate) fn parse_valid_until(
                 TtlOutcome::Live(parsed)
             }
         }
-        Err(_) => TtlOutcome::Malformed,
+        Err(error) => TtlOutcome::Malformed(error),
     }
 }
 
@@ -543,7 +543,14 @@ mod tests {
             .with_timezone(&chrono::Utc);
 
         assert_eq!(parse_valid_until(None, now), TtlOutcome::NotSet);
-        assert_eq!(parse_valid_until(Some("   "), now), TtlOutcome::NotSet);
+        assert!(matches!(
+            parse_valid_until(Some("   "), now),
+            TtlOutcome::Malformed(_)
+        ));
+        assert!(matches!(
+            parse_valid_until(Some(" 2026-08-12T23:00:00Z "), now),
+            TtlOutcome::Malformed(_)
+        ));
         assert_eq!(
             parse_valid_until(Some(future), now),
             TtlOutcome::Live(future_at)
@@ -552,10 +559,10 @@ mod tests {
             parse_valid_until(Some(past), now),
             TtlOutcome::Expired(past_at)
         );
-        assert_eq!(
+        assert!(matches!(
             parse_valid_until(Some("not-a-timestamp"), now),
-            TtlOutcome::Malformed
-        );
+            TtlOutcome::Malformed(_)
+        ));
     }
 
     #[test]

--- a/crates/gents/src/lifecycle/claim.rs
+++ b/crates/gents/src/lifecycle/claim.rs
@@ -439,8 +439,11 @@ impl RequestLifecycle {
 
         let valid_until_at_claim =
             match super::parse_valid_until(valid_until.as_deref(), chrono::Utc::now()) {
-                super::TtlOutcome::Malformed => {
-                    anyhow::bail!("invalid valid_until on request {}", self.request.doc_id);
+                super::TtlOutcome::Malformed(error) => {
+                    anyhow::bail!(
+                        "invalid valid_until on request {}: {error}",
+                        self.request.doc_id
+                    );
                 }
                 super::TtlOutcome::Expired(_) => {
                     self.transition_pending_to_dead_stale().await?;

--- a/crates/gents/src/lifecycle/claim.rs
+++ b/crates/gents/src/lifecycle/claim.rs
@@ -442,21 +442,13 @@ impl RequestLifecycle {
                 super::TtlOutcome::Malformed => {
                     anyhow::bail!("invalid valid_until on request {}", self.request.doc_id);
                 }
-                super::TtlOutcome::Expired => {
+                super::TtlOutcome::Expired(_) => {
                     self.transition_pending_to_dead_stale().await?;
                     self.state = LocalLifecycleState::Dead;
                     return Ok(ClaimOutcome::Expired);
                 }
                 super::TtlOutcome::NotSet => None,
-                super::TtlOutcome::Live => Some(
-                    chrono::DateTime::parse_from_rfc3339(
-                        valid_until
-                            .as_deref()
-                            .expect("TtlOutcome::Live implies valid_until is Some"),
-                    )
-                    .expect("TtlOutcome::Live implies valid_until already parsed")
-                    .with_timezone(&chrono::Utc),
-                ),
+                super::TtlOutcome::Live(parsed) => Some(parsed),
             };
 
         let dedup = self.check_deduplication().await?;

--- a/crates/gents/src/lifecycle/claim.rs
+++ b/crates/gents/src/lifecycle/claim.rs
@@ -437,25 +437,27 @@ impl RequestLifecycle {
             return Ok(ClaimOutcome::Interrupted);
         }
 
-        let valid_until_at_claim = match valid_until.as_deref() {
-            Some(s) => {
-                let dt = chrono::DateTime::parse_from_rfc3339(s)
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "invalid valid_until on request {}: {e}",
-                            self.request.doc_id
-                        )
-                    })?
-                    .with_timezone(&chrono::Utc);
-                if chrono::Utc::now() > dt {
+        let valid_until_at_claim =
+            match super::parse_valid_until(valid_until.as_deref(), chrono::Utc::now()) {
+                super::TtlOutcome::Malformed => {
+                    anyhow::bail!("invalid valid_until on request {}", self.request.doc_id);
+                }
+                super::TtlOutcome::Expired => {
                     self.transition_pending_to_dead_stale().await?;
                     self.state = LocalLifecycleState::Dead;
                     return Ok(ClaimOutcome::Expired);
                 }
-                Some(dt)
-            }
-            None => None,
-        };
+                super::TtlOutcome::NotSet => None,
+                super::TtlOutcome::Live => Some(
+                    chrono::DateTime::parse_from_rfc3339(
+                        valid_until
+                            .as_deref()
+                            .expect("TtlOutcome::Live implies valid_until is Some"),
+                    )
+                    .expect("TtlOutcome::Live implies valid_until already parsed")
+                    .with_timezone(&chrono::Utc),
+                ),
+            };
 
         let dedup = self.check_deduplication().await?;
         if !dedup.is_earliest {

--- a/crates/gents/src/tool_call_lifecycle.rs
+++ b/crates/gents/src/tool_call_lifecycle.rs
@@ -487,8 +487,12 @@ impl ToolCallLifecycle {
         self.doc_id = doc_id;
     }
 
-    pub(crate) fn deadline_at(&self) -> chrono::DateTime<chrono::Utc> {
-        self.deadline_at
+    /// True once `deadline_at` has passed (inclusive) relative to `now`. Single
+    /// owner for the deadline-expiry check shared by the parent-deadline sweep
+    /// (`hook.rs::timeout_expired_tool_calls`) and the held-approval sweep
+    /// (`hook/persistence/approval.rs::drive_held_tool_call`).
+    pub(crate) fn is_deadline_expired(&self, now: chrono::DateTime<chrono::Utc>) -> bool {
+        self.deadline_at <= now
     }
 
     pub(crate) fn is_subagent_bridge(&self) -> bool {

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -315,12 +315,13 @@ impl super::ToolCallLifecycle {
     /// 3. Require a terminal parent before any write.
     /// 4. Leave every native background row to the registry-aware orphan
     ///    sweep, regardless of parent state.
-    /// 5. Detached bridges under an *interrupted* parent are left running.
-    /// 6. Child-linked bridges under a *cleanly completed* parent are left
-    ///    running — clean completion is not a cancel signal (live cascade and
-    ///    recovery only cancel on cancel-worthy terminals).
-    /// 7. Then project already-terminal children onto bridges (matches startup
-    ///    child-precedence so restart and live ticks converge).
+    /// 5. Project already-terminal children onto bridges first (matches
+    ///    startup child-precedence so restart and live ticks converge).
+    /// 6. Only then: detached bridges under an *interrupted* parent (whose
+    ///    child hasn't independently gone terminal) are left running, and
+    ///    child-linked bridges under a *cleanly completed* parent are left
+    ///    running too — clean completion is not a cancel signal (live
+    ///    cascade and recovery only cancel on cancel-worthy terminals).
     ///
     /// Covers running native tool calls stranded under a terminal parent with
     /// no executor active.
@@ -371,13 +372,13 @@ impl super::ToolCallLifecycle {
                 continue;
             }
 
-            // Detached bridges may outlive an interrupted parent by design
-            // (startup recovery leaves them running too).
-            if is_detached_subagent_tool(&row) && request_is_interrupted(&parent) {
-                continue;
-            }
-
             // Child-terminal precedence only after owner + terminal-parent gates.
+            // (Detached bridges under an interrupted parent are still left
+            // running when their child hasn't independently gone terminal —
+            // that's `classify_terminal_parent_tool_recovery`'s
+            // `is_detached_subagent_tool && request_is_interrupted` branch,
+            // reached below. Checking child-terminal precedence first here
+            // matches the startup sweep's order, which does the same.)
             if recover_bridge_terminal_child(node, agent_did, &row).await? {
                 report.tool_calls_terminalized += 1;
                 tracing::info!(

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -389,18 +389,13 @@ impl super::ToolCallLifecycle {
                 continue;
             }
 
-            // Clean parent completion is not a cancel signal for linked
-            // background/cascade children — leave the bridge running.
-            if request_is_cleanly_completed(&parent) && child_request_id(&row).is_some() {
+            // Parent-driven cause, shared with the startup/orphan classifier
+            // (`classify_running_tool_recovery`) minus its deadline and
+            // live-background-parent screens: `None` covers the clean-parent-
+            // completion skip for linked background/cascade children (leave
+            // the bridge running — clean completion is not a cancel signal).
+            let Some(outcome) = classify_terminal_parent_tool_recovery(&row, &parent) else {
                 continue;
-            }
-
-            let outcome = if request_is_interrupted(&parent) {
-                RecoveryOutcome::Cancelled
-            } else {
-                // Cancel-worthy non-interrupt terminals, or a native composite
-                // stranded under a cleanly-completed parent.
-                RecoveryOutcome::Failed
             };
 
             // Cascade only for cancel-worthy terminals — never on clean complete.
@@ -2191,13 +2186,34 @@ fn classify_running_tool_recovery(
         && parent.is_some_and(|parent| !request_is_terminal(parent))
     {
         Some(RecoveryOutcome::BackgroundInterrupted)
-    } else if is_detached_subagent_tool(row) && parent.is_some_and(request_is_interrupted) {
+    } else {
+        parent.and_then(|parent| classify_terminal_parent_tool_recovery(row, parent))
+    }
+}
+
+/// Parent-driven recovery cause for a running tool call whose parent has
+/// already resolved (Lean `terminalParentToolRecover`: cause is
+/// `.parentInterrupted` when the parent is interrupted, else `.parentTerminal`
+/// — deadline expiry is not a predicate of `TerminalParentToolRow` at all).
+/// Shared by [`classify_running_tool_recovery`] (after its deadline and
+/// live-background-parent screens) and
+/// `ToolCallLifecycle::reconcile_terminal_parent_owned_tools`, whose Lean
+/// counterpart (`terminalParentOwnedToolSweep`) intentionally excludes
+/// deadline expiry from this sweep — a stranded row's own deadline is not
+/// evidence about its *parent's* terminal state, and deadline-expired rows
+/// are covered by the orphan/background sweep and the live in-flight
+/// deadline sweep instead.
+fn classify_terminal_parent_tool_recovery(
+    row: &RunningToolCallRow,
+    parent: &ParentRequestRow,
+) -> Option<RecoveryOutcome> {
+    if is_detached_subagent_tool(row) && request_is_interrupted(parent) {
         None
-    } else if parent.is_some_and(request_is_cleanly_completed) && child_request_id(row).is_some() {
+    } else if request_is_cleanly_completed(parent) && child_request_id(row).is_some() {
         None
-    } else if parent.is_some_and(request_is_interrupted) {
+    } else if request_is_interrupted(parent) {
         Some(RecoveryOutcome::Cancelled)
-    } else if parent.is_some_and(request_is_terminal) {
+    } else if request_is_terminal(parent) {
         Some(RecoveryOutcome::Failed)
     } else {
         None

--- a/crates/gents/src/toolset.rs
+++ b/crates/gents/src/toolset.rs
@@ -339,33 +339,41 @@ pub enum NativeTool {
 }
 
 impl NativeTool {
-    /// Names of the non-parameterized native tool kinds, i.e. every variant
-    /// except `Cli` (whose name is config-defined). Single source of truth
-    /// for callers that need to reserve or enumerate the built-in native
-    /// tool surface without constructing an instance of each variant; kept
-    /// in sync with `tool_name` by the
-    /// `reserved_names_cover_native_and_meta_tools` test.
-    pub const ALL_NAMES: [&'static str; 8] = [
-        "list_files",
-        "read_file",
-        "glob",
-        "grep",
-        "write_file",
-        "edit_file",
-        "bash",
-        "bash_unrestricted",
+    const LIST_FILES_NAME: &'static str = <ListFilesTool as crate::llm::tool::Tool>::NAME;
+    const READ_FILE_NAME: &'static str = <ReadFileTool as crate::llm::tool::Tool>::NAME;
+    const GLOB_NAME: &'static str = <GlobTool as crate::llm::tool::Tool>::NAME;
+    const GREP_NAME: &'static str = <GrepTool as crate::llm::tool::Tool>::NAME;
+    const WRITE_FILE_NAME: &'static str = <WriteFileTool as crate::llm::tool::Tool>::NAME;
+    const EDIT_FILE_NAME: &'static str = <EditFileTool as crate::llm::tool::Tool>::NAME;
+    const BASH_NAME: &'static str = <ReadOnlyBashTool as crate::llm::tool::Tool>::NAME;
+    const BASH_UNRESTRICTED_NAME: &'static str =
+        <UnrestrictedBashTool as crate::llm::tool::Tool>::NAME;
+
+    /// Names of every fixed-name `NativeTool` variant. The concrete `Tool`
+    /// implementations own the strings; this registry and `tool_name` both
+    /// derive from those constants. `Cli` is excluded because its name comes
+    /// from configuration.
+    pub(crate) const ALL_NAMES: [&'static str; 8] = [
+        Self::LIST_FILES_NAME,
+        Self::READ_FILE_NAME,
+        Self::GLOB_NAME,
+        Self::GREP_NAME,
+        Self::WRITE_FILE_NAME,
+        Self::EDIT_FILE_NAME,
+        Self::BASH_NAME,
+        Self::BASH_UNRESTRICTED_NAME,
     ];
 
     pub fn tool_name(&self) -> String {
         match self {
-            Self::ListFiles { .. } => "list_files".to_string(),
-            Self::ReadFile { .. } => "read_file".to_string(),
-            Self::Glob { .. } => "glob".to_string(),
-            Self::Grep { .. } => "grep".to_string(),
-            Self::WriteFile { .. } => "write_file".to_string(),
-            Self::EditFile { .. } => "edit_file".to_string(),
-            Self::BashReadOnly { .. } => "bash".to_string(),
-            Self::BashUnrestricted { .. } => "bash_unrestricted".to_string(),
+            Self::ListFiles { .. } => Self::LIST_FILES_NAME.to_string(),
+            Self::ReadFile { .. } => Self::READ_FILE_NAME.to_string(),
+            Self::Glob { .. } => Self::GLOB_NAME.to_string(),
+            Self::Grep { .. } => Self::GREP_NAME.to_string(),
+            Self::WriteFile { .. } => Self::WRITE_FILE_NAME.to_string(),
+            Self::EditFile { .. } => Self::EDIT_FILE_NAME.to_string(),
+            Self::BashReadOnly { .. } => Self::BASH_NAME.to_string(),
+            Self::BashUnrestricted { .. } => Self::BASH_UNRESTRICTED_NAME.to_string(),
             Self::Cli(tool) => tool.name.clone(),
         }
     }

--- a/crates/gents/src/toolset.rs
+++ b/crates/gents/src/toolset.rs
@@ -339,6 +339,23 @@ pub enum NativeTool {
 }
 
 impl NativeTool {
+    /// Names of the non-parameterized native tool kinds, i.e. every variant
+    /// except `Cli` (whose name is config-defined). Single source of truth
+    /// for callers that need to reserve or enumerate the built-in native
+    /// tool surface without constructing an instance of each variant; kept
+    /// in sync with `tool_name` by the
+    /// `reserved_names_cover_native_and_meta_tools` test.
+    pub const ALL_NAMES: [&'static str; 8] = [
+        "list_files",
+        "read_file",
+        "glob",
+        "grep",
+        "write_file",
+        "edit_file",
+        "bash",
+        "bash_unrestricted",
+    ];
+
     pub fn tool_name(&self) -> String {
         match self {
             Self::ListFiles { .. } => "list_files".to_string(),

--- a/crates/gents/src/watcher/query.rs
+++ b/crates/gents/src/watcher/query.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use super::{validate_agent_request, AgentRequest, DefraWatcher};
 
 mod rows;
-use rows::{AgentRequestRow, SessionQueueRow};
+use rows::{AgentRequestRow, PreclaimSignal, SessionQueueRow};
 
 pub(crate) const AGENT_REQUEST_FIELDS: &str = r#"
                     _docID
@@ -200,8 +200,17 @@ impl DefraWatcher {
         if !row.is_pending() {
             return Ok(false);
         }
-        if row.has_preclaim_terminal_signal() {
-            return Ok(true);
+        match row.preclaim_signal() {
+            PreclaimSignal::Terminal => return Ok(true),
+            PreclaimSignal::Malformed => {
+                tracing::warn!(
+                    doc_id = %row.doc_id,
+                    request_id = %row.request_id,
+                    "watcher refusing to claim AgentRequest with malformed valid_until"
+                );
+                return Ok(false);
+            }
+            PreclaimSignal::None => {}
         }
 
         let session_id = crate::graphql::escape_graphql_string(&row.session_id);
@@ -348,15 +357,25 @@ fn claimable_pending_rows_from_rows(rows: Vec<AgentRequestRow>) -> Vec<AgentRequ
 
     for row in rows {
         let is_pending = row.is_pending();
-        let is_preclaim_terminal = row.has_preclaim_terminal_signal();
         let pending_session_seen = seen_pending_sessions.contains(&row.session_id);
         let session_blocked = blocked_sessions.contains(&row.session_id);
 
-        if is_pending && (is_preclaim_terminal || (!session_blocked && !pending_session_seen)) {
-            claimable.push(row.clone());
-        }
-
         if is_pending {
+            match row.preclaim_signal() {
+                PreclaimSignal::Terminal => claimable.push(row.clone()),
+                PreclaimSignal::Malformed => {
+                    tracing::warn!(
+                        doc_id = %row.doc_id,
+                        request_id = %row.request_id,
+                        "watcher refusing to claim AgentRequest with malformed valid_until"
+                    );
+                }
+                PreclaimSignal::None => {
+                    if !session_blocked && !pending_session_seen {
+                        claimable.push(row.clone());
+                    }
+                }
+            }
             seen_pending_sessions.insert(row.session_id.clone());
         }
     }
@@ -470,5 +489,27 @@ mod tests {
         let ranked = prioritize_aged_background_wakes(rows, now);
         assert_eq!(ranked[0].request_id, "older-descendant");
         assert_eq!(ranked[1].request_id, "fresh-wake");
+    }
+
+    /// A malformed `valid_until` must fail closed (#1339): it is never
+    /// claimable, even though the sole other pending row in its session
+    /// would otherwise leave the ordinary FIFO gate open for it.
+    #[test]
+    fn malformed_valid_until_is_never_claimable() {
+        let mut row = pending_row(
+            "malformed-ttl",
+            "solo-session",
+            "2026-08-12T21:00:00Z",
+            None,
+            "interactive",
+        );
+        row["valid_until"] = serde_json::json!("not-a-timestamp");
+        let data = serde_json::json!({ "AgentRequest": [row] });
+        let rows = claimable_pending_rows_from_rows(active_runtime_rows(Some(&data)).unwrap());
+        assert!(
+            rows.is_empty(),
+            "malformed valid_until must never be claimable, got {} row(s)",
+            rows.len()
+        );
     }
 }

--- a/crates/gents/src/watcher/query/rows.rs
+++ b/crates/gents/src/watcher/query/rows.rs
@@ -104,7 +104,7 @@ impl AgentRequestRow {
             crate::lifecycle::TtlOutcome::Expired(_) => PreclaimSignal::Terminal,
             // Fail closed: an unparseable TTL is not evidence the request is
             // still live, so it must not be claimed as if unset.
-            crate::lifecycle::TtlOutcome::Malformed => PreclaimSignal::Malformed,
+            crate::lifecycle::TtlOutcome::Malformed(_) => PreclaimSignal::Malformed,
             crate::lifecycle::TtlOutcome::NotSet | crate::lifecycle::TtlOutcome::Live(_) => {
                 PreclaimSignal::None
             }

--- a/crates/gents/src/watcher/query/rows.rs
+++ b/crates/gents/src/watcher/query/rows.rs
@@ -12,6 +12,19 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
     })
 }
 
+/// Result of [`AgentRequestRow::preclaim_signal`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PreclaimSignal {
+    /// No terminal or malformed signal; ordinary session-based claimability
+    /// applies.
+    None,
+    /// Interrupted, or `valid_until` has expired: claim immediately so the
+    /// row can be terminalized.
+    Terminal,
+    /// `valid_until` is present but did not parse: never claimable.
+    Malformed,
+}
+
 #[derive(Clone, Deserialize)]
 pub(super) struct AgentRequestRow {
     #[serde(rename = "_docID")]
@@ -81,15 +94,21 @@ impl AgentRequestRow {
         !self.is_pending()
     }
 
-    pub(super) fn has_preclaim_terminal_signal(&self) -> bool {
+    /// Pre-claim disposition from `interrupt_requested_at` and `valid_until`,
+    /// checked before the watcher issues any claim-scoped query.
+    pub(super) fn preclaim_signal(&self) -> PreclaimSignal {
         if normalize_optional_string(self.interrupt_requested_at.clone()).is_some() {
-            return true;
+            return PreclaimSignal::Terminal;
         }
-        normalize_optional_string(self.valid_until.clone()).is_some_and(|value| {
-            chrono::DateTime::parse_from_rfc3339(&value)
-                .map(|dt| chrono::Utc::now() > dt.with_timezone(&chrono::Utc))
-                .unwrap_or(false)
-        })
+        match crate::lifecycle::parse_valid_until(self.valid_until.as_deref(), chrono::Utc::now()) {
+            crate::lifecycle::TtlOutcome::Expired => PreclaimSignal::Terminal,
+            // Fail closed: an unparseable TTL is not evidence the request is
+            // still live, so it must not be claimed as if unset.
+            crate::lifecycle::TtlOutcome::Malformed => PreclaimSignal::Malformed,
+            crate::lifecycle::TtlOutcome::NotSet | crate::lifecycle::TtlOutcome::Live => {
+                PreclaimSignal::None
+            }
+        }
     }
 
     pub(super) fn is_aged_background_completion_wakeup(

--- a/crates/gents/src/watcher/query/rows.rs
+++ b/crates/gents/src/watcher/query/rows.rs
@@ -101,11 +101,11 @@ impl AgentRequestRow {
             return PreclaimSignal::Terminal;
         }
         match crate::lifecycle::parse_valid_until(self.valid_until.as_deref(), chrono::Utc::now()) {
-            crate::lifecycle::TtlOutcome::Expired => PreclaimSignal::Terminal,
+            crate::lifecycle::TtlOutcome::Expired(_) => PreclaimSignal::Terminal,
             // Fail closed: an unparseable TTL is not evidence the request is
             // still live, so it must not be claimed as if unset.
             crate::lifecycle::TtlOutcome::Malformed => PreclaimSignal::Malformed,
-            crate::lifecycle::TtlOutcome::NotSet | crate::lifecycle::TtlOutcome::Live => {
+            crate::lifecycle::TtlOutcome::NotSet | crate::lifecycle::TtlOutcome::Live(_) => {
                 PreclaimSignal::None
             }
         }

--- a/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
+++ b/crates/gents/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
@@ -116,7 +116,7 @@ async fn wait_subagent_maps_child_terminal_failures_without_lifecycle_row() {
             "dead",
             "failed",
             None,
-            "child request reached terminal state dead",
+            "child request reached the dead terminal state",
         ),
         (
             "interrupted",

--- a/packages/gents-desktop-chat/src/chat-shell.ts
+++ b/packages/gents-desktop-chat/src/chat-shell.ts
@@ -6,9 +6,14 @@ import type {
   PendingTurnView,
 } from "@source-inc/gents-desktop-client";
 import {
+  isTerminalTurnState,
   projectClientOperationalStatus,
   projectRouteOperationalStatus,
 } from "@source-inc/gents-desktop-client";
+
+// Re-exported for existing `@source-inc/gents-desktop-chat` consumers; the
+// single owner is `@source-inc/gents-desktop-client`'s `turnState.ts` (#1339).
+export { isTerminalTurnState } from "@source-inc/gents-desktop-client";
 
 export type OptimisticPendingTurn = PendingTurnView & { sessionId: string };
 
@@ -162,17 +167,6 @@ export function reconcileProjectedWorkflow(
   }
 
   return localWorkflow;
-}
-
-export function isTerminalTurnState(
-  turnState?: string | null,
-): turnState is "completed" | "failed" | "superseded" | "interrupted" {
-  return (
-    turnState === "completed" ||
-    turnState === "failed" ||
-    turnState === "superseded" ||
-    turnState === "interrupted"
-  );
 }
 
 function isTurnState(value?: string | null): value is TurnState {

--- a/packages/gents-desktop-chat/src/chat-shell.ts
+++ b/packages/gents-desktop-chat/src/chat-shell.ts
@@ -11,10 +11,6 @@ import {
   projectRouteOperationalStatus,
 } from "@source-inc/gents-desktop-client";
 
-// Re-exported for existing `@source-inc/gents-desktop-chat` consumers; the
-// single owner is `@source-inc/gents-desktop-client`'s `turnState.ts` (#1339).
-export { isTerminalTurnState } from "@source-inc/gents-desktop-client";
-
 export type OptimisticPendingTurn = PendingTurnView & { sessionId: string };
 
 export type RequestProgressPresentation = {

--- a/packages/gents-desktop-chat/src/components/chat/ChatTranscriptPanel.tsx
+++ b/packages/gents-desktop-chat/src/components/chat/ChatTranscriptPanel.tsx
@@ -1,13 +1,11 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import {
-  isTerminalTurnState,
-  type OptimisticPendingTurn,
-} from "../../chat-shell.js";
+import type { OptimisticPendingTurn } from "../../chat-shell.js";
 import type {
   DesktopSessionSnapshot,
   RenderedTimelineItem,
 } from "@source-inc/gents-desktop-client";
+import { isTerminalTurnState } from "@source-inc/gents-desktop-client";
 import { MessageList } from "../Transcript.js";
 
 export type ChatTranscriptPanelProps = {

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -15,9 +15,9 @@ export type DesktopBridgeContract = GeneratedBridgeContract;
 export const PACKAGE_VERSION = "0.15.0";
 // The client and bridge share one exact breaking contract. Sync status comes
 // from database-owned gauges; goal permissions are explicit fields.
-export const BRIDGE_CONTRACT_VERSION = "6.2";
+export const BRIDGE_CONTRACT_VERSION = "6.3";
 export const EXPECTED_BRIDGE_WIRE_SCHEMA_HASH =
-  "df5cd8234a352627975cc23f8b8f258d7d0675a4c544d4a8f8b02b930f35010e";
+  "56091dd558796e1dd812bb794a134de193fee7706e81aa33082f53142232f47e";
 
 export function assertExactBridgeContract(
   contract: DesktopBridgeContract,

--- a/packages/gents-desktop-client/src/errors.test.ts
+++ b/packages/gents-desktop-client/src/errors.test.ts
@@ -18,6 +18,7 @@ describe("bridge error contract", () => {
         code: "backend",
         message: "query failed",
         retryable: true,
+        endpoint: null,
       }),
     ).toEqual({
       code: "backend",
@@ -25,6 +26,16 @@ describe("bridge error contract", () => {
       retryable: true,
       endpoint: null,
     });
+  });
+
+  it("rejects the pre-6.3 payload when endpoint is absent", () => {
+    expect(
+      asBridgeErrorPayload({
+        code: "backend",
+        message: "query failed",
+        retryable: true,
+      }),
+    ).toBeNull();
   });
 
   it("carries the structured endpoint for endpointUnreachable payloads", () => {

--- a/packages/gents-desktop-client/src/errors.test.ts
+++ b/packages/gents-desktop-client/src/errors.test.ts
@@ -19,6 +19,27 @@ describe("bridge error contract", () => {
         message: "query failed",
         retryable: true,
       }),
-    ).toEqual({ code: "backend", message: "query failed", retryable: true });
+    ).toEqual({
+      code: "backend",
+      message: "query failed",
+      retryable: true,
+      endpoint: null,
+    });
+  });
+
+  it("carries the structured endpoint for endpointUnreachable payloads", () => {
+    expect(
+      asBridgeErrorPayload({
+        code: "endpointUnreachable",
+        message: "sending GET request to http://127.0.0.1:9181/status",
+        retryable: true,
+        endpoint: "http://127.0.0.1:9181",
+      }),
+    ).toEqual({
+      code: "endpointUnreachable",
+      message: "sending GET request to http://127.0.0.1:9181/status",
+      retryable: true,
+      endpoint: "http://127.0.0.1:9181",
+    });
   });
 });

--- a/packages/gents-desktop-client/src/errors.ts
+++ b/packages/gents-desktop-client/src/errors.ts
@@ -21,12 +21,15 @@ const BRIDGE_ERROR_CODES = new Set<BridgeErrorCode>([
 export class BridgeInvokeError extends Error {
   readonly code: BridgeErrorCode;
   readonly retryable: boolean;
+  /** The unreachable endpoint, for `code === "endpointUnreachable"`. */
+  readonly endpoint: string | null;
 
   constructor(payload: BridgeErrorPayload) {
     super(payload.message);
     this.name = "BridgeInvokeError";
     this.code = payload.code;
     this.retryable = payload.retryable;
+    this.endpoint = payload.endpoint ?? null;
   }
 }
 
@@ -51,6 +54,7 @@ export function asBridgeErrorPayload(
       code: candidate.code as BridgeErrorCode,
       message: candidate.message,
       retryable: candidate.retryable,
+      endpoint: typeof candidate.endpoint === "string" ? candidate.endpoint : null,
     };
   }
   return null;

--- a/packages/gents-desktop-client/src/errors.ts
+++ b/packages/gents-desktop-client/src/errors.ts
@@ -29,7 +29,7 @@ export class BridgeInvokeError extends Error {
     this.name = "BridgeInvokeError";
     this.code = payload.code;
     this.retryable = payload.retryable;
-    this.endpoint = payload.endpoint ?? null;
+    this.endpoint = payload.endpoint;
   }
 }
 
@@ -48,13 +48,14 @@ export function asBridgeErrorPayload(
     typeof candidate.code === "string" &&
     BRIDGE_ERROR_CODES.has(candidate.code as BridgeErrorCode) &&
     typeof candidate.message === "string" &&
-    typeof candidate.retryable === "boolean"
+    typeof candidate.retryable === "boolean" &&
+    (typeof candidate.endpoint === "string" || candidate.endpoint === null)
   ) {
     return {
       code: candidate.code as BridgeErrorCode,
       message: candidate.message,
       retryable: candidate.retryable,
-      endpoint: typeof candidate.endpoint === "string" ? candidate.endpoint : null,
+      endpoint: candidate.endpoint as string | null,
     };
   }
   return null;

--- a/packages/gents-desktop-client/src/generated/BridgeError.ts
+++ b/packages/gents-desktop-client/src/generated/BridgeError.ts
@@ -4,4 +4,10 @@ import type { BridgeErrorCode } from "./BridgeErrorCode.js";
 /**
  * Serialized error shape returned by bridge commands after phase 3.
  */
-export type BridgeError = { code: BridgeErrorCode, message: string, retryable: boolean, };
+export type BridgeError = { code: BridgeErrorCode, message: string, retryable: boolean,
+/**
+ * The origin/address that could not be reached, for
+ * `EndpointUnreachable` errors. `None` for every other code. Structured
+ * so callers don't need to regex it back out of `message` (#1339).
+ */
+endpoint: string | null, };

--- a/packages/gents-desktop-client/src/index.ts
+++ b/packages/gents-desktop-client/src/index.ts
@@ -33,6 +33,7 @@ export type {
 } from "./api/types.js";
 export * from "./events.js";
 export * from "./operationalState.js";
+export * from "./turnState.js";
 export * from "./types.js";
 
 export const NARROW_BREAKPOINT_PX = 760;

--- a/packages/gents-desktop-client/src/turnState.ts
+++ b/packages/gents-desktop-client/src/turnState.ts
@@ -1,0 +1,21 @@
+export type TerminalTurnState =
+  | "completed"
+  | "failed"
+  | "superseded"
+  | "interrupted";
+
+/**
+ * True for the four terminal turn-state labels the bridge derives from
+ * `ClientTurnState::is_terminal` (Rust: `gents_protocol::client_protocol`).
+ * Single owner for the desktop-chat and desktop-fleet copies (#1339).
+ */
+export function isTerminalTurnState(
+  turnState?: string | null,
+): turnState is TerminalTurnState {
+  return (
+    turnState === "completed" ||
+    turnState === "failed" ||
+    turnState === "superseded" ||
+    turnState === "interrupted"
+  );
+}

--- a/packages/gents-desktop-fleet/src/components/FleetRow.tsx
+++ b/packages/gents-desktop-fleet/src/components/FleetRow.tsx
@@ -6,6 +6,7 @@ import type {
   DeploymentView,
   SyncHealthView,
 } from "@source-inc/gents-desktop-client";
+import { isTerminalTurnState } from "@source-inc/gents-desktop-client";
 import { ConfirmDialog } from "@source-inc/gents-desktop-ui";
 import {
   ChatIcon,
@@ -23,15 +24,6 @@ import {
   toolCeilingIcons,
   type ToolIcon,
 } from "../fleetMetrics.js";
-
-function isTerminalTurnState(turnState?: string | null) {
-  return (
-    turnState === "completed" ||
-    turnState === "failed" ||
-    turnState === "superseded" ||
-    turnState === "interrupted"
-  );
-}
 
 export type FleetRowProps = {
   bootstrap: BootstrapSummary | null;

--- a/packages/gents-desktop-fleet/src/fleetMetrics.ts
+++ b/packages/gents-desktop-fleet/src/fleetMetrics.ts
@@ -78,6 +78,9 @@ export function inferenceBackendTitle(deployment: DeploymentView) {
 }
 
 export function needsInferenceSetup(deployment: DeploymentView): boolean {
+  // Enrollment-owned deployments are configured by their remote runtime;
+  // this client cannot satisfy a credentials/readiness failure locally.
+  if (deployment.source === "enrollment") return false;
   return behaviorReadinessIsInferenceFailure(
     selectedBehaviorReadinessDecision(deployment, null),
   );

--- a/packages/gents-desktop-fleet/src/fleetMetrics.ts
+++ b/packages/gents-desktop-fleet/src/fleetMetrics.ts
@@ -4,8 +4,10 @@ import type {
   ToolSelectionView,
 } from "@source-inc/gents-desktop-client";
 import {
+  behaviorReadinessIsInferenceFailure,
   isLocalRuntimeSource,
   projectDeploymentOperationalState,
+  selectedBehaviorReadinessDecision,
 } from "@source-inc/gents-desktop-client";
 
 export { isLocalRuntimeSource } from "@source-inc/gents-desktop-client";
@@ -76,11 +78,8 @@ export function inferenceBackendTitle(deployment: DeploymentView) {
 }
 
 export function needsInferenceSetup(deployment: DeploymentView): boolean {
-  // Enrolled clients do not receive non-branchable backend documents and
-  // cannot configure them locally. Runtime-authored readiness is authoritative.
-  if (deployment.source === "enrollment") return false;
-  return !deployment.inferenceBackends.some(
-    (backend) => backend.enabled !== false && backend.models.length > 0,
+  return behaviorReadinessIsInferenceFailure(
+    selectedBehaviorReadinessDecision(deployment, null),
   );
 }
 

--- a/packages/gents-desktop-fleet/src/peerConnectionErrors.test.ts
+++ b/packages/gents-desktop-fleet/src/peerConnectionErrors.test.ts
@@ -42,6 +42,22 @@ describe("formatPeerConnectionError", () => {
     );
   });
 
+  it("prefers the bridge's structured endpoint over parsing the message", () => {
+    expect(
+      formatPeerConnectionError(
+        {
+          code: "endpointUnreachable",
+          message: "unused: structured endpoint takes precedence",
+          retryable: true,
+          endpoint: "http://127.0.0.1:9181",
+        },
+        "peer-status",
+      ),
+    ).toBe(
+      "Could not fetch runtime connection details from http://127.0.0.1:9181. Check that the runtime is running and the address is reachable.",
+    );
+  });
+
   it("keeps already useful errors unchanged", () => {
     expect(
       formatPeerConnectionError(

--- a/packages/gents-desktop-fleet/src/peerConnectionErrors.test.ts
+++ b/packages/gents-desktop-fleet/src/peerConnectionErrors.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from "vitest";
 
 import { formatPeerConnectionError } from "./peerConnectionErrors.js";
 
+function endpointUnreachable(endpoint: string, message = "unused") {
+  return {
+    code: "endpointUnreachable" as const,
+    message,
+    retryable: true,
+    endpoint,
+  };
+}
+
 describe("formatPeerConnectionError", () => {
-  it("turns local runtime transport context into operator-facing copy", () => {
+  it("turns a structured local-runtime endpoint into operator-facing copy", () => {
     expect(
       formatPeerConnectionError(
-        "sending GET request to http://127.0.0.1:9191/api/v0/p2p/shareable-address",
+        endpointUnreachable("http://127.0.0.1:9191"),
         "local-runtime",
       ),
     ).toBe(
@@ -14,12 +23,10 @@ describe("formatPeerConnectionError", () => {
     );
   });
 
-  it("turns peer status transport context into discovery copy", () => {
+  it("turns a structured peer-status endpoint into discovery copy", () => {
     expect(
       formatPeerConnectionError(
-        new Error(
-          "sending GET request to http://127.0.0.1:9181/api/v0/p2p/shareable-address.",
-        ),
+        endpointUnreachable("http://127.0.0.1:9181"),
         "peer-status",
       ),
     ).toBe(
@@ -30,7 +37,7 @@ describe("formatPeerConnectionError", () => {
   it("lets a white-label host own runtime and CLI names", () => {
     expect(
       formatPeerConnectionError(
-        "sending GET request to http://127.0.0.1:9191/api/v0/p2p/shareable-address",
+        endpointUnreachable("http://127.0.0.1:9191"),
         "local-runtime",
         {
           runtimeProductName: "Indigo Relay",
@@ -42,15 +49,10 @@ describe("formatPeerConnectionError", () => {
     );
   });
 
-  it("prefers the bridge's structured endpoint over parsing the message", () => {
+  it("recognizes the structured error nested under a Tauri invoke wrapper's message field", () => {
     expect(
       formatPeerConnectionError(
-        {
-          code: "endpointUnreachable",
-          message: "unused: structured endpoint takes precedence",
-          retryable: true,
-          endpoint: "http://127.0.0.1:9181",
-        },
+        { message: endpointUnreachable("http://127.0.0.1:9181") },
         "peer-status",
       ),
     ).toBe(
@@ -58,7 +60,7 @@ describe("formatPeerConnectionError", () => {
     );
   });
 
-  it("keeps already useful errors unchanged", () => {
+  it("keeps already useful errors unchanged when there's no structured endpoint", () => {
     expect(
       formatPeerConnectionError(
         "no running local Gents runtime found at /tmp/runtime.json; run `gents server` first",
@@ -67,5 +69,19 @@ describe("formatPeerConnectionError", () => {
     ).toBe(
       "no running local Gents runtime found at /tmp/runtime.json; run `gents server` first",
     );
+  });
+
+  it("leaves non-endpointUnreachable bridge errors unchanged", () => {
+    expect(
+      formatPeerConnectionError(
+        {
+          code: "backend",
+          message: "GraphQL mutation failed",
+          retryable: true,
+          endpoint: null,
+        },
+        "peer-status",
+      ),
+    ).toBe("GraphQL mutation failed");
   });
 });

--- a/packages/gents-desktop-fleet/src/peerConnectionErrors.ts
+++ b/packages/gents-desktop-fleet/src/peerConnectionErrors.ts
@@ -12,7 +12,10 @@ export function formatPeerConnectionError(
   copy: Pick<FleetCopy, "runtimeProductName" | "cliBinaryName"> = {},
 ): string {
   const message = errorMessage(error);
-  const url = requestUrlFromMessage(message);
+  // Prefer the bridge's structured endpoint (BridgeErrorCode.endpointUnreachable,
+  // #1339) when the error carries one; only a command not yet wired to emit a
+  // typed BridgeError falls back to parsing the underlying transport message.
+  const url = structuredEndpointFromError(error) ?? requestUrlFromMessage(message);
   if (!url) {
     return message;
   }
@@ -30,6 +33,11 @@ export function formatPeerConnectionError(
   }
 
   return message;
+}
+
+function structuredEndpointFromError(error: unknown): string | null {
+  const payload = asBridgeErrorPayload(error);
+  return payload?.code === "endpointUnreachable" ? payload.endpoint : null;
 }
 
 function errorMessage(error: unknown): string {
@@ -61,6 +69,8 @@ function endpointLabel(url: string): string {
     return url;
   }
 }
+import { asBridgeErrorPayload } from "@source-inc/gents-desktop-client";
+
 import {
   DEFAULT_CLI_BINARY_NAME,
   DEFAULT_RUNTIME_PRODUCT_NAME,

--- a/packages/gents-desktop-fleet/src/peerConnectionErrors.ts
+++ b/packages/gents-desktop-fleet/src/peerConnectionErrors.ts
@@ -1,3 +1,11 @@
+import { asBridgeErrorPayload } from "@source-inc/gents-desktop-client";
+
+import {
+  DEFAULT_CLI_BINARY_NAME,
+  DEFAULT_RUNTIME_PRODUCT_NAME,
+  type FleetCopy,
+} from "./copy.js";
+
 export type PeerConnectionAction =
   | "add-peer"
   | "local-runtime"
@@ -11,16 +19,19 @@ export function formatPeerConnectionError(
   action: PeerConnectionAction,
   copy: Pick<FleetCopy, "runtimeProductName" | "cliBinaryName"> = {},
 ): string {
-  const message = errorMessage(error);
-  // Prefer the bridge's structured endpoint (BridgeErrorCode.endpointUnreachable,
-  // #1339) when the error carries one; only a command not yet wired to emit a
-  // typed BridgeError falls back to parsing the underlying transport message.
-  const url = structuredEndpointFromError(error) ?? requestUrlFromMessage(message);
-  if (!url) {
+  // The bridge classifies connectivity failures into
+  // BridgeErrorCode.endpointUnreachable and attaches the endpoint as a
+  // structured field (#1339) — no message parsing on the TS side. Prefer the
+  // payload's own `message` (correctly extracted even for a plain object)
+  // over the generic `errorMessage` fallback, which only handles `Error`/
+  // string inputs.
+  const payload = asBridgeErrorPayload(error);
+  const message = payload?.message ?? errorMessage(error);
+  if (payload?.code !== "endpointUnreachable" || !payload.endpoint) {
     return message;
   }
 
-  const endpoint = endpointLabel(url);
+  const endpoint = endpointLabel(payload.endpoint);
   if (action === "local-runtime") {
     const productName =
       copy.runtimeProductName?.trim() || DEFAULT_RUNTIME_PRODUCT_NAME;
@@ -35,30 +46,11 @@ export function formatPeerConnectionError(
   return message;
 }
 
-function structuredEndpointFromError(error: unknown): string | null {
-  const payload = asBridgeErrorPayload(error);
-  return payload?.code === "endpointUnreachable" ? payload.endpoint : null;
-}
-
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
   }
   return String(error);
-}
-
-function requestUrlFromMessage(message: string): string | null {
-  const match = message.match(
-    /\b(?:sending|reading) GET request to (https?:\/\/\S+)/i,
-  );
-  if (!match) {
-    return null;
-  }
-  return stripTrailingPunctuation(match[1]);
-}
-
-function stripTrailingPunctuation(value: string): string {
-  return value.replace(/[),.;]+$/g, "");
 }
 
 function endpointLabel(url: string): string {
@@ -69,10 +61,3 @@ function endpointLabel(url: string): string {
     return url;
   }
 }
-import { asBridgeErrorPayload } from "@source-inc/gents-desktop-client";
-
-import {
-  DEFAULT_CLI_BINARY_NAME,
-  DEFAULT_RUNTIME_PRODUCT_NAME,
-  type FleetCopy,
-} from "./copy.js";


### PR DESCRIPTION
Closes #1339. Stacked on #1361 (`so/1338-provider-owner`).

## What changed

This consolidates the small duplicate-owner cases from #1339:

- Runtime:
  - Fixed native-tool names derive from the concrete `Tool::NAME` constants through one `NativeTool` registry.
  - Child-terminal projection owns the persisted status and reason used by foreground bridges and background notifications.
  - Tool-call deadline checks share `ToolCallLifecycle::is_deadline_expired`.
  - Startup and live terminal-parent recovery share the same parent-driven classifier.
  - Request TTL parsing has one `NotSet | Live | Expired | Malformed` result used by both watcher and claim paths.
- Desktop:
  - Rust turn terminality derives from `ClientTurnState::is_terminal`; TypeScript consumers share one `gents-desktop-client` predicate.
  - Inference-setup visibility follows the runtime-authored selected-behavior readiness decision and remains gated to locally configurable deployments.
  - Bridge contract 6.3 adds the required nullable `endpoint` field to `BridgeError`.
  - Peer-status and local-runtime transport failures are classified from typed `reqwest::Error` sources; fleet UI consumes the structured endpoint instead of parsing error prose.
- CLI and OAuth:
  - Config prune order is derived by reversing the apply order.
  - `gents-protocol` owns the ChatGPT OAuth client ID, default issuer, refresh-endpoint override environment-variable name, and token-endpoint construction rule used by login and runtime refresh paths.

## Observable behavior changes

Most changes preserve existing behavior. The deliberate corrections are:

- A present but malformed `valid_until` now fails closed in watcher scans instead of being treated as live; the claim path continues to reject it with its parse diagnostic.
- Live terminal-parent reconciliation projects an already-terminal child before applying parent-derived bridge exceptions, matching startup recovery.
- The foreground `Dead` child reason now uses the same wording as background completion: `child request reached the dead terminal state`.
- The inference-setup CTA is shown only for a locally configurable deployment whose selected behavior has a runtime-authored inference failure; enrolled deployments never offer an unusable local setup action.
- Bridge error payloads now require `endpoint: string | null`. Only typed connection, timeout, or response-body transport failures produce `endpointUnreachable`; message text alone no longer triggers endpoint-specific UI copy.

## Net code

This is not net-deleting overall. The final stacked diff is 713 additions and 295 deletions: the typed bridge-error contract/classifier, fail-closed TTL handling, and their tests add more code than the duplicate owners remove.

## Verification

Post-rebase local gates:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p gents-cli config_import` (24 passed)
- `cargo test -p gents-desktop-bridge error::tests:: --lib` (5 passed)
- `cargo test -p gents-chatgpt-login` (6 passed plus doc tests)
- `cargo test -p gents-protocol chatgpt_oauth::tests::` (1 passed)
- `cargo check --workspace --all-targets`
- `npm run build:packages`
- `npm test -w @source-inc/gents-desktop-client -- src/errors.test.ts` (4 passed)
- `npm test -w @source-inc/gents-desktop-fleet -- src/peerConnectionErrors.test.ts` (6 passed)
- `npm test -w @source-inc/gents-desktop-chat -- src/chat-shell.test.ts` (14 passed)
- `npm test -w @source-inc/gents-desktop-app -- tests/fleet-row.test.tsx tests/fleet-dashboard.test.tsx` (25 passed)
- `npm run format:check -w @source-inc/gents-desktop-app`

The workspace check emits only the pre-existing `Matcher.description` dead-code warning. The generated config-import case also emits the pre-existing Lean `unnecessarySimpa` linter warning.