### PR TITLE
test(runtime): keep lease recovery independently polled

### DIFF
--- a/crates/gents/src/agent/daemon/execution_lease_regression_tests.rs
+++ b/crates/gents/src/agent/daemon/execution_lease_regression_tests.rs
@@ -175,12 +175,24 @@ async fn eight_nonterminal_requests_converge_on_same_daemon(empty_forever: bool)
             // daemon or database restart occurs between these eight requests.
             let process = daemon.process_request(request, shutdown_rx.clone());
             tokio::pin!(process);
-            loop {
-                tokio::select! {
-                    _ = &mut process => break,
-                    _ = tokio::time::sleep(Duration::from_millis(100)) => {
-                        crate::RequestLifecycle::recover_all(&node, &agent_did).await.unwrap();
+            // Maintenance must stay independently pollable: `process` can hold
+            // the node write gate while a recovery pass waits on it, so
+            // awaiting `recover_all` inline in a select branch self-deadlocks.
+            // The scoped binding drops the pinned maintenance future the
+            // moment process completes, cancelling any in-flight recovery.
+            {
+                let maintenance = async {
+                    loop {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        crate::RequestLifecycle::recover_all(&node, &agent_did)
+                            .await
+                            .unwrap();
                     }
+                };
+                tokio::pin!(maintenance);
+                tokio::select! {
+                    _ = &mut process => {}
+                    _ = &mut maintenance => {}
                 }
             }
             loop {


### PR DESCRIPTION
The eight-request lease regression driver could suspend request execution while awaiting recovery on the same node mutation gate, making its own convergence check time out. Poll request execution and periodic recovery as sibling futures, and drop maintenance before the final convergence sweep.

The existing eight-request EOF and empty-stream assertions and timeouts are preserved. This changes test scheduling only; production lifecycle policy and Lean models are unchanged.

Validation: both focused eight-request regressions passed; `cargo test -p gents` passed (2,696 passed, 3 ignored); `cargo check --workspace --all-targets` passed. Independent review found no blocking issues. The tests cover eight sequential requests on one daemon, not the full periodic scheduler or forced gate contention.

Closes #1378
