### PR TITLE
One rule for request state in external adapter projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
   (`SubagentTreeNode.status`, `SessionHistoryRow.latest_request_status`,
   `RequestShowHeader.status`, `ChildRequestView.status`,
   `GraphRunRequestView.status`); read `lifecycle_state` instead.
+- External projections expose request state once in their native vocabulary:
+  OpenAI-Codex request items drop `lifecycle_state` (keep `status`), ATIF
+  request extras drop `status` (keep `lifecycle_state`), and Amy trace records
+  drop `request_lifecycle_state` (keep `request_status`). Session-history rows
+  rename session `status` to `session_status` and keep request state separately
+  as `latest_request_lifecycle_state`.
 
 ### Fixed
 

--- a/crates/gents-cli/src/commands/trace.rs
+++ b/crates/gents-cli/src/commands/trace.rs
@@ -514,9 +514,6 @@ fn build_records(
                 request_status: request
                     .and_then(|request| request.lifecycle_state)
                     .map(|state| state.as_str().to_string()),
-                request_lifecycle_state: request
-                    .and_then(|request| request.lifecycle_state)
-                    .map(|state| state.as_str().to_string()),
                 request_failure_reason: request.and_then(|request| request.failure_reason.clone()),
                 response_status: response.and_then(|response| response.status.clone()),
                 response_error_message: response

--- a/crates/gents-cli/src/http/sessions.rs
+++ b/crates/gents-cli/src/http/sessions.rs
@@ -3,6 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use gents::graphql::escape_graphql_string;
+use gents_protocol::request_lifecycle::RequestLifecycleState;
 use gents_protocol::row::AgentRequestRow;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -27,11 +28,11 @@ pub(crate) struct SessionHistoryRow {
     pub(crate) session_id: String,
     pub(crate) agent_name: Option<String>,
     pub(crate) behavior_id: Option<String>,
-    pub(crate) status: Option<String>,
+    pub(crate) session_status: Option<String>,
     pub(crate) started_at: Option<String>,
     pub(crate) ended_at: Option<String>,
     pub(crate) latest_request_id: Option<String>,
-    pub(crate) latest_request_lifecycle_state: Option<String>,
+    pub(crate) latest_request_lifecycle_state: Option<RequestLifecycleState>,
     pub(crate) latest_request_created_at: Option<String>,
     pub(crate) request_count: i64,
     pub(crate) message_count: i64,
@@ -259,13 +260,11 @@ fn build_session_history_snapshot(
                 behavior_id: session
                     .and_then(|row| clean(row.behavior_id.as_deref()))
                     .or_else(|| latest_request.and_then(|row| clean(row.behavior_id.as_deref()))),
-                status: session.and_then(|row| clean(row.status.as_deref())),
+                session_status: session.and_then(|row| clean(row.status.as_deref())),
                 started_at: session.and_then(|row| clean(row.started.as_deref())),
                 ended_at: session.and_then(|row| clean(row.ended.as_deref())),
                 latest_request_id: latest_request.and_then(|row| clean(Some(&row.request_id))),
-                latest_request_lifecycle_state: latest_request
-                    .and_then(|row| row.lifecycle_state)
-                    .map(|state| state.as_str().to_string()),
+                latest_request_lifecycle_state: latest_request.and_then(|row| row.lifecycle_state),
                 latest_request_created_at: latest_request
                     .and_then(|row| clean(row.created_at.as_deref())),
                 request_count: requests.len() as i64,
@@ -409,8 +408,16 @@ mod tests {
         assert_eq!(snapshot.sessions.len(), 2);
         assert_eq!(snapshot.sessions[0].session_id, "session-a");
         assert_eq!(
+            snapshot.sessions[0].session_status.as_deref(),
+            Some("active")
+        );
+        assert_eq!(
             snapshot.sessions[0].latest_request_id.as_deref(),
             Some("req-newer")
+        );
+        assert_eq!(
+            snapshot.sessions[0].latest_request_lifecycle_state,
+            Some(RequestLifecycleState::Completed)
         );
         assert_eq!(snapshot.sessions[0].request_count, 2);
         assert_eq!(snapshot.sessions[0].message_count, 2);

--- a/crates/gents-cli/tests/suites/cli_live.rs
+++ b/crates/gents-cli/tests/suites/cli_live.rs
@@ -51,6 +51,7 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         "2".to_string(),
         "--max-queue-depth".to_string(),
         "4".to_string(),
+        "--inference-url".to_string(),
         model_endpoint,
     ];
     let init_arg_refs = init_args.iter().map(String::as_str).collect::<Vec<_>>();
@@ -111,7 +112,7 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         Some("local-standard")
     );
     assert_eq!(
-        desktop_init.get("agent_did").and_then(Value::as_str),
+        desktop_init.get("agentDid").and_then(Value::as_str),
         Some(agent_did.as_str())
     );
     assert_eq!(
@@ -119,13 +120,13 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         Some(graphql.as_str())
     );
     assert_eq!(
-        desktop_init.get("p2p_transport").and_then(Value::as_str),
+        desktop_init.get("p2pTransport").and_then(Value::as_str),
         Some("iroh")
     );
     let desktop_next_steps = desktop_init
-        .get("next_steps")
+        .get("nextSteps")
         .and_then(Value::as_array)
-        .ok_or_else(|| anyhow!("desktop init output missing next_steps: {desktop_init}"))?;
+        .ok_or_else(|| anyhow!("desktop init output missing nextSteps: {desktop_init}"))?;
     assert!(
         desktop_next_steps.iter().any(|step| step
             .as_str()
@@ -241,7 +242,7 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
             home_arg,
             "--session-id",
             &session_id,
-            "--output-format",
+            "--output",
             "json",
             "--timeout-secs",
             "240",
@@ -272,7 +273,7 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
             home_arg,
             "--session-id",
             &session_id,
-            "--output-format",
+            "--output",
             "json",
             "--timeout-secs",
             "240",
@@ -349,6 +350,7 @@ async fn trace_project_exports_live_inference_turn_as_adapter_artifacts() -> Res
         init_args.push("--api-key-env-var".to_string());
         init_args.push("GENTS_CLI_E2E_API_KEY".to_string());
     }
+    init_args.push("--inference-url".to_string());
     init_args.push(model_endpoint);
     let init_arg_refs = init_args.iter().map(String::as_str).collect::<Vec<_>>();
     let init = run_init_json(&home_dir, &init_arg_refs)?;
@@ -733,6 +735,7 @@ async fn cli_flow_runs_real_tool_loop_against_live_endpoint() -> Result<()> {
         init_args.push("--api-key-env-var".to_string());
         init_args.push("GENTS_CLI_E2E_API_KEY".to_string());
     }
+    init_args.push("--inference-url".to_string());
     init_args.push(model_endpoint.clone());
     let init_arg_refs = init_args.iter().map(String::as_str).collect::<Vec<_>>();
     let init = run_init_json(&home_dir, &init_arg_refs)?;

--- a/crates/gents-cli/tests/suites/cli_trace_export.rs
+++ b/crates/gents-cli/tests/suites/cli_trace_export.rs
@@ -247,11 +247,9 @@ async fn trace_export_emits_amy_style_jsonl_and_classifies_completed_failures() 
         deadline.get("request_status").and_then(Value::as_str),
         Some("failed")
     );
-    assert_eq!(
-        deadline
-            .get("request_lifecycle_state")
-            .and_then(Value::as_str),
-        Some("failed")
+    assert!(
+        deadline.get("request_lifecycle_state").is_none(),
+        "Amy trace records must expose request state only as request_status: {deadline:#}"
     );
     assert_eq!(
         deadline.get("response_status").and_then(Value::as_str),
@@ -745,7 +743,6 @@ async fn trace_project_exports_first_adapter_shapes_from_persisted_rows() -> Res
             .is_some(),
         "ATIF projection should identify the Gents behavior: {atif:#}"
     );
-
     let openai = trace_project_json(tempdir.path(), home, "openai-codex", "public")?;
     assert_projection_json_matches_schema("openai_codex_run_trace", &openai)?;
     assert_eq!(

--- a/crates/gents/src/adapter_projection.rs
+++ b/crates/gents/src/adapter_projection.rs
@@ -258,8 +258,6 @@ pub enum OpenAiCodexTraceItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        lifecycle_state: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         agent_did: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         behavior_id: Option<String>,
@@ -782,7 +780,6 @@ pub fn adapter_projection_eval_jsonl_records(
                     OpenAiCodexTraceItem::Request {
                         id,
                         status,
-                        lifecycle_state: _,
                         agent_did,
                         behavior_id,
                         parent_request_id,
@@ -1332,7 +1329,6 @@ fn openai_codex_projection_schema() -> Value {
                                 "type": { "const": "request" },
                                 "id": string_schema(),
                                 "status": optional_string_schema(),
-                                "lifecycle_state": optional_string_schema(),
                                 "agent_did": optional_string_schema(),
                                 "behavior_id": optional_string_schema(),
                                 "parent_request_id": optional_string_schema(),
@@ -1859,7 +1855,6 @@ fn build_openai_codex_run_trace(
                 items.push(OpenAiCodexTraceItem::Request {
                     id: event.request_id.clone(),
                     status: event.lifecycle_state.clone(),
-                    lifecycle_state: event.lifecycle_state.clone(),
                     agent_did: event.agent_did.clone(),
                     behavior_id: event.behavior_id.clone(),
                     parent_request_id: event.parent_request_id.clone(),

--- a/crates/gents/src/adapter_projection/atif.rs
+++ b/crates/gents/src/adapter_projection/atif.rs
@@ -147,10 +147,6 @@ pub(super) fn build_atif_trajectory(
                     optional_string_value(timeline.session_id.as_deref()),
                 ),
                 (
-                    "status",
-                    optional_string_value(timeline.request.lifecycle_state.map(|s| s.as_str())),
-                ),
-                (
                     "lifecycle_state",
                     optional_string_value(timeline.request.lifecycle_state.map(|s| s.as_str())),
                 ),
@@ -328,10 +324,6 @@ pub(super) fn build_atif_trajectory(
             total_steps: steps.len(),
             extra: optional_extra([
                 ("request_id", string_value(&timeline.request_id)),
-                (
-                    "status",
-                    optional_string_value(timeline.request.lifecycle_state.map(|s| s.as_str())),
-                ),
                 (
                     "lifecycle_state",
                     optional_string_value(timeline.request.lifecycle_state.map(|s| s.as_str())),

--- a/crates/gents/src/adapter_projection/tests.rs
+++ b/crates/gents/src/adapter_projection/tests.rs
@@ -960,15 +960,14 @@ fn projection_terminal_status(envelope: &AdapterProjectionEnvelope) -> Option<St
             .final_metrics
             .as_ref()
             .and_then(|metrics| metrics.extra.as_ref())
-            .and_then(|extra| extra.get("lifecycle_state").or_else(|| extra.get("status")))
+            .and_then(|extra| extra.get("lifecycle_state"))
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
         AdapterProjection::OpenAiCodexRunTrace(projection) => projection.status.clone(),
         AdapterProjection::LangGraphStateHistory(projection) => projection
             .values
-            .get("lifecycle_state")
+            .get("status")
             .and_then(Value::as_str)
-            .or_else(|| projection.values.get("status").and_then(Value::as_str))
             .map(ToOwned::to_owned),
         AdapterProjection::MultiAgentTask(projection) => projection.status.clone(),
     }

--- a/crates/gents/src/toolset/session_history.rs
+++ b/crates/gents/src/toolset/session_history.rs
@@ -5,6 +5,7 @@ use crate::llm::tool::ToolDefinition;
 use crate::llm::tool::{Tool, ToolDyn};
 use anyhow::{anyhow, bail, Context, Result};
 use defra_node::EmbeddedNode;
+use gents_protocol::request_lifecycle::RequestLifecycleState;
 use gents_protocol::row::AgentRequestRow;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -40,12 +41,12 @@ pub struct SessionHistoryRow {
     pub session_id: String,
     pub agent_name: Option<String>,
     pub behavior_id: Option<String>,
-    pub status: Option<String>,
+    pub session_status: Option<String>,
     pub created_at: Option<String>,
     pub started_at: Option<String>,
     pub ended_at: Option<String>,
     pub latest_request_id: Option<String>,
-    pub latest_request_lifecycle_state: Option<String>,
+    pub latest_request_lifecycle_state: Option<RequestLifecycleState>,
     pub latest_request_created_at: Option<String>,
     pub request_count: i64,
     pub message_count: i64,
@@ -904,13 +905,7 @@ fn build_session_rows(
                 behavior_id: session
                     .and_then(|row| clean(row.behavior_id.as_ref()))
                     .or_else(|| latest_request.and_then(|row| clean(row.behavior_id.as_ref()))),
-                status: session
-                    .and_then(|row| clean(row.status.as_ref()))
-                    .or_else(|| {
-                        latest_request
-                            .and_then(|row| row.lifecycle_state)
-                            .map(|state| state.as_str().to_string())
-                    }),
+                session_status: session.and_then(|row| clean(row.status.as_ref())),
                 created_at: started_at
                     .clone()
                     .or_else(|| latest_request_created_at.clone()),
@@ -919,9 +914,7 @@ fn build_session_rows(
                 latest_request_id: latest_request
                     .map(|row| row.request_id.trim().to_string())
                     .filter(|request_id| !request_id.is_empty()),
-                latest_request_lifecycle_state: latest_request
-                    .and_then(|row| row.lifecycle_state)
-                    .map(|state| state.as_str().to_string()),
+                latest_request_lifecycle_state: latest_request.and_then(|row| row.lifecycle_state),
                 latest_request_created_at,
                 request_count: aggregate
                     .map(|aggregate| aggregate.request_count)
@@ -1304,7 +1297,7 @@ mod tests {
             .unwrap();
         assert_eq!(session_a.agent_name.as_deref(), Some("OpenAI Agent"));
         assert_eq!(session_a.behavior_id.as_deref(), Some("behavior-a"));
-        assert_eq!(session_a.status.as_deref(), Some("open"));
+        assert_eq!(session_a.session_status.as_deref(), Some("open"));
         assert_eq!(
             session_a.created_at.as_deref(),
             Some("2026-06-03T09:55:00Z")
@@ -1314,8 +1307,8 @@ mod tests {
             Some("request-a-new")
         );
         assert_eq!(
-            session_a.latest_request_lifecycle_state.as_deref(),
-            Some("processing")
+            session_a.latest_request_lifecycle_state,
+            Some(RequestLifecycleState::Processing)
         );
         assert_eq!(session_a.request_count, 2);
         assert_eq!(session_a.message_count, 2);
@@ -1350,6 +1343,11 @@ mod tests {
         assert_eq!(parsed.limit, 1);
         assert_eq!(parsed.sessions.len(), 1);
         assert_eq!(parsed.sessions[0].session_id, "session-b");
+
+        let row = serde_json::to_value(&parsed.sessions[0]).unwrap();
+        assert_eq!(row["session_status"], "open");
+        assert_eq!(row["latest_request_lifecycle_state"], "completed");
+        assert!(row.get("status").is_none());
     }
 
     #[tokio::test]

--- a/crates/gents/src/trace_export.rs
+++ b/crates/gents/src/trace_export.rs
@@ -92,7 +92,6 @@ pub struct AmyToolCallTraceRecord {
     pub session_id: String,
     pub request_id: Option<String>,
     pub request_status: Option<String>,
-    pub request_lifecycle_state: Option<String>,
     pub request_failure_reason: Option<String>,
     pub response_status: Option<String>,
     pub response_error_message: Option<String>,

--- a/crates/gents/tests/fixtures/adapter_projections/contracts/langgraph_state_history.schema.json
+++ b/crates/gents/tests/fixtures/adapter_projections/contracts/langgraph_state_history.schema.json
@@ -272,7 +272,8 @@
       "required": [
         "runtime",
         "source_projection_id",
-        "source_projection_version"
+        "source_projection_version",
+        "source_version_status"
       ],
       "type": "object"
     },

--- a/crates/gents/tests/fixtures/adapter_projections/contracts/multi_agent_task.schema.json
+++ b/crates/gents/tests/fixtures/adapter_projections/contracts/multi_agent_task.schema.json
@@ -330,7 +330,8 @@
       "required": [
         "runtime",
         "source_projection_id",
-        "source_projection_version"
+        "source_projection_version",
+        "source_version_status"
       ],
       "type": "object"
     },

--- a/crates/gents/tests/fixtures/adapter_projections/contracts/openai_codex_run_trace.schema.json
+++ b/crates/gents/tests/fixtures/adapter_projections/contracts/openai_codex_run_trace.schema.json
@@ -57,16 +57,6 @@
                           }
                         ]
                       },
-                      "lifecycle_state": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
                       "parent_request_id": {
                         "anyOf": [
                           {
@@ -409,7 +399,8 @@
       "required": [
         "runtime",
         "source_projection_id",
-        "source_projection_version"
+        "source_projection_version",
+        "source_version_status"
       ],
       "type": "object"
     },

--- a/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
+++ b/crates/gents/tests/fixtures/adapter_projections/envelopes/atif_trajectory.envelope.json
@@ -21,7 +21,6 @@
           "inference_call_count": 1,
           "lifecycle_state": "completed",
           "request_id": "req-atif-1",
-          "status": "completed",
           "tool_call_count": 1
         },
         "total_steps": 2

--- a/crates/gents/tests/fixtures/adapter_projections/envelopes/openai_codex_run_trace.envelope.json
+++ b/crates/gents/tests/fixtures/adapter_projections/envelopes/openai_codex_run_trace.envelope.json
@@ -9,7 +9,6 @@
         {
           "id": "req-codex-1",
           "input": "[training_safe_redacted]",
-          "lifecycle_state": "completed",
           "status": "completed",
           "timestamp": "2026-06-05T17:00:00Z",
           "type": "request"


### PR DESCRIPTION
Closes #1343

## Summary

- expose request state once in each external framework’s native vocabulary
- separate typed latest-request lifecycle state from session status, removing the fallback between them
- update schemas, fixtures, CLI HTTP output, and live workflow assertions
- preserve the distinct ATIF tool-call status/lifecycle contract

This is a representation/ownership cleanup only; it does not change legal request lifecycle transitions, so no Lean model change is required. The implementation is net deleting (54 additions, 70 deletions).

## Validation

- `cargo test -p gents --lib adapter_projection`
- `cargo test -p gents --lib toolset::session_history`
- `cargo test -p gents-cli --lib http::sessions`
- `cargo test -p gents-cli --test cli_seeded cli_trace_export`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
- live endpoint smoke: `standard_onboarding_live_demo_runs_real_conversation_with_filesystem_tools` against `GLM-5.3-Flash-NVFP4`

An independent final audit found no correctness or structure blockers.