### PR TITLE
fix(goals): atomically resume lineage-preserving continuations

### DIFF
--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -3072,6 +3072,8 @@ pub(crate) enum GoalCommand {
     Show(GoalShowArgs),
     #[command(about = "Create or update the durable goal for a session")]
     Set(GoalSetArgs),
+    #[command(about = "Resume a goal and atomically enqueue its continuation")]
+    ResumeRequest(GoalResumeArgs),
     #[command(about = "Delete the durable goal for a session")]
     Clear(GoalShowArgs),
 }
@@ -3095,6 +3097,20 @@ pub(crate) struct GoalScopeArgs {
 pub(crate) struct GoalShowArgs {
     #[command(flatten)]
     pub(crate) scope: GoalScopeArgs,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    pub(crate) output: OutputFormat,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct GoalResumeArgs {
+    #[command(flatten)]
+    pub(crate) scope: GoalScopeArgs,
+    #[arg(
+        long,
+        value_name = "REQUEST_ID",
+        help = "Terminal predecessor; reuse this ID when retrying the same resume"
+    )]
+    pub(crate) from: String,
     #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
     pub(crate) output: OutputFormat,
 }

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -849,3 +849,91 @@ fn chain_query_command_parses() {
         _ => panic!("expected chain query"),
     }
 }
+
+#[test]
+fn goal_resume_request_requires_session_and_predecessor() {
+    for args in [
+        vec!["gents", "goal", "resume-request", "--session", "session-1"],
+        vec!["gents", "goal", "resume-request", "--from", "request-1"],
+        vec!["gents", "goal", "resume-request"],
+    ] {
+        let error = match Cli::try_parse_from(args) {
+            Ok(_) => panic!("resume requires both stable selectors"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+}
+
+#[test]
+fn goal_resume_request_preserves_stable_predecessor_selector() {
+    let cli = Cli::try_parse_from([
+        "gents",
+        "goal",
+        "resume-request",
+        "--home",
+        "/tmp/resume-client",
+        "--graphql",
+        "http://127.0.0.1:8000/api/v0/graphql",
+        "--session",
+        "session:workflow-1",
+        "--from",
+        "goal-cont-00000000000000000004-abcdef",
+    ])
+    .expect("typed resume command");
+    let Command::Goal {
+        command: GoalCommand::ResumeRequest(args),
+    } = cli.command
+    else {
+        panic!("expected typed goal resume-request");
+    };
+    assert_eq!(args.scope.session, "session:workflow-1");
+    assert_eq!(args.from, "goal-cont-00000000000000000004-abcdef");
+    assert_eq!(args.scope.home, Some(PathBuf::from("/tmp/resume-client")));
+    assert_eq!(
+        args.scope.graphql.as_deref(),
+        Some("http://127.0.0.1:8000/api/v0/graphql")
+    );
+    assert!(matches!(args.output, OutputFormat::Json));
+}
+
+#[test]
+fn goal_resume_request_rejects_caller_supplied_lineage_flags() {
+    for flag in [
+        "--correlation",
+        "--caused-by-correlation",
+        "--trigger-id",
+        "--trigger-context",
+        "--parent-request-id",
+        "--parent-request-doc-id",
+        "--workspace-id",
+        "--workspace-authority",
+        "--workspace-owner-deployment-id",
+        "--workspace-seal-hash",
+        "--execution-origin",
+        "--subagent-depth",
+    ] {
+        let error = match Cli::try_parse_from([
+            "gents",
+            "goal",
+            "resume-request",
+            "--session",
+            "session-1",
+            "--from",
+            "request-1",
+            flag,
+            "forged-lineage",
+        ]) {
+            Ok(_) => panic!("resume accepted authority override {flag}"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::UnknownArgument,
+            "{flag} must not become a lineage override"
+        );
+    }
+}

--- a/crates/gents-cli/src/commands/goal.rs
+++ b/crates/gents-cli/src/commands/goal.rs
@@ -1,14 +1,15 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use chrono::Utc;
 use gents::config_client::ConfigAccess;
 use gents::goal::{
-    apply_operator_status_transition, delete_goals_for_session, deterministic_goal_id,
-    load_canonical_goal, set_goal, GoalDocument, GoalSnapshot, GoalState, GoalStatus,
-    BLOCKED_AUDIT_THRESHOLD, GOAL_FIELDS,
+    delete_goals_for_session, load_canonical_goal, set_goal_from_access, GoalDocument,
+    GoalSnapshot, GoalStatus, GOAL_FIELDS,
 };
 use gents::graphql::escape_graphql_string;
 
-use crate::cli::args::{GoalCommand, GoalScopeArgs, GoalSetArgs, GoalShowArgs, GoalStatusArg};
+use crate::cli::args::{
+    GoalCommand, GoalResumeArgs, GoalScopeArgs, GoalSetArgs, GoalShowArgs, GoalStatusArg,
+};
 use crate::cli::output_format::OutputFormat;
 use crate::{print_json, resolve_agent_did, resolve_config_access};
 
@@ -16,6 +17,7 @@ pub(crate) async fn dispatch(command: GoalCommand) -> Result<()> {
     match command {
         GoalCommand::Show(args) => goal_show(args).await,
         GoalCommand::Set(args) => goal_set(args).await,
+        GoalCommand::ResumeRequest(args) => goal_resume(args).await,
         GoalCommand::Clear(args) => goal_clear(args).await,
     }
 }
@@ -43,34 +45,36 @@ async fn goal_set(args: GoalSetArgs) -> Result<()> {
     } else {
         args.token_budget.map(Some)
     };
-    let goal = match &access {
-        ConfigAccess::Local(node) => {
-            set_goal(
-                node,
-                &agent_did,
-                &args.scope.session,
-                args.objective.as_deref(),
-                status,
-                budget,
-            )
-            .await?
-        }
-        ConfigAccess::Graphql(_) => {
-            set_goal_over_graphql(
-                &access,
-                &agent_did,
-                &args.scope.session,
-                args.objective.as_deref(),
-                status,
-                budget,
-            )
-            .await?
-        }
-    };
+    let goal = set_goal_from_access(
+        &access,
+        &agent_did,
+        &args.scope.session,
+        args.objective.as_deref(),
+        status,
+        budget,
+    )
+    .await?;
     print_json(&serde_json::to_value(GoalSnapshot::from_document(
         &goal,
         Utc::now(),
     ))?)
+}
+
+async fn goal_resume(args: GoalResumeArgs) -> Result<()> {
+    args.output
+        .ensure_supported("goal resume-request", &[OutputFormat::Json])?;
+    let (access, agent_did) = access_and_did(&args.scope).await?;
+    crate::request_helpers::ensure_local_request_signer(args.scope.home.as_deref(), &agent_did)?;
+    let identity = gents::identity::RegisteredIdentity::from_registered_did(&agent_did, None)?;
+    let receipt = gents::goal::resume_goal_request(
+        &access,
+        &identity,
+        &agent_did,
+        &args.scope.session,
+        &args.from,
+    )
+    .await?;
+    print_json(&serde_json::to_value(receipt)?)
 }
 
 async fn goal_clear(args: GoalShowArgs) -> Result<()> {
@@ -180,132 +184,6 @@ async fn load_goal(
             .then_with(|| left.doc_id.cmp(&right.doc_id))
     });
     Ok(goals.into_iter().next())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn set_goal_over_graphql(
-    access: &ConfigAccess,
-    agent_did: &str,
-    session_id: &str,
-    objective: Option<&str>,
-    status: Option<GoalStatus>,
-    token_budget: Option<Option<i64>>,
-) -> Result<GoalDocument> {
-    let existing = load_goal(access, agent_did, session_id).await?;
-    let objective = objective
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .or_else(|| existing.as_ref().map(|goal| goal.objective.clone()))
-        .context("a goal objective is required")?;
-    let status = status
-        .or_else(|| existing.as_ref().and_then(GoalDocument::parsed_status))
-        .unwrap_or(GoalStatus::Active);
-    let budget =
-        token_budget.unwrap_or_else(|| existing.as_ref().and_then(|goal| goal.token_budget));
-    if budget.is_some_and(|value| value <= 0) {
-        bail!("goal token budget must be positive");
-    }
-
-    let now = Utc::now();
-    let now_string = now.to_rfc3339();
-    let objective = escape_graphql_string(&objective);
-    let escaped_agent_did = escape_graphql_string(agent_did);
-    let escaped_session_id = escape_graphql_string(session_id);
-    let escaped_now = escape_graphql_string(&now_string);
-    let budget_field = budget
-        .map(|value| format!("token_budget: {value},"))
-        .unwrap_or_else(|| "token_budget: null,".to_string());
-    let started_field = if status.accrues_active_time() {
-        format!(r#"active_started_at: "{escaped_now}","#)
-    } else {
-        "active_started_at: null,".to_string()
-    };
-
-    let mutation = if let Some(existing) = existing {
-        let pre = existing
-            .state()
-            .context("existing Goal has an unknown status")?;
-        let post = apply_operator_status_transition(pre, status)?;
-        let resumed = pre.status != GoalStatus::Active && post.status == GoalStatus::Active;
-        let doc_id = escape_graphql_string(&existing.doc_id);
-        let active_time = existing.current_active_time_seconds(now);
-        let reset_fields = if resumed {
-            "last_blocked_request_id: null, last_blocked_reason: null, last_failure: null, infrastructure_retry_count: 0, completion_evidence: null,"
-        } else {
-            ""
-        };
-        format!(
-            r#"mutation {{
-                update_Goal(
-                    filter: {{
-                        _docID: {{ _eq: "{doc_id}" }},
-                        agent_did: {{ _eq: "{escaped_agent_did}" }}
-                    }},
-                    input: {{
-                        objective: "{objective}",
-                        status: "{status}",
-                        {budget_field}
-                        tokens_used: {tokens_used},
-                        active_time_seconds: {active_time},
-                        {started_field}
-                        consecutive_blocked_audits: {blocked_audits},
-                        wrapup_requested: {wrapup_requested},
-                        wrapup_completed: {wrapup_completed},
-                        {reset_fields}
-                        updated_at: "{escaped_now}"
-                    }}
-                ) {{ _docID }}
-            }}"#,
-            status = post.status.as_str(),
-            tokens_used = existing.tokens_used.unwrap_or_default().max(0),
-            blocked_audits = post.blocked_audits,
-            wrapup_requested = post.wrapup_requested,
-            wrapup_completed = post.wrapup_completed,
-        )
-    } else {
-        let goal_id = escape_graphql_string(&deterministic_goal_id(agent_did, session_id));
-        let initial_state = GoalState {
-            status,
-            blocked_audits: if status == GoalStatus::Blocked {
-                BLOCKED_AUDIT_THRESHOLD
-            } else {
-                0
-            },
-            wrapup_requested: status == GoalStatus::BudgetLimited,
-            wrapup_completed: status == GoalStatus::Complete,
-        };
-        format!(
-            r#"mutation {{
-                create_Goal(input: {{
-                    goal_id: "{goal_id}",
-                    session_id: "{escaped_session_id}",
-                    agent_did: "{escaped_agent_did}",
-                    objective: "{objective}",
-                    status: "{status}",
-                    {budget_field}
-                    tokens_used: 0,
-                    active_time_seconds: 0,
-                    {started_field}
-                    consecutive_blocked_audits: {blocked_audits},
-                    continuation_sequence: 0,
-                    wrapup_requested: {wrapup_requested},
-                    wrapup_completed: {wrapup_completed},
-                    infrastructure_retry_count: 0,
-                    created_at: "{escaped_now}",
-                    updated_at: "{escaped_now}"
-                }}) {{ _docID }}
-            }}"#,
-            status = status.as_str(),
-            blocked_audits = initial_state.blocked_audits,
-            wrapup_requested = initial_state.wrapup_requested,
-            wrapup_completed = initial_state.wrapup_completed,
-        )
-    };
-    access.execute(&mutation).await?;
-    load_goal(access, agent_did, session_id)
-        .await?
-        .context("durable Goal disappeared after write")
 }
 
 impl From<GoalStatusArg> for GoalStatus {

--- a/crates/gents-cli/tests/suites/cli_goal.rs
+++ b/crates/gents-cli/tests/suites/cli_goal.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn goal_set_get_pause_resume_and_clear_are_durable() -> Result<()> {
+async fn goal_configuration_rejects_implicit_resume_and_clear_is_durable() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
@@ -78,7 +78,7 @@ async fn goal_set_get_pause_resume_and_clear_are_durable() -> Result<()> {
         Some(objective)
     );
 
-    let resumed = run_cli_json(
+    let rejected = run_cli_failure_stderr(
         &home_dir,
         &[
             "goal",
@@ -91,10 +91,7 @@ async fn goal_set_get_pause_resume_and_clear_are_durable() -> Result<()> {
             "active",
         ],
     )?;
-    assert_eq!(
-        resumed.get("status").and_then(Value::as_str),
-        Some("active")
-    );
+    assert!(rejected.contains("resume-request"), "{rejected}");
 
     let shown = run_cli_json(
         &home_dir,
@@ -110,6 +107,11 @@ async fn goal_set_get_pause_resume_and_clear_are_durable() -> Result<()> {
     assert_eq!(
         shown.get("objective").and_then(Value::as_str),
         Some(objective)
+    );
+    assert_eq!(shown.get("status").and_then(Value::as_str), Some("paused"));
+    assert_eq!(
+        shown.get("continuation_sequence"),
+        paused.get("continuation_sequence")
     );
 
     let unbudgeted = run_cli_json(
@@ -174,5 +176,149 @@ async fn goal_set_get_pause_resume_and_clear_are_durable() -> Result<()> {
             .map(Vec::len),
         Some(0)
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn goal_resume_request_reuses_signed_predecessor_and_returns_same_child() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+    let model_name = format!("mock-resume-cli-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockChatEndpoint::start(&model_name, "Durable predecessor complete.")?;
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let agent_name = format!("cli-resume-{}", Uuid::new_v4().simple());
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            "--inference-url",
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    let session_id = format!("resume-session-{}", Uuid::new_v4().simple());
+
+    // The real CLI signs and submits the predecessor; the running daemon owns
+    // its completion. No unsigned request or forged terminal row is seeded.
+    let submitted = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "submit",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--session-id",
+            &session_id,
+            "--content",
+            "Finish this predecessor before operator recovery.",
+            "--timeout-secs",
+            "30",
+            "--poll-secs",
+            "1",
+        ],
+    )?;
+    assert_eq!(
+        submitted
+            .pointer("/response/status")
+            .and_then(Value::as_str),
+        Some("complete")
+    );
+    let predecessor = submitted
+        .get("request_id")
+        .and_then(Value::as_str)
+        .context("signed submission request ID")?;
+    let paused = run_cli_json(
+        &home_dir,
+        &[
+            "goal",
+            "set",
+            "--graphql",
+            &graphql,
+            "--session",
+            &session_id,
+            "--objective",
+            "Resume from this completed signed predecessor.",
+            "--status",
+            "paused",
+            "--token-budget",
+            "1",
+        ],
+    )?;
+    assert_eq!(paused.get("status").and_then(Value::as_str), Some("paused"));
+    let resume_args = [
+        "goal",
+        "resume-request",
+        "--graphql",
+        &graphql,
+        "--session",
+        &session_id,
+        "--from",
+        predecessor,
+    ];
+    let first = run_cli_json(&home_dir, &resume_args)?;
+    assert_eq!(first.get("created").and_then(Value::as_bool), Some(true));
+    let child_id = first
+        .get("request_id")
+        .and_then(Value::as_str)
+        .context("resume receipt request ID")?;
+    let second = run_cli_json(&home_dir, &resume_args)?;
+    assert_eq!(second.get("created").and_then(Value::as_bool), Some(false));
+    assert_eq!(second.get("request_id"), first.get("request_id"));
+    assert_eq!(second.get("doc_id"), first.get("doc_id"));
+    assert_eq!(second.get("goal_id"), first.get("goal_id"));
+
+    let response = graphql_query(
+        &graphql,
+        &format!(
+            r#"{{
+        AgentRequest(filter: {{ caused_by_parent_request_id: {{ _eq: "{}" }} }}) {{
+            _docID request_id session_id agent_did caused_by_trigger_kind
+            caused_by_parent_request_id caused_by_parent_request_doc_id
+        }}
+    }}"#,
+            escape_graphql_string(predecessor)
+        ),
+    )
+    .await?;
+    let children = response
+        .pointer("/data/AgentRequest")
+        .and_then(Value::as_array)
+        .context("physical resume children")?;
+    assert_eq!(
+        children.len(),
+        1,
+        "one child of this predecessor: {response}"
+    );
+    let child = &children[0];
+    assert_eq!(
+        child.get("request_id").and_then(Value::as_str),
+        Some(child_id)
+    );
+    assert_eq!(
+        child.get("session_id").and_then(Value::as_str),
+        Some(session_id.as_str())
+    );
+    assert_eq!(
+        child.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert_eq!(
+        child.get("caused_by_trigger_kind").and_then(Value::as_str),
+        Some("goal")
+    );
+    assert!(child
+        .get("caused_by_parent_request_doc_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.is_empty()));
     Ok(())
 }

--- a/crates/gents/proofs/Proofs.lean
+++ b/crates/gents/proofs/Proofs.lean
@@ -22,6 +22,9 @@ import Proofs.ScopeTemplates
 import Proofs.Triggers
 import Proofs.Goals
 import Proofs.GoalAutomation
+import Proofs.GoalAutomation.OperatorResume
+import Proofs.GoalAutomation.ClaimedPublication
+import Proofs.GoalAutomation.RequestHead
 import Proofs.Mailbox
 import Proofs.Client
 import Proofs.ClientShell

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -32,6 +32,9 @@ import Proofs.Conformance.CoverageLedger
 import Proofs.Identity.Conformance
 import Proofs.Conformance.EventDelivery
 import Proofs.Conformance.GraphPipeline
+import Proofs.Conformance.GoalOperatorResume
+import Proofs.Conformance.GoalClaimedPublication
+import Proofs.Conformance.GoalRequestHead
 import Proofs.Conformance.GraphFailureAttribution
 import Proofs.Conformance.RequestExecutionLease
 import Proofs.Conformance.InferenceRegistry
@@ -49,6 +52,14 @@ def snapshotJson : String :=
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
     ++ "\"graph_failure_attribution_traces\":"
       ++ Conformance.GraphFailureAttributionContracts.traceCasesJson ++ ","
+    ++ "\"goal_request_head_cases\":"
+      ++ Conformance.GoalRequestHeadContracts.casesJson ++ ","
+    ++ "\"goal_claimed_publication_cases\":"
+      ++ Conformance.GoalClaimedPublicationContracts.casesJson ++ ","
+    ++ "\"goal_operator_resume_cases\":"
+      ++ Conformance.GoalOperatorResumeContracts.resumeCasesJson ++ ","
+    ++ "\"goal_config_reactivation_cases\":"
+      ++ Conformance.GoalOperatorResumeContracts.configCasesJson ++ ","
     ++ "\"graph_pipeline_validation_cases\":"
       ++ Conformance.GraphPipelineContracts.validationCasesJson ++ ","
     ++ "\"graph_pipeline_revision_gate_cases\":"

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -633,7 +633,7 @@ def caseCoverage : List CoverageEntry :=
   , tagged (consumerCoverage
       "goal_decision_cases"
       "GoalDecisionCases"
-      "cli_goal::goal_set_get_pause_resume_and_clear_are_durable")
+      "cli_goal::goal_configuration_rejects_implicit_resume_and_clear_is_durable")
       "durable-goals" [Surface.operatorCli]
   , tagged (consumerCoverage
       "goal_decision_cases"
@@ -841,6 +841,31 @@ def caseCoverage : List CoverageEntry :=
       "GraphFailureAttributionTraces"
       "graph_pipeline::run::attribution_contract_tests::generated_graph_failure_attribution_traces_drive_real_transactions")
       "graph-pipeline" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "goal_claimed_publication_cases"
+      "GoalClaimedPublicationCases"
+      "goal::claimed_publication::contract_tests::generated_goal_claimed_publication_cases_drive_real_transactions")
+      "durable-goals" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "goal_request_head_cases"
+      "GoalRequestHeadCases"
+      "goal::request_head::tests::generated_goal_request_head_cases_drive_signed_row_selector")
+      "durable-goals" [Surface.operatorCli, Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "goal_operator_resume_cases"
+      "GoalOperatorResumeCases"
+      "goal::operator_resume::contract_tests::generated_goal_operator_resume_cases_drive_real_transactions")
+      "durable-goals" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "goal_operator_resume_cases"
+      "GoalOperatorResumeCases"
+      "cli_goal::goal_resume_request_reuses_signed_predecessor_and_returns_same_child")
+      "durable-goals" [Surface.operatorCli]
+  , tagged (consumerCoverage
+      "goal_config_reactivation_cases"
+      "GoalConfigReactivationCases"
+      "goal::operator_resume::contract_tests::generated_goal_config_reactivation_cases_drive_transactional_setter")
+      "durable-goals" [Surface.operatorCli, Surface.runtimeInternal]
   , tagged (consumerCoverage
       "graph_pipeline_validation_cases"
       "GraphPipelineValidationCases"

--- a/crates/gents/proofs/Proofs/Conformance/GoalClaimedPublication.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GoalClaimedPublication.lean
@@ -1,0 +1,71 @@
+import Proofs.GoalAutomation.ClaimedPublication
+import Proofs.Conformance.GoalOperatorResume
+
+namespace Conformance.GoalClaimedPublicationContracts
+open GoalAutomation.OperatorResume
+open Conformance.GoalOperatorResumeContracts (parentBinding snapshotJson bindingJson)
+
+def claimed : Snapshot :=
+  ⟨⟨.active, 2, false, false⟩, 1, some 10, 10, [], 37, some 1000⟩
+def request : ClaimedRequest :=
+  ⟨⟨.active, 1, true, true, true, true, parentBinding⟩, some 10⟩
+def published : Snapshot :=
+  ⟨⟨.active, 2, false, false⟩, 1, some 10, 20, [parentBinding], 37, some 1000⟩
+def budgetClaimed : Snapshot :=
+  { claimed with goal := ⟨.budgetLimited, 2, true, false⟩ }
+def paused : Snapshot := { claimed with goal := {claimed.goal with status := .paused} }
+def laterEpoch : Snapshot := {claimed with sequence := 3}
+def changedWatermark : Snapshot := {claimed with lastContinuedFrom := some 30}
+def recoveredLater : Snapshot :=
+  {published with goal := {published.goal with status := .paused}, sequence := 3,
+                  lastContinuedFrom := some 30, latestRequest := 40}
+
+structure PublicationCase where
+  name : String
+  before : Snapshot
+  request : ClaimedRequest
+  commit : Bool
+  expected : Snapshot
+  outcome : Outcome
+  deriving DecidableEq, Repr
+
+def cases : List PublicationCase :=
+  [ ⟨"claimed_active_publishes_without_reclaim", claimed, request, true, published, .created⟩
+  , ⟨"claimed_budget_wrapup_publishes", budgetClaimed,
+       {request with expectedStatus := .budgetLimited}, true,
+       {published with goal := budgetClaimed.goal}, .created⟩
+  , ⟨"pause_preempts_unpublished_child", paused, request, true, paused, .stale⟩
+  , ⟨"new_resume_epoch_preempts_old_claim", laterEpoch, request, true, laterEpoch, .stale⟩
+  , ⟨"changed_parent_watermark_preempts", changedWatermark, request, true, changedWatermark, .stale⟩
+  , ⟨"discard_publishes_nothing", claimed, request, false, claimed, .rolledBack⟩
+  , ⟨"exact_receipt_recovers_after_pause_and_progress", recoveredLater, request, true,
+       recoveredLater, .recovered⟩
+  , ⟨"foreign_receipt_cannot_recover", {published with children :=
+       [{parentBinding with semanticFingerprint := "foreign"}]}, request, true,
+       {published with children := [{parentBinding with semanticFingerprint := "foreign"}]}, .conflict⟩
+  ]
+
+theorem explicit_cases_replay : ∀ c ∈ cases,
+    publishClaimed c.before c.request c.commit = (c.expected, c.outcome) := by decide
+
+
+private def outcomeJson : Outcome → String
+  | .denied => "denied" | .stale => "stale" | .illegal => "illegal"
+  | .conflict => "conflict" | .rolledBack => "rolled_back"
+  | .created => "created" | .recovered => "recovered"
+
+def requestJson (r : ClaimedRequest) : String :=
+  let base := Conformance.GoalOperatorResumeContracts.requestJson r.toRequest
+  String.mk (base.toList.take (base.length - 1)) ++ ",\"expected_last_continued_from\":" ++
+    (match r.expectedLastContinuedFrom with | none => "null" | some n => toString n) ++ "}"
+
+def caseJson (c : PublicationCase) : String :=
+  "{\"name\":" ++ Conformance.Contracts.jsonString c.name ++
+  ",\"before\":" ++ snapshotJson c.before ++ ",\"request\":" ++ requestJson c.request ++
+  ",\"commit\":" ++ (if c.commit then "true" else "false") ++
+  ",\"expected\":" ++ snapshotJson c.expected ++ ",\"outcome\":" ++
+  Conformance.Contracts.jsonString (outcomeJson c.outcome) ++ "}"
+
+def casesJson : String := Conformance.Contracts.jsonArray (cases.map caseJson)
+
+end Conformance.GoalClaimedPublicationContracts

--- a/crates/gents/proofs/Proofs/Conformance/GoalOperatorResume.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GoalOperatorResume.lean
@@ -1,0 +1,94 @@
+import Proofs.GoalAutomation.OperatorResume
+import Proofs.Conformance.ContractTypes
+namespace Conformance.GoalOperatorResumeContracts
+open GoalAutomation.OperatorResume Conformance.Contracts
+
+def parentBinding : Binding :=
+  ⟨1, "owner", "session", 10, 100, some "graph-correlation", some "source",
+    some "context", some "workspace-authority", "full-semantic-fingerprint", 20, 1⟩
+def initial : Snapshot :=
+  ⟨⟨.paused, 2, false, false⟩, 0, none, 10, [], 37, some 1000⟩
+def request : Request := ⟨.paused, 0, true, true, true, true, parentBinding⟩
+/-- Explicit durable expectation, never computed from resume. -/
+def published : Snapshot :=
+  ⟨⟨.active, 0, false, false⟩, 1, some 10, 20, [parentBinding], 37, some 1000⟩
+def later : Snapshot :=
+  { published with goal := { published.goal with status := .paused }, latestRequest := 30 }
+
+structure ResumeCase where
+  name : String
+  before : Snapshot
+  request : Request
+  commit : Bool
+  expected : Snapshot
+  outcome : Outcome
+  deriving DecidableEq, Repr
+
+def resumeCases : List ResumeCase :=
+  [ ⟨"atomic_publication", initial, request, true, published, .created⟩
+  , ⟨"staging_failure_rolls_back", initial, request, false, initial, .rolledBack⟩
+  , ⟨"lost_ack_returns_same_child", published, request, true, published, .recovered⟩
+  , ⟨"retry_after_later_progress", later, request, true, later, .recovered⟩
+  , ⟨"unauthorized_cannot_publish", initial, {request with authorized := false}, true, initial, .denied⟩
+  , ⟨"foreign_parent_cannot_recover", published, {request with parentBelongsToGoal := false}, true, published, .denied⟩
+  , ⟨"non_latest_parent_cannot_publish", {initial with latestRequest := 30}, request, true,
+       {initial with latestRequest := 30}, .illegal⟩
+  , ⟨"nonterminal_parent_cannot_publish", initial, {request with terminalParent := false}, true, initial, .illegal⟩
+  , ⟨"busy_session_cannot_publish", initial, {request with sessionIdle := false}, true, initial, .illegal⟩
+  , ⟨"foreign_fingerprint_conflicts",
+       {published with children := [{parentBinding with semanticFingerprint := "foreign"}]},
+       request, true,
+       {published with children := [{parentBinding with semanticFingerprint := "foreign"}]}, .conflict⟩
+  , ⟨"budget_limited_cannot_resume", {initial with goal := {initial.goal with status := .budgetLimited}},
+       {request with expectedStatus := .budgetLimited}, true,
+       {initial with goal := {initial.goal with status := .budgetLimited}}, .illegal⟩
+  ]
+
+theorem cases_replay_explicit_expectations :
+  ∀ c ∈ resumeCases, resume c.before c.request c.commit = (c.expected, c.outcome) := by decide
+
+theorem published_retry_is_noop : resume published request true = (published, .recovered) := by decide
+
+theorem stale_pause_after_resume_is_noop : controllerWrite published .active 0 .pause = published := by decide
+
+def configCases : List (Goals.Status × Goals.Status × Bool) :=
+  [(.active, .active, true), (.paused, .active, false), (.blocked, .active, false),
+   (.usageLimited, .active, false), (.budgetLimited, .active, false), (.complete, .active, false),
+   (.paused, .paused, true)]
+theorem configCases_match :
+  ∀ c ∈ configCases, configMaySetStatus c.1 c.2.1 = c.2.2 := by decide
+
+private def b (x : Bool) : String := if x then "true" else "false"
+private def n : Option Nat → String | none => "null" | some x => toString x
+private def str : Option String → String | none => "null" | some x => jsonString x
+private def status (x : Goals.Status) : String := jsonString x.toDefraDB
+private def outcome : Outcome → String
+ | .denied => "denied" | .stale => "stale" | .illegal => "illegal" | .conflict => "conflict"
+ | .rolledBack => "rolled_back" | .created => "created" | .recovered => "recovered"
+def bindingJson (x : Binding) : String :=
+  "{\"goal\":" ++ toString x.goal ++ ",\"owner\":" ++ jsonString x.owner ++
+  ",\"session\":" ++ jsonString x.session ++ ",\"predecessor\":" ++ toString x.predecessor ++
+  ",\"predecessor_doc\":" ++ toString x.predecessorDoc ++ ",\"correlation\":" ++ str x.correlation ++
+  ",\"source_document\":" ++ str x.sourceDocument ++ ",\"trigger_context\":" ++ str x.triggerContext ++
+  ",\"workspace_fingerprint\":" ++ str x.workspaceFingerprint ++
+  ",\"semantic_fingerprint\":" ++ jsonString x.semanticFingerprint ++
+  ",\"child\":" ++ toString x.child ++ ",\"sequence\":" ++ toString x.sequence ++ "}"
+def snapshotJson (x : Snapshot) : String :=
+  "{\"status\":" ++ status x.goal.status ++ ",\"blocked_audits\":" ++ toString x.goal.blockedAudits ++
+  ",\"wrapup_requested\":" ++ b x.goal.wrapupRequested ++ ",\"wrapup_completed\":" ++ b x.goal.wrapupCompleted ++
+  ",\"sequence\":" ++ toString x.sequence ++ ",\"last_continued_from\":" ++ n x.lastContinuedFrom ++
+  ",\"latest_request\":" ++ toString x.latestRequest ++ ",\"children\":" ++ jsonArray (x.children.map bindingJson) ++
+  ",\"tokens_used\":" ++ toString x.tokensUsed ++ ",\"token_budget\":" ++ n x.tokenBudget ++ "}"
+def requestJson (x : Request) : String :=
+  "{\"expected_status\":" ++ status x.expectedStatus ++ ",\"expected_sequence\":" ++ toString x.expectedSequence ++
+  ",\"authorized\":" ++ b x.authorized ++ ",\"parent_belongs_to_goal\":" ++ b x.parentBelongsToGoal ++
+  ",\"terminal_parent\":" ++ b x.terminalParent ++ ",\"session_idle\":" ++ b x.sessionIdle ++
+  ",\"binding\":" ++ bindingJson x.binding ++ "}"
+def caseJson (c : ResumeCase) : String :=
+  "{\"name\":" ++ jsonString c.name ++ ",\"before\":" ++ snapshotJson c.before ++
+  ",\"request\":" ++ requestJson c.request ++ ",\"commit\":" ++ b c.commit ++
+  ",\"expected\":" ++ snapshotJson c.expected ++ ",\"outcome\":" ++ jsonString (outcome c.outcome) ++ "}"
+def resumeCasesJson : String := jsonArray (resumeCases.map caseJson)
+def configCasesJson : String := jsonArray (configCases.map fun c =>
+  "{\"current\":" ++ status c.1 ++ ",\"target\":" ++ status c.2.1 ++ ",\"allowed\":" ++ b c.2.2 ++ "}")
+end Conformance.GoalOperatorResumeContracts

--- a/crates/gents/proofs/Proofs/Conformance/GoalRequestHead.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GoalRequestHead.lean
@@ -1,0 +1,71 @@
+import Proofs.GoalAutomation.RequestHead
+import Proofs.Conformance.ContractTypes
+
+namespace Conformance.GoalRequestHeadContracts
+
+open GoalAutomation.RequestHead Conformance.Contracts
+
+structure Case where
+  name : String
+  rows : List Row
+  expected : Option Row
+  deriving DecidableEq, Repr
+
+def scope : Scope := ⟨1, 1, 1⟩
+def root : Row := ⟨10, 100, 1, 1, none, none, none, 0, true, true⟩
+def child : Row := ⟨20, 200, 1, 1, some 1, some 10, some 100, 1, true, true⟩
+def grandchild : Row := ⟨30, 300, 1, 1, some 1, some 20, some 200, 2, true, true⟩
+def unrelated : Row := ⟨40, 400, 1, 1, none, none, none, 0, true, true⟩
+
+/-- Explicit query-order inputs and expected heads. The graph/task names label
+actual lexical order witnesses; numeric IDs are abstract physical identities. -/
+def cases : List Case :=
+  [ ⟨"same_second_graph_parent", [root, child], some child⟩
+  , ⟨"legacy_source_omission_keeps_physical_edge", [root, child], some child⟩
+  , ⟨"same_second_task_parent_chain", [root, grandchild, child], some grandchild⟩
+  , ⟨"reverse_lexical_order", [child, root], some child⟩
+  , ⟨"unrelated_latest_keeps_priority", [unrelated, root, child], some unrelated⟩
+  , ⟨"foreign_edge_cannot_suppress", [root, {child with owner := 2}], some root⟩
+  , ⟨"arbitrary_signed_parent_link_cannot_suppress", [root, {child with goal := none}], some root⟩
+  , ⟨"other_goal_link_cannot_suppress", [root, {child with goal := some 2}], some root⟩
+  , ⟨"missing_parent_does_not_suppress_unrelated_head", [root, {child with parentDoc := some 99}], some root⟩
+  , ⟨"mismatched_physical_pair_does_not_suppress", [root, {child with parentRequest := some 999}], some root⟩
+  , ⟨"invalid_signature_does_not_suppress", [root, {child with receiptValid := false}], some root⟩
+  , ⟨"wrong_deterministic_identity_does_not_suppress", [root, {child with deterministicIdentity := false}], some root⟩
+  , ⟨"branch_leaves_keep_canonical_order", [root, child, {grandchild with parentDoc := some 10, parentRequest := some 100}], some child⟩
+  , ⟨"new_goal_epoch_may_reset_sequence", [root, {child with sequence := 5}, {grandchild with sequence := 1}], some {grandchild with sequence := 1}⟩
+  , ⟨"empty_session", [], none⟩
+  ]
+
+-- Abstract relation only: mutually deterministic hash identities are not a
+-- realizable signed-row fixture. This is not emitted as consumer coverage.
+example : select scope [{child with parentDoc := some 30, parentRequest := some 300}, grandchild] = none := by decide
+
+theorem cases_replay_explicit_expectations : ∀ c ∈ cases, select scope c.rows = c.expected := by decide
+
+
+private def boolJson (value : Bool) : String := if value then "true" else "false"
+private def optionalNatJson : Option Nat → String
+  | none => "null"
+  | some value => toString value
+
+def rowJson (row : Row) : String :=
+  "{\"doc\":" ++ toString row.doc ++ ",\"request\":" ++ toString row.request ++
+  ",\"owner\":" ++ toString row.owner ++ ",\"session\":" ++ toString row.session ++
+  ",\"goal\":" ++ optionalNatJson row.goal ++ ",\"parent_doc\":" ++ optionalNatJson row.parentDoc ++
+  ",\"parent_request\":" ++ optionalNatJson row.parentRequest ++ ",\"sequence\":" ++ toString row.sequence ++
+  ",\"receipt_valid\":" ++ boolJson row.receiptValid ++
+  ",\"deterministic_identity\":" ++ boolJson row.deterministicIdentity ++ "}"
+
+def caseJson (testCase : Case) : String :=
+  "{\"name\":" ++ jsonString testCase.name ++
+  ",\"scope\":{\"owner\":" ++ toString scope.owner ++
+  ",\"session\":" ++ toString scope.session ++ ",\"goal\":" ++ toString scope.goal ++ "}" ++
+  ",\"rows\":" ++ jsonArray (testCase.rows.map rowJson) ++
+  ",\"expected\":" ++ (match testCase.expected with | none => "null" | some row => rowJson row) ++ "}"
+
+def casesJson : String := jsonArray (cases.map caseJson)
+
+theorem cases_count : cases.length = 15 := by decide
+
+end Conformance.GoalRequestHeadContracts

--- a/crates/gents/proofs/Proofs/GoalAutomation/ClaimedPublication.lean
+++ b/crates/gents/proofs/Proofs/GoalAutomation/ClaimedPublication.lean
@@ -1,0 +1,85 @@
+import Proofs.GoalAutomation.OperatorResume
+
+/-! Transaction-boundary refinement of the existing claimed → childPresent
+phase. Claim has already consumed the Goal sequence. `commit` means the SAME
+native ConfigApplyTxn committed the Goal CAS write and signed AgentRequest;
+false includes native conflict and discard. No new durable state or clock.
+The Goal write must participate even though modeled Goal fields are unchanged.
+-/
+namespace GoalAutomation.OperatorResume
+
+structure ClaimedRequest extends Request where
+  expectedLastContinuedFrom : Option Nat
+  deriving DecidableEq, Repr
+
+def publishClaimed (s : Snapshot) (r : ClaimedRequest) (commit : Bool) :
+    Snapshot × Outcome :=
+  if !r.authorized || !r.parentBelongsToGoal then (s, .denied)
+  else match s.children.find? (sameKey r.binding) with
+  | some existing => if existing = r.binding then (s, .recovered) else (s, .conflict)
+  | none =>
+      if s.goal.status ≠ r.expectedStatus || s.sequence != r.expectedSequence ||
+          s.lastContinuedFrom != r.expectedLastContinuedFrom then (s, .stale)
+      else if (s.goal.status != .active && s.goal.status != .budgetLimited) ||
+          !r.terminalParent || !r.sessionIdle ||
+          r.binding.predecessor != s.latestRequest ||
+          s.lastContinuedFrom != some r.binding.predecessor ||
+          r.binding.sequence == 0 || r.binding.sequence != s.sequence then (s, .illegal)
+      else if commit then
+        ({ s with latestRequest := r.binding.child,
+                  children := r.binding :: s.children }, .created)
+      else (s, .rolledBack)
+
+theorem publication_preserves_claim_and_budget (s : Snapshot) (r : ClaimedRequest)
+    (commit : Bool) :
+    (publishClaimed s r commit).1.goal = s.goal ∧
+    (publishClaimed s r commit).1.sequence = s.sequence ∧
+    (publishClaimed s r commit).1.lastContinuedFrom = s.lastContinuedFrom ∧
+    (publishClaimed s r commit).1.tokensUsed = s.tokensUsed ∧
+    (publishClaimed s r commit).1.tokenBudget = s.tokenBudget := by
+  unfold publishClaimed
+  split
+  · simp
+  · split
+    · split <;> simp
+    · split
+      · simp
+      · split
+        · simp
+        · split <;> simp
+
+theorem discarded_claimed_publication_is_noop (s : Snapshot) (r : ClaimedRequest) :
+    (publishClaimed s r false).1 = s := by
+  unfold publishClaimed
+  split
+  · rfl
+  · split
+    · split <;> rfl
+    · split
+      · rfl
+      · split <;> rfl
+
+theorem created_requires_current_claim (s : Snapshot) (r : ClaimedRequest)
+    (commit : Bool) (h : (publishClaimed s r commit).2 = .created) :
+    s.goal.status = r.expectedStatus ∧ s.sequence = r.expectedSequence ∧
+    s.lastContinuedFrom = r.expectedLastContinuedFrom ∧
+    (s.goal.status = .active ∨ s.goal.status = .budgetLimited) ∧
+    (publishClaimed s r commit).1.children = r.binding :: s.children := by
+  unfold publishClaimed at *
+  split at * <;> try simp_all
+  split at *
+  · split at * <;> simp_all
+  · split at * <;> try simp_all
+    split at * <;> try simp_all
+    split at * <;> simp_all
+    rename_i hguard hcommit
+    have hn : r.expectedSequence ≠ 0 := by
+      intro hz
+      exact hguard.1.2 (hguard.2.trans hz)
+    have hs := hguard.1.1.1.1.1.1
+    by_cases ha : r.expectedStatus = .active
+    · simp [ha, hn]
+    · have hb := hs ha
+      simp [hb, hn]
+
+end GoalAutomation.OperatorResume

--- a/crates/gents/proofs/Proofs/GoalAutomation/OperatorResume.lean
+++ b/crates/gents/proofs/Proofs/GoalAutomation/OperatorResume.lean
@@ -1,0 +1,182 @@
+import Proofs.GoalAutomation
+
+/-! #1354: transaction-boundary refinement, not a new Goal status machine.
+`children` projects existing AgentRequest rows; no new durable registry.
+A binding represents the immutable semantic fingerprint prepared by the one
+existing goal-continuation RequestSpec builder, after authenticated ancestry
+validation. Readiness is deliberately absent: this slice is ready-backend only.
+-/
+namespace GoalAutomation.OperatorResume
+
+structure Binding where
+  goal : Nat
+  owner : String
+  session : String
+  predecessor : Nat
+  predecessorDoc : Nat
+  correlation : Option String
+  sourceDocument : Option String
+  triggerContext : Option String
+  workspaceFingerprint : Option String
+  /-- Abstract full signed-semantic fingerprint, excluding runtime mutations. -/
+  semanticFingerprint : String
+  child : Nat
+  sequence : Nat
+  deriving DecidableEq, Repr
+
+structure Snapshot where
+  goal : Goals.State
+  sequence : Nat
+  lastContinuedFrom : Option Nat
+  latestRequest : Nat
+  children : List Binding
+  tokensUsed : Nat
+  tokenBudget : Option Nat
+  deriving DecidableEq, Repr
+
+structure Request where
+  expectedStatus : Goals.Status
+  expectedSequence : Nat
+  /-- Results of authenticated owner/canonical parent checks in the transaction. -/
+  authorized : Bool
+  parentBelongsToGoal : Bool
+  terminalParent : Bool
+  sessionIdle : Bool
+  /-- Prepared from parent for fresh publication; on retry reconstructed only
+      after verifying the stored child signature and independent stable ancestry.
+      This is not caller-controlled payload or recomputed mutable Goal text. -/
+  binding : Binding
+  deriving DecidableEq, Repr
+
+inductive Outcome where
+  | denied | stale | illegal | conflict | rolledBack
+  | created | recovered
+  deriving DecidableEq, Repr
+
+def sameKey (a b : Binding) : Bool :=
+  a.goal == b.goal && a.predecessor == b.predecessor
+
+/-- One transaction publishes both Goal resume and its child. `commit=false`
+includes staging failure/discard; an acknowledgement lost AFTER commit is
+`commit=true` followed by retry against the resulting durable snapshot. -/
+def resume (s : Snapshot) (r : Request) (commit : Bool) : Snapshot × Outcome :=
+  if !r.authorized || !r.parentBelongsToGoal then (s, .denied)
+  else match s.children.find? (sameKey r.binding) with
+  | some existing => if existing = r.binding then (s, .recovered) else (s, .conflict)
+  | none =>
+      if s.goal.status ≠ r.expectedStatus || s.sequence != r.expectedSequence then (s, .stale)
+      else if !r.terminalParent || !r.sessionIdle || r.binding.predecessor != s.latestRequest || r.binding.sequence != s.sequence + 1 then
+        (s, .illegal)
+      else match Goals.step? s.goal .resume with
+      | none => (s, .illegal)
+      | some post =>
+          if commit then
+            ({ s with goal := post, sequence := s.sequence + 1, lastContinuedFrom := some r.binding.predecessor, latestRequest := r.binding.child, children := r.binding :: s.children }, .created)
+          else (s, .rolledBack)
+
+/-- Strengthen the existing GoalSource update guard with its observed sequence.
+The actual fields/transition remain owned by existing Goals.step?. -/
+def controllerWrite (s : Snapshot) (expectedStatus : Goals.Status)
+    (expectedSequence : Nat) (action : Goals.Action) : Snapshot :=
+  if s.goal.status = expectedStatus ∧ s.sequence = expectedSequence then
+    match Goals.step? s.goal action with
+    | none => s
+    | some post => { s with goal := post }
+  else s
+
+theorem unauthorized_resume_is_noop (s : Snapshot) (r : Request)
+    (h : r.authorized = false) (commit : Bool) : resume s r commit = (s, .denied) := by
+  simp [resume, h]
+
+theorem discarded_resume_publishes_nothing (s : Snapshot) (r : Request) :
+    (resume s r false).1 = s := by
+  unfold resume
+  split
+  · rfl
+  · split
+    · split <;> rfl
+    · split
+      · rfl
+      · split
+        · rfl
+        · split <;> rfl
+
+theorem stale_controller_epoch_is_noop (s : Snapshot) (status : Goals.Status)
+    (sequence : Nat) (action : Goals.Action) (h : s.sequence ≠ sequence) :
+    controllerWrite s status sequence action = s := by
+  simp [controllerWrite, h]
+
+theorem resume_preserves_budget_and_usage (s : Snapshot) (r : Request) (commit : Bool) :
+    (resume s r commit).1.tokensUsed = s.tokensUsed ∧
+    (resume s r commit).1.tokenBudget = s.tokenBudget := by
+  unfold resume
+  split
+  · exact ⟨rfl, rfl⟩
+  · split
+    · split <;> exact ⟨rfl, rfl⟩
+    · split
+      · exact ⟨rfl, rfl⟩
+      · split
+        · exact ⟨rfl, rfl⟩
+        · split
+          · exact ⟨rfl, rfl⟩
+          · split <;> exact ⟨rfl, rfl⟩
+
+theorem recovered_is_noop (s : Snapshot) (r : Request) (commit : Bool)
+    (h : (resume s r commit).2 = .recovered) : (resume s r commit).1 = s := by
+  unfold resume at *
+  split at * <;> try simp_all
+  split at *
+  · split at * <;> try simp_all
+  · split at * <;> try simp_all
+    split at * <;> try simp_all
+    split at * <;> try simp_all
+    split at * <;> try simp_all
+
+theorem created_publishes_atomically (s : Snapshot) (r : Request) (commit : Bool)
+    (h : (resume s r commit).2 = .created) :
+    (resume s r commit).1.goal.status = .active ∧
+    (resume s r commit).1.children = r.binding :: s.children ∧
+    (resume s r commit).1.sequence = s.sequence + 1 ∧
+    (resume s r commit).1.lastContinuedFrom = some r.binding.predecessor ∧
+    (resume s r commit).1.latestRequest = r.binding.child := by
+  unfold resume at *
+  split at * <;> try simp_all
+  split at *
+  · split at * <;> try simp_all
+  · split at * <;> try simp_all
+    split at * <;> try simp_all
+    split at * <;> try simp_all
+    rename_i post hpost
+    split at * <;> try simp_all
+    unfold Goals.step? at hpost
+    split at hpost <;> try simp_all
+    exact congrArg Goals.State.status hpost.2.symm
+
+theorem successful_commit_retry_recovers_same_child (s : Snapshot) (r : Request)
+    (h : (resume s r true).2 = .created) :
+    resume (resume s r true).1 r true = ((resume s r true).1, .recovered) := by
+  have publication := created_publishes_atomically s r true h
+  have auth : r.authorized = true ∧ r.parentBelongsToGoal = true := by
+    unfold resume at h
+    split at h
+    · simp at h
+    · rename_i allowed
+      simpa using allowed
+  generalize hx : (resume s r true).1 = post at *
+  simp only [resume, auth.1, auth.2, Bool.not_true, Bool.false_or, Bool.false_eq_true,
+    ↓reduceIte, publication.2.1]
+  simp [List.find?, sameKey]
+
+/-- Configuration may preserve Active but cannot reactivate an existing Goal.
+The actual non-resume transition remains the existing Goals.step? policy. -/
+def configMaySetStatus (current target : Goals.Status) : Bool :=
+  !(current != .active && target == .active)
+
+theorem config_cannot_reactivate (current : Goals.Status) (h : current ≠ .active) :
+    configMaySetStatus current .active = false := by
+  cases current <;> try simp_all [configMaySetStatus]
+
+theorem active_config_remains_allowed : configMaySetStatus .active .active = true := rfl
+
+end GoalAutomation.OperatorResume

--- a/crates/gents/proofs/Proofs/GoalAutomation/RequestHead.lean
+++ b/crates/gents/proofs/Proofs/GoalAutomation/RequestHead.lean
@@ -1,0 +1,93 @@
+import Proofs.GoalAutomation
+
+/-! Candidate-local refinement: the selector changes ordering only when a
+verified current-Goal child proves its exact physical parent superseded.
+Invalid/missing edges have no ordering authority. Selecting a row does NOT
+admit it or authorize publication; existing owner checks still apply.
+-/
+namespace GoalAutomation.RequestHead
+
+structure Scope where
+  owner : Nat
+  session : Nat
+  goal : Nat
+  deriving DecidableEq, Repr
+
+structure Row where
+  doc : Nat
+  request : Nat
+  owner : Nat
+  session : Nat
+  goal : Option Nat
+  parentDoc : Option Nat
+  parentRequest : Option Nat
+  sequence : Nat
+  /-- Results of the existing receipt validator, evaluated only for matching edges. -/
+  receiptValid : Bool
+  deterministicIdentity : Bool
+  deriving DecidableEq, Repr
+
+def inScope (s : Scope) (r : Row) : Bool := r.owner == s.owner && r.session == s.session
+
+/-- Cheap qualification/binding checks precede cryptographic validation.
+The shared Goal physical-edge helper checks original parent/child signatures,
+owner/session, exact physical parent pair, canonical Goal metadata and original
+deterministic request/retry identity. Historical omission of inherited source
+fields does not erase a signed physical edge. Fresh typed-resume receipt checks
+remain stricter; this ordering projection does not authorize publication. -/
+def verifiedEdge (s : Scope) (parent child : Row) : Bool :=
+  child.goal == some s.goal && child.parentDoc == some parent.doc &&
+  child.parentRequest == some parent.request && child.doc != parent.doc &&
+  inScope s parent && inScope s child && child.sequence > 0 &&
+  child.receiptValid && child.deterministicIdentity
+
+def superseded (s : Scope) (rows : List Row) (parent : Row) : Bool :=
+  rows.any (verifiedEdge s parent)
+
+/-- Input order is the existing canonical query order. Multiple unrelated or
+branched leaves retain that order. No-head (empty or all superseded) cannot
+authorize a new continuation. Busy/unknown-state guards remain outside here. -/
+def select (s : Scope) (orderedRows : List Row) : Option Row :=
+  let rows := orderedRows.filter (inScope s)
+  rows.find? fun row => !superseded s rows row
+
+theorem selected_is_scoped_member (s : Scope) (rows : List Row) (head : Row)
+    (h : select s rows = some head) : head ∈ rows.filter (inScope s) :=
+  List.mem_of_find?_eq_some h
+
+theorem selected_has_no_verified_child (s : Scope) (rows : List Row) (head : Row)
+    (h : select s rows = some head) : superseded s (rows.filter (inScope s)) head = false := by
+  have hp := List.find?_some h
+  simpa using hp
+
+theorem verified_child_supersedes_exact_parent (s : Scope) (rows : List Row)
+    (child parent : Row) (hm : child ∈ rows) (hv : verifiedEdge s parent child = true) :
+    superseded s rows parent = true := by
+  simp only [superseded, List.any_eq_true]
+  exact ⟨child, hm, hv⟩
+
+theorem arbitrary_parent_link_has_no_authority (s : Scope) (parent child : Row)
+    (h : child.goal ≠ some s.goal) : verifiedEdge s parent child = false := by
+  simp [verifiedEdge, h]
+
+theorem invalid_receipt_has_no_authority (s : Scope) (parent child : Row)
+    (h : child.receiptValid = false) : verifiedEdge s parent child = false := by
+  simp [verifiedEdge, h]
+
+theorem wrong_physical_binding_has_no_authority (s : Scope) (parent child : Row)
+    (h : child.parentDoc ≠ some parent.doc) : verifiedEdge s parent child = false := by
+  simp [verifiedEdge, h]
+
+theorem foreign_child_has_no_authority (s : Scope) (parent child : Row)
+    (h : child.owner ≠ s.owner) : verifiedEdge s parent child = false := by
+  simp [verifiedEdge, inScope, h]
+
+theorem canonical_order_among_heads (s : Scope) (rows : List Row) (head : Row)
+    (h : select s rows = some head) :
+    ∃ before after, rows.filter (inScope s) = before ++ head :: after ∧
+      ∀ row ∈ before, superseded s (rows.filter (inScope s)) row = true := by
+  have hf := List.find?_eq_some_iff_append.mp h
+  obtain ⟨before, after, heq, hp⟩ := hf.2
+  exact ⟨before, after, heq, by simpa using hp⟩
+
+end GoalAutomation.RequestHead

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -1109,3 +1109,32 @@ These proofs do not establish:
 
 Those are handled through explicit assumptions, Rust integration tests,
 operational diagnostics, TLA+ specs, or platform-specific tests.
+
+### Goal resume and continuation publication
+
+`GoalAutomation/OperatorResume.lean` composes the existing Goal resume action
+with one signed child publication. Eleven generated cases exercise real
+transactions, including discard and recovery of an existing receipt after
+later Goal progress. Seven configuration cases prevent the ordinary setter
+from reactivating a Goal without its continuation. Usage and budget remain
+unchanged; status and sequence fence stale controller writes.
+
+`GoalAutomation/RequestHead.lean` preserves canonical request ordering among
+causal heads while excluding an authenticated continuation's physical parent.
+Fifteen generated cases drive the production selector with signed request
+rows, including coincident timestamps and historical optional-field omissions.
+This is an ordering boundary, not fresh request admission or a proof of database
+uniqueness. Candidate edges are authenticated lazily, and invalid edges cannot
+suppress a parent.
+
+`GoalAutomation/ClaimedPublication.lean` refines the existing continuation claim
+with transaction-boundary publication. The claim has already advanced its
+sequence: publication preserves Goal state, sequence, parent watermark, usage,
+and budget while atomically adding the signed child. A competing pause, newer
+resume epoch, or changed watermark prevents fresh publication; an exact
+authenticated receipt can recover without reactivating the Goal. Native commit
+conflict or discard publishes nothing. The implementation must write the Goal
+and child in the same existing transaction, even though the modeled Goal fields
+remain unchanged. Eight explicit conformance cases accompany the general laws.
+The older claimed-phase convergence theorem assumes publication remains
+authorized; a historical claim alone cannot override a later pause.

--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -11,6 +11,13 @@ use crate::graphql::{
     rows,
 };
 
+mod claimed_publication;
+mod operator_resume;
+mod request_head;
+pub(crate) use claimed_publication::publish_claimed_continuation;
+pub use operator_resume::{resume_goal_request, GoalResumeReceipt};
+pub(crate) use request_head::{goal_session_is_idle, latest_goal_request};
+
 pub const GOAL_TRIGGER_KIND: &str = "goal";
 pub const GET_GOAL_TOOL_NAME: &str = "get_goal";
 pub const UPDATE_GOAL_TOOL_NAME: &str = "update_goal";
@@ -1902,7 +1909,77 @@ pub async fn set_goal(
     status: Option<GoalStatus>,
     token_budget: Option<Option<i64>>,
 ) -> Result<GoalDocument> {
-    let existing = load_canonical_goal(node, agent_did, session_id).await?;
+    let txn = crate::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+    finish_set_goal(txn, agent_did, session_id, objective, status, token_budget).await
+}
+
+/// Configure a goal through the same transactional policy for local and HTTP access.
+pub async fn set_goal_from_access(
+    access: &crate::ConfigAccess,
+    agent_did: &str,
+    session_id: &str,
+    objective: Option<&str>,
+    status: Option<GoalStatus>,
+    token_budget: Option<Option<i64>>,
+) -> Result<GoalDocument> {
+    let txn = access.begin_apply_txn().await?;
+    finish_set_goal(txn, agent_did, session_id, objective, status, token_budget).await
+}
+
+async fn finish_set_goal(
+    txn: crate::config_client::ConfigApplyTxn<'_>,
+    agent_did: &str,
+    session_id: &str,
+    objective: Option<&str>,
+    status: Option<GoalStatus>,
+    token_budget: Option<Option<i64>>,
+) -> Result<GoalDocument> {
+    match set_goal_in_txn(&txn, agent_did, session_id, objective, status, token_budget).await {
+        Ok(goal) => {
+            txn.commit().await?;
+            Ok(goal)
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn load_canonical_goal_in_txn(
+    txn: &crate::config_client::ConfigApplyTxn<'_>,
+    agent_did: &str,
+    session_id: &str,
+) -> Result<Option<GoalDocument>> {
+    let agent_did = escape_graphql_string(agent_did);
+    let session_id = escape_graphql_string(session_id);
+    let response = txn
+        .execute(&format!(
+            r#"{{ Goal(filter: {{
+        agent_did: {{ _eq: "{agent_did}" }}, session_id: {{ _eq: "{session_id}" }}
+    }}) {{ {GOAL_FIELDS} }} }}"#
+        ))
+        .await?;
+    let mut goals: Vec<GoalDocument> = serde_json::from_value(
+        response
+            .pointer("/data/Goal")
+            .cloned()
+            .context("transactional Goal query omitted rows")?,
+    )
+    .context("decoding transactional Goal rows")?;
+    sort_goals_canonical(&mut goals);
+    Ok(goals.into_iter().next())
+}
+
+async fn set_goal_in_txn(
+    txn: &crate::config_client::ConfigApplyTxn<'_>,
+    agent_did: &str,
+    session_id: &str,
+    objective: Option<&str>,
+    status: Option<GoalStatus>,
+    token_budget: Option<Option<i64>>,
+) -> Result<GoalDocument> {
+    let existing = load_canonical_goal_in_txn(txn, agent_did, session_id).await?;
     let objective = objective
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -1924,7 +2001,10 @@ pub async fn set_goal(
         let pre = existing
             .state()
             .context("existing Goal has an unknown status")?;
-        let action = operator_action_for_status(pre.status, status);
+        anyhow::ensure!(
+            pre.status == GoalStatus::Active || status != GoalStatus::Active,
+            "reactivating an existing goal requires goal resume-request --from REQUEST_ID"
+        );
         let post = apply_operator_status_transition(pre, status)?;
         let active_time = existing.current_active_time_seconds(now);
         let active_started_at = if post.status.accrues_active_time() {
@@ -1938,24 +2018,14 @@ pub async fn set_goal(
             (!active_started_at.is_empty()).then_some(active_started_at.as_str()),
         );
         let doc_id = escape_graphql_string(&existing.doc_id);
-        let agent_did = escape_graphql_string(agent_did);
+        let escaped_agent_did = escape_graphql_string(agent_did);
         let objective = escape_graphql_string(&objective);
         let status = post.status.as_str();
-        let reset_audit_fields = if action == Some(GoalAction::Resume) {
-            "last_blocked_request_id: null, last_blocked_reason: null, last_failure: null, infrastructure_retry_count: 0,"
-        } else {
-            ""
-        };
-        let reset_completion_field = if action == Some(GoalAction::Resume) {
-            "completion_evidence: null,"
-        } else {
-            ""
-        };
         let now = escape_graphql_string(&now_string);
         let mutation = format!(
             r#"mutation {{
                 update_Goal(
-                    filter: {{ _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{agent_did}" }} }},
+                    filter: {{ _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{escaped_agent_did}" }} }},
                     input: {{
                         objective: "{objective}",
                         status: "{status}",
@@ -1966,8 +2036,6 @@ pub async fn set_goal(
                         consecutive_blocked_audits: {blocked_audits},
                         wrapup_requested: {wrapup_requested},
                         wrapup_completed: {wrapup_completed},
-                        {reset_audit_fields}
-                        {reset_completion_field}
                         updated_at: "{now}"
                     }}
                 ) {{ _docID }}
@@ -1977,8 +2045,8 @@ pub async fn set_goal(
             wrapup_requested = post.wrapup_requested,
             wrapup_completed = post.wrapup_completed,
         );
-        execute_goal_mutation(node, &mutation, "update goal").await?;
-        return load_goal_by_doc_id(node, &existing.doc_id)
+        txn.execute(&mutation).await?;
+        return load_canonical_goal_in_txn(txn, agent_did, session_id)
             .await?
             .context("updated Goal row disappeared");
     }
@@ -2035,8 +2103,8 @@ pub async fn set_goal(
         wrapup_requested = initial_state.wrapup_requested,
         wrapup_completed = initial_state.wrapup_completed,
     );
-    execute_goal_mutation(node, &mutation, "create goal").await?;
-    load_canonical_goal(node, agent_did, session_id)
+    txn.execute(&mutation).await?;
+    load_canonical_goal_in_txn(txn, agent_did, session_id)
         .await?
         .context("created Goal row not found")
 }
@@ -2109,27 +2177,9 @@ pub async fn delete_goals_for_session(
     }
 }
 
-pub async fn update_goal_fields(
-    node: &EmbeddedNode,
-    goal: &GoalDocument,
-    fields: &str,
-) -> Result<()> {
-    let doc_id = escape_graphql_string(&goal.doc_id);
-    let agent_did = escape_graphql_string(&goal.agent_did);
-    let mutation = format!(
-        r#"mutation {{
-            update_Goal(
-                filter: {{ _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{agent_did}" }} }},
-                input: {{ {fields} }}
-            ) {{ _docID }}
-        }}"#
-    );
-    execute_goal_mutation(node, &mutation, "update goal fields").await
-}
-
-/// Apply controller-owned fields only while the goal still has the status on
-/// which the controller based its decision. Operator/model status changes win
-/// races with continuation bookkeeping.
+/// Apply controller-owned fields only while both the observed status and
+/// continuation sequence remain current. A resumed goal may have the same
+/// status as an older snapshot, but belongs to a newer continuation.
 pub async fn update_goal_fields_if_status(
     node: &EmbeddedNode,
     goal: &GoalDocument,
@@ -2139,13 +2189,15 @@ pub async fn update_goal_fields_if_status(
     let doc_id = escape_graphql_string(&goal.doc_id);
     let agent_did = escape_graphql_string(&goal.agent_did);
     let expected_status = escape_graphql_string(expected_status.as_str());
+    let expected_sequence = goal.continuation_sequence();
     let mutation = format!(
         r#"mutation {{
             update_Goal(
                 filter: {{
                     _docID: {{ _eq: "{doc_id}" }},
                     agent_did: {{ _eq: "{agent_did}" }},
-                    status: {{ _eq: "{expected_status}" }}
+                    status: {{ _eq: "{expected_status}" }},
+                    continuation_sequence: {{ _eq: {expected_sequence} }}
                 }},
                 input: {{ {fields} }}
             ) {{ _docID }}
@@ -2173,7 +2225,9 @@ pub async fn claim_continuation(
     let agent_did = escape_graphql_string(&goal.agent_did);
     let parent_request_id = escape_graphql_string(parent_request_id);
     let expected_sequence = goal.continuation_sequence();
-    let next_sequence = expected_sequence.saturating_add(1);
+    let next_sequence = expected_sequence
+        .checked_add(1)
+        .context("goal continuation sequence exhausted")?;
     let expected_status = escape_graphql_string(&goal.status);
     let now = escape_graphql_string(&Utc::now().to_rfc3339());
     let mutation = format!(
@@ -2217,7 +2271,9 @@ pub async fn claim_retry_continuation(
     let parent_request_id = escape_graphql_string(parent_request_id);
     let failure = escape_graphql_string(failure);
     let expected_sequence = goal.continuation_sequence();
-    let next_sequence = expected_sequence.saturating_add(1);
+    let next_sequence = expected_sequence
+        .checked_add(1)
+        .context("goal continuation sequence exhausted")?;
     let expected_status = escape_graphql_string(&goal.status);
     let now = escape_graphql_string(&Utc::now().to_rfc3339());
     let mutation = format!(
@@ -2325,29 +2381,19 @@ pub async fn refresh_goal_usage(node: &EmbeddedNode, goal: &GoalDocument) -> Res
             .is_some_and(GoalStatus::accrues_active_time)
             .then_some(now_string.as_str()),
     );
-    update_goal_fields(
+    let status = goal
+        .parsed_status()
+        .context("Goal usage snapshot has an unknown status")?;
+    update_goal_fields_if_status(
         node,
         goal,
+        status,
         &format!(
             "tokens_used: {tokens}, active_time_seconds: {active_time}, {active_started_field} updated_at: \"{updated_at}\""
         ),
     )
     .await?;
     Ok(tokens)
-}
-
-async fn load_goal_by_doc_id(node: &EmbeddedNode, doc_id: &str) -> Result<Option<GoalDocument>> {
-    let doc_id = escape_graphql_string(doc_id);
-    let query = format!(
-        r#"{{ Goal(filter: {{ _docID: {{ _eq: "{doc_id}" }} }}, limit: 1) {{ {GOAL_FIELDS} }} }}"#
-    );
-    Ok(decode_goal_rows(node, &query).await?.into_iter().next())
-}
-
-async fn execute_goal_mutation(node: &EmbeddedNode, mutation: &str, label: &str) -> Result<()> {
-    execute_goal_mutation_response(node, mutation, label)
-        .await
-        .map(|_| ())
 }
 
 async fn execute_goal_mutation_response(

--- a/crates/gents/src/goal/claimed_publication.rs
+++ b/crates/gents/src/goal/claimed_publication.rs
@@ -1,0 +1,203 @@
+//! Publish an already claimed continuation through the existing Goal transaction.
+use super::*;
+use crate::config_client::ConfigApplyTxn;
+use crate::identity::{AgentIdentity, RegisteredIdentity};
+use crate::lifecycle::materialize::{sign_request, RequestSigner};
+use crate::lifecycle::queue::{
+    goal_continuation_behavior, goal_continuation_identity, prepare_goal_continuation,
+};
+use crate::request_admission::{verify_runtime_local_control_receipt, SIGNED_REQUEST_FIELDS};
+use gents_protocol::row::AgentRequestRow;
+
+pub(crate) async fn publish_claimed_continuation(
+    node: &EmbeddedNode,
+    observed: &GoalDocument,
+    parent_request_id: &str,
+    content: &str,
+    wrapup: bool,
+) -> Result<Option<GoalResumeReceipt>> {
+    let identity = RegisteredIdentity::from_registered_did(&observed.agent_did, None)?;
+    // Preserve the automatic queue writer's node actor; target identity signs
+    // the child independently of the database actor.
+    let txn = ConfigApplyTxn::begin_local(node, None).await?;
+    match stage_claimed_continuation(
+        &txn,
+        &identity,
+        observed,
+        parent_request_id,
+        content,
+        wrapup,
+    )
+    .await
+    {
+        Ok(Some(receipt)) => {
+            if receipt.created {
+                txn.commit().await?;
+            } else {
+                txn.discard().await?;
+            }
+            Ok(Some(receipt))
+        }
+        Ok(None) => {
+            txn.discard().await?;
+            Ok(None)
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn stage_claimed_continuation(
+    txn: &ConfigApplyTxn<'_>,
+    identity: &dyn AgentIdentity,
+    observed: &GoalDocument,
+    parent_request_id: &str,
+    content: &str,
+    wrapup: bool,
+) -> Result<Option<GoalResumeReceipt>> {
+    anyhow::ensure!(
+        identity.did() == observed.agent_did,
+        "claimed publication requires the goal owner's signing identity"
+    );
+    let Some(goal) =
+        load_canonical_goal_in_txn(txn, &observed.agent_did, &observed.session_id).await?
+    else {
+        return Ok(None);
+    };
+    if goal.doc_id != observed.doc_id {
+        return Ok(None);
+    }
+    let did = escape_graphql_string(&goal.agent_did);
+    let session = escape_graphql_string(&goal.session_id);
+    let response = txn
+        .execute(&format!(
+            r#"{{ AgentRequest(filter: {{
+        agent_did: {{ _eq: "{did}" }}, session_id: {{ _eq: "{session}" }}
+    }}, order: [{{ created_at: DESC }}, {{ request_id: DESC }}]) {{ {SIGNED_REQUEST_FIELDS} }} }}"#
+        ))
+        .await?;
+    let requests: Vec<AgentRequestRow> = serde_json::from_value(
+        response
+            .pointer("/data/AgentRequest")
+            .cloned()
+            .context("claimed parent query omitted rows")?,
+    )?;
+    let parents: Vec<_> = requests
+        .iter()
+        .filter(|row| row.request_id == parent_request_id)
+        .collect();
+    anyhow::ensure!(
+        parents.len() == 1,
+        "claimed predecessor must uniquely belong to the goal owner and session"
+    );
+    let parent_row = parents[0];
+    let parent = crate::watcher::AgentRequest::try_from(parent_row.clone())?;
+    let behavior = goal_continuation_behavior(txn, &parent).await?;
+    let sequence = observed.continuation_sequence();
+    let now = Utc::now();
+    let created_at = now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let mut create = prepare_goal_continuation(
+        &parent,
+        behavior,
+        &goal.goal_id,
+        content,
+        sequence,
+        wrapup,
+        &created_at,
+    )?;
+    let expected = GoalBackedRequestFingerprint::from_create(&create)?;
+    let key = goal_continuation_identity(&goal.goal_id, parent_request_id, sequence)?.retry_key;
+    let key = escape_graphql_string(&key);
+    let response = txn.execute(&format!(r#"{{ AgentRequest(filter: {{ retry_key: {{ _eq: "{key}" }} }}) {{ {SIGNED_REQUEST_FIELDS} }} }}"#)).await?;
+    let children: Vec<AgentRequestRow> = serde_json::from_value(
+        response
+            .pointer("/data/AgentRequest")
+            .cloned()
+            .context("claimed receipt query omitted rows")?,
+    )?;
+    anyhow::ensure!(
+        children.len() <= 1,
+        "ambiguous claimed continuation receipt"
+    );
+    if let Some(child) = children.first() {
+        verify_runtime_local_control_receipt(child, &goal.agent_did, parent_request_id)?;
+        let actual: GoalBackedRequestFingerprint =
+            serde_json::from_value(serde_json::to_value(child)?)?;
+        anyhow::ensure!(
+            actual == expected,
+            "claimed continuation receipt conflicts with the observed publication"
+        );
+        return Ok(Some(GoalResumeReceipt {
+            goal_id: goal.goal_id,
+            request_id: child.request_id.clone(),
+            doc_id: child
+                .doc_id
+                .clone()
+                .context("claimed receipt has no document ID")?,
+            created: false,
+        }));
+    }
+    if goal.status != observed.status
+        || goal.continuation_sequence() != sequence
+        || goal.last_continued_from_request_id != observed.last_continued_from_request_id
+    {
+        return Ok(None);
+    }
+    if !matches!(
+        goal.parsed_status(),
+        Some(GoalStatus::Active | GoalStatus::BudgetLimited)
+    ) || goal.last_continued_from_request_id.as_deref() != Some(parent_request_id)
+        || !parent_row
+            .lifecycle_state
+            .is_some_and(RequestLifecycleState::is_terminal)
+        || !goal_session_is_idle(&requests)
+        || !latest_goal_request(&goal, &requests).is_some_and(|row| row.doc_id == parent_row.doc_id)
+    {
+        return Ok(None);
+    }
+    sign_request(&mut create, RequestSigner::Identity(identity)).await?;
+    let doc_id = escape_graphql_string(&goal.doc_id);
+    let status = escape_graphql_string(&goal.status);
+    let parent_id = escape_graphql_string(parent_request_id);
+    let timestamp = escape_graphql_string(&now.to_rfc3339());
+    // Updating the timestamp makes this a real write on the same Goal row as
+    // pause/completion/resume, so competing transactions cannot both publish.
+    let response = txn
+        .execute(&format!(
+            r#"mutation {{ update_Goal(filter: {{
+        _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{did}" }},
+        status: {{ _eq: "{status}" }}, continuation_sequence: {{ _eq: {sequence} }},
+        last_continued_from_request_id: {{ _eq: "{parent_id}" }}
+    }}, input: {{ updated_at: "{timestamp}" }}) {{ _docID }} }}"#
+        ))
+        .await?;
+    if !response
+        .pointer("/data/update_Goal")
+        .is_some_and(mutation_returned_rows)
+    {
+        return Ok(None);
+    }
+    let response = txn
+        .execute(&create.graphql_mutation().map_err(anyhow::Error::msg)?)
+        .await?;
+    let child = response
+        .pointer("/data/create_AgentRequest")
+        .or_else(|| response.pointer("/data/add_AgentRequest"))
+        .context("claimed child create omitted result")?;
+    let child_doc = child
+        .get("_docID")
+        .or_else(|| child.get(0).and_then(|row| row.get("_docID")))
+        .and_then(serde_json::Value::as_str)
+        .context("claimed child create omitted document ID")?;
+    Ok(Some(GoalResumeReceipt {
+        goal_id: goal.goal_id,
+        request_id: create.request_id,
+        doc_id: child_doc.to_owned(),
+        created: true,
+    }))
+}
+
+#[cfg(test)]
+mod contract_tests;

--- a/crates/gents/src/goal/claimed_publication/contract_tests.rs
+++ b/crates/gents/src/goal/claimed_publication/contract_tests.rs
@@ -1,0 +1,188 @@
+//! Generated cases exercise the actual native transaction and publication owner.
+use super::*;
+use crate::identity::AgentIdentity;
+use crate::lifecycle::materialize::{sign_request, RequestSigner};
+use crate::lifecycle::queue::{goal_continuation_identity, prepare_goal_continuation};
+use crate::request_admission::SIGNED_REQUEST_FIELDS;
+use gents_protocol::row::AgentRequestRow;
+use serde::Deserialize;
+use serde_json::json;
+
+// Reuse the existing real-DB Goal fixture and independent signed-field checks.
+#[path = "../operator_resume/support.rs"]
+mod support;
+use support::*;
+
+#[derive(Deserialize)]
+struct PublicationContracts {
+    goal_claimed_publication_cases: Vec<ResumeCase>,
+}
+
+#[tokio::test]
+async fn generated_goal_claimed_publication_cases_drive_real_transactions() {
+    let contracts: PublicationContracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    assert_eq!(contracts.goal_claimed_publication_cases.len(), 8);
+    let mut seen = std::collections::BTreeSet::new();
+    for case in contracts.goal_claimed_publication_cases {
+        assert!(seen.insert(case.name.clone()), "duplicate generated case");
+        let fixture = Fixture::new(&case.before).await;
+        if !case.before["children"].as_array().unwrap().is_empty() {
+            fixture.seed_child(case.outcome == "conflict").await;
+        }
+        if case.before["latest_request"] == 40 {
+            fixture
+                .other_request("claimed-later-request", "2030-01-01T00:00:00Z", "completed")
+                .await;
+        }
+        assert_eq!(
+            fixture.observe().await,
+            case.before,
+            "{} initial",
+            case.name
+        );
+        let mut observed = load_canonical_goal(&fixture.node, fixture.identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        observed.status = case.request["expected_status"].as_str().unwrap().into();
+        observed.continuation_sequence = case.request["expected_sequence"].as_i64();
+        observed.last_continued_from_request_id =
+            match case.request["expected_last_continued_from"].as_u64() {
+                Some(10) => Some(PARENT.into()),
+                None => None,
+                value => panic!("unmapped observed watermark {value:?}"),
+            };
+        let wrapup = observed.parsed_status() == Some(GoalStatus::BudgetLimited);
+        let txn = ConfigApplyTxn::begin_local(&fixture.node, None)
+            .await
+            .unwrap();
+        let result = stage_claimed_continuation(
+            &txn,
+            fixture.identity.as_ref(),
+            &observed,
+            PARENT,
+            "Original signed continuation",
+            wrapup,
+        )
+        .await;
+        match case.outcome.as_str() {
+            "created" | "rolled_back" => {
+                let receipt = result.unwrap().expect("current claim must stage a child");
+                assert!(receipt.created);
+                let staged_goal = load_canonical_goal_in_txn(&txn, fixture.identity.did(), SESSION)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(staged_goal.status, case.before["status"].as_str().unwrap());
+                assert_eq!(
+                    staged_goal.continuation_sequence(),
+                    case.before["sequence"].as_i64().unwrap()
+                );
+                assert_eq!(
+                    staged_goal.last_continued_from_request_id.as_deref(),
+                    Some(PARENT)
+                );
+                let staged = txn.execute(&format!(
+                    r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}) {{ {SIGNED_REQUEST_FIELDS} }} }}"#,
+                    escape_graphql_string(&receipt.request_id),
+                )).await.unwrap();
+                let rows: Vec<AgentRequestRow> =
+                    serde_json::from_value(staged["data"]["AgentRequest"].clone()).unwrap();
+                assert_eq!(rows.len(), 1);
+                crate::request_admission::verify_runtime_local_control_receipt(
+                    &rows[0],
+                    fixture.identity.did(),
+                    PARENT,
+                )
+                .unwrap();
+                assert_eq!(rows[0].doc_id.as_deref(), Some(receipt.doc_id.as_str()));
+                if case.commit {
+                    txn.commit().await.unwrap();
+                } else {
+                    txn.discard().await.unwrap();
+                }
+            }
+            "recovered" => {
+                let receipt = result.unwrap().expect("existing child must recover");
+                assert!(!receipt.created);
+                assert_eq!(
+                    receipt.request_id,
+                    goal_continuation_identity(&fixture.goal.goal_id, PARENT, 1)
+                        .unwrap()
+                        .request_id
+                );
+                txn.discard().await.unwrap();
+            }
+            "stale" => {
+                assert!(
+                    result.unwrap().is_none(),
+                    "{} must not publish from stale observation",
+                    case.name
+                );
+                txn.discard().await.unwrap();
+            }
+            "conflict" => {
+                let error = format!("{:#}", result.unwrap_err());
+                assert!(
+                    error.contains("binding")
+                        || error.contains("receipt")
+                        || error.contains("immutable"),
+                    "{}: {error}",
+                    case.name
+                );
+                txn.discard().await.unwrap();
+            }
+            outcome => panic!("unmapped generated publication outcome {outcome}"),
+        }
+        assert_eq!(
+            fixture.observe().await,
+            case.expected,
+            "{} durable result",
+            case.name
+        );
+        fixture.node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn queued_claimed_publication_observes_pause_before_creating_child() {
+    let before = json!({"status":"active","blocked_audits":2,"wrapup_requested":false,
+        "wrapup_completed":false,"sequence":1,"last_continued_from":10,"latest_request":10,
+        "children":[],"tokens_used":37,"token_budget":1000});
+    let fixture = Fixture::new(&before).await;
+    let observed = load_canonical_goal(&fixture.node, fixture.identity.did(), SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    let txn = ConfigApplyTxn::begin_local(&fixture.node, None)
+        .await
+        .unwrap();
+    let publication = publish_claimed_continuation(
+        &fixture.node,
+        &observed,
+        PARENT,
+        "Original signed continuation",
+        false,
+    );
+    tokio::pin!(publication);
+    assert!(
+        matches!(
+            futures::poll!(publication.as_mut()),
+            std::task::Poll::Pending
+        ),
+        "publisher must wait behind the held native transaction gate"
+    );
+    txn.execute(&format!(
+        r#"mutation {{ update_Goal(docID: "{}", input: {{ status: "paused", active_started_at: null }}) {{ _docID }} }}"#,
+        escape_graphql_string(&fixture.goal.doc_id),
+    )).await.unwrap();
+    txn.commit().await.unwrap();
+    assert!(
+        publication.await.unwrap().is_none(),
+        "paused claim must not publish a child"
+    );
+    let mut expected = before;
+    expected["status"] = json!("paused");
+    assert_eq!(fixture.observe().await, expected);
+    fixture.node.shutdown().await;
+}

--- a/crates/gents/src/goal/operator_resume.rs
+++ b/crates/gents/src/goal/operator_resume.rs
@@ -1,0 +1,206 @@
+//! Operator resume composes the existing Goal and request owners in one transaction.
+use super::*;
+use crate::config_client::ConfigApplyTxn;
+use crate::identity::AgentIdentity;
+use crate::lifecycle::materialize::{sign_request, RequestSigner};
+use crate::lifecycle::queue::{goal_continuation_identity, prepare_goal_continuation};
+use crate::request_admission::{verify_request_receipt_signature, SIGNED_REQUEST_FIELDS};
+use gents_protocol::row::AgentRequestRow;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GoalResumeReceipt {
+    pub goal_id: String,
+    pub request_id: String,
+    pub doc_id: String,
+    pub created: bool,
+}
+
+/// Resume the canonical goal and publish its continuation atomically.
+/// `from_request_id` identifies the operation across retries, including retries
+/// after the child has finished and the goal has advanced again.
+pub async fn resume_goal_request(
+    access: &crate::ConfigAccess,
+    identity: &dyn AgentIdentity,
+    agent_did: &str,
+    session_id: &str,
+    from_request_id: &str,
+) -> Result<GoalResumeReceipt> {
+    anyhow::ensure!(
+        identity.did() == agent_did,
+        "goal resume requires the target principal's signing identity"
+    );
+    let txn = match access {
+        crate::ConfigAccess::Local(node) => {
+            ConfigApplyTxn::begin_local(
+                node,
+                Some(::identity::Did::new(identity.did().to_owned())?),
+            )
+            .await?
+        }
+        crate::ConfigAccess::Graphql(_) => access.begin_apply_txn().await?,
+    };
+    match stage_resume(&txn, identity, agent_did, session_id, from_request_id).await {
+        Ok(receipt) => {
+            if receipt.created {
+                txn.commit().await?;
+            } else {
+                txn.discard().await?;
+            }
+            Ok(receipt)
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
+}
+
+async fn stage_resume(
+    txn: &ConfigApplyTxn<'_>,
+    identity: &dyn AgentIdentity,
+    agent_did: &str,
+    session_id: &str,
+    from_request_id: &str,
+) -> Result<GoalResumeReceipt> {
+    let goal = load_canonical_goal_in_txn(txn, agent_did, session_id)
+        .await?
+        .context("no canonical goal exists for this owner and session")?;
+    let escaped_did = escape_graphql_string(agent_did);
+    let escaped_session = escape_graphql_string(session_id);
+    let response = txn
+        .execute(&format!(
+            r#"{{ AgentRequest(filter: {{
+        agent_did: {{ _eq: "{escaped_did}" }}, session_id: {{ _eq: "{escaped_session}" }}
+    }}, order: [{{ created_at: DESC }}, {{ request_id: DESC }}]) {{ {SIGNED_REQUEST_FIELDS} }} }}"#
+        ))
+        .await?;
+    let requests: Vec<AgentRequestRow> = serde_json::from_value(
+        response
+            .pointer("/data/AgentRequest")
+            .cloned()
+            .context("request query omitted rows")?,
+    )?;
+    let parents: Vec<_> = requests
+        .iter()
+        .filter(|row| row.request_id == from_request_id)
+        .collect();
+    anyhow::ensure!(
+        parents.len() == 1,
+        "resume predecessor must uniquely belong to the goal owner and session"
+    );
+    let parent_row = parents[0];
+    verify_request_receipt_signature(parent_row)?;
+    let parent = crate::watcher::AgentRequest::try_from(parent_row.clone())?;
+    let behavior = parent
+        .behavior_id
+        .clone()
+        .context("resume predecessor has no behavior binding")?;
+
+    // The stable key is independent of today's sequence. Its historical child
+    // is authenticated before any current-status/latest-request checks.
+    let key = goal_continuation_identity(&goal.goal_id, from_request_id, 1)?.retry_key;
+    let escaped_key = escape_graphql_string(&key);
+    let response = txn.execute(&format!(r#"{{ AgentRequest(filter: {{ retry_key: {{ _eq: "{escaped_key}" }} }}) {{ {SIGNED_REQUEST_FIELDS} }} }}"#)).await?;
+    let children: Vec<AgentRequestRow> = serde_json::from_value(
+        response
+            .pointer("/data/AgentRequest")
+            .cloned()
+            .context("receipt query omitted rows")?,
+    )?;
+    anyhow::ensure!(children.len() <= 1, "ambiguous goal continuation receipt");
+    if let Some(child) = children.first() {
+        super::request_head::verify_goal_continuation_receipt(&goal, parent_row, child)?;
+        return Ok(GoalResumeReceipt {
+            goal_id: goal.goal_id,
+            request_id: child.request_id.clone(),
+            doc_id: child
+                .doc_id
+                .clone()
+                .context("continuation receipt lacks document ID")?,
+            created: false,
+        });
+    }
+
+    anyhow::ensure!(
+        parent_row
+            .lifecycle_state
+            .is_some_and(RequestLifecycleState::is_terminal),
+        "resume predecessor must be terminal"
+    );
+    anyhow::ensure!(
+        latest_goal_request(&goal, &requests).is_some_and(|row| row.doc_id == parent_row.doc_id),
+        "resume predecessor is no longer the latest request"
+    );
+    anyhow::ensure!(
+        goal_session_is_idle(&requests),
+        "goal session still has unfinished requests"
+    );
+    let state = goal.state().context("goal has an unknown status")?;
+    let post = state
+        .step(GoalAction::Resume)
+        .context("goal status does not allow operator resume")?;
+    let sequence = goal
+        .continuation_sequence()
+        .checked_add(1)
+        .context("goal continuation sequence exhausted")?;
+    let now = Utc::now();
+    let created_at = now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let wrapup = post.wrapup_requested && !post.wrapup_completed;
+    let content = crate::trigger_engine::goal_source::continuation_prompt(&goal, None, wrapup);
+    let mut create = prepare_goal_continuation(
+        &parent,
+        behavior,
+        &goal.goal_id,
+        &content,
+        sequence,
+        wrapup,
+        &created_at,
+    )?;
+    sign_request(&mut create, RequestSigner::Identity(identity)).await?;
+    let doc_id = escape_graphql_string(&goal.doc_id);
+    let expected_status = escape_graphql_string(&goal.status);
+    let expected_sequence = goal.continuation_sequence();
+    let from = escape_graphql_string(from_request_id);
+    let timestamp = escape_graphql_string(&now.to_rfc3339());
+    let active_time = goal.current_active_time_seconds(now);
+    let response = txn.execute(&format!(r#"mutation {{ update_Goal(filter: {{
+        _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{escaped_did}" }},
+        status: {{ _eq: "{expected_status}" }}, continuation_sequence: {{ _eq: {expected_sequence} }}
+    }}, input: {{
+        status: "{status}", continuation_sequence: {sequence}, last_continued_from_request_id: "{from}",
+        consecutive_blocked_audits: {audits}, wrapup_requested: {wrapup_requested}, wrapup_completed: {wrapup_completed},
+        last_blocked_request_id: null, last_blocked_reason: null, last_failure: null,
+        infrastructure_retry_count: 0, completion_evidence: null,
+        active_time_seconds: {active_time}, active_started_at: "{timestamp}", updated_at: "{timestamp}"
+    }}) {{ _docID }} }}"#,
+        status = post.status.as_str(), audits = post.blocked_audits,
+        wrapup_requested = post.wrapup_requested, wrapup_completed = post.wrapup_completed)).await?;
+    anyhow::ensure!(
+        response
+            .pointer("/data/update_Goal")
+            .is_some_and(mutation_returned_rows),
+        "goal changed while staging resume"
+    );
+    let response = txn
+        .execute(&create.graphql_mutation().map_err(anyhow::Error::msg)?)
+        .await?;
+    let child = response
+        .pointer("/data/create_AgentRequest")
+        .or_else(|| response.pointer("/data/add_AgentRequest"))
+        .context("continuation create omitted result")?;
+    let doc_id = child
+        .get("_docID")
+        .or_else(|| child.get(0).and_then(|row| row.get("_docID")))
+        .and_then(serde_json::Value::as_str)
+        .context("continuation create omitted document ID")?
+        .to_owned();
+    Ok(GoalResumeReceipt {
+        goal_id: goal.goal_id,
+        request_id: create.request_id,
+        doc_id,
+        created: true,
+    })
+}
+
+#[cfg(test)]
+mod contract_tests;

--- a/crates/gents/src/goal/operator_resume/contract_tests.rs
+++ b/crates/gents/src/goal/operator_resume/contract_tests.rs
@@ -1,0 +1,190 @@
+use super::*;
+#[path = "support.rs"]
+mod support;
+use serde::Deserialize;
+use serde_json::json;
+use support::*;
+
+#[derive(Deserialize)]
+struct Contracts {
+    pub goal_operator_resume_cases: Vec<ResumeCase>,
+    pub goal_config_reactivation_cases: Vec<ConfigCase>,
+}
+
+#[derive(Deserialize)]
+struct ConfigCase {
+    pub current: String,
+    pub target: String,
+    pub allowed: bool,
+}
+
+#[tokio::test]
+async fn generated_goal_operator_resume_cases_drive_real_transactions() {
+    let contracts: Contracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    assert_eq!(contracts.goal_operator_resume_cases.len(), 11);
+    let mut seen = std::collections::BTreeSet::new();
+    for case in contracts.goal_operator_resume_cases {
+        assert!(seen.insert(case.name.clone()), "duplicate generated case");
+        let f = Fixture::new(&case.before).await;
+        let conflict = case.name == "foreign_fingerprint_conflicts";
+        if !case.before["children"].as_array().unwrap().is_empty() {
+            f.seed_child(conflict).await;
+        }
+        if case.before["latest_request"] == 30 {
+            f.other_request("later-request", "2030-01-01T00:00:00Z", "completed")
+                .await;
+        }
+        match case.name.as_str() {
+            "nonterminal_parent_cannot_publish" => execute(&f.node, &format!(r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{PARENT}" }} }}, input: {{ lifecycle_state: "processing" }}) {{ _docID }} }}"#)).await,
+            "busy_session_cannot_publish" => f.other_request("older-active", "2019-01-01T00:00:00Z", "processing").await,
+            "atomic_publication" | "staging_failure_rolls_back" | "lost_ack_returns_same_child"
+            | "retry_after_later_progress" | "unauthorized_cannot_publish" | "foreign_parent_cannot_recover"
+            | "non_latest_parent_cannot_publish" | "foreign_fingerprint_conflicts" | "budget_limited_cannot_resume" => {},
+            name => panic!("unmapped generated resume case {name}"),
+        }
+        assert_eq!(f.observe().await, case.before, "{} initial", case.name);
+        let access = crate::ConfigAccess::Local(f.node.clone());
+        if !case.commit {
+            assert_eq!(case.name, "staging_failure_rolls_back");
+            let txn = ConfigApplyTxn::begin_local(&f.node, None).await.unwrap();
+            let receipt =
+                stage_resume(&txn, f.identity.as_ref(), f.identity.did(), SESSION, PARENT)
+                    .await
+                    .unwrap();
+            assert!(receipt.created);
+            let staged_goal = load_canonical_goal_in_txn(&txn, f.identity.did(), SESSION)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(staged_goal.parsed_status(), Some(GoalStatus::Active));
+            assert_eq!(staged_goal.continuation_sequence(), 1);
+            let staged = txn
+                .execute(&format!(
+                    "{{ AgentRequest(filter: {{ request_id: {{ _eq: \"{}\" }} }}) {{ _docID }} }}",
+                    escape_graphql_string(&receipt.request_id)
+                ))
+                .await
+                .unwrap();
+            assert_eq!(staged["data"]["AgentRequest"].as_array().unwrap().len(), 1);
+            txn.discard().await.unwrap();
+            assert_eq!(case.outcome, "rolled_back");
+        } else {
+            let foreign_temp = tempfile::tempdir().unwrap();
+            let foreign = crate::identity::KeyIdentity::load_or_create(
+                foreign_temp.path().join("foreign.key"),
+                None,
+            )
+            .unwrap();
+            let identity: &dyn AgentIdentity = if case.request["authorized"] == false {
+                &foreign
+            } else {
+                f.identity.as_ref()
+            };
+            let predecessor = if case.request["parent_belongs_to_goal"] == false {
+                "foreign-parent"
+            } else {
+                PARENT
+            };
+            let result =
+                resume_goal_request(&access, identity, f.identity.did(), SESSION, predecessor)
+                    .await;
+            match case.outcome.as_str() {
+                "created" | "recovered" => {
+                    let receipt = result.unwrap();
+                    assert_eq!(receipt.created, case.outcome == "created");
+                    let expected = goal_continuation_identity(&f.goal.goal_id, PARENT, 1).unwrap();
+                    assert_eq!(receipt.request_id, expected.request_id);
+                    assert_eq!(receipt.goal_id, f.goal.goal_id);
+                    let rows = request_rows(&f.node).await;
+                    assert_eq!(
+                        rows.iter()
+                            .filter(|r| r.doc_id.as_deref() == Some(receipt.doc_id.as_str()))
+                            .count(),
+                        1
+                    );
+                    if case.name == "atomic_publication" {
+                        let row = rows
+                            .into_iter()
+                            .find(|r| r.request_id == receipt.request_id)
+                            .unwrap();
+                        let request = crate::watcher::AgentRequest::try_from(row).unwrap();
+                        let (_authority_owner, authority) =
+                            crate::agent::p2p_reconcile::enrollment_authority_channel();
+                        let verifier = crate::request_admission::AgentRequestAdmissionVerifier::new(
+                            f.node.clone(),
+                            f.identity.clone(),
+                            authority,
+                        );
+                        verifier
+                            .verify_fresh(&request, "contract-behavior")
+                            .await
+                            .expect("published continuation must pass actual execution admission");
+                    }
+                }
+                "denied" | "illegal" | "conflict" => {
+                    let error = format!("{:#}", result.unwrap_err());
+                    let expected_reason = match case.name.as_str() {
+                        "unauthorized_cannot_publish" => "target principal",
+                        "foreign_parent_cannot_recover" => "predecessor must uniquely belong",
+                        "non_latest_parent_cannot_publish" => "no longer the latest",
+                        "nonterminal_parent_cannot_publish" => "predecessor must be terminal",
+                        "busy_session_cannot_publish" => "still has unfinished requests",
+                        "foreign_fingerprint_conflicts" => "physical predecessor binding",
+                        "budget_limited_cannot_resume" => "does not allow operator resume",
+                        name => panic!("unmapped rejection {name}"),
+                    };
+                    assert!(error.contains(expected_reason), "{}: {error}", case.name);
+                }
+                outcome => panic!("unmapped outcome {outcome}"),
+            }
+        }
+        assert_eq!(
+            f.observe().await,
+            case.expected,
+            "{} durable result",
+            case.name
+        );
+        f.node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn generated_goal_config_reactivation_cases_drive_transactional_setter() {
+    let contracts: Contracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    assert_eq!(contracts.goal_config_reactivation_cases.len(), 7);
+    let mut seen = std::collections::BTreeSet::new();
+    for case in contracts.goal_config_reactivation_cases {
+        assert!(seen.insert((case.current.clone(), case.target.clone())));
+        let before = json!({"status":case.current,"blocked_audits":2,"wrapup_requested":false,
+            "wrapup_completed":false,"sequence":0,"last_continued_from":null,"latest_request":10,
+            "children":[],"tokens_used":37,"token_budget":1000});
+        let f = Fixture::new(&before).await;
+        assert_eq!(f.observe().await, before);
+        let access = crate::ConfigAccess::Local(f.node.clone());
+        let result = set_goal_from_access(
+            &access,
+            f.identity.did(),
+            SESSION,
+            None,
+            Some(GoalStatus::parse(&case.target).unwrap()),
+            None,
+        )
+        .await;
+        assert_eq!(
+            result.is_ok(),
+            case.allowed,
+            "{} -> {}: {result:?}",
+            case.current,
+            case.target
+        );
+        if let Err(error) = result {
+            assert!(format!("{error:#}").contains("requires goal resume-request"));
+        }
+        let mut expected = before;
+        if case.allowed {
+            expected["status"] = json!(case.target);
+        }
+        assert_eq!(f.observe().await, expected);
+        f.node.shutdown().await;
+    }
+}

--- a/crates/gents/src/goal/operator_resume/support.rs
+++ b/crates/gents/src/goal/operator_resume/support.rs
@@ -1,0 +1,274 @@
+use super::*;
+use crate::identity::KeyIdentity;
+use crate::request_admission::verify_runtime_local_control_receipt;
+use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+pub(super) struct ResumeCase {
+    pub name: String,
+    pub before: Value,
+    pub request: Value,
+    pub commit: bool,
+    pub expected: Value,
+    pub outcome: String,
+}
+
+pub(super) const SESSION: &str = "contract-session";
+pub(super) const PARENT: &str = "contract-parent";
+pub(super) struct Fixture {
+    pub node: Arc<EmbeddedNode>,
+    pub identity: Arc<KeyIdentity>,
+    pub goal: GoalDocument,
+    pub parent: crate::watcher::AgentRequest,
+    _temp: tempfile::TempDir,
+}
+impl Fixture {
+    pub async fn new(before: &Value) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let identity =
+            Arc::new(KeyIdentity::load_or_create(temp.path().join("target.key"), None).unwrap());
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::schema::ensure_runtime_schemas(&node).await.unwrap();
+        let goal = set_goal(
+            &node,
+            identity.did(),
+            SESSION,
+            Some("Finish the original work"),
+            Some(GoalStatus::parse(before["status"].as_str().unwrap()).unwrap()),
+            Some(Some(1000)),
+        )
+        .await
+        .unwrap();
+        let mut create = AgentRequestCreate::base(
+            PARENT,
+            identity.did(),
+            identity.did(),
+            "contract-behavior",
+            SESSION,
+            "Original context",
+            "interactive",
+            "2020-01-01T00:00:00Z",
+            AgentRequestAdmissionRecord::local_self(identity.did()),
+        );
+        create.caused_by_correlation = Some("graph-correlation".into());
+        create.caused_by_source_doc_id = Some("source".into());
+        create.caused_by_trigger_context = Some(r#"{"contract":"context"}"#.into());
+        create.workspace_id = Some("contract-workspace".into());
+        create.workspace_authority = Some("readOnly".into());
+        create.workspace_owner_deployment_id = Some("contract-deployment".into());
+        create.workspace_seal_hash = Some("contract-seal".into());
+        crate::sign_agent_request_create(identity.as_ref(), &mut create)
+            .await
+            .unwrap();
+        execute(&node, &create.graphql_mutation().unwrap()).await;
+        execute(&node, &format!(r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{PARENT}" }} }}, input: {{ lifecycle_state: "completed" }}) {{ _docID }} }}"#)).await;
+        let rows = request_rows(&node).await;
+        let parent = crate::watcher::AgentRequest::try_from(
+            rows.into_iter().find(|r| r.request_id == PARENT).unwrap(),
+        )
+        .unwrap();
+        let f = Self {
+            node,
+            identity,
+            goal,
+            parent,
+            _temp: temp,
+        };
+        f.seed_goal_snapshot(before).await;
+        f
+    }
+    pub async fn seed_goal_snapshot(&self, before: &Value) {
+        let last = if before["last_continued_from"].is_null() {
+            "null".to_owned()
+        } else {
+            let request = match before["last_continued_from"].as_u64().unwrap() {
+                10 => PARENT,
+                30 => "watermark-parent",
+                value => panic!("unmapped predecessor watermark {value}"),
+            };
+            format!("\"{request}\"")
+        };
+        execute(&self.node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{
+            continuation_sequence: {}, last_continued_from_request_id: {last}, consecutive_blocked_audits: {},
+            wrapup_requested: {}, wrapup_completed: {}, tokens_used: {}, token_budget: {}
+        }}) {{ _docID }} }}"#, escape_graphql_string(&self.goal.doc_id), before["sequence"], before["blocked_audits"],
+            before["wrapup_requested"], before["wrapup_completed"], before["tokens_used"], before["token_budget"])).await;
+    }
+    pub async fn seed_child(&self, conflicting: bool) {
+        let mut create = prepare_goal_continuation(
+            &self.parent,
+            "contract-behavior".into(),
+            &self.goal.goal_id,
+            "Original signed continuation",
+            1,
+            false,
+            "2021-01-01T00:00:00Z",
+        )
+        .unwrap();
+        if conflicting {
+            let mut metadata: Value =
+                serde_json::from_str(create.metadata.as_deref().unwrap()).unwrap();
+            metadata["queue"]["key"] = json!("goal:foreign");
+            create.metadata = Some(metadata.to_string());
+        }
+        sign_request(&mut create, RequestSigner::Identity(self.identity.as_ref()))
+            .await
+            .unwrap();
+        execute(&self.node, &create.graphql_mutation().unwrap()).await;
+        // Historical receipt recovery must not require pending admission.
+        execute(&self.node, &format!(r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, input: {{ lifecycle_state: "completed", deadline: "2021-01-01T00:00:01Z" }}) {{ _docID }} }}"#, create.request_id)).await;
+    }
+    pub async fn other_request(&self, id: &str, date: &str, state: &str) {
+        let mut create = AgentRequestCreate::base(
+            id,
+            self.identity.did(),
+            self.identity.did(),
+            "contract-behavior",
+            SESSION,
+            "Other work",
+            "interactive",
+            date,
+            AgentRequestAdmissionRecord::local_self(self.identity.did()),
+        );
+        crate::sign_agent_request_create(self.identity.as_ref(), &mut create)
+            .await
+            .unwrap();
+        execute(&self.node, &create.graphql_mutation().unwrap()).await;
+        execute(&self.node, &format!(r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{id}" }} }}, input: {{ lifecycle_state: "{state}" }}) {{ _docID }} }}"#)).await;
+    }
+    pub async fn observe(&self) -> Value {
+        let g = load_canonical_goal(&self.node, self.identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        let rows = request_rows(&self.node).await;
+        let mut children = Vec::new();
+        for child in rows.iter().filter(|r| {
+            r.retry_key
+                .as_deref()
+                .is_some_and(|k| k.starts_with("goal-continuation:"))
+        }) {
+            verify_runtime_local_control_receipt(child, self.identity.did(), PARENT).unwrap();
+            let metadata: Value = serde_json::from_str(child.metadata.as_deref().unwrap()).unwrap();
+            // Assert concrete lineage independently of prepare_goal_continuation:
+            // sharing its implementation must not hide a producer deletion.
+            assert_eq!(child.agent_did.as_deref(), Some(self.identity.did()));
+            assert_eq!(child.requester_did.as_deref(), Some(self.identity.did()));
+            assert_eq!(child.session_id.as_deref(), Some(SESSION));
+            assert_eq!(child.behavior_id.as_deref(), Some("contract-behavior"));
+            assert_eq!(child.execution_origin.as_deref(), Some("scheduled"));
+            assert_eq!(child.caused_by_parent_request_id.as_deref(), Some(PARENT));
+            assert_eq!(
+                child.caused_by_parent_request_doc_id.as_deref(),
+                Some(self.parent.doc_id.as_str())
+            );
+            assert_eq!(child.caused_by_parent_tool_call_id, None);
+            assert_eq!(child.caused_by_parent_tool_call_doc_id, None);
+            assert_eq!(child.subagent_depth, Some(0));
+            assert_eq!(
+                child.caused_by_trigger_id.as_deref(),
+                Some(self.goal.goal_id.as_str())
+            );
+            assert_eq!(child.caused_by_trigger_kind.as_deref(), Some("goal"));
+            assert_eq!(child.caused_by_trigger_doc_id, None);
+            assert_eq!(
+                child.caused_by_correlation.as_deref(),
+                Some("graph-correlation")
+            );
+            assert_eq!(child.caused_by_source_doc_id.as_deref(), Some("source"));
+            assert_eq!(
+                child.caused_by_trigger_context.as_deref(),
+                Some(r#"{"contract":"context"}"#)
+            );
+            assert_eq!(child.workspace_id.as_deref(), Some("contract-workspace"));
+            assert_eq!(child.workspace_authority.as_deref(), Some("readOnly"));
+            assert_eq!(
+                child.workspace_owner_deployment_id.as_deref(),
+                Some("contract-deployment")
+            );
+            assert_eq!(child.workspace_seal_hash.as_deref(), Some("contract-seal"));
+            assert_eq!(metadata["goal"]["goal_id"], self.goal.goal_id);
+            assert_eq!(metadata["goal"]["parent_request_id"], PARENT);
+            let wrapup = self.goal.parsed_status() == Some(GoalStatus::BudgetLimited);
+            assert_eq!(metadata["goal"]["wrapup"], wrapup);
+            assert_eq!(metadata["queue"]["source"], "goal");
+            assert_eq!(metadata["queue"]["policy"], "coalesce");
+            assert_eq!(metadata["queue"]["queued_after_request_id"], PARENT);
+            let seq = metadata["goal"]["continuation_sequence"].as_i64().unwrap();
+            assert_eq!(seq, 1);
+            let identity = goal_continuation_identity(&self.goal.goal_id, PARENT, 1).unwrap();
+            assert_eq!(child.request_id, identity.request_id);
+            assert_eq!(
+                child.retry_key.as_deref(),
+                Some(identity.retry_key.as_str())
+            );
+            if metadata["queue"]["key"] != "goal:foreign" {
+                assert_eq!(metadata["queue"]["key"], identity.queue_key);
+            }
+
+            let expected = prepare_goal_continuation(
+                &self.parent,
+                "contract-behavior".into(),
+                &g.goal_id,
+                child.content.as_deref().unwrap(),
+                seq,
+                wrapup,
+                child.created_at.as_deref().unwrap(),
+            )
+            .unwrap();
+            let actual: GoalBackedRequestFingerprint =
+                serde_json::from_value(serde_json::to_value(child).unwrap()).unwrap();
+            let mut comparison = expected.clone();
+            let foreign = metadata["queue"]["key"] == "goal:foreign";
+            if foreign {
+                let mut metadata: Value =
+                    serde_json::from_str(comparison.metadata.as_deref().unwrap()).unwrap();
+                metadata["queue"]["key"] = json!("goal:foreign");
+                comparison.metadata = Some(metadata.to_string());
+            }
+            assert_eq!(
+                actual,
+                GoalBackedRequestFingerprint::from_create(&comparison).unwrap(),
+                "all concrete signed child semantics must match before abstraction"
+            );
+            children.push(json!({"goal":1,"owner":"owner","session":"session","predecessor":10,
+                "predecessor_doc":100,"correlation":"graph-correlation","source_document":"source",
+                "trigger_context":"context","workspace_fingerprint":"workspace-authority",
+                "semantic_fingerprint":if foreign {"foreign"} else {"full-semantic-fingerprint"},"child":20,"sequence":seq}));
+        }
+        let latest = rows
+            .first()
+            .map(|r| match r.request_id.as_str() {
+                PARENT => 10,
+                "later-request" => 30,
+                "older-active" | "claimed-later-request" => 40,
+                id if id.starts_with("goal-cont-") => 20,
+                id => panic!("unknown request {id}"),
+            })
+            .unwrap();
+        let last = g
+            .last_continued_from_request_id
+            .as_deref()
+            .map(|id| match id {
+                PARENT => 10,
+                "watermark-parent" => 30,
+                other => panic!("unmapped predecessor watermark {other}"),
+            });
+        json!({"status":g.status,"blocked_audits":g.consecutive_blocked_audits.unwrap_or(0),
+            "wrapup_requested":g.wrapup_requested.unwrap_or(false),"wrapup_completed":g.wrapup_completed.unwrap_or(false),
+            "sequence":g.continuation_sequence(),"last_continued_from":last,"latest_request":latest,
+            "children":children,"tokens_used":g.tokens_used.unwrap_or(0),"token_budget":g.token_budget})
+    }
+}
+pub(super) async fn execute(node: &EmbeddedNode, query: &str) {
+    let response = node.execute(query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+}
+pub(super) async fn request_rows(node: &EmbeddedNode) -> Vec<AgentRequestRow> {
+    let response=node.execute(&format!("{{ AgentRequest(order: [{{ created_at: DESC }}, {{ request_id: DESC }}]) {{ {SIGNED_REQUEST_FIELDS} }} }}")).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    crate::graphql::rows(&response, "AgentRequest").unwrap()
+}

--- a/crates/gents/src/goal/request_head.rs
+++ b/crates/gents/src/goal/request_head.rs
@@ -1,0 +1,142 @@
+//! Shared validation of Goal continuation receipts and request ordering.
+use super::*;
+use crate::lifecycle::queue::{goal_continuation_identity, prepare_goal_continuation};
+use crate::request_admission::{
+    verify_request_receipt_signature, verify_runtime_local_control_receipt,
+};
+use gents_protocol::row::AgentRequestRow;
+
+/// Authenticate causal ancestry independently of the current producer defaults.
+/// Historical children can have different inherited optional fields; their
+/// original target signature still binds the exact physical predecessor.
+fn verify_goal_continuation_edge(
+    goal: &GoalDocument,
+    parent_row: &AgentRequestRow,
+    child: &AgentRequestRow,
+) -> Result<(i64, bool)> {
+    anyhow::ensure!(
+        parent_row.agent_did.as_deref() == Some(goal.agent_did.as_str())
+            && parent_row.session_id.as_deref() == Some(goal.session_id.as_str())
+            && child.session_id.as_deref() == Some(goal.session_id.as_str()),
+        "continuation predecessor is outside the goal owner/session"
+    );
+    verify_request_receipt_signature(parent_row)?;
+    let parent_doc = parent_row
+        .doc_id
+        .as_deref()
+        .context("continuation predecessor has no document ID")?;
+    verify_runtime_local_control_receipt(child, &goal.agent_did, &parent_row.request_id)?;
+    anyhow::ensure!(
+        child.caused_by_parent_request_doc_id.as_deref() == Some(parent_doc)
+            && child
+                .doc_id
+                .as_deref()
+                .is_some_and(|id| !id.is_empty() && id != parent_doc)
+            && child.caused_by_trigger_kind.as_deref() == Some(GOAL_TRIGGER_KIND)
+            && child.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str()),
+        "continuation receipt has a different physical goal edge"
+    );
+    let metadata: serde_json::Value = serde_json::from_str(
+        child
+            .metadata
+            .as_deref()
+            .context("continuation receipt lacks metadata")?,
+    )?;
+    anyhow::ensure!(
+        metadata
+            .pointer("/goal/goal_id")
+            .and_then(serde_json::Value::as_str)
+            == Some(goal.goal_id.as_str())
+            && metadata
+                .pointer("/goal/parent_request_id")
+                .and_then(serde_json::Value::as_str)
+                == Some(parent_row.request_id.as_str()),
+        "continuation receipt has different goal metadata"
+    );
+    let sequence = metadata
+        .pointer("/goal/continuation_sequence")
+        .and_then(serde_json::Value::as_i64)
+        .context("continuation receipt lacks its original sequence")?;
+    let identity = goal_continuation_identity(&goal.goal_id, &parent_row.request_id, sequence)?;
+    anyhow::ensure!(
+        child.request_id == identity.request_id
+            && child.retry_key.as_deref() == Some(identity.retry_key.as_str()),
+        "continuation receipt has a different deterministic identity"
+    );
+    let wrapup = metadata
+        .pointer("/goal/wrapup")
+        .and_then(serde_json::Value::as_bool)
+        .context("continuation receipt lacks its original wrapup policy")?;
+    Ok((sequence, wrapup))
+}
+
+pub(super) fn verify_goal_continuation_receipt(
+    goal: &GoalDocument,
+    parent_row: &AgentRequestRow,
+    child: &AgentRequestRow,
+) -> Result<()> {
+    let (sequence, wrapup) = verify_goal_continuation_edge(goal, parent_row, child)?;
+    let parent = crate::watcher::AgentRequest::try_from(parent_row.clone())?;
+    let behavior = parent
+        .behavior_id
+        .clone()
+        .context("continuation predecessor has no behavior binding")?;
+    let expected = prepare_goal_continuation(
+        &parent,
+        behavior,
+        &goal.goal_id,
+        child
+            .content
+            .as_deref()
+            .context("continuation receipt lacks content")?,
+        sequence,
+        wrapup,
+        child
+            .created_at
+            .as_deref()
+            .context("continuation receipt lacks creation time")?,
+    )?;
+    let actual: GoalBackedRequestFingerprint =
+        serde_json::from_value(serde_json::to_value(child)?)?;
+    anyhow::ensure!(
+        actual == GoalBackedRequestFingerprint::from_create(&expected)?,
+        "continuation receipt conflicts with the goal and physical predecessor binding"
+    );
+    Ok(())
+}
+
+/// Preserve canonical query order among heads, but never select an authenticated
+/// Goal continuation's physical ancestor ahead of that child. Only matching
+/// candidate edges pay for signature verification; ordinary latest leaves do not.
+pub(crate) fn latest_goal_request<'a>(
+    goal: &GoalDocument,
+    rows: &'a [AgentRequestRow],
+) -> Option<&'a AgentRequestRow> {
+    let in_scope = |row: &&AgentRequestRow| {
+        row.agent_did.as_deref() == Some(goal.agent_did.as_str())
+            && row.session_id.as_deref() == Some(goal.session_id.as_str())
+    };
+    rows.iter().filter(in_scope).find(|parent| {
+        !rows.iter().filter(in_scope).any(|child| {
+            parent.doc_id.is_some()
+                && child.doc_id != parent.doc_id
+                && child.caused_by_parent_request_doc_id == parent.doc_id
+                && child.caused_by_parent_request_id.as_deref() == Some(parent.request_id.as_str())
+                && child.caused_by_trigger_kind.as_deref() == Some(GOAL_TRIGGER_KIND)
+                && child.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str())
+                && verify_goal_continuation_edge(goal, parent, child).is_ok()
+        })
+    })
+}
+
+/// A continuation cannot bypass an unfinished or unrecognized request row.
+pub(crate) fn goal_session_is_idle(rows: &[AgentRequestRow]) -> bool {
+    rows.iter().all(|row| {
+        row.lifecycle_state
+            .is_some_and(RequestLifecycleState::is_terminal)
+    })
+}
+
+#[cfg(test)]
+#[path = "request_head_tests.rs"]
+mod tests;

--- a/crates/gents/src/goal/request_head_tests.rs
+++ b/crates/gents/src/goal/request_head_tests.rs
@@ -1,0 +1,291 @@
+//! Real signed-row selector consumer; synthetic physical IDs deliberately do
+//! not claim database storage uniqueness, transaction, or replication coverage.
+use super::*;
+use crate::identity::{AgentIdentity, KeyIdentity};
+use crate::lifecycle::queue::prepare_goal_continuation;
+use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize)]
+struct Snapshot {
+    goal_request_head_cases: Vec<Case>,
+}
+#[derive(Deserialize)]
+struct Scope {
+    owner: u64,
+    session: u64,
+    goal: u64,
+}
+#[derive(Clone, Debug, Deserialize)]
+struct ModelRow {
+    doc: u64,
+    request: u64,
+    owner: u64,
+    session: u64,
+    goal: Option<u64>,
+    parent_doc: Option<u64>,
+    parent_request: Option<u64>,
+    sequence: u64,
+    receipt_valid: bool,
+    deterministic_identity: bool,
+}
+#[derive(Deserialize)]
+struct Case {
+    name: String,
+    scope: Scope,
+    rows: Vec<ModelRow>,
+    expected: Option<ModelRow>,
+}
+
+fn signed_row(create: &AgentRequestCreate, doc: u64) -> AgentRequestRow {
+    AgentRequestRow {
+        doc_id: Some(format!("physical-{doc}")),
+        request_id: create.request_id.clone(),
+        agent_did: Some(create.agent_did.clone()),
+        requester_did: Some(create.requester_did.clone()),
+        behavior_id: create.behavior_id.clone(),
+        session_id: Some(create.session_id.clone()),
+        retry_parent_request: create.retry_parent_request.clone(),
+        retry_parent_request_doc_id: create.retry_parent_request_doc_id.clone(),
+        retry_root_request: create.retry_root_request.clone(),
+        retry_key: create.retry_key.clone(),
+        content: Some(create.content.clone()),
+        temperature: create.temperature,
+        top_p: create.top_p,
+        top_k: create.top_k,
+        seed: create.seed,
+        max_tokens: create.max_tokens,
+        max_total_tokens: create.max_total_tokens,
+        metadata: create.metadata.clone(),
+        backend_id: create.backend_id.clone(),
+        execution_origin: Some(create.execution_origin.clone()),
+        caused_by_trigger_id: create.caused_by_trigger_id.clone(),
+        caused_by_trigger_doc_id: create.caused_by_trigger_doc_id.clone(),
+        caused_by_trigger_kind: create.caused_by_trigger_kind.clone(),
+        caused_by_correlation: create.caused_by_correlation.clone(),
+        caused_by_trigger_context: create.caused_by_trigger_context.clone(),
+        caused_by_source_doc_id: create.caused_by_source_doc_id.clone(),
+        created_at: Some(create.created_at.clone()),
+        retry_count: Some(create.retry_count),
+        max_retries: Some(create.max_retries),
+        valid_until: create.valid_until.clone(),
+        subagent_depth: Some(i64::from(create.subagent_depth)),
+        caused_by_parent_request_id: create.caused_by_parent_request_id.clone(),
+        caused_by_parent_request_doc_id: create.caused_by_parent_request_doc_id.clone(),
+        caused_by_parent_tool_call_id: create.caused_by_parent_tool_call_id.clone(),
+        caused_by_parent_tool_call_doc_id: create.caused_by_parent_tool_call_doc_id.clone(),
+        workspace_id: create.workspace_id.clone(),
+        workspace_authority: create.workspace_authority.clone(),
+        workspace_owner_deployment_id: create.workspace_owner_deployment_id.clone(),
+        workspace_seal_hash: create.workspace_seal_hash.clone(),
+        lifecycle_state: Some(RequestLifecycleState::Completed),
+        admission_kind: Some(create.admission.kind.as_str().into()),
+        admission_signer_did: Some(create.admission.signer_did.clone()),
+        admission_signature: Some(bs58::encode(&create.admission.signature).into_string()),
+        runtime_issuer_did: create.admission.runtime_issuer_did.clone(),
+        runtime_source_request_id: create.admission.runtime_source_request_id.clone(),
+        runtime_source_kind: create
+            .admission
+            .runtime_source_kind
+            .map(|kind| kind.as_str().into()),
+        ..Default::default()
+    }
+}
+
+struct Fixture<'a> {
+    case: &'a Case,
+    identities: &'a [KeyIdentity],
+    built: HashMap<u64, AgentRequestRow>,
+}
+impl Fixture<'_> {
+    fn identity(&self, owner: u64) -> &KeyIdentity {
+        &self.identities[(owner - 1) as usize]
+    }
+    fn base_id(&self, request: u64) -> String {
+        match request {
+            100 if self.case.name == "same_second_task_parent_chain" => {
+                "task-goal-request:original".into()
+            }
+            100 => "graph-parent".into(),
+            400 => "unrelated-latest".into(),
+            _ => format!("ordinary-{request}"),
+        }
+    }
+    fn timestamp(&self, request: u64) -> String {
+        if self.case.name.starts_with("same_second_") {
+            return "2026-07-15T00:00:00Z".into();
+        }
+        let index = self
+            .case
+            .rows
+            .iter()
+            .position(|row| row.request == request)
+            .unwrap_or(0);
+        format!("2026-07-15T00:00:{:02}Z", 59 - index)
+    }
+    fn build<'a>(
+        &'a mut self,
+        model: ModelRow,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = AgentRequestRow> + 'a>> {
+        Box::pin(async move {
+            if let Some(row) = self.built.get(&model.request) {
+                return row.clone();
+            }
+            let now = self.timestamp(model.request);
+            let mut create = if let Some(goal) = model.goal {
+                let parent_request = model.parent_request.unwrap();
+                let parent_model = self
+                    .case
+                    .rows
+                    .iter()
+                    .find(|row| row.request == parent_request)
+                    .cloned();
+                let mut parent = if let Some(parent_model) = parent_model {
+                    self.build(parent_model).await
+                } else {
+                    let identity = self.identity(model.owner);
+                    let base = AgentRequestCreate::base(
+                        self.base_id(parent_request),
+                        identity.did(),
+                        identity.did(),
+                        "head-behavior",
+                        format!("session-{}", model.session),
+                        "parent",
+                        "interactive",
+                        &now,
+                        AgentRequestAdmissionRecord::local_self(identity.did()),
+                    );
+                    signed_row(&base, model.parent_doc.unwrap())
+                };
+                // Model fields name the claimed physical pair, independently of
+                // whether it matches any actual parent in the input snapshot.
+                parent.doc_id = model.parent_doc.map(|doc| format!("physical-{doc}"));
+                parent.agent_did = Some(self.identity(model.owner).did().into());
+                parent.session_id = Some(format!("session-{}", model.session));
+                let parent = crate::watcher::AgentRequest::try_from(parent).unwrap();
+                prepare_goal_continuation(
+                    &parent,
+                    "head-behavior".into(),
+                    &format!("goal-{goal}"),
+                    "signed child",
+                    i64::try_from(model.sequence).unwrap(),
+                    false,
+                    &now,
+                )
+                .unwrap()
+            } else {
+                let identity = self.identity(model.owner);
+                let mut base = AgentRequestCreate::base(
+                    self.base_id(model.request),
+                    identity.did(),
+                    identity.did(),
+                    "head-behavior",
+                    format!("session-{}", model.session),
+                    "signed root",
+                    "interactive",
+                    &now,
+                    AgentRequestAdmissionRecord::local_self(identity.did()),
+                );
+                base.caused_by_parent_request_id =
+                    model.parent_request.map(|request| self.base_id(request));
+                base.caused_by_parent_request_doc_id =
+                    model.parent_doc.map(|doc| format!("physical-{doc}"));
+                base
+            };
+            if self.case.name == "legacy_source_omission_keeps_physical_edge" {
+                // Old automatic continuations were validly signed without this
+                // inherited field; change it before signing the fixture DTO.
+                create.caused_by_source_doc_id = if model.goal.is_none() {
+                    Some("original-event-source".into())
+                } else {
+                    None
+                };
+            }
+            if !model.deterministic_identity {
+                create.request_id.push_str("-wrong-identity");
+            }
+            crate::sign_agent_request_create(self.identity(model.owner), &mut create)
+                .await
+                .unwrap();
+            let mut row = signed_row(&create, model.doc);
+            if !model.receipt_valid {
+                row.content = Some("altered after signing".into());
+            }
+            assert_eq!(
+                verify_request_receipt_signature(&row).is_ok(),
+                model.receipt_valid,
+                "{}: actual signature",
+                self.case.name
+            );
+            self.built.insert(model.request, row.clone());
+            row
+        })
+    }
+}
+
+#[tokio::test]
+async fn generated_goal_request_head_cases_drive_signed_row_selector() {
+    let snapshot: Snapshot = gents_lean_contract::load_contract_snapshot().unwrap();
+    assert_eq!(snapshot.goal_request_head_cases.len(), 15);
+    let temp = tempfile::tempdir().unwrap();
+    let identities = [
+        KeyIdentity::load_or_create(temp.path().join("owner.key"), None).unwrap(),
+        KeyIdentity::load_or_create(temp.path().join("foreign.key"), None).unwrap(),
+    ];
+    for case in snapshot.goal_request_head_cases {
+        let goal: GoalDocument = serde_json::from_value(serde_json::json!({
+            "_docID": "goal-doc", "goal_id": format!("goal-{}", case.scope.goal),
+            "agent_did": identities[(case.scope.owner - 1) as usize].did(),
+            "session_id": format!("session-{}", case.scope.session), "status": "active",
+        }))
+        .unwrap();
+        let mut fixture = Fixture {
+            case: &case,
+            identities: &identities,
+            built: HashMap::new(),
+        };
+        let mut rows = Vec::new();
+        for model in &case.rows {
+            rows.push(fixture.build(model.clone()).await);
+        }
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.doc_id.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            case.rows
+                .iter()
+                .map(|row| format!("physical-{}", row.doc))
+                .collect::<Vec<_>>(),
+            "{}: preserve Lean input mapping",
+            case.name
+        );
+        assert!(
+            rows.windows(2)
+                .all(|pair| (pair[0].created_at.as_ref(), &pair[0].request_id)
+                    >= (pair[1].created_at.as_ref(), &pair[1].request_id)),
+            "{}: real canonical input order",
+            case.name
+        );
+        if case.name == "legacy_source_omission_keeps_physical_edge" {
+            assert_eq!(
+                rows[0].caused_by_source_doc_id.as_deref(),
+                Some("original-event-source")
+            );
+            assert_eq!(rows[1].caused_by_source_doc_id, None);
+            verify_request_receipt_signature(&rows[0]).unwrap();
+            verify_request_receipt_signature(&rows[1]).unwrap();
+        }
+        let selected = latest_goal_request(&goal, &rows).and_then(|row| row.doc_id.as_deref());
+        let expected = case
+            .expected
+            .as_ref()
+            .map(|row| format!("physical-{}", row.doc));
+        assert_eq!(
+            selected,
+            expected.as_deref(),
+            "{}: production selector must honor authenticated causal head",
+            case.name
+        );
+    }
+}

--- a/crates/gents/src/hook/persistence/goal_tools.rs
+++ b/crates/gents/src/hook/persistence/goal_tools.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 
 use crate::goal::{
     create_goal_for_session, load_canonical_goal, next_blocked_audit, refresh_goal_usage,
-    update_goal_fields, CreateGoalForSessionError, GoalAction, GoalSnapshot, GoalStatus,
+    update_goal_fields_if_status, CreateGoalForSessionError, GoalAction, GoalSnapshot, GoalStatus,
     BLOCKED_AUDIT_THRESHOLD, CREATE_GOAL_TOOL_NAME, GET_GOAL_TOOL_NAME, UPDATE_GOAL_TOOL_NAME,
 };
 use crate::graphql::escape_graphql_string;
@@ -208,16 +208,21 @@ impl DefraSessionHook {
                     .as_deref()
                     .map(|reason| format!(r#"completion_evidence: "{reason}","#))
                     .unwrap_or_else(|| "completion_evidence: null,".to_string());
-                update_goal_fields(
+                let applied = update_goal_fields_if_status(
                     &self.node,
                     &goal,
+                    pre.status,
                     &format!(
                         r#"status: "{}", active_time_seconds: {active_time}, active_started_at: null, wrapup_completed: {}, last_failure: null, {evidence_field} updated_at: "{updated_at}""#,
                         post.status.as_str(), post.wrapup_completed
                     ),
                 )
                 .await?;
-                json!({"accepted": true, "status": GoalStatus::Complete.as_str()})
+                if applied {
+                    json!({"accepted": true, "status": GoalStatus::Complete.as_str()})
+                } else {
+                    json!({"accepted": false, "error": "goal changed while applying completion; reload its durable state"})
+                }
             }
             "blocked" => {
                 if pre.status != GoalStatus::Active {
@@ -261,21 +266,26 @@ impl DefraSessionHook {
                 };
                 let reason = escape_graphql_string(reason);
                 let request_id = escape_graphql_string(&request_id);
-                update_goal_fields(
+                let applied = update_goal_fields_if_status(
                     &self.node,
                     &goal,
+                    pre.status,
                     &format!(
                         r#"status: "{}", consecutive_blocked_audits: {audits}, last_blocked_request_id: "{request_id}", last_blocked_reason: "{reason}", {active_fields} updated_at: "{updated_at}""#,
                         status.as_str()
                     ),
                 )
                 .await?;
-                json!({
-                    "accepted": accepted,
-                    "status": status.as_str(),
-                    "consecutive_blocked_audits": audits,
-                    "required_blocked_audits": BLOCKED_AUDIT_THRESHOLD,
-                })
+                if applied {
+                    json!({
+                        "accepted": accepted,
+                        "status": status.as_str(),
+                        "consecutive_blocked_audits": audits,
+                        "required_blocked_audits": BLOCKED_AUDIT_THRESHOLD,
+                    })
+                } else {
+                    json!({"accepted": false, "error": "goal changed while applying blocked audit; reload its durable state"})
+                }
             }
             other => json!({
                 "error": format!("unsupported goal status {other:?}; expected complete or blocked")

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -34,6 +34,10 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) graph_pipeline_revision_gate_cases: Vec<LeanGraphPipelineRevisionGateCase>,
     #[serde(default)]
     pub(crate) graph_pipeline_run_terminal_cases: Vec<LeanGraphPipelineRunTerminalCase>,
+    pub(crate) goal_claimed_publication_cases: Vec<serde_json::Value>,
+    pub(crate) goal_request_head_cases: Vec<serde_json::Value>,
+    pub(crate) goal_operator_resume_cases: Vec<serde_json::Value>,
+    pub(crate) goal_config_reactivation_cases: Vec<serde_json::Value>,
     pub(crate) graph_failure_attribution_traces: Vec<serde_json::Value>,
     pub(crate) request_transition_cases: Vec<LeanLifecycleTransitionCase>,
     pub(crate) process_transition_cases: Vec<LeanLifecycleTransitionCase>,

--- a/crates/gents/src/lifecycle/queue.rs
+++ b/crates/gents/src/lifecycle/queue.rs
@@ -40,7 +40,9 @@ use coalescing::{
 pub use draining::drain_automated_wakeups;
 pub(crate) use draining::drain_subagent_owned_queue;
 pub(crate) use enqueue::{enqueue_session_request, enqueue_steering_request_with_message};
-pub(crate) use goal_continuation::enqueue_goal_continuation;
+pub(crate) use goal_continuation::{
+    goal_continuation_behavior, goal_continuation_identity, prepare_goal_continuation,
+};
 pub use metadata::QueueSource;
 pub(crate) use metadata::{
     is_automated_wakeup, is_goal_queue, is_steering_input_message_key, is_subagent_owned_queue,

--- a/crates/gents/src/lifecycle/queue/goal_continuation.rs
+++ b/crates/gents/src/lifecycle/queue/goal_continuation.rs
@@ -1,37 +1,58 @@
 use super::*;
 
-use crate::lifecycle::materialize::{
-    build_request, sign_request, ParentLink, RequestIdentity, RequestSigner, RequestSpec,
-};
+use crate::lifecycle::materialize::{build_request, ParentLink, RequestIdentity, RequestSpec};
 use crate::lifecycle::{ExecutionOrigin, TriggerLineage, WorkspaceLineage};
 
-pub(crate) async fn enqueue_goal_continuation(
-    node: &EmbeddedNode,
-    parent: &AgentRequest,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GoalContinuationIdentity {
+    pub(crate) request_id: String,
+    pub(crate) retry_key: String,
+    pub(crate) queue_key: String,
+}
+
+/// Preserve the existing goal/parent retry identity and stable sequence IDs.
+pub(crate) fn goal_continuation_identity(
     goal_id: &str,
-    content: &str,
+    parent_request_id: &str,
     continuation_sequence: i64,
-    wrapup: bool,
-) -> Result<EnqueuedAgentRequest> {
+) -> Result<GoalContinuationIdentity> {
     use sha2::{Digest, Sha256};
 
-    let behavior_id = parent_behavior_id(node, parent).await?;
-    let digest = Sha256::digest(format!("{goal_id}\0{}", parent.request_id).as_bytes());
+    anyhow::ensure!(
+        continuation_sequence > 0,
+        "goal continuation sequence must be positive"
+    );
+    let digest = Sha256::digest(format!("{goal_id}\0{parent_request_id}").as_bytes());
     let digest_hex = digest[..16]
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();
-    // Signed request timestamps are canonicalized to whole seconds, so several
-    // fast continuations can legitimately share `created_at`. Keep the durable
-    // controller sequence in the request ID so the request query's documented
-    // `(created_at, request_id)` ordering remains causal within that second.
-    let request_id = format!("goal-cont-{continuation_sequence:020}-{}", digest_hex);
-    let retry_key = format!("goal-continuation:{digest_hex}");
-    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    // The sequence distinguishes continuation IDs. The shared Goal head selector
+    // follows physical ancestry when whole-second timestamps coincide.
+    Ok(GoalContinuationIdentity {
+        request_id: format!("goal-cont-{continuation_sequence:020}-{digest_hex}"),
+        retry_key: format!("goal-continuation:{digest_hex}"),
+        queue_key: format!("goal:{digest_hex}"),
+    })
+}
+
+/// Prepare the existing continuation DTO without reads, signing, or publication.
+/// Transaction owners resolve behavior and time before staging this request.
+pub(crate) fn prepare_goal_continuation(
+    parent: &AgentRequest,
+    behavior_id: String,
+    goal_id: &str,
+    content: &str,
+    continuation_sequence: i64,
+    wrapup: bool,
+    created_at: &str,
+) -> Result<gents_protocol::request_admission::AgentRequestCreate> {
+    let continuation =
+        goal_continuation_identity(goal_id, &parent.request_id, continuation_sequence)?;
     let queue_hints = QueueHints {
         source: QueueSource::Goal,
         policy: QueuePolicy::Coalesce,
-        key: Some(format!("goal:{digest_hex}")),
+        key: Some(continuation.queue_key),
         queued_after_request_id: Some(parent.request_id.clone()),
         interrupted_request_id: None,
     };
@@ -52,13 +73,13 @@ pub(crate) async fn enqueue_goal_continuation(
         );
     let identity = RequestIdentity {
         requester_did: None,
-        request_id: request_id.clone(),
+        request_id: continuation.request_id,
         agent_did: parent.agent_did.clone(),
         behavior_id,
         session_id: parent.session_id.clone(),
         content: content.to_string(),
         execution_origin: ExecutionOrigin::Scheduled,
-        created_at: now,
+        created_at: created_at.to_owned(),
     };
     let spec = RequestSpec {
         trigger_lineage: TriggerLineage {
@@ -66,6 +87,7 @@ pub(crate) async fn enqueue_goal_continuation(
             trigger_kind: Some("goal".to_string()),
             correlation: parent.caused_by_correlation.clone(),
             trigger_context: parent.caused_by_trigger_context.clone(),
+            source_doc_id: parent.caused_by_source_doc_id.clone(),
             ..Default::default()
         },
         workspace: Some(WorkspaceLineage {
@@ -81,55 +103,53 @@ pub(crate) async fn enqueue_goal_continuation(
             ..Default::default()
         }),
         metadata: Some(metadata),
-        retry_key: Some(retry_key.clone()),
+        retry_key: Some(continuation.retry_key),
         ..RequestSpec::new(identity, admission)
     };
-    // Peek at the unsigned DTO before paying for a signature: the dedupe
-    // lookup below only needs a fingerprint of the pre-signature fields.
-    let mut create = build_request(spec)?;
-    let expected = crate::goal::GoalBackedRequestFingerprint::from_create(&create)?;
-    if let Some(doc_id) =
-        crate::goal::load_agent_request_by_retry_key(node, &retry_key, &expected).await?
-    {
-        return Ok(EnqueuedAgentRequest {
-            doc_id,
-            request_id,
-            session_id: parent.session_id.clone(),
-        });
-    }
-    sign_request(&mut create, RequestSigner::RegisteredTarget).await?;
-    let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
-    let response =
-        session::execute_mutation_with_retry(node, &mutation, "enqueue_goal_continuation").await;
-    let doc_id = match response {
-        Ok(response) => match extract_single_doc_id(&response, "create_AgentRequest") {
-            Some(doc_id) => Some(doc_id),
-            None => {
-                crate::goal::load_agent_request_by_retry_key(node, &retry_key, &expected).await?
-            }
-        },
-        Err(create_error) => {
-            // `retry_key` is unique. A concurrent reconciler or a lost create
-            // acknowledgement therefore resolves to the same durable child.
-            // Only surface the original error when no such child exists.
-            match crate::goal::load_agent_request_by_retry_key(node, &retry_key, &expected).await? {
-                Some(doc_id) => Some(doc_id),
-                None => return Err(create_error),
-            }
-        }
-    }
-    .context("goal continuation create returned no _docID")?;
-
-    Ok(EnqueuedAgentRequest {
-        doc_id,
-        request_id,
-        session_id: parent.session_id.clone(),
-    })
+    build_request(spec)
 }
 
-// SAFETY (#664): `agent_did` scopes the candidate query AND the supersede
-// mutation to the owning principal. Under P2P replication a foreign-DID
-// `AgentRequest` sharing this `session_id` can be replicated onto this node;
-// without the owner guard the session-only filter would supersede that foreign
-// replica locally. Defense in depth: the foreign row never becomes a candidate,
-// and the write is DID-scoped even if it somehow did.
+/// Resolve the historical conversation fallback through the caller's transaction.
+/// This helper prepares request binding only; Goal owns publication.
+pub(crate) async fn goal_continuation_behavior(
+    txn: &crate::config_client::ConfigApplyTxn<'_>,
+    parent: &AgentRequest,
+) -> Result<String> {
+    if let Some(behavior) = parent
+        .behavior_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(behavior.to_owned());
+    }
+    let agent_did = escape_graphql_string(&parent.agent_did);
+    let session_id = escape_graphql_string(&parent.session_id);
+    let response = txn
+        .execute(&format!(
+            r#"{{ AgentConversation(filter: {{
+        agent_did: {{ _eq: "{agent_did}" }}, session_id: {{ _eq: "{session_id}" }}
+    }}, limit: 2) {{ behavior_id }} }}"#
+        ))
+        .await?;
+    let rows = response
+        .pointer("/data/AgentConversation")
+        .and_then(serde_json::Value::as_array)
+        .context("parent conversation query omitted rows")?;
+    anyhow::ensure!(
+        rows.len() <= 1,
+        "parent conversation scope resolved to multiple rows"
+    );
+    rows.first()
+        .and_then(|row| row.get("behavior_id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+        .with_context(|| {
+            format!(
+                "cannot enqueue same-session request: parent request {} has no behavior_id",
+                parent.request_id
+            )
+        })
+}

--- a/crates/gents/src/lifecycle/queue/tests.rs
+++ b/crates/gents/src/lifecycle/queue/tests.rs
@@ -247,18 +247,12 @@ mod background_completion;
 mod coalescing;
 mod metadata;
 
-/// Pins today's `AgentRequestCreate::graphql_input_fields()` output for the
-/// `lifecycle::queue` production writers (#1336 Task 1), before they are
-/// switched onto `build_signed_request` (#1336 Task 2). Both writers take
-/// `created_at` (and, for the session-mutation site, `request_id` and
-/// `retry_key`) as caller-supplied parameters, so — with a deterministic
-/// signing identity — their output is fully stable across runs; no
-/// normalization is needed here (contrast `lifecycle::materialize::pin_tests`,
-/// where `created_at` is generated internally).
+/// Pin signed GraphQL fields through the production preparation functions.
+/// Fixed timestamps and a deterministic signing identity keep these wire
+/// compatibility checks stable without duplicating request construction.
 mod pin_tests {
     use super::*;
     use crate::lifecycle::test_support::{pin_fixed_signing_identity, PIN_FIXED_DID};
-    use crate::lifecycle::{TriggerLineage, WorkspaceLineage};
 
     fn pin_parent_request() -> AgentRequest {
         let mut parent = parent_request(PIN_FIXED_DID, "sess-pin-parent");
@@ -305,19 +299,9 @@ mod pin_tests {
         );
     }
 
-    // --- Site 4: `lifecycle::queue::goal_continuation::enqueue_goal_continuation` ---
-    // This persists to a live node and returns only the doc/request/session
-    // ids, not the `AgentRequestCreate` it built, and its retry-key dedupe
-    // lookup also requires a node. The block below reproduces its
-    // DTO-construction statements verbatim (see the production function),
-    // substituting a fixed `now` for `Utc::now()` and inlining
-    // `parent_behavior_id`'s no-node-needed fast path (returning
-    // `parent.behavior_id` directly, since it is set here).
-
+    // Pin the production preparation seam; do not reconstruct its DTO here.
     #[tokio::test]
-    async fn pin_enqueue_goal_continuation_dto_construction() {
-        use sha2::{Digest, Sha256};
-
+    async fn pin_goal_continuation_preparation() {
         let tempdir = tempfile::tempdir().unwrap();
         let _identity = pin_fixed_signing_identity(tempdir.path());
 
@@ -332,78 +316,18 @@ mod pin_tests {
         let content = "continue the goal";
         let behavior_id = parent.behavior_id.clone().unwrap();
 
-        let digest = Sha256::digest(format!("{goal_id}\0{}", parent.request_id).as_bytes());
-        let digest_hex = digest[..16]
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>();
-        let request_id = format!("goal-cont-{continuation_sequence:020}-{digest_hex}");
-        let retry_key = format!("goal-continuation:{digest_hex}");
-        let now = "2030-01-01T00:00:00Z".to_string();
-        let queue_hints = QueueHints {
-            source: QueueSource::Goal,
-            policy: QueuePolicy::Coalesce,
-            key: Some(format!("goal:{digest_hex}")),
-            queued_after_request_id: Some(parent.request_id.clone()),
-            interrupted_request_id: None,
-        };
-        let metadata = serde_json::json!({
-            "queue": queue_hints,
-            "goal": {
-                "goal_id": goal_id,
-                "parent_request_id": parent.request_id,
-                "continuation_sequence": continuation_sequence,
-                "wrapup": false,
-            }
-        })
-        .to_string();
-        let admission =
-            gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
-                &parent.agent_did,
-                &parent.request_id,
-            );
-        let spec = crate::lifecycle::materialize::RequestSpec {
-            identity: crate::lifecycle::materialize::RequestIdentity {
-                requester_did: None,
-                request_id: request_id.clone(),
-                agent_did: parent.agent_did.clone(),
-                behavior_id,
-                session_id: parent.session_id.clone(),
-                content: content.to_string(),
-                execution_origin: ExecutionOrigin::Scheduled,
-                created_at: now,
-            },
-            admission,
-            initial_lifecycle_state: RequestLifecycleState::Pending,
-            trigger_lineage: TriggerLineage {
-                trigger_id: Some(goal_id.to_string()),
-                trigger_kind: Some("goal".to_string()),
-                source_doc_id: None,
-                correlation: parent.caused_by_correlation.clone(),
-                trigger_context: parent.caused_by_trigger_context.clone(),
-            },
-            trigger_doc_id: None,
-            workspace: Some(WorkspaceLineage {
-                workspace_id: parent.workspace_id.clone(),
-                workspace_authority: parent.workspace_authority.clone(),
-                workspace_owner_deployment_id: parent.workspace_owner_deployment_id.clone(),
-                workspace_seal_hash: parent.workspace_seal_hash.clone(),
-            }),
-            subagent: Some(crate::lifecycle::materialize::ParentLink {
-                depth: parent.subagent_depth,
-                parent_request_id: parent.request_id.clone(),
-                parent_request_doc_id: parent.doc_id.clone(),
-                parent_tool_call_id: None,
-                parent_tool_call_doc_id: None,
-            }),
-            retry: None,
-            sampling: None,
-            metadata: Some(metadata),
-            retry_key: Some(retry_key.clone()),
-            valid_until: None,
-        };
-        let create = crate::lifecycle::materialize::build_signed_request(
-            spec,
+        let mut create = prepare_goal_continuation(
+            &parent,
+            behavior_id,
+            goal_id,
+            content,
+            continuation_sequence,
+            false,
+            "2030-01-01T00:00:00Z",
+        )
+        .expect("prepare goal continuation");
+        crate::lifecycle::materialize::sign_request(
+            &mut create,
             crate::lifecycle::materialize::RequestSigner::RegisteredTarget,
         )
         .await

--- a/crates/gents/src/request_admission.rs
+++ b/crates/gents/src/request_admission.rs
@@ -1039,6 +1039,60 @@ fn require_pending_deadline_absent(deadline: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// Verify the original immutable request payload and its declared admission
+/// branch. Historical receipt authentication does not re-admit execution or
+/// require today's enrollment, TTL, lifecycle, or backend readiness. The
+/// operation's owner separately checks its expected principal/source scope.
+pub(crate) fn verify_request_receipt_signature(row: &AgentRequestRow) -> Result<()> {
+    let admission = row_admission(row)?;
+    admission.validate_canonical_fields()?;
+    admission
+        .validate_branch_fields()
+        .map_err(anyhow::Error::msg)?;
+    let fields = row_signing_fields(row)?;
+    validate_signing_fields(&fields)?;
+    anyhow::ensure!(
+        crate::identity::verify_did_signature(
+            &admission.signer_did,
+            &admission.signing_payload(&fields),
+            &admission.signature,
+        )?,
+        "immutable request receipt signature is invalid"
+    );
+    Ok(())
+}
+
+/// Authenticate an already-authored runtime local-control receipt. This is
+/// not fresh execution admission: terminal/expired children remain receipts.
+/// The caller separately binds the exact goal, parent docID and sequence and
+/// authorizes its own operation; no execution capability is returned here.
+pub(crate) fn verify_runtime_local_control_receipt(
+    row: &AgentRequestRow,
+    expected_target_did: &str,
+    expected_source_request_id: &str,
+) -> Result<()> {
+    let admission = row_admission(row)?;
+    verify_request_receipt_signature(row)?;
+    anyhow::ensure!(
+        admission.kind == AgentRequestAdmissionKind::RuntimeInternal
+            && admission.runtime_source_kind == Some(RuntimeInternalSourceKind::LocalControl)
+            && admission.signer_did == expected_target_did
+            && admission.runtime_issuer_did.as_deref() == Some(expected_target_did)
+            && row.agent_did.as_deref() == Some(expected_target_did)
+            && row.requester_did.as_deref() == Some(expected_target_did)
+            && admission.runtime_source_request_id.as_deref() == Some(expected_source_request_id)
+            && row.caused_by_parent_request_id.as_deref() == Some(expected_source_request_id)
+            && row
+                .caused_by_parent_request_doc_id
+                .as_deref()
+                .is_some_and(|id| !id.is_empty())
+            && row.caused_by_parent_tool_call_id.is_none()
+            && row.caused_by_parent_tool_call_doc_id.is_none(),
+        "runtime local-control receipt does not match expected target/source binding"
+    );
+    Ok(())
+}
+
 fn row_admission(row: &AgentRequestRow) -> Result<AgentRequestAdmissionRecord> {
     AgentRequestAdmissionRecord::from_wire_fields(
         row.admission_kind.as_deref(),
@@ -1131,15 +1185,11 @@ fn required_row_string<'a>(value: Option<&'a str>, field: &str) -> AdmissionResu
     })
 }
 
-async fn load_signed_request(
-    node: &EmbeddedNode,
-    doc_id: &str,
-) -> AdmissionResult<AgentRequestRow> {
-    let doc_id = escape_graphql_string(doc_id);
-    let response = node
-        .execute(&format!(
-            r#"{{ AgentRequest(filter: {{ _docID: {{ _eq: "{doc_id}" }} }}, limit: 1) {{
-                _docID request_id agent_did requester_did behavior_id session_id
+/// Complete immutable request signature projection shared by fresh admission
+/// and transaction-scoped historical receipt readers. Lifecycle is included
+/// for callers decoding the row, but is not part of the signed payload.
+pub(crate) const SIGNED_REQUEST_FIELDS: &str = r#"
+_docID lifecycle_state request_id agent_did requester_did behavior_id session_id
                 retry_parent_request retry_parent_request_doc_id retry_root_request retry_key
                 content temperature top_p top_k seed max_tokens max_total_tokens metadata
                 execution_origin caused_by_trigger_id caused_by_trigger_kind caused_by_correlation
@@ -1153,6 +1203,17 @@ async fn load_signed_request(
                 enrollment_request_digest enrollment_admin_did enrollment_authorization_sequence
                 enrollment_authorization_expires_at runtime_issuer_did runtime_source_request_id
                 runtime_source_kind runtime_bridge_author_did
+"#;
+
+async fn load_signed_request(
+    node: &EmbeddedNode,
+    doc_id: &str,
+) -> AdmissionResult<AgentRequestRow> {
+    let doc_id = escape_graphql_string(doc_id);
+    let response = node
+        .execute(&format!(
+            r#"{{ AgentRequest(filter: {{ _docID: {{ _eq: "{doc_id}" }} }}, limit: 1) {{
+                {SIGNED_REQUEST_FIELDS}
             }} }}"#,
         ))
         .await;
@@ -1200,6 +1261,72 @@ mod tests {
         assert!(error
             .to_string()
             .contains("caller-authored execution deadline"));
+    }
+
+    #[tokio::test]
+    async fn runtime_receipt_authenticates_terminal_expired_child_and_rejects_forgery() {
+        let temp = tempfile::tempdir().unwrap();
+        let identity = KeyIdentity::load_or_create(temp.path().join("receipt.key"), None).unwrap();
+        let node = defra_node::EmbeddedNode::builder().build().await.unwrap();
+        ensure_runtime_schemas(&node).await.unwrap();
+        let mut create = AgentRequestCreate::base(
+            "receipt-child",
+            identity.did(),
+            identity.did(),
+            "behavior-1",
+            "receipt-session",
+            "original continuation",
+            "scheduled",
+            "2020-01-01T00:00:00Z",
+            AgentRequestAdmissionRecord::runtime_local_control(identity.did(), "receipt-parent"),
+        );
+        create.caused_by_parent_request_id = Some("receipt-parent".into());
+        create.caused_by_parent_request_doc_id = Some("receipt-parent-doc".into());
+        create.valid_until = Some("2020-01-01T00:00:01Z".into());
+        crate::sign_agent_request_create(&identity, &mut create)
+            .await
+            .unwrap();
+        let response = node.execute(&create.graphql_mutation().unwrap()).await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        let query = format!("{{ AgentRequest {{ {} }} }}", super::SIGNED_REQUEST_FIELDS);
+        let response = node.execute(&query).await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        let mut row: gents_protocol::row::AgentRequestRow =
+            crate::graphql::first_row(&response, "AgentRequest")
+                .unwrap()
+                .unwrap();
+        row.lifecycle_state =
+            Some(gents_protocol::request_lifecycle::RequestLifecycleState::Completed);
+        row.deadline = Some("2020-01-01T00:00:01Z".into());
+        super::verify_runtime_local_control_receipt(&row, identity.did(), "receipt-parent")
+            .expect("terminal and expired original receipt remains authenticated");
+        assert!(super::verify_runtime_local_control_receipt(
+            &row,
+            identity.did(),
+            "different-parent"
+        )
+        .is_err());
+        let foreign = KeyIdentity::load_or_create(temp.path().join("foreign.key"), None).unwrap();
+        assert!(
+            super::verify_runtime_local_control_receipt(&row, foreign.did(), "receipt-parent")
+                .is_err()
+        );
+        row.content = Some("forged continuation".into());
+        assert!(super::verify_runtime_local_control_receipt(
+            &row,
+            identity.did(),
+            "receipt-parent"
+        )
+        .is_err());
+        row.content = Some("original continuation".into());
+        row.admission_signature = Some("not-a-valid-signature".into());
+        assert!(super::verify_runtime_local_control_receipt(
+            &row,
+            identity.did(),
+            "receipt-parent"
+        )
+        .is_err());
+        node.shutdown().await;
     }
 
     #[tokio::test]
@@ -1253,6 +1380,8 @@ mod tests {
         let row = super::load_signed_request(node.as_ref(), &doc_id)
             .await
             .unwrap();
+        super::verify_request_receipt_signature(&row)
+            .expect("original local-self immutable receipt signature");
         let mut queued = super::row_into_agent_request(row, &doc_id).unwrap();
         queued.content = "stale queued content".to_string();
 

--- a/crates/gents/src/trigger_engine/goal_source.rs
+++ b/crates/gents/src/trigger_engine/goal_source.rs
@@ -11,12 +11,12 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
 use defra_node::EmbeddedNode;
-use gents_protocol::request_lifecycle::RequestLifecycleState;
 use gents_protocol::row::AgentRequestRow;
 use tokio::sync::watch;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
+use crate::goal::publish_claimed_continuation;
 use crate::goal::{
     claim_continuation, claim_retry_continuation, decide_goal_continuation,
     goal_continuation_materialization_step, load_goal_by_id, load_goals_for_session,
@@ -25,7 +25,6 @@ use crate::goal::{
     GOAL_TRIGGER_KIND, MAX_INFRASTRUCTURE_RETRIES,
 };
 use crate::graphql::escape_graphql_string;
-use crate::lifecycle::queue::enqueue_goal_continuation;
 use crate::runtime_snapshot::{ActiveRuntimeSnapshot, ConcurrencyMode, ResolvedTask};
 use crate::watcher::AgentRequest;
 use crate::UpdateSubscriptionSource;
@@ -33,6 +32,15 @@ use crate::UpdateSubscriptionSource;
 use super::{FireIntent, FireResult, TriggerKind, TriggerSource};
 
 const GOAL_RESCAN_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Request/claim evidence selected before a usage refresh belongs to this
+/// observed Goal epoch. Reloading must not relabel it with a resumed epoch.
+fn continuation_evidence_is_current(observed: &GoalDocument, current: &GoalDocument) -> bool {
+    observed.doc_id == current.doc_id
+        && observed.status == current.status
+        && observed.continuation_sequence() == current.continuation_sequence()
+        && observed.last_continued_from_request_id == current.last_continued_from_request_id
+}
 
 pub struct GoalSource {
     snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
@@ -303,9 +311,16 @@ impl GoalSource {
         let has_activity = terminal != GoalRequestTerminal::Completed
             || self.request_has_activity(&latest.request_id).await?;
         let tokens_used = refresh_goal_usage(&self.node, &goal).await?;
-        goal = load_goal_by_id(&self.node, &goal.agent_did, &goal.goal_id)
+        let refreshed_goal = load_goal_by_id(&self.node, &goal.agent_did, &goal.goal_id)
             .await?
             .context("refreshed Goal row disappeared")?;
+        if !continuation_evidence_is_current(&goal, &refreshed_goal) {
+            // In particular, an operator may have resumed the Goal and
+            // published a child while usage was refreshing. Re-select the
+            // idle request and continuation phase on the next reconciliation.
+            return Ok(None);
+        }
+        goal = refreshed_goal;
         let budget_reached = goal
             .token_budget
             .is_some_and(|budget| tokens_used >= budget);
@@ -461,6 +476,14 @@ impl GoalSource {
             GoalContinuationAction::Materialize,
         );
 
+        // Carry the exact tuple installed by our successful claim. Reloading
+        // here could silently authorize a newer owner's claim after an await.
+        goal.continuation_sequence = Some(
+            goal.continuation_sequence()
+                .checked_add(1)
+                .context("claimed continuation sequence exhausted")?,
+        );
+        goal.last_continued_from_request_id = Some(latest.request_id.clone());
         self.materialize_claimed_continuation(
             goal,
             latest,
@@ -473,7 +496,7 @@ impl GoalSource {
 
     async fn materialize_claimed_continuation(
         &self,
-        mut goal: GoalDocument,
+        goal: GoalDocument,
         latest: AgentRequestRow,
         retry_prefix: Option<String>,
         wrapup: bool,
@@ -482,40 +505,15 @@ impl GoalSource {
         if authorized_phase != GoalContinuationPhase::ChildPresent {
             return Ok(None);
         }
-        let Some(still_latest) = self.latest_request_when_session_idle(&goal).await? else {
-            return Ok(None);
-        };
-        if still_latest.request_id != latest.request_id {
-            return Ok(None);
-        }
-
-        // The operator or model may have changed goal authority after the
-        // continuation decision. Re-read the claimed row before publication;
-        // the claim CAS itself also fences the expected status and sequence.
-        goal = load_goal_by_id(&self.node, &goal.agent_did, &goal.goal_id)
-            .await?
-            .context("claimed Goal row disappeared")?;
-        if !matches!(
-            goal.parsed_status(),
-            Some(GoalStatus::Active | GoalStatus::BudgetLimited)
-        ) || goal.last_continued_from_request_id.as_deref() != Some(latest.request_id.as_str())
-        {
-            return Ok(None);
-        }
-
-        let sequence = goal.continuation_sequence();
         let prompt = continuation_prompt(&goal, retry_prefix.as_deref(), wrapup);
         let parent = AgentRequest::try_from(latest)
             .context("decode goal continuation parent AgentRequest")?;
-        let child = enqueue_goal_continuation(
-            &self.node,
-            &parent,
-            &goal.goal_id,
-            &prompt,
-            sequence,
-            wrapup,
-        )
-        .await?;
+        let Some(child) =
+            publish_claimed_continuation(&self.node, &goal, &parent.request_id, &prompt, wrapup)
+                .await?
+        else {
+            return Ok(None);
+        };
         let task = ResolvedTask {
             task_id: format!("goal:{}", goal.goal_id),
             name: Some("Durable goal continuation".to_string()),
@@ -584,16 +582,10 @@ impl GoalSource {
                     filter: {{ agent_did: {{ _eq: "{agent_did}" }}, session_id: {{ _eq: "{session_id}" }} }},
                     order: [{{ created_at: DESC }}, {{ request_id: DESC }}]
                 ) {{
-                    _docID request_id agent_did requester_did behavior_id session_id content
-                    temperature top_p top_k seed max_tokens max_total_tokens metadata execution_origin
-                    lifecycle_state created_at deadline subagent_depth
-                    caused_by_parent_request_id caused_by_parent_request_doc_id
-                    caused_by_parent_tool_call_id caused_by_parent_tool_call_doc_id
-                    caused_by_correlation caused_by_trigger_context
-                    workspace_id workspace_authority
-                    workspace_owner_deployment_id workspace_seal_hash
+                    {signed_fields}
                 }}
-            }}"#
+            }}"#,
+            signed_fields = crate::request_admission::SIGNED_REQUEST_FIELDS,
         );
         let response = self.node.execute(&query).await;
         if response.has_errors() {
@@ -612,13 +604,10 @@ impl GoalSource {
                 .unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
         )
         .context("decoding goal session requests")?;
-        if rows.iter().any(|row| {
-            row.lifecycle_state
-                .is_some_and(RequestLifecycleState::is_active_runtime)
-        }) {
+        if !crate::goal::goal_session_is_idle(&rows) {
             return Ok(None);
         }
-        Ok(rows.into_iter().next())
+        Ok(crate::goal::latest_goal_request(goal, &rows).cloned())
     }
 
     async fn continuation_child_exists(
@@ -779,7 +768,11 @@ fn request_is_goal_wrapup(request: &AgentRequestRow, goal_id: &str) -> bool {
         })
 }
 
-fn continuation_prompt(goal: &GoalDocument, retry_prefix: Option<&str>, wrapup: bool) -> String {
+pub(crate) fn continuation_prompt(
+    goal: &GoalDocument,
+    retry_prefix: Option<&str>,
+    wrapup: bool,
+) -> String {
     let objective_json = serde_json::to_string(&goal.objective)
         .unwrap_or_else(|_| String::from(r#""<invalid objective>""#));
     let budget = goal
@@ -855,6 +848,44 @@ mod tests {
             "tokens_used": 250
         }))
         .expect("goal fixture")
+    }
+
+    #[test]
+    fn usage_refresh_cannot_relabel_stale_terminal_evidence_with_resumed_epoch() {
+        let mut observed = goal();
+        observed.continuation_sequence = Some(4);
+        observed.last_continued_from_request_id = Some("earlier-parent".to_owned());
+
+        // The same active status after pause/resume is an ABA: the old
+        // interrupted request must not be evaluated using the new sequence.
+        let mut resumed = observed.clone();
+        resumed.continuation_sequence = Some(5);
+        resumed.last_continued_from_request_id = Some("interrupted-parent".to_owned());
+        assert!(!continuation_evidence_is_current(&observed, &resumed));
+
+        let mut sequence_only = observed.clone();
+        sequence_only.continuation_sequence = Some(5);
+        assert!(!continuation_evidence_is_current(&observed, &sequence_only));
+
+        let mut watermark_only = observed.clone();
+        watermark_only.last_continued_from_request_id = Some("interrupted-parent".to_owned());
+        assert!(!continuation_evidence_is_current(
+            &observed,
+            &watermark_only
+        ));
+
+        let mut completed = observed.clone();
+        completed.status = "complete".to_owned();
+        assert!(!continuation_evidence_is_current(&observed, &completed));
+
+        // Ordinary accounting refresh is not a new continuation decision.
+        let mut accounting_only = observed.clone();
+        accounting_only.tokens_used = Some(300);
+        accounting_only.active_time_seconds = Some(10);
+        assert!(continuation_evidence_is_current(
+            &observed,
+            &accounting_only
+        ));
     }
 
     #[test]

--- a/crates/gents/src/trigger_engine/tests/event_source.rs
+++ b/crates/gents/src/trigger_engine/tests/event_source.rs
@@ -1826,3 +1826,6 @@ async fn event_source_reconcile_excludes_invalid_source_collection_identifiers()
          desired set; identifier-invalid names must be excluded",
     );
 }
+
+#[path = "event_source/resumed_goal.rs"]
+mod resumed_goal;

--- a/crates/gents/src/trigger_engine/tests/event_source/resumed_goal.rs
+++ b/crates/gents/src/trigger_engine/tests/event_source/resumed_goal.rs
@@ -1,0 +1,163 @@
+use super::*;
+use crate::defra_write::{BoundedWriteParams, BoundedWriteTool};
+use crate::document_config::{WriteToolDecl, WriteToolField, WriteToolFieldFill};
+use crate::identity::AgentIdentity;
+use crate::llm::tool::Tool;
+use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
+use gents_protocol::row::AgentRequestRow;
+
+#[tokio::test]
+async fn resumed_goal_tool_output_reaches_correlation_keyed_event_trigger() {
+    let temp = tempfile::tempdir().unwrap();
+    let identity = KeyIdentity::load_or_create(temp.path().join("principal.key"), None).unwrap();
+    let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+    ensure_runtime_schemas(&node).await.unwrap();
+    node.add_schema("type ResumedGoalOutput { run_id: String @index summary: String }")
+        .await
+        .unwrap();
+    crate::goal::set_goal(
+        &node,
+        identity.did(),
+        "resumed-event-session",
+        Some("Emit the remaining correlated result"),
+        Some(crate::goal::GoalStatus::Paused),
+        Some(Some(1000)),
+    )
+    .await
+    .unwrap();
+    let mut parent = AgentRequestCreate::base(
+        "resumed-event-parent",
+        identity.did(),
+        identity.did(),
+        "general",
+        "resumed-event-session",
+        "Original correlated work",
+        "interactive",
+        "2020-01-01T00:00:00Z",
+        AgentRequestAdmissionRecord::local_self(identity.did()),
+    );
+    parent.caused_by_correlation = Some("resumed-run-correlation".into());
+    crate::sign_agent_request_create(&identity, &mut parent)
+        .await
+        .unwrap();
+    let response = node.execute(&parent.graphql_mutation().unwrap()).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let response = node
+        .execute(
+            r#"mutation {
+        update_AgentRequest(filter: {request_id: {_eq: "resumed-event-parent"}},
+            input: {lifecycle_state: "completed"}) { _docID }
+    }"#,
+        )
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let receipt = crate::goal::resume_goal_request(
+        &crate::ConfigAccess::Local(node.clone()),
+        &identity,
+        identity.did(),
+        "resumed-event-session",
+        "resumed-event-parent",
+    )
+    .await
+    .unwrap();
+    assert!(receipt.created);
+    let response = node
+        .execute(&format!(
+            "{{ AgentRequest(filter: {{request_id: {{_eq: \"{}\"}}}}) {{ {} }} }}",
+            escape_graphql_string(&receipt.request_id),
+            crate::request_admission::SIGNED_REQUEST_FIELDS,
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let rows: Vec<AgentRequestRow> =
+        serde_json::from_value(response.data.unwrap()["AgentRequest"].clone()).unwrap();
+    assert_eq!(rows.len(), 1);
+    let child = crate::watcher::AgentRequest::try_from(rows[0].clone()).unwrap();
+    assert_eq!(
+        child.caused_by_correlation.as_deref(),
+        Some("resumed-run-correlation")
+    );
+
+    let trigger = ResolvedEventTrigger {
+        correlation_field: Some("run_id".into()),
+        ..resolved_event_trigger_with_filter(
+            "resumed-output-trigger",
+            "ResumedGoalOutput",
+            resolved_task("{{ event.correlation }}"),
+            r#"{ run_id: { _eq: "resumed-run-correlation" } }"#,
+        )
+    };
+    let snapshot = snapshot_with_event_triggers(
+        1,
+        HashMap::from([("resumed-output-trigger".to_owned(), trigger)]),
+    );
+    let (_tx, rx) = watch::channel(snapshot.clone());
+    let mut source = EventSource::new(rx, node.clone(), CancellationToken::new());
+    source.reconcile_subscriptions(snapshot.as_ref()).await;
+    let tool = BoundedWriteTool::new(
+        node.clone(),
+        WriteToolDecl {
+            tool_name: "write_resumed_output".into(),
+            collection: "ResumedGoalOutput".into(),
+            description: "Publish the correlated result".into(),
+            fields: vec![
+                WriteToolField {
+                    name: "summary".into(),
+                    required: true,
+                    fill: None,
+                },
+                WriteToolField {
+                    name: "run_id".into(),
+                    required: false,
+                    fill: Some(WriteToolFieldFill::Correlation),
+                },
+            ],
+            output_obligation: None,
+        },
+    );
+    // Use the persisted resumed request at the daemon's actual tool scope seam.
+    // The tool receives no model-authored run_id and must stamp it itself.
+    crate::tool_call_lifecycle::runtime::scope_request_tool_execution_with_trigger_context(
+        None,
+        CancellationToken::new(),
+        None,
+        None,
+        Some(child.session_id.clone()),
+        child.caused_by_correlation.clone(),
+        Default::default(),
+        false,
+        async {
+            Tool::call(
+                &tool,
+                BoundedWriteParams(
+                    serde_json::json!({"summary": "remaining work complete"})
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                ),
+            )
+            .await
+            .unwrap();
+        },
+    )
+    .await;
+    let response = node
+        .execute("{ ResumedGoalOutput { _docID run_id summary } }")
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let outputs = response.data.unwrap()["ResumedGoalOutput"]
+        .as_array()
+        .unwrap()
+        .clone();
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0]["run_id"], "resumed-run-correlation");
+    let intent = tokio::time::timeout(Duration::from_secs(2), source.next_fire())
+        .await
+        .expect("resumed correlated output delivery timed out")
+        .expect("resumed correlated output should pass the event trigger filter");
+    assert_eq!(
+        intent.correlation.as_deref(),
+        Some("resumed-run-correlation")
+    );
+    assert_eq!(intent.event_vars["source_doc_id"], outputs[0]["_docID"]);
+}

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -536,6 +536,30 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "ProcessTransitions".to_string(),
         ));
     }
+    if !snapshot.goal_claimed_publication_cases.is_empty() {
+        emitted.insert((
+            "goal_claimed_publication_cases".to_string(),
+            "GoalClaimedPublicationCases".to_string(),
+        ));
+    }
+    if !snapshot.goal_request_head_cases.is_empty() {
+        emitted.insert((
+            "goal_request_head_cases".to_string(),
+            "GoalRequestHeadCases".to_string(),
+        ));
+    }
+    if !snapshot.goal_operator_resume_cases.is_empty() {
+        emitted.insert((
+            "goal_operator_resume_cases".to_string(),
+            "GoalOperatorResumeCases".to_string(),
+        ));
+    }
+    if !snapshot.goal_config_reactivation_cases.is_empty() {
+        emitted.insert((
+            "goal_config_reactivation_cases".to_string(),
+            "GoalConfigReactivationCases".to_string(),
+        ));
+    }
     if !snapshot.graph_failure_attribution_traces.is_empty() {
         emitted.insert((
             "graph_failure_attribution_traces".to_string(),
@@ -1279,6 +1303,10 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "task_goal_recovery_cases",
         "goal_submission_cases",
         "goal_continuation_materialization_cases",
+        "goal_claimed_publication_cases",
+        "goal_request_head_cases",
+        "goal_operator_resume_cases",
+        "goal_config_reactivation_cases",
         "graph_failure_attribution_traces",
         "graph_pipeline_validation_cases",
         "graph_pipeline_revision_gate_cases",

--- a/crates/gents/tests/misc/goal_controller.rs
+++ b/crates/gents/tests/misc/goal_controller.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use gents::goal::{
     claim_continuation, claim_retry_continuation, create_goal_for_session,
     delete_goals_for_session, load_canonical_goal, load_goals_for_session, session_token_usage,
-    set_goal, update_goal_fields, update_goal_fields_if_status, CreateGoalForSessionError,
-    CreateGoalForSessionOutcome, GoalStatus,
+    set_goal, update_goal_fields_if_status, CreateGoalForSessionError, CreateGoalForSessionOutcome,
+    GoalStatus,
 };
 use gents::{
     ActiveRuntimeSnapshot, ConfigAccess, GoalSource, TriggerSource, UpdateSubscriptionSource,
@@ -661,7 +661,7 @@ async fn continuation_claim_rejects_a_stale_active_status_snapshot() {
     )
     .await
     .expect("set goal");
-    update_goal_fields(db.node.as_ref(), &stale, r#"status: "paused""#)
+    seed_goal_fields(db.node.as_ref(), &stale, r#"status: "paused""#)
         .await
         .expect("pause goal");
     assert!(
@@ -684,7 +684,7 @@ async fn controller_status_cas_never_overwrites_a_newer_completion() {
     )
     .await
     .expect("set goal");
-    update_goal_fields(db.node.as_ref(), &stale, r#"status: "complete""#)
+    seed_goal_fields(db.node.as_ref(), &stale, r#"status: "complete""#)
         .await
         .expect("complete goal");
     assert!(!update_goal_fields_if_status(
@@ -700,6 +700,82 @@ async fn controller_status_cas_never_overwrites_a_newer_completion() {
         .expect("load goal")
         .expect("goal exists");
     assert_eq!(current.parsed_status(), Some(GoalStatus::Complete));
+}
+
+async fn assert_stale_controller_cannot_mutate_new_continuation(status: GoalStatus) {
+    let db = test_db("goal-controller-continuation-cas").await;
+    let stale = set_goal(
+        db.node.as_ref(),
+        db.node_identity.did(),
+        SESSION,
+        Some("Preserve the newer continuation from stale controller decisions"),
+        Some(GoalStatus::Active),
+        None,
+    )
+    .await
+    .expect("set active goal");
+    assert_eq!(stale.continuation_sequence(), 0);
+    assert!(
+        claim_continuation(db.node.as_ref(), &stale, "newly-claimed-parent")
+            .await
+            .expect("claim newer continuation")
+    );
+    let claimed = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .expect("load claimed goal")
+        .expect("goal exists");
+    assert_eq!(claimed.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(claimed.continuation_sequence(), 1);
+    assert_eq!(
+        claimed.last_continued_from_request_id.as_deref(),
+        Some("newly-claimed-parent")
+    );
+    let fields = format!(
+        r#"status: "{}", last_failure: "stale controller observation""#,
+        status.as_str()
+    );
+    assert!(
+        !update_goal_fields_if_status(db.node.as_ref(), &stale, GoalStatus::Active, &fields,)
+            .await
+            .expect("stale controller mutation returns cleanly"),
+        "same status must not authorize an older continuation snapshot"
+    );
+    let current = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .expect("reload goal after rejected stale write")
+        .expect("goal exists");
+    assert_eq!(current.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(
+        current.continuation_sequence(),
+        claimed.continuation_sequence()
+    );
+    assert_eq!(
+        current.last_continued_from_request_id,
+        claimed.last_continued_from_request_id
+    );
+    assert_eq!(current.last_failure, claimed.last_failure);
+    // A current observation must still authorize the legitimate transition.
+    assert!(
+        update_goal_fields_if_status(db.node.as_ref(), &current, GoalStatus::Active, &fields,)
+            .await
+            .expect("current controller mutation")
+    );
+    let updated = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .expect("reload current update")
+        .expect("goal exists");
+    assert_eq!(updated.parsed_status(), Some(status));
+    assert_eq!(updated.continuation_sequence(), 1);
+}
+
+#[tokio::test]
+async fn controller_pause_rejects_same_status_from_an_older_continuation() {
+    assert_stale_controller_cannot_mutate_new_continuation(GoalStatus::Paused).await;
+}
+
+#[tokio::test]
+async fn controller_block_rejects_same_status_from_an_older_continuation() {
+    assert_stale_controller_cannot_mutate_new_continuation(GoalStatus::Blocked).await;
 }
 
 #[tokio::test]
@@ -867,7 +943,7 @@ async fn goal_backed_submission_commits_goal_before_request_visibility_and_retri
         .await
         .expect("load committed goal")
         .expect("goal exists");
-    update_goal_fields(db.node.as_ref(), &committed_goal, r#"status: "complete""#)
+    seed_goal_fields(db.node.as_ref(), &committed_goal, r#"status: "complete""#)
         .await
         .expect("simulate progress after an ambiguous commit acknowledgement");
     let late_retry = gents::goal::submit_goal_backed_request(
@@ -1336,43 +1412,6 @@ async fn session_token_usage_charges_cached_input_as_part_of_the_total() {
 }
 
 #[tokio::test]
-async fn resume_resets_blocked_audit_identity_and_count() {
-    let db = test_db("goal-resume-audit-reset").await;
-    let goal = set_goal(
-        db.node.as_ref(),
-        db.node_identity.did(),
-        SESSION,
-        Some("Resume with a fresh blocked audit"),
-        Some(GoalStatus::Active),
-        None,
-    )
-    .await
-    .expect("set goal");
-    update_goal_fields(
-        db.node.as_ref(),
-        &goal,
-        r#"status: "blocked", consecutive_blocked_audits: 3, last_blocked_request_id: "request-3", last_blocked_reason: "needs approval", active_started_at: null"#,
-    )
-    .await
-    .expect("seed blocked audit");
-
-    let resumed = set_goal(
-        db.node.as_ref(),
-        db.node_identity.did(),
-        SESSION,
-        None,
-        Some(GoalStatus::Active),
-        None,
-    )
-    .await
-    .expect("resume goal");
-    assert_eq!(resumed.parsed_status(), Some(GoalStatus::Active));
-    assert_eq!(resumed.consecutive_blocked_audits, Some(0));
-    assert_eq!(resumed.last_blocked_request_id, None);
-    assert_eq!(resumed.last_blocked_reason, None);
-}
-
-#[tokio::test]
 async fn provider_usage_limit_moves_active_goal_to_usage_limited() {
     let db = test_db("goal-provider-usage-limit").await;
     create_request_for_agent_with_signed_fields(
@@ -1508,4 +1547,1052 @@ async fn failed_wrapup_retries_twice_then_is_durably_abandoned() {
         .as_deref()
         .is_some_and(|reason| reason.contains("after 2 retries")));
     assert_eq!(goal_children(&db).await.len(), 3);
+}
+
+#[tokio::test]
+async fn config_set_cannot_reactivate_without_publishing_a_continuation() {
+    let db = test_db("goal-config-resume-denied").await;
+    for status in [
+        GoalStatus::Paused,
+        GoalStatus::Blocked,
+        GoalStatus::UsageLimited,
+        GoalStatus::BudgetLimited,
+        GoalStatus::Complete,
+    ] {
+        let session = format!("config-resume-{}", status.as_str());
+        let before = set_goal(
+            &db.node,
+            db.node_identity.did(),
+            &session,
+            Some("Keep configuration separate from continuation admission"),
+            Some(status),
+            Some(Some(1000)),
+        )
+        .await
+        .expect("create goal");
+        let result = set_goal(
+            &db.node,
+            db.node_identity.did(),
+            &session,
+            None,
+            Some(GoalStatus::Active),
+            None,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "{} must require a typed continuation",
+            status.as_str()
+        );
+        let after = load_canonical_goal(&db.node, db.node_identity.did(), &session)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.status, before.status);
+        assert_eq!(
+            after.continuation_sequence(),
+            before.continuation_sequence()
+        );
+        assert_eq!(after.token_budget, before.token_budget);
+    }
+}
+
+#[tokio::test]
+async fn continuation_sequence_exhaustion_rejects_claims_without_retry_charge() {
+    for retry in [false, true] {
+        let name = if retry {
+            "goal-retry-sequence-exhaustion"
+        } else {
+            "goal-sequence-exhaustion"
+        };
+        let db = test_db(name).await;
+        let initial = set_goal(
+            db.node.as_ref(),
+            db.node_identity.did(),
+            SESSION,
+            Some("Never reuse an exhausted continuation sequence"),
+            Some(GoalStatus::Active),
+            None,
+        )
+        .await
+        .unwrap();
+        seed_goal_fields(
+            db.node.as_ref(),
+            &initial,
+            &format!(
+                "continuation_sequence: {}, infrastructure_retry_count: 0, last_failure: null, last_continued_from_request_id: null",
+                i64::MAX - 1
+            ),
+        )
+        .await
+        .unwrap();
+        let before = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        let claimed = if retry {
+            claim_retry_continuation(db.node.as_ref(), &before, "last-parent", 1, "failed").await
+        } else {
+            claim_continuation(db.node.as_ref(), &before, "last-parent").await
+        };
+        assert!(claimed.expect("MAX-1 must permit one final sequence advance"));
+        let exhausted = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(exhausted.continuation_sequence(), i64::MAX);
+        assert_eq!(
+            exhausted.last_continued_from_request_id.as_deref(),
+            Some("last-parent")
+        );
+        assert_eq!(exhausted.infrastructure_retry_count, Some(i64::from(retry)));
+        let rejected = if retry {
+            claim_retry_continuation(
+                db.node.as_ref(),
+                &exhausted,
+                "must-not-be-claimed",
+                2,
+                "must-not-be-charged",
+            )
+            .await
+        } else {
+            claim_continuation(db.node.as_ref(), &exhausted, "must-not-be-claimed").await
+        };
+        assert!(
+            rejected.is_err(),
+            "exhaustion must fail explicitly: {rejected:?}"
+        );
+        let after = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            serde_json::to_value(&after).unwrap(),
+            serde_json::to_value(&exhausted).unwrap(),
+            "rejected claim must not change watermark, retry charge, failure, or timestamp"
+        );
+    }
+}
+
+#[tokio::test]
+async fn stale_usage_refresh_preserves_completed_goal_time_accounting() {
+    let db = test_db("goal-stale-usage-after-completion").await;
+    let initial = set_goal(
+        db.node.as_ref(),
+        db.node_identity.did(),
+        SESSION,
+        Some("A stale observer cannot restart completed goal accounting"),
+        Some(GoalStatus::Active),
+        None,
+    )
+    .await
+    .unwrap();
+    seed_goal_fields(
+        db.node.as_ref(),
+        &initial,
+        "active_time_seconds: 7, active_started_at: null",
+    )
+    .await
+    .unwrap();
+    let stale = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    set_goal(
+        db.node.as_ref(),
+        db.node_identity.did(),
+        SESSION,
+        None,
+        Some(GoalStatus::Complete),
+        None,
+    )
+    .await
+    .unwrap();
+    // Pin a distinguishable completed accounting value without elapsed-clock
+    // assertions. The stale snapshot still carries seven active seconds.
+    seed_goal_fields(
+        db.node.as_ref(),
+        &stale,
+        "active_time_seconds: 73, active_started_at: null",
+    )
+    .await
+    .unwrap();
+    let completed = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed.status, "complete");
+    assert_eq!(completed.active_time_seconds, Some(73));
+    assert!(completed.active_started_at.is_none());
+
+    gents::goal::refresh_goal_usage(db.node.as_ref(), &stale)
+        .await
+        .expect("stale usage observation must safely skip obsolete accounting writes");
+    let after = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(after.status, "complete");
+    assert_eq!(after.active_time_seconds, completed.active_time_seconds);
+    assert_eq!(after.active_started_at, completed.active_started_at);
+    assert_eq!(
+        after.continuation_sequence(),
+        completed.continuation_sequence()
+    );
+}
+
+async fn seed_operator_resume_parent(db: &TestDb, request_id: &str) -> String {
+    let did = db.node_identity.did();
+    let mut parent = gents_protocol::request_admission::AgentRequestCreate::base(
+        request_id,
+        did,
+        did,
+        crate::support::AGENT_NAME,
+        SESSION,
+        "Continue the original graph work",
+        "interactive",
+        "2026-07-15T00:00:00Z",
+        gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(did),
+    );
+    parent.caused_by_trigger_id = Some("original-graph-trigger".into());
+    parent.caused_by_trigger_kind = Some("event".into());
+    parent.caused_by_correlation = Some("original-graph-correlation".into());
+    parent.caused_by_source_doc_id = Some("original-event-document".into());
+    parent.caused_by_trigger_context = Some(r#"{"source_fields":{"artifact":"original"}}"#.into());
+    parent.subagent_depth = 2;
+    parent.caused_by_parent_request_id = Some("upstream-request".into());
+    parent.caused_by_parent_request_doc_id = Some("upstream-document".into());
+    parent.caused_by_parent_tool_call_id = Some("upstream-tool-call".into());
+    parent.caused_by_parent_tool_call_doc_id = Some("upstream-tool-document".into());
+    parent.workspace_id = Some("resume-workspace".into());
+    parent.workspace_authority = Some("readOnly".into());
+    parent.workspace_owner_deployment_id = Some("resume-deployment".into());
+    parent.workspace_seal_hash = Some("resume-seal".into());
+    gents::sign_agent_request_create(db.node_identity.as_ref(), &mut parent)
+        .await
+        .unwrap();
+    let response = db.node.execute(&parent.graphql_mutation().unwrap()).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let query = format!(
+        r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+        gents::graphql::escape_graphql_string(request_id),
+    );
+    let response = db.node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let doc_id = response.data.unwrap()["AgentRequest"][0]["_docID"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    set_request_lifecycle_state(db.node.as_ref(), &doc_id, "interrupted").await;
+    doc_id
+}
+
+async fn operator_resume_child_row(db: &TestDb, doc_id: &str) -> serde_json::Value {
+    let query = format!(
+        r#"{{ AgentRequest(filter: {{ _docID: {{ _eq: "{}" }} }}) {{
+        _docID request_id agent_did requester_did session_id behavior_id lifecycle_state
+        content created_at execution_origin retry_key metadata admission_kind admission_signer_did
+        admission_signature runtime_issuer_did runtime_source_request_id runtime_source_kind
+        caused_by_trigger_id caused_by_trigger_doc_id caused_by_trigger_kind
+        caused_by_correlation caused_by_source_doc_id caused_by_trigger_context
+        caused_by_parent_request_id caused_by_parent_request_doc_id
+        caused_by_parent_tool_call_id caused_by_parent_tool_call_doc_id
+        subagent_depth workspace_id workspace_authority workspace_owner_deployment_id workspace_seal_hash
+    }} }}"#,
+        gents::graphql::escape_graphql_string(doc_id)
+    );
+    let response = db.node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    response.data.unwrap()["AgentRequest"][0].clone()
+}
+
+#[tokio::test]
+async fn operator_resume_publishes_one_lineage_child_and_fences_old_pause() {
+    let db = test_db("operator-resume-lineage").await;
+    let did = db.node_identity.did();
+    let parent_doc = seed_operator_resume_parent(&db, "resume-parent").await;
+    let stale_active = set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Complete graph work"),
+        Some(GoalStatus::Active),
+        Some(Some(1000)),
+    )
+    .await
+    .unwrap();
+    set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        None,
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let access = ConfigAccess::Local(db.node.clone());
+    let receipt = gents::goal::resume_goal_request(
+        &access,
+        db.node_identity.as_ref(),
+        did,
+        SESSION,
+        "resume-parent",
+    )
+    .await
+    .unwrap();
+    assert!(receipt.created);
+    let goal = load_canonical_goal(db.node.as_ref(), did, SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(receipt.goal_id, goal.goal_id);
+    assert_eq!(goal.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(goal.continuation_sequence(), 1);
+    assert_eq!(
+        goal.last_continued_from_request_id.as_deref(),
+        Some("resume-parent")
+    );
+    assert_eq!(goal.token_budget, Some(1000));
+    assert_eq!(goal_children(&db).await.len(), 1);
+    let child = operator_resume_child_row(&db, &receipt.doc_id).await;
+    assert_eq!(child["request_id"], receipt.request_id);
+    for field in [
+        "agent_did",
+        "requester_did",
+        "admission_signer_did",
+        "runtime_issuer_did",
+    ] {
+        assert_eq!(child[field], did, "{field}");
+    }
+    assert_eq!(child["session_id"], SESSION);
+    assert_eq!(child["behavior_id"], crate::support::AGENT_NAME);
+    assert_eq!(child["lifecycle_state"], "pending");
+    assert_eq!(child["execution_origin"], "scheduled");
+    assert_eq!(child["runtime_source_request_id"], "resume-parent");
+    assert!(child["admission_signature"]
+        .as_str()
+        .is_some_and(|v| !v.is_empty()));
+    assert_eq!(child["caused_by_trigger_id"], goal.goal_id);
+    assert_eq!(child["caused_by_trigger_kind"], "goal");
+    assert!(child["caused_by_trigger_doc_id"].is_null());
+    assert_eq!(child["caused_by_correlation"], "original-graph-correlation");
+    assert_eq!(child["caused_by_source_doc_id"], "original-event-document");
+    assert_eq!(
+        child["caused_by_trigger_context"],
+        r#"{"source_fields":{"artifact":"original"}}"#
+    );
+    assert_eq!(child["caused_by_parent_request_id"], "resume-parent");
+    assert_eq!(child["caused_by_parent_request_doc_id"], parent_doc);
+    assert!(child["caused_by_parent_tool_call_id"].is_null());
+    assert!(child["caused_by_parent_tool_call_doc_id"].is_null());
+    assert_eq!(child["subagent_depth"], 2);
+    assert_eq!(child["workspace_id"], "resume-workspace");
+    assert_eq!(child["workspace_authority"], "readOnly");
+    assert_eq!(child["workspace_owner_deployment_id"], "resume-deployment");
+    assert_eq!(child["workspace_seal_hash"], "resume-seal");
+    assert!(
+        !update_goal_fields_if_status(
+            db.node.as_ref(),
+            &stale_active,
+            GoalStatus::Active,
+            r#"status: "paused""#
+        )
+        .await
+        .unwrap(),
+        "pre-resume Active snapshot must lose ABA"
+    );
+    assert_eq!(
+        load_canonical_goal(db.node.as_ref(), did, SESSION)
+            .await
+            .unwrap()
+            .unwrap()
+            .parsed_status(),
+        Some(GoalStatus::Active)
+    );
+}
+
+#[tokio::test]
+async fn operator_resume_retry_after_goal_progress_returns_original_child_without_mutation() {
+    let db = test_db("operator-resume-retry-progress").await;
+    let did = db.node_identity.did();
+    seed_operator_resume_parent(&db, "retry-parent").await;
+    set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Original objective"),
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let access = ConfigAccess::Local(db.node.clone());
+    let first = gents::goal::resume_goal_request(
+        &access,
+        db.node_identity.as_ref(),
+        did,
+        SESSION,
+        "retry-parent",
+    )
+    .await
+    .unwrap();
+    set_request_lifecycle_state(db.node.as_ref(), &first.doc_id, "interrupted").await;
+    let before = set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Changed objective after progress"),
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let child_before = operator_resume_child_row(&db, &first.doc_id).await;
+    let retry = gents::goal::resume_goal_request(
+        &access,
+        db.node_identity.as_ref(),
+        did,
+        SESSION,
+        "retry-parent",
+    )
+    .await
+    .unwrap();
+    assert!(!retry.created);
+    assert_eq!(
+        (retry.request_id, retry.doc_id),
+        (first.request_id, first.doc_id)
+    );
+    let after = load_canonical_goal(db.node.as_ref(), did, SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        serde_json::to_value(after).unwrap(),
+        serde_json::to_value(before).unwrap()
+    );
+    assert_eq!(
+        operator_resume_child_row(&db, &child_before["_docID"].as_str().unwrap()).await,
+        child_before
+    );
+    assert_eq!(goal_children(&db).await.len(), 1);
+}
+
+#[tokio::test]
+async fn operator_resume_rejects_foreign_identity_even_with_target_key_registered() {
+    let target = test_db("operator-resume-target").await;
+    let foreign = test_db("operator-resume-foreign").await;
+    let did = target.node_identity.did();
+    seed_operator_resume_parent(&target, "owned-parent").await;
+    let before = set_goal(
+        target.node.as_ref(),
+        did,
+        SESSION,
+        Some("Owner work"),
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let access = ConfigAccess::Local(target.node.clone());
+    assert!(gents::goal::resume_goal_request(
+        &access,
+        foreign.node_identity.as_ref(),
+        did,
+        SESSION,
+        "owned-parent"
+    )
+    .await
+    .is_err());
+    assert!(goal_children(&target).await.is_empty());
+    assert_eq!(
+        serde_json::to_value(
+            load_canonical_goal(target.node.as_ref(), did, SESSION)
+                .await
+                .unwrap()
+                .unwrap()
+        )
+        .unwrap(),
+        serde_json::to_value(before).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn operator_resume_rejects_busy_session_and_old_predecessor() {
+    for newer_status in ["pending", "completed"] {
+        let db = test_db(&format!("operator-resume-newer-{newer_status}")).await;
+        let did = db.node_identity.did();
+        seed_operator_resume_parent(&db, "older-parent").await;
+        create_request_for_agent_with_signed_fields(
+            db.node.as_ref(),
+            did,
+            "newer-request",
+            SESSION,
+            newer_status,
+            "2026-07-15T00:00:01Z",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        let before = set_goal(
+            db.node.as_ref(),
+            did,
+            SESSION,
+            Some("Respect latest work"),
+            Some(GoalStatus::Paused),
+            None,
+        )
+        .await
+        .unwrap();
+        let access = ConfigAccess::Local(db.node.clone());
+        assert!(gents::goal::resume_goal_request(
+            &access,
+            db.node_identity.as_ref(),
+            did,
+            SESSION,
+            "older-parent"
+        )
+        .await
+        .is_err());
+        assert!(goal_children(&db).await.is_empty());
+        assert_eq!(
+            serde_json::to_value(
+                load_canonical_goal(db.node.as_ref(), did, SESSION)
+                    .await
+                    .unwrap()
+                    .unwrap()
+            )
+            .unwrap(),
+            serde_json::to_value(before).unwrap()
+        );
+    }
+}
+
+// Replace the existing resume_resets_blocked_audit_identity_and_count test with
+// this function (same name) rather than leave the status-only setter bypass.
+#[tokio::test]
+async fn resume_resets_blocked_audit_identity_and_count() {
+    let db = test_db("goal-resume-audit-reset").await;
+    let did = db.node_identity.did();
+    seed_operator_resume_parent(&db, "request-3").await;
+    let goal = set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Resume with a fresh blocked audit"),
+        Some(GoalStatus::Active),
+        None,
+    )
+    .await
+    .unwrap();
+    seed_goal_fields(db.node.as_ref(), &goal,
+        r#"status: "blocked", consecutive_blocked_audits: 3, last_blocked_request_id: "request-3", last_blocked_reason: "needs approval", active_started_at: null"#).await.unwrap();
+    let access = ConfigAccess::Local(db.node.clone());
+    let receipt = gents::goal::resume_goal_request(
+        &access,
+        db.node_identity.as_ref(),
+        did,
+        SESSION,
+        "request-3",
+    )
+    .await
+    .unwrap();
+    assert!(receipt.created);
+    let resumed = load_canonical_goal(db.node.as_ref(), did, SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(resumed.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(resumed.consecutive_blocked_audits, Some(0));
+    assert_eq!(resumed.last_blocked_request_id, None);
+    assert_eq!(resumed.last_blocked_reason, None);
+    assert_eq!(goal_children(&db).await.len(), 1);
+}
+
+#[tokio::test]
+async fn concurrent_operator_resumes_publish_one_child() {
+    let db = test_db("operator-resume-concurrent").await;
+    let did = db.node_identity.did();
+    seed_operator_resume_parent(&db, "concurrent-parent").await;
+    set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("One operator continuation"),
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let access = ConfigAccess::Local(db.node.clone());
+    let (left, right) = tokio::join!(
+        gents::goal::resume_goal_request(
+            &access,
+            db.node_identity.as_ref(),
+            did,
+            SESSION,
+            "concurrent-parent"
+        ),
+        gents::goal::resume_goal_request(
+            &access,
+            db.node_identity.as_ref(),
+            did,
+            SESSION,
+            "concurrent-parent"
+        ),
+    );
+    let left = left.unwrap();
+    let right = right.unwrap();
+    assert_ne!(left.created, right.created);
+    assert_eq!(
+        (left.request_id, left.doc_id),
+        (right.request_id, right.doc_id)
+    );
+    assert_eq!(goal_children(&db).await.len(), 1);
+    let goal = load_canonical_goal(db.node.as_ref(), did, SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(goal.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(goal.continuation_sequence(), 1);
+}
+
+#[tokio::test]
+async fn operator_resume_rejects_corrupted_child_receipt_without_reactivation() {
+    let db = test_db("operator-resume-corrupt-receipt").await;
+    let did = db.node_identity.did();
+    seed_operator_resume_parent(&db, "corrupt-parent").await;
+    set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Original signed work"),
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let access = ConfigAccess::Local(db.node.clone());
+    let first = gents::goal::resume_goal_request(
+        &access,
+        db.node_identity.as_ref(),
+        did,
+        SESSION,
+        "corrupt-parent",
+    )
+    .await
+    .unwrap();
+    set_request_lifecycle_state(db.node.as_ref(), &first.doc_id, "interrupted").await;
+    let goal_before = set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        None,
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    // Immutable content cannot be updated in place. Model hostile persisted
+    // input by replacing the fixture row while retaining its original signature.
+    let original = db.node.execute(&format!(
+        r#"{{ AgentRequest(filter: {{ _docID: {{ _eq: "{}" }} }}) {{
+            request_id agent_did requester_did admission_kind admission_signer_did admission_signature enrollment_request_id enrollment_request_digest enrollment_admin_did enrollment_authorization_sequence enrollment_authorization_expires_at runtime_issuer_did runtime_source_request_id runtime_source_kind runtime_bridge_author_did behavior_id session_id retry_parent_request retry_parent_request_doc_id retry_root_request retry_key content temperature top_p top_k seed max_tokens max_total_tokens metadata execution_origin caused_by_trigger_id caused_by_trigger_doc_id caused_by_trigger_kind caused_by_correlation caused_by_trigger_context caused_by_source_doc_id created_at retry_count max_retries valid_until subagent_depth caused_by_parent_request_id caused_by_parent_request_doc_id caused_by_parent_tool_call_id caused_by_parent_tool_call_doc_id workspace_id workspace_authority workspace_owner_deployment_id workspace_seal_hash lifecycle_state
+        }} }}"#, gents::graphql::escape_graphql_string(&first.doc_id),
+    )).await;
+    assert!(!original.has_errors(), "{:?}", original.errors);
+    let mut forged = original.data.unwrap()["AgentRequest"][0].clone();
+    forged["content"] = serde_json::json!("unsigned replacement");
+    let removed = db
+        .node
+        .execute(&format!(
+            r#"mutation {{ delete_AgentRequest(docID: "{}") {{ _docID }} }}"#,
+            gents::graphql::escape_graphql_string(&first.doc_id),
+        ))
+        .await;
+    assert!(!removed.has_errors(), "{:?}", removed.errors);
+    let inserted = db
+        .node
+        .execute(&format!(
+            "mutation {{ add_AgentRequest(input: {}) {{ _docID }} }}",
+            gents_protocol::graphql::graphql_input_literal(&forged).unwrap(),
+        ))
+        .await;
+    assert!(!inserted.has_errors(), "{:?}", inserted.errors);
+    let inserted = &inserted.data.as_ref().unwrap()["add_AgentRequest"];
+    let forged_doc_id = inserted
+        .get("_docID")
+        .or_else(|| inserted.get(0).and_then(|row| row.get("_docID")))
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let child_before = operator_resume_child_row(&db, &forged_doc_id).await;
+    assert_eq!(child_before["content"], "unsigned replacement");
+    assert!(
+        gents::goal::resume_goal_request(
+            &access,
+            db.node_identity.as_ref(),
+            did,
+            SESSION,
+            "corrupt-parent",
+        )
+        .await
+        .is_err(),
+        "a matching retry key must not authenticate changed content"
+    );
+    let goal_after = load_canonical_goal(db.node.as_ref(), did, SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        serde_json::to_value(goal_after).unwrap(),
+        serde_json::to_value(goal_before).unwrap()
+    );
+    assert_eq!(
+        operator_resume_child_row(&db, &forged_doc_id).await,
+        child_before
+    );
+    assert_eq!(goal_children(&db).await.len(), 1);
+}
+
+#[tokio::test]
+async fn operator_resume_rejects_older_unfinished_siblings_without_mutation() {
+    for (label, state) in [
+        ("missing", None),
+        ("unknown", Some("unknownState")),
+        ("input", Some("inputRequired")),
+        ("workspace", Some("workspaceBindingPending")),
+    ] {
+        let db = test_db(&format!("operator-resume-unfinished-{label}")).await;
+        let did = db.node_identity.did();
+        // Both signed fixtures share created_at; the canonical secondary
+        // ordering makes a-older precede z-parent. The latest-parent guard
+        // therefore cannot hide a missing whole-session terminal check.
+        let sibling = seed_operator_resume_parent(&db, "a-older").await;
+        seed_operator_resume_parent(&db, "z-parent").await;
+        let state = state
+            .map(|value| format!("\"{}\"", gents::graphql::escape_graphql_string(value)))
+            .unwrap_or_else(|| "null".to_owned());
+        let response = db.node.execute(&format!(
+            r#"mutation {{ update_AgentRequest(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ lifecycle_state: {state} }}) {{ _docID }} }}"#,
+            gents::graphql::escape_graphql_string(&sibling)
+        )).await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        let before = set_goal(
+            db.node.as_ref(),
+            did,
+            SESSION,
+            Some("Do not bypass unfinished sibling work"),
+            Some(GoalStatus::Paused),
+            None,
+        )
+        .await
+        .unwrap();
+        let error = gents::goal::resume_goal_request(
+            &ConfigAccess::Local(db.node.clone()),
+            db.node_identity.as_ref(),
+            did,
+            SESSION,
+            "z-parent",
+        )
+        .await
+        .expect_err("every unfinished sibling must block resume");
+        let detail = format!("{error:#}");
+        assert!(
+            !detail.contains("no longer the latest"),
+            "wrong guard masked unfinished row: {detail}"
+        );
+        if label != "unknown" {
+            assert!(detail.contains("unfinished"), "unexpected guard: {detail}");
+        }
+        assert!(goal_children(&db).await.is_empty());
+        let after = load_canonical_goal(db.node.as_ref(), did, SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            serde_json::to_value(after).unwrap(),
+            serde_json::to_value(before).unwrap()
+        );
+    }
+}
+
+#[tokio::test]
+async fn operator_resume_preserves_pending_wrapup_in_child_policy() {
+    let db = test_db("operator-resume-retained-wrapup").await;
+    let did = db.node_identity.did();
+    seed_operator_resume_parent(&db, "wrapup-parent").await;
+    let paused = set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Finish the already requested wrap-up"),
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    seed_goal_fields(
+        db.node.as_ref(),
+        &paused,
+        "wrapup_requested: true, wrapup_completed: false",
+    )
+    .await
+    .unwrap();
+    let receipt = gents::goal::resume_goal_request(
+        &ConfigAccess::Local(db.node.clone()),
+        db.node_identity.as_ref(),
+        did,
+        SESSION,
+        "wrapup-parent",
+    )
+    .await
+    .unwrap();
+    let goal = load_canonical_goal(db.node.as_ref(), did, SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(goal.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(goal.wrapup_requested, Some(true));
+    assert_eq!(goal.wrapup_completed, Some(false));
+    let child = operator_resume_child_row(&db, &receipt.doc_id).await;
+    let metadata: serde_json::Value =
+        serde_json::from_str(child["metadata"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        metadata
+            .pointer("/goal/wrapup")
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+    let content = child["content"].as_str().unwrap();
+    assert!(content.contains("one final wrap-up turn"), "{content}");
+    assert!(
+        content.contains("Do not expect another automatic continuation"),
+        "{content}"
+    );
+}
+
+/// Fixture-only mutation for constructing boundary states. Production writes
+/// go through the guarded Goal owner; tests do not require an unfenced API.
+async fn seed_goal_fields(
+    node: &defra_node::EmbeddedNode,
+    goal: &gents::goal::GoalDocument,
+    fields: &str,
+) -> anyhow::Result<()> {
+    let doc_id = gents::graphql::escape_graphql_string(&goal.doc_id);
+    let agent_did = gents::graphql::escape_graphql_string(&goal.agent_did);
+    let response = node.execute(&format!(
+        r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{agent_did}" }} }}, input: {{ {fields} }}) {{ _docID }} }}"#
+    )).await;
+    anyhow::ensure!(
+        !response.has_errors(),
+        "seed Goal fields: {:?}",
+        response.errors
+    );
+    Ok(())
+}
+
+async fn seed_same_second_canonical_goal_child(
+    db: &TestDb,
+    parent_id: &str,
+    paused: bool,
+) -> (String, String) {
+    use sha2::{Digest, Sha256};
+    let did = db.node_identity.did();
+    // The generic completed-row fixture does not sign admission. This test
+    // exercises authenticated ancestry, so create a real signed root first.
+    let mut parent = gents_protocol::request_admission::AgentRequestCreate::base(
+        parent_id,
+        did,
+        did,
+        crate::support::AGENT_NAME,
+        SESSION,
+        "Signed root of the same-second continuation chain",
+        "interactive",
+        "2026-07-15T00:00:00Z",
+        gents_protocol::request_admission::AgentRequestAdmissionRecord::local_self(did),
+    );
+    gents::sign_agent_request_create(db.node_identity.as_ref(), &mut parent)
+        .await
+        .unwrap();
+    let response = db.node.execute(&parent.graphql_mutation().unwrap()).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let response = db
+        .node
+        .execute(&format!(
+            r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+            gents::graphql::escape_graphql_string(parent_id),
+        ))
+        .await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let parent_doc = response.data.unwrap()["AgentRequest"][0]["_docID"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    set_request_lifecycle_state(db.node.as_ref(), &parent_doc, "completed").await;
+    let goal = set_goal(
+        db.node.as_ref(),
+        did,
+        SESSION,
+        Some("Continue from the actual causal head"),
+        Some(if paused {
+            GoalStatus::Paused
+        } else {
+            GoalStatus::Active
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+    let digest = Sha256::digest(format!("{}\0{parent_id}", goal.goal_id).as_bytes());
+    let suffix = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let child_id = format!("goal-cont-{:020}-{suffix}", 1);
+    assert!(
+        child_id.as_str() < parent_id,
+        "fixture must defeat lexical head selection"
+    );
+    let identity = gents::RequestIdentity {
+        requester_did: None,
+        request_id: child_id.clone(),
+        agent_did: did.to_owned(),
+        behavior_id: crate::support::AGENT_NAME.to_owned(),
+        session_id: SESSION.to_owned(),
+        content: "The canonical continuation made durable progress".to_owned(),
+        execution_origin: gents::lifecycle::ExecutionOrigin::Scheduled,
+        created_at: "2026-07-15T00:00:00Z".to_owned(),
+    };
+    let admission =
+        gents_protocol::request_admission::AgentRequestAdmissionRecord::runtime_local_control(
+            did, parent_id,
+        );
+    let mut spec = gents::RequestSpec::new(identity, admission);
+    spec.trigger_lineage.trigger_id = Some(goal.goal_id.clone());
+    spec.trigger_lineage.trigger_kind = Some("goal".to_owned());
+    spec.subagent = Some(gents::ParentLink {
+        parent_request_id: parent_id.to_owned(),
+        parent_request_doc_id: parent_doc,
+        ..Default::default()
+    });
+    spec.retry_key = Some(format!("goal-continuation:{suffix}"));
+    spec.metadata = Some(
+        serde_json::json!({
+            "queue": {
+                "source": "goal", "policy": "coalesce", "key": format!("goal:{suffix}"),
+                "queued_after_request_id": parent_id
+            },
+            "goal": {
+                "goal_id": goal.goal_id, "parent_request_id": parent_id,
+                "continuation_sequence": 1, "wrapup": false
+            }
+        })
+        .to_string(),
+    );
+    let child = gents::build_signed_request(
+        spec,
+        gents::RequestSigner::Identity(db.node_identity.as_ref()),
+    )
+    .await
+    .unwrap();
+    let response = db.node.execute(&child.graphql_mutation().unwrap()).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let children = goal_children(db).await;
+    assert_eq!(children.len(), 1);
+    let child_doc = children[0].doc_id.clone();
+    set_request_lifecycle_state(
+        db.node.as_ref(),
+        &child_doc,
+        if paused { "interrupted" } else { "completed" },
+    )
+    .await;
+    create_response_with_content_and_status(
+        db.node.as_ref(),
+        "same-second-child-response",
+        &child_id,
+        SESSION,
+        "canonical child produced durable activity",
+        if paused { "interrupted" } else { "complete" },
+    )
+    .await;
+    seed_goal_fields(
+        db.node.as_ref(),
+        &goal,
+        &format!(
+            "continuation_sequence: 1, last_continued_from_request_id: \"{}\"",
+            gents::graphql::escape_graphql_string(parent_id),
+        ),
+    )
+    .await
+    .unwrap();
+    (child_id, child_doc)
+}
+
+#[tokio::test]
+async fn goal_source_continues_same_second_child_that_sorts_before_root() {
+    for parent_id in ["graph-parent", "task-goal-request:parent"] {
+        let db = test_db(&format!("goal-head-order-{}", parent_id.replace(':', "-"))).await;
+        let (child_id, _) = seed_same_second_canonical_goal_child(&db, parent_id, false).await;
+        let (mut controller, _snapshot_tx) = source(&db);
+        let intent = tokio::time::timeout(Duration::from_secs(2), controller.next_fire())
+            .await
+            .expect("causal child must not be hidden by lexical root ordering")
+            .expect("continuation intent");
+        let next_id = intent
+            .pre_materialized_request_id
+            .expect("materialized child");
+        let children = goal_children(&db).await;
+        let next = children
+            .iter()
+            .find(|row| row.request_id == next_id)
+            .unwrap();
+        assert_eq!(
+            next.caused_by_parent_request_id.as_deref(),
+            Some(child_id.as_str())
+        );
+        let goal = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(goal.continuation_sequence(), 2);
+        assert_eq!(
+            goal.last_continued_from_request_id.as_deref(),
+            Some(child_id.as_str())
+        );
+    }
+}
+
+#[tokio::test]
+async fn operator_resume_accepts_same_second_child_that_sorts_before_root() {
+    for parent_id in ["graph-parent", "task-goal-request:parent"] {
+        let db = test_db(&format!(
+            "resume-head-order-{}",
+            parent_id.replace(':', "-")
+        ))
+        .await;
+        let (child_id, child_doc) =
+            seed_same_second_canonical_goal_child(&db, parent_id, true).await;
+        let receipt = gents::goal::resume_goal_request(
+            &ConfigAccess::Local(db.node.clone()),
+            db.node_identity.as_ref(),
+            db.node_identity.did(),
+            SESSION,
+            &child_id,
+        )
+        .await
+        .expect("canonical child is latest despite its lexical position");
+        let next = operator_resume_child_row(&db, &receipt.doc_id).await;
+        assert_eq!(next["caused_by_parent_request_id"], child_id);
+        assert_eq!(next["caused_by_parent_request_doc_id"], child_doc);
+        let goal = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(goal.continuation_sequence(), 2);
+        assert_eq!(goal.parsed_status(), Some(GoalStatus::Active));
+    }
 }

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -56,6 +56,41 @@ impl ConformanceConsumer {
 pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
     &[
         ConformanceConsumer::RustTest {
+            id: "goal::request_head::tests::generated_goal_request_head_cases_drive_signed_row_selector",
+            package: "gents",
+            source_path: "crates/gents/src/goal/request_head_tests.rs",
+            module_path: "goal::request_head::tests",
+            function: "generated_goal_request_head_cases_drive_signed_row_selector",
+        },
+        ConformanceConsumer::RustTest {
+            id: "goal::claimed_publication::contract_tests::generated_goal_claimed_publication_cases_drive_real_transactions",
+            package: "gents",
+            source_path: "crates/gents/src/goal/claimed_publication/contract_tests.rs",
+            module_path: "goal::claimed_publication::contract_tests",
+            function: "generated_goal_claimed_publication_cases_drive_real_transactions",
+        },
+        ConformanceConsumer::RustTest {
+            id: "goal::operator_resume::contract_tests::generated_goal_operator_resume_cases_drive_real_transactions",
+            package: "gents",
+            source_path: "crates/gents/src/goal/operator_resume/contract_tests.rs",
+            module_path: "goal::operator_resume::contract_tests",
+            function: "generated_goal_operator_resume_cases_drive_real_transactions",
+        },
+        ConformanceConsumer::RustTest {
+            id: "goal::operator_resume::contract_tests::generated_goal_config_reactivation_cases_drive_transactional_setter",
+            package: "gents",
+            source_path: "crates/gents/src/goal/operator_resume/contract_tests.rs",
+            module_path: "goal::operator_resume::contract_tests",
+            function: "generated_goal_config_reactivation_cases_drive_transactional_setter",
+        },
+        ConformanceConsumer::RustTest {
+            id: "cli_goal::goal_resume_request_reuses_signed_predecessor_and_returns_same_child",
+            package: "gents-cli",
+            source_path: "crates/gents-cli/tests/suites/cli_goal.rs",
+            module_path: "cli_goal",
+            function: "goal_resume_request_reuses_signed_predecessor_and_returns_same_child",
+        },
+        ConformanceConsumer::RustTest {
             id: "graph_pipeline::run::attribution_contract_tests::generated_graph_failure_attribution_traces_drive_real_transactions",
             package: "gents",
             source_path: "crates/gents/src/graph_pipeline/attribution_contract_tests.rs",
@@ -168,11 +203,11 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "durable_goal_continues_with_real_inference_until_model_completes",
         },
         ConformanceConsumer::RustTest {
-            id: "cli_goal::goal_set_get_pause_resume_and_clear_are_durable",
+            id: "cli_goal::goal_configuration_rejects_implicit_resume_and_clear_is_durable",
             package: "gents-cli",
             source_path: "crates/gents-cli/tests/suites/cli_goal.rs",
             module_path: "cli_goal",
-            function: "goal_set_get_pause_resume_and_clear_are_durable",
+            function: "goal_configuration_rejects_implicit_resume_and_clear_is_durable",
         },
         ConformanceConsumer::RustTest {
             id: "cli_codex_shim::thread_goal_round_trip_survives_shim_restart",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3,6 +3,32 @@
 Operational reference beyond the [getting-started walkthrough](demo.md):
 desktop enrollment, multi-runtime bring-up, and the operations API.
 
+## Resume a durable goal
+
+Use the terminal request you intend to continue as the stable operation key:
+
+```bash
+gents goal resume-request --home /path/to/agent-home \
+  --graphql http://localhost:9191/api/v0/graphql \
+  --session SESSION_ID --from REQUEST_ID
+```
+
+The command requires the goal owner's local signing identity. It resumes a
+paused, blocked, or usage-limited goal and creates its signed continuation in
+one transaction, preserving the predecessor's session, behavior, graph
+correlation, physical parent, and workspace bindings. The session must have no
+unfinished requests, and the predecessor must be its current causal head.
+
+If the response is lost, repeat the same command with the same `--from` value.
+The JSON receipt returns the original child and `created: false`; it does not
+reactivate the goal again, even if that child has already finished. Token usage
+and the configured budget are preserved.
+
+`goal set` continues to create goals and edit their configuration, but cannot
+reactivate an existing inactive goal. The Codex `thread/goal/set` operation has
+the same restriction because it does not carry a predecessor request ID. Use
+`goal resume-request` for that action.
+
 ## Container image
 
 Each published release includes a multi-platform image for Linux amd64 and


### PR DESCRIPTION
A paused durable goal could be reactivated without a replacement request, letting GoalSource immediately pause it again against the same interrupted predecessor. `gents goal resume-request --session SESSION --from REQUEST_ID` now commits the Goal resume and one signed, lineage-preserving continuation together. Retrying the same predecessor returns the original child without reactivating the Goal or resetting its budget.

The runtime owns both local and HTTP goal configuration; ordinary setters reject inactive-to-active changes and point operators to the typed action. This also applies to Codex `thread/goal/set`, whose wire request has no predecessor selector. The action requires the target signing identity and a signed, terminal, current predecessor in an idle session. It preserves correlation, trigger context/source, physical parent links, workspace bindings, and usage/budget; no free-form lineage overrides are exposed.

Continuation ordering uses authenticated physical ancestry when timestamps coincide. Controller updates compare status and continuation sequence. Automatic publication now checks the observed claim and writes Goal plus child through the existing `ConfigApplyTxn`; a pause or newer claim wins before publication. The old separate queue publication writer and duplicated CLI setter are removed. Existing automatic legacy-parent acceptance and node ACP actor are preserved; operator resume has the explicit signature boundary. This adds no transaction mechanism or durable authority field.

Lean models drive real transaction consumers (11 resume, 7 configuration, 8 claimed-publication cases), plus 15 signed-row causal-head cases. Database regressions cover retry, concurrent resume, stale controller writes, queued pause, unfinished siblings, same-second ancestry, and retained wrapup policy. A typed-resume/tool-write/EventSource regression exercises correlation propagation to the next trigger.

Validation:

- `lake build`: passed (1,047 targets).
- `cargo test -p gents`: 2,730 passed, 3 existing opt-in tests ignored.
- `cargo test -p gents-cli --lib goal_`: 21 passed.
- `cargo test -p gents-cli --test cli_runtime cli_goal::`: 2 passed, including real CLI resume/retry against a controlled provider.
- `cargo test -p gents-cli --test cli_codex_shim thread_goal_`: 1 passed.
- `cargo check --workspace --all-targets`: passed; existing `Matcher.description` dead-code warning remains.
- Formatting and staged diff checks passed. Independent production/test reviews and two Opus reviews were adjudicated against the full source.

These are historical local package and controlled-provider checks. Final real-model QA and completed review graph `315587bb-2553-46c7-b566-8cb540714dd5` at `98f1bccbf` are reported in #1413.

Closes #1354. Stacked above #1383 in native stack #1381. Follow-on #1385 adds graph logical-invocation projection and fences both continuation paths against graph closure. Durable backend waiting remains #1366/#897 and is not claimed here.

Review corrections are in #1395: resume receipts expose the transaction-observed Goal status, including a paused historical replay. InputRequired and WorkspaceBindingPending requests intentionally retain the existing request and block duplicate continuation. A regression overlaps native storage transactions independently of the local mutation gate; this is not claimed as two HTTP resume calls. Historical validation above is scoped to this PR boundary; final-tip checks are reported in #1413.
