### PR TITLE
fix(graph): follow authenticated Goal invocation chains

### DIFF
--- a/crates/gents-cli/src/commands/graph.rs
+++ b/crates/gents-cli/src/commands/graph.rs
@@ -499,6 +499,7 @@ fn progress(view: &GraphRunView) -> Value {
         "revision_digest": view.revision_digest,
         "deadline_at": view.deadline_at,
         "active_requests": view.active_request_count,
+        "outstanding_invocations": view.outstanding_invocation_count,
         "terminal_requests": view.terminal_request_count,
         "stages": view.stages,
         "groups": view.groups,

--- a/crates/gents/proofs/Proofs.lean
+++ b/crates/gents/proofs/Proofs.lean
@@ -66,6 +66,7 @@ import Proofs.Conformance.EventDelivery
 import Proofs.Conformance.RequestExecutionLease
 import Proofs.GraphPipeline
 import Proofs.GraphPipeline.FailureAttribution
+import Proofs.GraphPipeline.LogicalInvocation
 import Proofs.EthSubmission
 import Proofs.PeerRegistryDiscovery.DirectoryProjection
 import Proofs.PeerRegistryDiscovery.PersonaRequest

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -36,6 +36,7 @@ import Proofs.Conformance.GoalOperatorResume
 import Proofs.Conformance.GoalClaimedPublication
 import Proofs.Conformance.GoalRequestHead
 import Proofs.Conformance.GraphFailureAttribution
+import Proofs.Conformance.GraphLogicalInvocation
 import Proofs.Conformance.RequestExecutionLease
 import Proofs.Conformance.InferenceRegistry
 
@@ -54,6 +55,10 @@ def snapshotJson : String :=
       ++ Conformance.GraphFailureAttributionContracts.traceCasesJson ++ ","
     ++ "\"goal_request_head_cases\":"
       ++ Conformance.GoalRequestHeadContracts.casesJson ++ ","
+    ++ "\"graph_logical_invocation_cases\":"
+      ++ Conformance.GraphLogicalInvocationContracts.casesJson ++ ","
+    ++ "\"graph_invocation_publication_cases\":"
+      ++ Conformance.GraphLogicalInvocationContracts.publicationCasesJson ++ ","
     ++ "\"goal_claimed_publication_cases\":"
       ++ Conformance.GoalClaimedPublicationContracts.casesJson ++ ","
     ++ "\"goal_operator_resume_cases\":"

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -842,6 +842,16 @@ def caseCoverage : List CoverageEntry :=
       "graph_pipeline::run::attribution_contract_tests::generated_graph_failure_attribution_traces_drive_real_transactions")
       "graph-pipeline" [Surface.runtimeInternal]
   , tagged (consumerCoverage
+      "graph_logical_invocation_cases"
+      "GraphLogicalInvocationCases"
+      "graph_pipeline::logical_invocation_contract_tests::generated_graph_logical_invocations_drive_persisted_run_projection")
+      "graph-pipeline" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "graph_invocation_publication_cases"
+      "GraphInvocationPublicationCases"
+      "graph_pipeline::run::publication_contract_tests::generated_graph_invocation_publication_traces_drive_real_transactions")
+      "graph-pipeline" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "goal_claimed_publication_cases"
       "GoalClaimedPublicationCases"
       "goal::claimed_publication::contract_tests::generated_goal_claimed_publication_cases_drive_real_transactions")

--- a/crates/gents/proofs/Proofs/Conformance/GraphLogicalInvocation.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GraphLogicalInvocation.lean
@@ -1,0 +1,137 @@
+import Proofs.GraphPipeline.LogicalInvocation
+import Proofs.Conformance.GraphFailureAttribution
+
+namespace Conformance.GraphLogicalInvocationContracts
+open GraphPipeline.LogicalInvocation Conformance.Contracts
+
+structure Case where
+  name : String
+  rows : List Attempt
+  edges : List Edge
+  root : Doc := 10
+  goal : Option GoalEvidence := none
+  headBindingMatches : Bool := true
+  resultSatisfied : Bool := false
+  maximum : Nat := 10
+  expected : Outcome
+  physicalCount : Nat
+  deriving DecidableEq, Repr
+
+private def r : Attempt := ⟨10, true, some .failed⟩
+private def c : Attempt := ⟨20, false, some .completed⟩
+private def e : Edge := ⟨10,20,true⟩
+private def active : GoalEvidence := ⟨.active,.unclaimed,false,false⟩
+private def done : GoalEvidence := {active with status := .complete}
+
+def cases : List Case :=
+  [ {name := "active_goal_preclaim", rows := [r], edges := [], goal := some active,
+      expected := .outstanding, physicalCount := 1}
+  , {name := "claimed_publication_gap", rows := [r], edges := [],
+      goal := some {active with phase := .claimed}, expected := .outstanding, physicalCount := 1}
+  , {name := "pending_child", rows := [r, {c with terminal := none}], edges := [e],
+      goal := some done, expected := .outstanding, physicalCount := 2}
+  , {name := "successful_descendant_complete_goal", rows := [r,c], edges := [e],
+      goal := some done, resultSatisfied := true, expected := .succeeded, physicalCount := 2}
+  , {name := "paused_failed_tip_despite_result", rows := [r,{c with terminal := some .failed}], edges := [e],
+      goal := some {active with status := .paused}, resultSatisfied := true,
+      expected := .failed 20, physicalCount := 2}
+  , {name := "failed_root_without_goal", rows := [r], edges := [], expected := .failed 10, physicalCount := 1}
+  , {name := "unrelated_same_correlation", rows := [r,c], edges := [], resultSatisfied := true,
+      expected := .failed 10, physicalCount := 1}
+  , {name := "wrong_physical_parent_edge", rows := [r,c], edges := [{e with authenticated := false}],
+      resultSatisfied := true, expected := .failed 10, physicalCount := 1}
+  , {name := "wrong_child_owner", rows := [r,c], edges := [{e with authenticated := false}],
+      resultSatisfied := true, expected := .failed 10, physicalCount := 1}
+  , {name := "same_second_child_before_root", rows := [c,r], edges := [e],
+      goal := some done, resultSatisfied := true, expected := .succeeded, physicalCount := 2}
+  , {name := "historical_head_canonical_goal_mismatch", rows := [c,r], edges := [e],
+      goal := some active, headBindingMatches := false, resultSatisfied := true,
+      expected := .succeeded, physicalCount := 2}
+  , {name := "physical_invocation_limit", rows := [r,c], edges := [e], maximum := 1,
+      goal := some done, resultSatisfied := true, expected := .limitExceeded, physicalCount := 2}
+  , {name := "branching_authenticated_tips", rows := [r,c,{c with doc := 30}], edges := [e,⟨10,30,true⟩],
+      resultSatisfied := true, expected := .invalid, physicalCount := 3}
+  , {name := "unfinished_budget_wrapup", rows := [r], edges := [],
+      goal := some {active with status := .budgetLimited, wrapupRequested := true},
+      expected := .outstanding, physicalCount := 1}
+  , {name := "successful_tip_missing_result", rows := [r,c], edges := [e], goal := some done,
+      expected := .failed 20, physicalCount := 2}
+  ]
+
+theorem cases_replay : ∀ c ∈ cases,
+    projectLimited c.rows c.edges c.root (associatedGoal c.goal c.headBindingMatches) c.resultSatisfied c.maximum = c.expected ∧
+    (members c.rows c.edges c.root).length = c.physicalCount := by decide
+
+private def b (x : Bool) := if x then "true" else "false"
+private def natOpt : Option Nat → String | none => "null" | some n => toString n
+private def terminalJson : Option Goals.RequestTerminal → String
+  | none => "null" | some .completed => "\"completed\"" | some .failed => "\"failed\""
+  | some .dead => "\"dead\"" | some .interrupted => "\"interrupted\"" | some .superseded => "\"superseded\""
+private def rowJson (a : Attempt) :=
+  "{\"doc\":" ++ toString a.doc ++ ",\"pinned_root\":" ++ b a.pinnedRoot ++
+  ",\"terminal\":" ++ terminalJson a.terminal ++ "}"
+private def edgeJson (e : Edge) :=
+  "{\"parent\":" ++ toString e.parent ++ ",\"child\":" ++ toString e.child ++
+  ",\"authenticated\":" ++ b e.authenticated ++ "}"
+private def phaseJson : GoalAutomation.ContinuationPhase → String
+  | .unclaimed => "unclaimed" | .claimed => "claimed" | .childPresent => "child_present"
+private def goalJson : Option GoalEvidence → String
+  | none => "null"
+  | some g => "{\"status\":" ++ jsonString g.status.toDefraDB ++
+    ",\"phase\":" ++ jsonString (phaseJson g.phase) ++
+    ",\"wrapup_requested\":" ++ b g.wrapupRequested ++
+    ",\"wrapup_completed\":" ++ b g.wrapupCompleted ++ "}"
+private def outcomeName : Outcome → String
+  | .outstanding => "outstanding" | .succeeded => "succeeded" | .failed _ => "failed"
+  | .invalid => "invalid" | .limitExceeded => "limit_exceeded"
+private def tip : Outcome → Option Nat | .failed n => some n | _ => none
+private def caseJson (c : Case) :=
+  "{\"name\":" ++ jsonString c.name ++ ",\"rows\":" ++ jsonArray (c.rows.map rowJson) ++
+  ",\"edges\":" ++ jsonArray (c.edges.map edgeJson) ++ ",\"root\":" ++ toString c.root ++
+  ",\"head_binding_matches\":" ++ b c.headBindingMatches ++
+  ",\"goal\":" ++ goalJson c.goal ++ ",\"result_satisfied\":" ++ b c.resultSatisfied ++
+  ",\"max_invocations\":" ++ toString c.maximum ++ ",\"expected\":{\"outcome\":" ++
+  jsonString (outcomeName c.expected) ++ ",\"tip\":" ++ natOpt (tip c.expected) ++
+  ",\"physical_count\":" ++ toString c.physicalCount ++ "}}"
+def casesJson := jsonArray (cases.map caseJson)
+
+structure PublicationCase where
+  name : String
+  events : List PublicationEvent
+  expected : List PublicationState
+  deriving DecidableEq, Repr
+private def initial : PublicationState := ⟨GraphPipeline.FailureAttribution.initial,0⟩
+private def state (generation children : Nat) (cancel : Bool := false)
+    (primary : Option Nat := none) (status : GraphPipeline.RunStatus := .running) : PublicationState :=
+  {graph := {initial.graph with generation := generation, primary := primary, run := {initial.graph.run with cancellationRequested := cancel, status := status}}, children := children}
+def publicationCases : List PublicationCase :=
+  [ ⟨"publication_wins_stale_terminal", [.publish 0, .finish 0 90], [state 1 1, state 1 1]⟩
+  , ⟨"terminal_wins_publication", [.finish 0 90, .publish 1],
+      [state 1 0 false (some 90) .failed, state 1 0 false (some 90) .failed]⟩
+  , ⟨"latched_failure_blocks_publication", [.capture 0 90, .publish 1],
+      [state 1 0 false (some 90), state 1 0 false (some 90)]⟩
+  , ⟨"cancellation_blocks_publication", [.cancel, .publish 1], [state 1 0 true, state 1 0 true]⟩
+  , ⟨"publication_invalidates_stale_capture", [.publish 0, .capture 0 90], [state 1 1, state 1 1]⟩
+  ]
+private def trace (s : PublicationState) : List PublicationEvent → List PublicationState
+  | [] => []
+  | e::es => let next := publicationStep s e; next :: trace next es
+
+theorem publication_cases_replay : ∀ c ∈ publicationCases,
+    trace initial c.events = c.expected := by decide
+
+private def eventJson : PublicationEvent → String
+  | .cancel => "{\"kind\":\"cancel\"}"
+  | .publish n => "{\"kind\":\"publish\",\"expected_generation\":" ++ toString n ++ "}"
+  | .capture n cause => "{\"kind\":\"capture\",\"expected_generation\":" ++ toString n ++ ",\"cause\":" ++ toString cause ++ "}"
+  | .finish n cause => "{\"kind\":\"finish\",\"expected_generation\":" ++ toString n ++ ",\"cause\":" ++ toString cause ++ "}"
+private def publicationStateJson (s : PublicationState) :=
+  let observation := GraphFailureAttributionContracts.observationJson (GraphFailureAttributionContracts.observe s.graph)
+  String.mk (observation.toList.take (observation.length - 1)) ++
+    ",\"children\":" ++ toString s.children ++ "}"
+private def publicationCaseJson (c : PublicationCase) :=
+  "{\"name\":" ++ jsonString c.name ++ ",\"initial\":" ++ publicationStateJson initial ++
+  ",\"events\":" ++ jsonArray (c.events.map eventJson) ++
+  ",\"expected\":" ++ jsonArray (c.expected.map publicationStateJson) ++ "}"
+def publicationCasesJson := jsonArray (publicationCases.map publicationCaseJson)
+end Conformance.GraphLogicalInvocationContracts

--- a/crates/gents/proofs/Proofs/GraphPipeline/LogicalInvocation.lean
+++ b/crates/gents/proofs/Proofs/GraphPipeline/LogicalInvocation.lean
@@ -1,0 +1,185 @@
+import Proofs.GoalAutomation
+import Proofs.GraphPipeline.FailureAttribution
+
+/- IDs denote physical documents, not timestamps. Authentication is
+   established by the existing signed physical-edge validator. No new persisted
+   identity or Goal policy is introduced. Finite safety, not scheduler liveness. -/
+namespace GraphPipeline.LogicalInvocation
+abbrev Doc := Nat
+structure Attempt where
+  doc : Doc
+  pinnedRoot : Bool
+  terminal : Option Goals.RequestTerminal
+  deriving DecidableEq, Repr
+structure Edge where
+  parent : Doc
+  child : Doc
+  authenticated : Bool
+  deriving DecidableEq, Repr
+
+def parents (edges : List Edge) (child : Doc) : List Doc :=
+  (edges.filter (fun e => e.authenticated && e.child == child)).map Edge.parent
+
+/-- Finite paths include their root. Fuel is row count, sufficient for an
+acyclic unique-document graph; exhausted/ambiguous paths fail closed. -/
+def rootsAt (rows : List Attempt) (edges : List Edge) : Nat → Doc → List Doc
+  | 0, _ => []
+  | n+1, doc =>
+      let direct := if rows.any (fun a => a.doc == doc && a.pinnedRoot) then [doc] else []
+      direct ++ (parents edges doc).flatMap (rootsAt rows edges n)
+
+def roots (rows : List Attempt) (edges : List Edge) (doc : Doc) : List Doc :=
+  (rootsAt rows edges (rows.length + 1) doc).eraseDups
+
+def members (rows : List Attempt) (edges : List Edge) (root : Doc) : List Attempt :=
+  rows.filter (fun a => roots rows edges a.doc == [root])
+
+def ambiguous (rows : List Attempt) (edges : List Edge) : Bool :=
+  rows.any (fun a => (roots rows edges a.doc).length > 1 ||
+    (parents edges a.doc).eraseDups.length > 1)
+
+def tips (rows : List Attempt) (edges : List Edge) (root : Doc) : List Attempt :=
+  let ms := members rows edges root
+  ms.filter (fun a => !(edges.any (fun e => e.authenticated && e.parent == a.doc &&
+    ms.any (fun child => child.doc == e.child))))
+
+structure GoalEvidence where
+  status : Goals.Status
+  phase : GoalAutomation.ContinuationPhase
+  wrapupRequested : Bool
+  wrapupCompleted : Bool
+  deriving DecidableEq, Repr
+
+/-- Graph observes committed Goal ownership, never replays GoalSource's decision
+inputs or retry policy. Active includes undecided and claimed publication gaps.
+The existing graph deadline bounds an unavailable Goal owner. Caller binds this
+snapshot to the canonical physical Goal and authenticated invocation. -/
+def obligation (g : GoalEvidence) : Bool :=
+  g.status == .active ||
+    (g.status == .budgetLimited && g.wrapupRequested && !g.wrapupCompleted)
+
+inductive Outcome where
+  | outstanding | succeeded | failed (tip : Doc) | invalid | limitExceeded
+  deriving DecidableEq, Repr
+
+def project (rows : List Attempt) (edges : List Edge) (root : Doc)
+    (goal : Option GoalEvidence) (resultSatisfied : Bool) : Outcome :=
+  if ambiguous rows edges then .invalid
+  else if (members rows edges root).any (fun a => a.terminal.isNone) then .outstanding
+  else match tips rows edges root with
+  | [tip] => match tip.terminal with
+    | none => .outstanding
+    | some terminal =>
+      if goal.any obligation then .outstanding
+      else if terminal == .completed && resultSatisfied then .succeeded
+      else .failed tip.doc
+  | _ => .invalid
+
+/-- Historical ancestry survives Goal replacement. Only matching current head
+binding grants the canonical Goal's continuation obligation. -/
+def associatedGoal (goal : Option GoalEvidence) (headBindingMatches : Bool) : Option GoalEvidence :=
+  if headBindingMatches then goal else none
+
+theorem replaced_goal_does_not_grant_obligation (g : GoalEvidence) :
+    associatedGoal (some g) false = none := rfl
+
+/-- Limits count physical members, never logical chains. -/
+def projectLimited (rows : List Attempt) (edges : List Edge) (root : Doc)
+    (goal : Option GoalEvidence) (resultSatisfied : Bool) (maximum : Nat) : Outcome :=
+  if (members rows edges root).length > maximum then .limitExceeded
+  else project rows edges root goal resultSatisfied
+
+/-- This supplies the existing first-cause owner, not a second latch. -/
+def witness : Outcome → Option Nat
+  | .failed tip => some tip
+  | .invalid | .limitExceeded => some 0 -- abstract contract-drift cause, not a request ID
+  | _ => none
+
+def capture (s : FailureAttribution.Snapshot) (expected : Nat) (o : Outcome) :=
+  FailureAttribution.capture s expected (witness o)
+
+theorem outstanding_has_no_failure : witness .outstanding = none := rfl
+
+theorem successful_has_no_failure : witness .succeeded = none := rfl
+
+theorem outstanding_cannot_latch (s : FailureAttribution.Snapshot) (n : Nat) :
+    capture s n .outstanding = s := by
+  simp [capture, witness, FailureAttribution.capture]
+
+private def root : Attempt := ⟨10, true, some .failed⟩
+private def child : Attempt := ⟨20, false, some .completed⟩
+private def edge : Edge := ⟨10, 20, true⟩
+private def active : GoalEvidence := ⟨.active, .unclaimed, false, false⟩
+private def complete : GoalEvidence := { active with status := .complete }
+
+theorem active_goal_defers_failed_root :
+    project [root] [] 10 (some active) false = .outstanding := by decide
+
+theorem claimed_gap_stays_outstanding :
+    project [root] [] 10 (some {active with phase := .claimed}) false = .outstanding := by decide
+
+theorem completed_descendant_heals_physical_failure :
+    project [root, child] [edge] 10 (some complete) true = .succeeded := by decide
+
+theorem failed_without_goal_is_immediate :
+    project [root] [] 10 none false = .failed 10 := by decide
+
+theorem unauthenticated_candidate_cannot_heal :
+    project [root, child] [{edge with authenticated := false}] 10 none true = .failed 10 := by decide
+
+theorem paused_failed_tip_cannot_succeed_from_result :
+    project [root, {child with terminal := some .failed}] [edge] 10
+      (some {active with status := .paused}) true = .failed 20 := by decide
+
+theorem pending_descendant_stays_outstanding :
+    project [root, {child with terminal := none}] [edge] 10 (some complete) true = .outstanding := by decide
+
+theorem physical_counts_do_not_collapse :
+    (members [root, child] [edge] 10).length = 2 := by decide
+
+theorem two_authenticated_roots_fail_closed :
+    project [root, {root with doc := 30}, child] [edge, ⟨30,20,true⟩]
+      10 none true = .invalid := by decide
+
+/-- Existing GraphRun key is the shared write witness. `children` represents
+new pending physical rows in the same transaction, not a persisted authority.
+This model assumes same-store write conflict; scans provide no phantom fence.
+Fresh unassociated Goal/root discovery is explicitly outside this refinement. -/
+structure PublicationState where
+  graph : FailureAttribution.Snapshot
+  children : Nat
+  deriving DecidableEq, Repr
+
+def publish (s : PublicationState) (expected : Nat) : PublicationState :=
+  if s.graph.run.status = .running ∧ s.graph.run.cancellationRequested = false ∧
+      s.graph.primary = none ∧ s.graph.generation = expected then
+    { s with graph := {s.graph with generation := expected + 1}
+             children := s.children + 1 }
+  else s
+
+inductive PublicationEvent where
+  | publish (expected : Nat)
+  | capture (expected cause : Nat)
+  | finish (expected cause : Nat)
+  | cancel
+  deriving DecidableEq, Repr
+
+def publicationStep (s : PublicationState) : PublicationEvent → PublicationState
+  | .publish n => publish s n
+  | .capture n cause => {s with graph := FailureAttribution.capture s.graph n (some cause)}
+  | .finish n cause => {s with graph := FailureAttribution.finish s.graph n (s.children == 0) (some cause)}
+  | .cancel => {s with graph := FailureAttribution.requestCancel s.graph}
+
+theorem stale_publication_noop (s : PublicationState) (n : Nat)
+    (h : s.graph.generation ≠ n) : publish s n = s := by
+  simp [publish, h]
+
+theorem captured_failure_blocks_publication (s : PublicationState) (n : Nat)
+    (h : s.graph.primary ≠ none) : publish s n = s := by
+  simp [publish, h]
+
+theorem cancellation_blocks_publication (s : PublicationState) (n : Nat)
+    (h : s.graph.run.cancellationRequested = true) : publish s n = s := by
+  simp [publish, h]
+
+end GraphPipeline.LogicalInvocation

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -220,6 +220,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/ManagedExec.lean` | Barrel for managed native executor state, executable transitions, liveness properties, and tool composition |
 | `Proofs/GraphPipeline.lean` | Model-callable graph publication and run lifecycle: validation/materialization gates, active-pointer alignment, immutable revision identity, atomic seed/run start, cancellation suppression, result-commit-gated success, and terminal CAS safety |
 | `Proofs/GraphPipeline/FailureAttribution.lean` | Existing GraphRun transaction refinement: capture the first durable failure before interrupting siblings, preserve it through drain/restart, reject stale generation writes, and retain explicit cancellation precedence. “First” means the first committed fail-fast decision; evidence discovery and logical continuation eligibility remain separate inputs. |
+| `Proofs/GraphPipeline/LogicalInvocation.lean` | Derived authenticated physical ancestry, conservative committed Goal obligations, logical tip outcome and physical limits; existing GraphRun publication generation fence. Fifteen projection cases and five publication traces are consumed by real signed-row and transaction tests. |
 | `Proofs/PromptAssembly/` | Provider-view sanitation and prompt assembly, per-turn context budgeting, and the request-wide aggregate token ledger. Fences: generated cases consumed by `agent::loop_stream::tests`. |
 | `Proofs/P2PBackpressure.lean` | Obligation model (no conformance bridge): success-ack backing, pending-DAG capacity, strict push-slot release on timeout |
 | `Proofs/PeerRegistryDiscovery/DirectoryProjection.lean` | Agent directory projection (machine index v1): source-owned membership, foreign-row preservation, idempotent convergence, write-free settled fixpoint, retraction soundness. Fence: `tests/conformance/directory_projection.rs`. |
@@ -1138,3 +1139,41 @@ and child in the same existing transaction, even though the modeled Goal fields
 remain unchanged. Eight explicit conformance cases accompany the general laws.
 The older claimed-phase convergence theorem assumes publication remains
 authorized; a historical claim alone cannot override a later pause.
+
+### Graph logical invocation boundary (#1357)
+
+The logical identity is the authenticated pinned root; no invocation row is added.
+Active Goals and unfinished BudgetLimited wrap-up defer graph completion. Graph
+does not duplicate GoalSource retry/activity/budget decisions. An unsuccessful
+tip cannot succeed merely because results exist. Physical descendants still
+count individually. Authentication booleans in the model must be discharged by
+real signed-row consumers, including physical parent, owner and pinned route.
+
+Publication and terminal/failure transactions write the existing GraphRun key.
+This refinement assumes same-native-store write conflict validation; scans do
+not establish predicate/phantom protection, and independent replicas do not gain
+consensus. Fresh unassociated Goal/first-root discovery and Goal-creation
+association policy remain explicit unresolved boundaries, not proven fixed by
+this model. Finite path/case proofs establish safety for admitted identities and
+edges, not provider progress or scheduler fairness.
+
+Ambiguous multiple-root input remains a fail-closed abstract theorem. It is not
+an emitted DB fixture: one immutable child row cannot authenticate two distinct
+physical parents. The branching-tip case uses two independently signed historical
+Goal identities; distinct retry keys make both physical children representable.
+
+The generated `graph_logical_invocation_cases` consumer exercises persisted
+signed roots/children and reads the actual GraphRun projection. Its historical
+head case verifies that canonical Goal replacement cannot relabel a root ahead
+of its same-second child; the emitted association guard abstracts that validated
+binding and does not prove signature verification itself. The generated
+`graph_invocation_publication_cases` consumer drives the existing publication,
+capture, cancellation and terminal transaction owners and reads durable state.
+
+`overlapping_native_graph_publication_and_closure_conflict_atomically` additionally
+opens two native handles before either commits, bypassing only the local gents
+mutation gate. Both match the same GraphRun generation; in both commit orders
+the loser reports a storage transaction conflict and only the winner's child
+effect survives. This establishes the tested same-store owner-key conflict
+mechanism, not absent-range protection or cross-replica consensus. Caller tests
+separately cover typed resume, automatic continuation and fresh Goal opening.

--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -16,7 +16,10 @@ mod operator_resume;
 mod request_head;
 pub(crate) use claimed_publication::publish_claimed_continuation;
 pub use operator_resume::{resume_goal_request, GoalResumeReceipt};
-pub(crate) use request_head::{goal_session_is_idle, latest_goal_request};
+pub(crate) use request_head::{
+    goal_session_is_idle, latest_authenticated_session_request, latest_goal_request,
+    verify_goal_continuation_edge,
+};
 
 pub const GOAL_TRIGGER_KIND: &str = "goal";
 pub const GET_GOAL_TOOL_NAME: &str = "get_goal";
@@ -278,6 +281,15 @@ pub struct GoalState {
 }
 
 impl GoalState {
+    /// Committed continuation ownership observed by graph projection/publication.
+    /// Active includes the gap before GoalSource decides or publishes a child.
+    pub(crate) fn has_continuation_obligation(self) -> bool {
+        self.status == GoalStatus::Active
+            || (self.status == GoalStatus::BudgetLimited
+                && self.wrapup_requested
+                && !self.wrapup_completed)
+    }
+
     /// Executable mirror of `Goals.step?` in `proofs/Proofs/Goals.lean`.
     pub fn step(self, action: GoalAction) -> Option<Self> {
         match action {
@@ -833,6 +845,67 @@ struct StagedGoal {
 /// immutable creation claim. Ownership, objective/budget conflict semantics,
 /// deterministic identity, and physical-create arbitration stay single-owned
 /// for every create-only path.
+/// Opening an obligation on an already rooted session participates in the
+/// GraphRun owner's existing transaction fence. Initial graph root + Goal
+/// publication fences its root separately in the same factory transaction.
+/// Arbitrary independent pre-root Goal creation across HTTP transactions is
+/// not a supported posthoc association guarantee: absent scans do not conflict.
+async fn fence_opened_graph_goal_in_txn(
+    txn: &crate::config_client::ConfigApplyTxn<'_>,
+    previous: Option<GoalState>,
+    goal: &GoalDocument,
+) -> Result<()> {
+    let current = goal
+        .state()
+        .context("graph Goal opening has unknown status")?;
+    if !current.has_continuation_obligation()
+        || previous.is_some_and(GoalState::has_continuation_obligation)
+    {
+        return Ok(());
+    }
+    let did = escape_graphql_string(&goal.agent_did);
+    let session = escape_graphql_string(&goal.session_id);
+    let fields = crate::request_admission::SIGNED_REQUEST_FIELDS;
+    let response = txn
+        .execute(&format!(
+            r#"{{ AgentRequest(filter: {{
+        agent_did: {{ _eq: "{did}" }}, session_id: {{ _eq: "{session}" }}
+    }}, order: [{{ created_at: DESC }}, {{ request_id: DESC }}]) {{ {fields} }} }}"#
+        ))
+        .await?;
+    let requests: Vec<gents_protocol::row::AgentRequestRow> = serde_json::from_value(
+        response
+            .pointer("/data/AgentRequest")
+            .cloned()
+            .context("Goal opening request query omitted rows")?,
+    )?;
+    let Some(head) =
+        latest_authenticated_session_request(&goal.agent_did, &goal.session_id, &requests)
+    else {
+        return Ok(());
+    };
+    if head.caused_by_trigger_kind.as_deref() == Some(GOAL_TRIGGER_KIND)
+        && head.caused_by_trigger_id.as_deref() != Some(goal.goal_id.as_str())
+    {
+        return Ok(());
+    }
+    let head_doc = head
+        .doc_id
+        .as_deref()
+        .context("Goal opening head has no physical document ID")?;
+    if let Some(binding) =
+        crate::graph_pipeline::graph_binding_for_request_in_txn(txn, head_doc).await?
+    {
+        crate::graph_pipeline::fence_graph_publication_in_txn(
+            txn,
+            &binding.run_id,
+            &binding.revision_digest,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
 async fn stage_goal_and_claim(
     txn: &crate::config_client::ConfigApplyTxn<'_>,
     agent_did: &str,
@@ -977,7 +1050,7 @@ async fn stage_goal_and_claim(
         escape_graphql_string(now),
     ))
     .await?;
-    Ok(StagedGoal {
+    let staged = StagedGoal {
         disposition: StagedGoalDisposition::Created,
         goal: GoalDocument {
             doc_id: String::new(),
@@ -1003,7 +1076,9 @@ async fn stage_goal_and_claim(
             created_at: Some(now.to_string()),
             updated_at: Some(now.to_string()),
         },
-    })
+    };
+    fence_opened_graph_goal_in_txn(txn, None, &staged.goal).await?;
+    Ok(staged)
 }
 
 /// Create the current principal/session goal without granting update semantics.
@@ -1427,6 +1502,7 @@ async fn stage_goal_backed_request(
         staged_goal.goal.parsed_status() == Some(GoalStatus::Active),
         "the session already has a non-active goal"
     );
+    crate::graph_pipeline::fence_graph_root_request_in_txn(txn, request).await?;
     let request_fields = request.graphql_input_fields().map_err(anyhow::Error::msg)?;
     txn.execute(&format!(
         "mutation {{ create_AgentRequest(input: {{ {request_fields} }}) {{ _docID }} }}"
@@ -1887,7 +1963,7 @@ pub async fn load_goal_by_id(
     Ok(goals.into_iter().next())
 }
 
-fn sort_goals_canonical(goals: &mut [GoalDocument]) {
+pub(crate) fn sort_goals_canonical(goals: &mut [GoalDocument]) {
     goals.sort_by(|left, right| {
         left.created_at
             .cmp(&right.created_at)
@@ -2046,9 +2122,11 @@ async fn set_goal_in_txn(
             wrapup_completed = post.wrapup_completed,
         );
         txn.execute(&mutation).await?;
-        return load_canonical_goal_in_txn(txn, agent_did, session_id)
+        let updated = load_canonical_goal_in_txn(txn, agent_did, session_id)
             .await?
-            .context("updated Goal row disappeared");
+            .context("updated Goal row disappeared")?;
+        fence_opened_graph_goal_in_txn(txn, Some(pre), &updated).await?;
+        return Ok(updated);
     }
 
     let initial_state = GoalState {
@@ -2104,9 +2182,11 @@ async fn set_goal_in_txn(
         wrapup_completed = initial_state.wrapup_completed,
     );
     txn.execute(&mutation).await?;
-    load_canonical_goal_in_txn(txn, agent_did, session_id)
+    let created = load_canonical_goal_in_txn(txn, agent_did, session_id)
         .await?
-        .context("created Goal row not found")
+        .context("created Goal row not found")?;
+    fence_opened_graph_goal_in_txn(txn, None, &created).await?;
+    Ok(created)
 }
 
 pub async fn delete_goal(node: &EmbeddedNode, goal: &GoalDocument) -> Result<bool> {

--- a/crates/gents/src/goal/claimed_publication.rs
+++ b/crates/gents/src/goal/claimed_publication.rs
@@ -158,6 +158,23 @@ async fn stage_claimed_continuation(
         return Ok(None);
     }
     sign_request(&mut create, RequestSigner::Identity(identity)).await?;
+    if let Some(binding) = crate::graph_pipeline::graph_binding_for_request_in_txn(
+        txn,
+        parent_row
+            .doc_id
+            .as_deref()
+            .context("goal predecessor lacks document ID")?,
+    )
+    .await?
+    {
+        crate::graph_pipeline::fence_graph_publication_in_txn(
+            txn,
+            &binding.run_id,
+            &binding.revision_digest,
+        )
+        .await?;
+    }
+
     let doc_id = escape_graphql_string(&goal.doc_id);
     let status = escape_graphql_string(&goal.status);
     let parent_id = escape_graphql_string(parent_request_id);

--- a/crates/gents/src/goal/operator_resume.rs
+++ b/crates/gents/src/goal/operator_resume.rs
@@ -157,6 +157,23 @@ async fn stage_resume(
         &created_at,
     )?;
     sign_request(&mut create, RequestSigner::Identity(identity)).await?;
+    if let Some(binding) = crate::graph_pipeline::graph_binding_for_request_in_txn(
+        txn,
+        parent_row
+            .doc_id
+            .as_deref()
+            .context("goal predecessor lacks document ID")?,
+    )
+    .await?
+    {
+        crate::graph_pipeline::fence_graph_publication_in_txn(
+            txn,
+            &binding.run_id,
+            &binding.revision_digest,
+        )
+        .await?;
+    }
+
     let doc_id = escape_graphql_string(&goal.doc_id);
     let expected_status = escape_graphql_string(&goal.status);
     let expected_sequence = goal.continuation_sequence();

--- a/crates/gents/src/goal/request_head.rs
+++ b/crates/gents/src/goal/request_head.rs
@@ -9,15 +9,17 @@ use gents_protocol::row::AgentRequestRow;
 /// Authenticate causal ancestry independently of the current producer defaults.
 /// Historical children can have different inherited optional fields; their
 /// original target signature still binds the exact physical predecessor.
-fn verify_goal_continuation_edge(
-    goal: &GoalDocument,
+pub(crate) fn verify_goal_continuation_edge(
+    agent_did: &str,
+    session_id: &str,
+    goal_id: &str,
     parent_row: &AgentRequestRow,
     child: &AgentRequestRow,
 ) -> Result<(i64, bool)> {
     anyhow::ensure!(
-        parent_row.agent_did.as_deref() == Some(goal.agent_did.as_str())
-            && parent_row.session_id.as_deref() == Some(goal.session_id.as_str())
-            && child.session_id.as_deref() == Some(goal.session_id.as_str()),
+        parent_row.agent_did.as_deref() == Some(agent_did)
+            && parent_row.session_id.as_deref() == Some(session_id)
+            && child.session_id.as_deref() == Some(session_id),
         "continuation predecessor is outside the goal owner/session"
     );
     verify_request_receipt_signature(parent_row)?;
@@ -25,7 +27,7 @@ fn verify_goal_continuation_edge(
         .doc_id
         .as_deref()
         .context("continuation predecessor has no document ID")?;
-    verify_runtime_local_control_receipt(child, &goal.agent_did, &parent_row.request_id)?;
+    verify_runtime_local_control_receipt(child, agent_did, &parent_row.request_id)?;
     anyhow::ensure!(
         child.caused_by_parent_request_doc_id.as_deref() == Some(parent_doc)
             && child
@@ -33,7 +35,7 @@ fn verify_goal_continuation_edge(
                 .as_deref()
                 .is_some_and(|id| !id.is_empty() && id != parent_doc)
             && child.caused_by_trigger_kind.as_deref() == Some(GOAL_TRIGGER_KIND)
-            && child.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str()),
+            && child.caused_by_trigger_id.as_deref() == Some(goal_id),
         "continuation receipt has a different physical goal edge"
     );
     let metadata: serde_json::Value = serde_json::from_str(
@@ -46,7 +48,7 @@ fn verify_goal_continuation_edge(
         metadata
             .pointer("/goal/goal_id")
             .and_then(serde_json::Value::as_str)
-            == Some(goal.goal_id.as_str())
+            == Some(goal_id)
             && metadata
                 .pointer("/goal/parent_request_id")
                 .and_then(serde_json::Value::as_str)
@@ -57,7 +59,7 @@ fn verify_goal_continuation_edge(
         .pointer("/goal/continuation_sequence")
         .and_then(serde_json::Value::as_i64)
         .context("continuation receipt lacks its original sequence")?;
-    let identity = goal_continuation_identity(&goal.goal_id, &parent_row.request_id, sequence)?;
+    let identity = goal_continuation_identity(goal_id, &parent_row.request_id, sequence)?;
     anyhow::ensure!(
         child.request_id == identity.request_id
             && child.retry_key.as_deref() == Some(identity.retry_key.as_str()),
@@ -75,7 +77,13 @@ pub(super) fn verify_goal_continuation_receipt(
     parent_row: &AgentRequestRow,
     child: &AgentRequestRow,
 ) -> Result<()> {
-    let (sequence, wrapup) = verify_goal_continuation_edge(goal, parent_row, child)?;
+    let (sequence, wrapup) = verify_goal_continuation_edge(
+        &goal.agent_did,
+        &goal.session_id,
+        &goal.goal_id,
+        parent_row,
+        child,
+    )?;
     let parent = crate::watcher::AgentRequest::try_from(parent_row.clone())?;
     let behavior = parent
         .behavior_id
@@ -112,19 +120,47 @@ pub(crate) fn latest_goal_request<'a>(
     goal: &GoalDocument,
     rows: &'a [AgentRequestRow],
 ) -> Option<&'a AgentRequestRow> {
+    latest_scoped_request(&goal.agent_did, &goal.session_id, Some(&goal.goal_id), rows)
+}
+
+/// Preserve original signed physical ancestry across canonical Goal replacement.
+/// Association with a current Goal is checked separately by the graph owner.
+pub(crate) fn latest_authenticated_session_request<'a>(
+    agent_did: &str,
+    session_id: &str,
+    rows: &'a [AgentRequestRow],
+) -> Option<&'a AgentRequestRow> {
+    latest_scoped_request(agent_did, session_id, None, rows)
+}
+
+fn latest_scoped_request<'a>(
+    agent_did: &str,
+    session_id: &str,
+    goal_id: Option<&str>,
+    rows: &'a [AgentRequestRow],
+) -> Option<&'a AgentRequestRow> {
     let in_scope = |row: &&AgentRequestRow| {
-        row.agent_did.as_deref() == Some(goal.agent_did.as_str())
-            && row.session_id.as_deref() == Some(goal.session_id.as_str())
+        row.agent_did.as_deref() == Some(agent_did) && row.session_id.as_deref() == Some(session_id)
     };
     rows.iter().filter(in_scope).find(|parent| {
         !rows.iter().filter(in_scope).any(|child| {
+            let Some(original_goal_id) = child.caused_by_trigger_id.as_deref() else {
+                return false;
+            };
             parent.doc_id.is_some()
                 && child.doc_id != parent.doc_id
                 && child.caused_by_parent_request_doc_id == parent.doc_id
                 && child.caused_by_parent_request_id.as_deref() == Some(parent.request_id.as_str())
                 && child.caused_by_trigger_kind.as_deref() == Some(GOAL_TRIGGER_KIND)
-                && child.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str())
-                && verify_goal_continuation_edge(goal, parent, child).is_ok()
+                && goal_id.is_none_or(|expected| expected == original_goal_id)
+                && verify_goal_continuation_edge(
+                    agent_did,
+                    session_id,
+                    original_goal_id,
+                    parent,
+                    child,
+                )
+                .is_ok()
         })
     })
 }

--- a/crates/gents/src/graph_pipeline/attribution_contract_tests.rs
+++ b/crates/gents/src/graph_pipeline/attribution_contract_tests.rs
@@ -83,18 +83,13 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
             // A third live row allows the lower lexical failed sibling to be
             // observed while real active work still prevents terminal commit.
             for id in ["a-cause", "z-cause", "m-drain-sentinel"] {
-                execute_fixture(
+                super::super::runtime::seed_signed_graph_request(
                     &node,
-                    format!(
-                        r#"mutation {{ create_AgentRequest(input: {{
-                    request_id: "{id}", agent_did: "did:key:worker", requester_did: "did:key:owner",
-                    behavior_id: "worker-v1", lifecycle_state: "processing",
-                    caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                    created_at: "2026-08-25T00:00:00Z"
-                }}) {{ _docID }} }}"#,
-                        escape_graphql_string(&trigger),
-                        escape_graphql_string(&run.correlation)
-                    ),
+                    &run,
+                    &trigger,
+                    id,
+                    "processing",
+                    "",
                 )
                 .await;
             }

--- a/crates/gents/src/graph_pipeline/logical_invocation.rs
+++ b/crates/gents/src/graph_pipeline/logical_invocation.rs
@@ -1,0 +1,218 @@
+//! Derive logical invocations from authenticated physical request ancestry.
+//! Goal remains the continuation owner; this projection observes its committed
+//! obligation without replaying retry, activity, or budget decisions.
+use super::*;
+use crate::goal::{GoalDocument, GOAL_FIELDS};
+use crate::request_admission::{verify_request_receipt_signature, SIGNED_REQUEST_FIELDS};
+
+pub(super) struct Invocation {
+    pub root_request_id: String,
+    pub member_doc_ids: BTreeSet<String>,
+    pub node_id: String,
+    pub tip: Option<GraphRunRequestView>,
+    pub outstanding: bool,
+    pub invalid: bool,
+}
+
+pub(super) struct Projection {
+    pub requests: Vec<GraphRunRequestView>,
+    pub invocations: Vec<Invocation>,
+}
+
+fn request_view(row: &AgentRequestRow, node_id: Option<String>) -> GraphRunRequestView {
+    GraphRunRequestView {
+        request_id: row.request_id.clone(),
+        session_id: row.session_id.clone(),
+        node_id,
+        behavior_id: row.behavior_id.clone().unwrap_or_default(),
+        lifecycle_state: row.lifecycle_state.map(|state| state.as_str().to_owned()),
+        failure_reason: row.failure_reason.clone(),
+        terminal: row
+            .lifecycle_state
+            .is_some_and(RequestLifecycleState::is_terminal),
+        succeeded: row.lifecycle_state == Some(RequestLifecycleState::Completed),
+    }
+}
+
+fn authentic_root(row: &AgentRequestRow) -> bool {
+    let Some(target) = row.agent_did.as_deref().filter(|s| !s.is_empty()) else {
+        return false;
+    };
+    verify_request_receipt_signature(row).is_ok()
+        && row.doc_id.as_deref().is_some_and(|id| !id.is_empty())
+        && row.session_id.as_deref().is_some_and(|id| !id.is_empty())
+        && row.admission_kind.as_deref() == Some("runtime-internal")
+        && row.runtime_source_kind.as_deref() == Some("automated-trigger")
+        && row.admission_signer_did.as_deref() == Some(target)
+        && row.runtime_issuer_did.as_deref() == Some(target)
+        && row.requester_did.as_deref() == Some(target)
+        && row.runtime_source_request_id == row.caused_by_trigger_id
+        // Historical seal coherence from automated-trigger admission. Current
+        // trigger/task existence and enablement belong to fresh admission only.
+        && matches!(row.caused_by_trigger_kind.as_deref(), Some("event" | "schedule"))
+        && row.caused_by_trigger_doc_id.as_deref().is_some_and(|id| !id.is_empty())
+}
+
+pub(super) async fn load(
+    executor: &(impl GraphRunQuery + ?Sized),
+    correlation: &str,
+    plan: &GraphPlan,
+) -> Result<Projection> {
+    let routes = planned_trigger_nodes(plan)?;
+    let response = executor
+        .execute_graph_query(&format!(
+            r#"{{ AgentRequest(filter: {{ caused_by_correlation: {{ _eq: "{}" }},
+        caused_by_trigger_id: {{ _in: {} }} }}) {{ {SIGNED_REQUEST_FIELDS} failure_reason }} }}"#,
+            escape_graphql_string(correlation),
+            graphql_string_list_literal(&routes.keys().cloned().collect::<Vec<_>>()),
+        ))
+        .await?;
+    let root_rows: Vec<AgentRequestRow> =
+        serde_json::from_value(Value::Array(rows(&response, "AgentRequest").to_vec()))?;
+    let mut physical = BTreeMap::<String, GraphRunRequestView>::new();
+    let mut invocations = Vec::new();
+    let mut sessions = BTreeMap::new();
+    for root in &root_rows {
+        let node_id = routes
+            .get(root.caused_by_trigger_id.as_deref().unwrap_or_default())
+            .context("selected graph route is absent from pinned plan")?
+            .clone();
+        if !authentic_root(root) {
+            physical.insert(
+                root.doc_id
+                    .clone()
+                    .unwrap_or_else(|| root.request_id.clone()),
+                request_view(root, None),
+            );
+            continue;
+        }
+        let owner = root.agent_did.as_deref().unwrap();
+        let session = root.session_id.as_deref().unwrap();
+        let key = (owner.to_owned(), session.to_owned());
+        if !sessions.contains_key(&key) {
+            let response = executor.execute_graph_query(&format!(
+                r#"{{ AgentRequest(filter: {{ agent_did: {{ _eq: "{}" }},
+                session_id: {{ _eq: "{}" }} }},
+                order: [{{ created_at: DESC }}, {{ request_id: DESC }}]) {{ {SIGNED_REQUEST_FIELDS} failure_reason }}
+                Goal(filter: {{ agent_did: {{ _eq: "{}" }}, session_id: {{ _eq: "{}" }} }}) {{ {GOAL_FIELDS} }} }}"#,
+                escape_graphql_string(owner), escape_graphql_string(session),
+                escape_graphql_string(owner), escape_graphql_string(session),
+            )).await?;
+            let requests: Vec<AgentRequestRow> =
+                serde_json::from_value(Value::Array(rows(&response, "AgentRequest").to_vec()))?;
+            let mut goals: Vec<GoalDocument> =
+                serde_json::from_value(Value::Array(rows(&response, "Goal").to_vec()))?;
+            crate::goal::sort_goals_canonical(&mut goals);
+            sessions.insert(key.clone(), (requests, goals.into_iter().next()));
+        }
+        let (requests, goal) = &sessions[&key];
+        let root_doc = root.doc_id.as_deref().unwrap();
+        let mut members = BTreeSet::from([root_doc.to_owned()]);
+        let mut parents = BTreeMap::<String, String>::new();
+        let mut invalid = false;
+        // Finite monotone closure; no timestamp ordering enters ancestry.
+        for _ in 0..requests.len() {
+            let mut changed = false;
+            for child in requests {
+                let Some(parent_doc) = child.caused_by_parent_request_doc_id.as_deref() else {
+                    continue;
+                };
+                if !members.contains(parent_doc) {
+                    continue;
+                }
+                let Some(child_doc) = child.doc_id.as_deref() else {
+                    continue;
+                };
+                let Some(goal_id) = child.caused_by_trigger_id.as_deref() else {
+                    continue;
+                };
+                let Some(parent) = requests
+                    .iter()
+                    .find(|r| r.doc_id.as_deref() == Some(parent_doc))
+                else {
+                    continue;
+                };
+                if crate::goal::verify_goal_continuation_edge(
+                    owner, session, goal_id, parent, child,
+                )
+                .is_err()
+                {
+                    continue;
+                }
+                if child_doc == root_doc
+                    || root_rows
+                        .iter()
+                        .any(|r| r.doc_id.as_deref() == Some(child_doc))
+                {
+                    invalid = true;
+                }
+                if parents.get(child_doc).is_some_and(|p| p != parent_doc) {
+                    invalid = true;
+                }
+                parents.insert(child_doc.to_owned(), parent_doc.to_owned());
+                changed |= members.insert(child_doc.to_owned());
+            }
+            if !changed {
+                break;
+            }
+        }
+        let member_rows = requests
+            .iter()
+            .filter(|r| r.doc_id.as_ref().is_some_and(|id| members.contains(id)))
+            .collect::<Vec<_>>();
+        let tips = member_rows
+            .iter()
+            .filter(|r| {
+                !parents
+                    .values()
+                    .any(|p| Some(p.as_str()) == r.doc_id.as_deref())
+            })
+            .collect::<Vec<_>>();
+        let physically_active = member_rows.iter().any(|r| {
+            !r.lifecycle_state
+                .is_some_and(RequestLifecycleState::is_terminal)
+        });
+        invalid |= !physically_active && tips.len() != 1;
+        let obligation = goal.as_ref().is_some_and(|goal| {
+            let open = goal
+                .state()
+                .is_some_and(crate::goal::GoalState::has_continuation_obligation);
+            open && crate::goal::latest_authenticated_session_request(owner, session, requests)
+                .is_some_and(|head| {
+                    head.doc_id.as_ref().is_some_and(|id| members.contains(id))
+                        && (head.caused_by_trigger_kind.as_deref() != Some("goal")
+                            || head.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str()))
+                })
+        });
+        let outstanding = obligation || physically_active;
+        for row in &member_rows {
+            let doc = row.doc_id.as_ref().unwrap();
+            if physical.contains_key(doc) {
+                invalid = true;
+            }
+            physical.insert(doc.clone(), request_view(row, Some(node_id.clone())));
+        }
+        invocations.push(Invocation {
+            root_request_id: root.request_id.clone(),
+            member_doc_ids: members,
+            node_id,
+            tip: tips.first().map(|r| {
+                request_view(
+                    r,
+                    routes
+                        .get(root.caused_by_trigger_id.as_deref().unwrap())
+                        .cloned(),
+                )
+            }),
+            outstanding,
+            invalid,
+        });
+    }
+    let mut requests = physical.into_values().collect::<Vec<_>>();
+    requests.sort_by(|a, b| a.request_id.cmp(&b.request_id));
+    invocations.sort_by(|a, b| a.root_request_id.cmp(&b.root_request_id));
+    Ok(Projection {
+        requests,
+        invocations,
+    })
+}

--- a/crates/gents/src/graph_pipeline/logical_invocation_contract_tests.rs
+++ b/crates/gents/src/graph_pipeline/logical_invocation_contract_tests.rs
@@ -1,0 +1,885 @@
+//! Real persisted graph invocations; request signatures use the actual target key.
+use super::*;
+use crate::goal::{set_goal, GoalStatus};
+use crate::identity::{AgentIdentity, KeyIdentity};
+use crate::request_admission::SIGNED_REQUEST_FIELDS;
+use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
+
+pub(super) async fn execute(node: &defra_node::EmbeddedNode, query: &str) -> serde_json::Value {
+    let response = node.execute(query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    response.data.unwrap()
+}
+
+pub(super) async fn signed_invocation_fixture(
+    max_invocations: u32,
+) -> (
+    std::sync::Arc<defra_node::EmbeddedNode>,
+    GraphRunReceipt,
+    crate::goal::GoalDocument,
+    KeyIdentity,
+    tempfile::TempDir,
+) {
+    let (node, run, trigger) = runtime::attribution_test_fixture(max_invocations).await;
+    let temp = tempfile::tempdir().unwrap();
+    let identity = KeyIdentity::load_or_create(temp.path().join("worker.key"), None).unwrap();
+    let goal = set_goal(
+        &node,
+        identity.did(),
+        "logical-session",
+        Some("Finish the report"),
+        Some(GoalStatus::Active),
+        Some(Some(1000)),
+    )
+    .await
+    .unwrap();
+    let mut root = AgentRequestCreate::base(
+        "graph-logical-root",
+        identity.did(),
+        identity.did(),
+        "test-behavior",
+        "logical-session",
+        "Produce the report",
+        "scheduled",
+        "2026-08-25T00:00:00Z",
+        AgentRequestAdmissionRecord::runtime_automated_trigger(identity.did(), &trigger),
+    );
+    let trigger_rows = execute(
+        &node,
+        &format!(
+            r#"{{ EventTrigger(filter: {{ trigger_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+            crate::graphql::escape_graphql_string(&trigger)
+        ),
+    )
+    .await;
+    root.caused_by_trigger_doc_id = Some(
+        trigger_rows["EventTrigger"][0]["_docID"]
+            .as_str()
+            .unwrap()
+            .into(),
+    );
+    root.caused_by_trigger_id = Some(trigger);
+    root.caused_by_trigger_kind = Some("event".into());
+    root.caused_by_correlation = Some(run.correlation.clone());
+    root.caused_by_source_doc_id = Some(run.seed_doc_id.clone());
+    crate::sign_agent_request_create(&identity, &mut root)
+        .await
+        .unwrap();
+    execute(&node, &root.graphql_mutation().unwrap()).await;
+    execute(&node, r#"mutation { update_AgentRequest(filter: { request_id: { _eq: "graph-logical-root" } }, input: { lifecycle_state: "failed", failure_reason: "provider turn budget exhausted" }) { _docID } }"#).await;
+
+    let persisted = persisted_requests(&node).await;
+    assert_eq!(persisted.len(), 1);
+    crate::request_admission::verify_request_receipt_signature(&persisted[0]).unwrap();
+    assert_eq!(
+        persisted[0].caused_by_trigger_doc_id,
+        root.caused_by_trigger_doc_id
+    );
+    (node, run, goal, identity, temp)
+}
+
+#[tokio::test]
+async fn failed_graph_root_with_active_goal_remains_running_without_failure_latch() {
+    let (node, run, goal, _identity, _temp) = signed_invocation_fixture(3).await;
+    let view = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        view.status, "running",
+        "an active Goal keeps its logical invocation outstanding"
+    );
+    assert!(
+        view.error.is_none(),
+        "a physical predecessor failure is not a terminal logical failure"
+    );
+    let durable = execute(&node, &format!("{{ GraphRun {{ status error }} Goal {{ goal_id status }} AgentRequest {{ {SIGNED_REQUEST_FIELDS} }} }}")).await;
+    assert_eq!(durable["GraphRun"][0]["status"], "running");
+    assert!(durable["GraphRun"][0]["error"].is_null());
+    assert_eq!(durable["Goal"][0]["goal_id"], goal.goal_id);
+    assert_eq!(durable["Goal"][0]["status"], "active");
+    assert_eq!(durable["AgentRequest"][0]["lifecycle_state"], "failed");
+    let row: gents_protocol::row::AgentRequestRow =
+        serde_json::from_value(durable["AgentRequest"][0].clone()).unwrap();
+    crate::request_admission::verify_request_receipt_signature(&row).unwrap();
+    node.shutdown().await;
+}
+
+async fn persisted_requests(
+    node: &defra_node::EmbeddedNode,
+) -> Vec<gents_protocol::row::AgentRequestRow> {
+    let value = execute(
+        node,
+        &format!("{{ AgentRequest {{ {SIGNED_REQUEST_FIELDS} }} }}"),
+    )
+    .await;
+    serde_json::from_value(value["AgentRequest"].clone()).unwrap()
+}
+
+pub(super) async fn prepare_signed_child(
+    node: &defra_node::EmbeddedNode,
+    identity: &KeyIdentity,
+    goal: &crate::goal::GoalDocument,
+    variant: &str,
+) -> AgentRequestCreate {
+    let root = persisted_requests(node)
+        .await
+        .into_iter()
+        .find(|row| row.request_id == "graph-logical-root")
+        .unwrap();
+    crate::request_admission::verify_request_receipt_signature(&root).unwrap();
+    let mut parent = crate::watcher::AgentRequest::try_from(root).unwrap();
+    let foreign_temp = tempfile::tempdir().unwrap();
+    let foreign =
+        KeyIdentity::load_or_create(foreign_temp.path().join("foreign.key"), None).unwrap();
+    let signer = if variant == "wrong_child_owner" {
+        parent.agent_did = foreign.did().to_owned();
+        &foreign
+    } else {
+        identity
+    };
+    let mut child = crate::lifecycle::queue::prepare_goal_continuation(
+        &parent,
+        "test-behavior".into(),
+        &goal.goal_id,
+        "Finish the report after the prior attempt",
+        1,
+        false,
+        "2026-08-25T00:00:00Z",
+    )
+    .unwrap();
+    if variant == "wrong_physical_parent_edge" {
+        child.caused_by_parent_request_doc_id = Some("unrelated-physical-document".into());
+    } else if variant == "unrelated_same_correlation" {
+        child = AgentRequestCreate::base(
+            "unrelated-request",
+            identity.did(),
+            identity.did(),
+            "test-behavior",
+            "unrelated-session",
+            "Independent work",
+            "interactive",
+            "2026-08-25T00:00:00Z",
+            AgentRequestAdmissionRecord::local_self(identity.did()),
+        );
+        child.caused_by_correlation = parent.caused_by_correlation.clone();
+    }
+    crate::sign_agent_request_create(signer, &mut child)
+        .await
+        .unwrap();
+    child
+}
+
+async fn signed_child(
+    node: &defra_node::EmbeddedNode,
+    identity: &KeyIdentity,
+    goal: &crate::goal::GoalDocument,
+    variant: &str,
+    terminal: Option<&str>,
+) -> String {
+    let child = prepare_signed_child(node, identity, goal, variant).await;
+    execute(node, &child.graphql_mutation().unwrap()).await;
+    if let Some(state) = terminal {
+        execute(node, &format!(r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, input: {{ lifecycle_state: "{state}", failure_reason: "physical tip failed" }}) {{ _docID }} }}"#, child.request_id)).await;
+    }
+    let row = persisted_requests(node)
+        .await
+        .into_iter()
+        .find(|row| row.request_id == child.request_id)
+        .unwrap();
+    crate::request_admission::verify_request_receipt_signature(&row).unwrap();
+    child.request_id
+}
+
+#[tokio::test]
+async fn successful_signed_goal_child_completes_graph_invocation() {
+    let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+    let child = signed_child(&node, &identity, &goal, "valid", Some("completed")).await;
+    execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "complete" }}) {{ _docID }} create_PipelineResult(input: {{ graph_run_id: "{}", report: "finished" }}) {{ _docID }} }}"#, goal.doc_id, run.correlation)).await;
+    let view = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(view.status, "succeeded");
+    assert!(view.error.is_none());
+    assert_eq!(view.outstanding_invocation_count, 0);
+    assert!(view.terminal_stages_completed);
+    assert_eq!(view.stages[0].failed, 1);
+    assert_eq!(view.stages[0].succeeded, 1);
+    assert_eq!(
+        view.requests.len(),
+        2,
+        "both physical attempts remain observable"
+    );
+    assert!(view
+        .requests
+        .iter()
+        .any(|request| request.request_id == child));
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn paused_goal_failure_uses_authenticated_tip_cause() {
+    let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+    let child = signed_child(&node, &identity, &goal, "valid", Some("failed")).await;
+    execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "paused" }}) {{ _docID }} }}"#, goal.doc_id)).await;
+    let view = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(view.status, "failed");
+    assert_eq!(view.error.as_ref().unwrap()["request_id"], child);
+    assert_eq!(
+        view.error.as_ref().unwrap()["root_request_id"],
+        "graph-logical-root"
+    );
+    let repeated = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(repeated.error, view.error);
+    node.shutdown().await;
+}
+
+#[derive(serde::Deserialize)]
+struct Contracts {
+    graph_logical_invocation_cases: Vec<InvocationCase>,
+}
+#[derive(serde::Deserialize)]
+struct InvocationCase {
+    name: String,
+    rows: Vec<CaseRow>,
+    edges: Vec<CaseEdge>,
+    root: u64,
+    goal: Option<serde_json::Value>,
+    result_satisfied: bool,
+    max_invocations: u32,
+    expected: serde_json::Value,
+}
+#[derive(serde::Deserialize)]
+struct CaseEdge {
+    parent: u64,
+    child: u64,
+    authenticated: bool,
+}
+#[derive(serde::Deserialize)]
+struct CaseRow {
+    doc: u64,
+    pinned_root: bool,
+    terminal: Option<String>,
+}
+
+#[tokio::test]
+async fn generated_graph_logical_invocations_drive_persisted_run_projection() {
+    let snapshot: Contracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    assert_eq!(snapshot.graph_logical_invocation_cases.len(), 15);
+    for case in snapshot.graph_logical_invocation_cases {
+        assert_eq!(case.root, 10, "{}", case.name);
+        let (node, run, goal, identity, _temp) =
+            signed_invocation_fixture(case.max_invocations).await;
+        let mut request_ids =
+            std::collections::BTreeMap::from([(10, "graph-logical-root".to_owned())]);
+        for row in &case.rows {
+            if row.pinned_root {
+                assert_eq!(row.doc, 10);
+                assert_eq!(row.terminal.as_deref(), Some("failed"));
+                continue;
+            }
+            let mut original_goal = goal.clone();
+            if row.doc == 30 || case.name == "historical_head_canonical_goal_mismatch" {
+                // Historical replacement Goal identities produce different durable
+                // retry keys. Each original signed physical edge remains causal.
+                original_goal.goal_id = "historical-other-goal".into();
+            }
+            let child = signed_child(
+                &node,
+                &identity,
+                &original_goal,
+                &case.name,
+                row.terminal.as_deref(),
+            )
+            .await;
+            request_ids.insert(row.doc, child);
+        }
+        if case.name == "same_second_child_before_root"
+            || case.name == "historical_head_canonical_goal_mismatch"
+        {
+            let ordered = execute(&node, "{ AgentRequest(order: [{ created_at: ASC }, { request_id: ASC }]) { request_id created_at } }").await;
+            assert_eq!(ordered["AgentRequest"][0]["request_id"], request_ids[&20]);
+            assert_eq!(ordered["AgentRequest"][1]["request_id"], request_ids[&10]);
+            assert_eq!(
+                ordered["AgentRequest"][0]["created_at"],
+                ordered["AgentRequest"][1]["created_at"]
+            );
+            assert_eq!(
+                case.rows.iter().map(|row| row.doc).collect::<Vec<_>>(),
+                vec![20, 10]
+            );
+        }
+        let persisted = persisted_requests(&node).await;
+        assert_eq!(
+            persisted.len(),
+            case.rows.len(),
+            "{} raw fixture rows",
+            case.name
+        );
+        for edge in &case.edges {
+            let parent = persisted
+                .iter()
+                .find(|row| row.request_id == request_ids[&edge.parent])
+                .unwrap();
+            let child = persisted
+                .iter()
+                .find(|row| row.request_id == request_ids[&edge.child])
+                .unwrap();
+            let original_goal =
+                if edge.child == 30 || case.name == "historical_head_canonical_goal_mismatch" {
+                    "historical-other-goal"
+                } else {
+                    &goal.goal_id
+                };
+            assert_eq!(
+                crate::goal::verify_goal_continuation_edge(
+                    identity.did(),
+                    "logical-session",
+                    original_goal,
+                    parent,
+                    child
+                )
+                .is_ok(),
+                edge.authenticated,
+                "{} signed edge",
+                case.name
+            );
+            if edge.authenticated {
+                assert_eq!(
+                    child.caused_by_parent_request_doc_id.as_deref(),
+                    parent.doc_id.as_deref()
+                );
+            }
+        }
+        if let Some(goal_case) = &case.goal {
+            let status = goal_case["status"].as_str().unwrap();
+            let claimed = goal_case["phase"] == "claimed";
+            let watermark = if claimed {
+                "\"graph-logical-root\""
+            } else {
+                "null"
+            };
+            execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "{status}", continuation_sequence: {}, last_continued_from_request_id: {watermark}, wrapup_requested: {}, wrapup_completed: {} }}) {{ _docID }} }}"#, goal.doc_id, i64::from(claimed), goal_case["wrapup_requested"], goal_case["wrapup_completed"])).await;
+        } else {
+            execute(&node, &format!(r#"mutation {{ delete_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}) {{ _docID }} }}"#, goal.doc_id)).await;
+        }
+        if case.result_satisfied {
+            execute(&node, &format!(r#"mutation {{ create_PipelineResult(input: {{ graph_run_id: "{}", report: "finished" }}) {{ _docID }} }}"#, run.correlation)).await;
+        }
+        let view = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            view.requests.len(),
+            case.expected["physical_count"].as_u64().unwrap() as usize,
+            "{} physical membership",
+            case.name
+        );
+        let expected = case.expected["outcome"].as_str().unwrap();
+        assert_eq!(
+            view.outstanding_invocation_count,
+            usize::from(expected == "outstanding"),
+            "{} logical outstanding",
+            case.name
+        );
+        assert_eq!(
+            view.stages.iter().map(|stage| stage.total).sum::<usize>(),
+            view.requests.len(),
+            "{} physical stage accounting",
+            case.name
+        );
+        match expected {
+            "outstanding" => {
+                assert!(
+                    view.failure_evidence.is_none(),
+                    "{}: {:?}",
+                    case.name,
+                    view.failure_evidence
+                );
+            }
+            "succeeded" => assert!(
+                view.failure_evidence.is_none(),
+                "{}: {:?}",
+                case.name,
+                view.failure_evidence
+            ),
+            "failed" => {
+                let failure = view.failure_evidence.as_ref().expect(&case.name);
+                if case.name == "successful_tip_missing_result" {
+                    assert_eq!(
+                        failure["code"], "result_contract_unsatisfied",
+                        "{}",
+                        case.name
+                    );
+                } else {
+                    let tip = case.expected["tip"].as_u64().unwrap();
+                    assert_eq!(failure["request_id"], request_ids[&tip], "{}", case.name);
+                }
+            }
+            "invalid" => assert_eq!(
+                view.failure_evidence.as_ref().expect(&case.name)["code"],
+                "contract_drift",
+                "{}",
+                case.name
+            ),
+            "limit_exceeded" => assert_eq!(
+                view.failure_evidence.as_ref().expect(&case.name)["code"],
+                "invocation_limit_exceeded",
+                "{}",
+                case.name
+            ),
+            other => panic!("unknown outcome {other}"),
+        }
+        let terminal = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+            .await
+            .unwrap();
+        let status = match expected {
+            "outstanding" => "running",
+            "succeeded" => "succeeded",
+            _ => "failed",
+        };
+        assert_eq!(terminal.status, status, "{}", case.name);
+        node.shutdown().await;
+    }
+}
+
+async fn publication_state(node: &defra_node::EmbeddedNode) -> serde_json::Value {
+    execute(node, "{ GraphRun { status error update_generation cancel_requested_at } Goal { _docID status continuation_sequence last_continued_from_request_id updated_at } AgentRequest { _docID request_id lifecycle_state } }").await
+}
+
+#[tokio::test]
+async fn typed_resume_obeys_cancelled_or_failed_graph_fence() {
+    for cancel in [true, false] {
+        let (node, run, _goal, identity, _temp) = signed_invocation_fixture(3).await;
+        set_goal(
+            &node,
+            identity.did(),
+            "logical-session",
+            None,
+            Some(GoalStatus::Paused),
+            None,
+        )
+        .await
+        .unwrap();
+        let fenced = if cancel {
+            request_graph_run_cancellation(
+                &node,
+                None,
+                "did:key:owner",
+                &run.run_id,
+                Some("operator cancelled"),
+            )
+            .await
+            .unwrap()
+        } else {
+            let closed = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+                .await
+                .unwrap();
+            assert_eq!(closed.status, "failed");
+            assert_eq!(
+                closed.error.as_ref().unwrap()["request_id"],
+                "graph-logical-root"
+            );
+            closed
+        };
+        if cancel {
+            assert!(fenced.cancellation_requested_at.is_some());
+        }
+        let before = publication_state(&node).await;
+        let result = crate::goal::resume_goal_request(
+            &crate::ConfigAccess::Local(node.clone()),
+            &identity,
+            identity.did(),
+            "logical-session",
+            "graph-logical-root",
+        )
+        .await;
+        let error = result.expect_err("a fenced graph must reject typed child publication");
+        assert!(
+            error.to_string().contains("graph run"),
+            "unexpected pre-fence rejection: {error:#}"
+        );
+        assert_eq!(
+            publication_state(&node).await,
+            before,
+            "resume must roll back Goal and child together"
+        );
+        assert_eq!(before["Goal"][0]["status"], "paused");
+        assert_eq!(before["AgentRequest"].as_array().unwrap().len(), 1);
+        node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn typed_resume_advances_graph_generation_with_signed_child() {
+    let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+    set_goal(
+        &node,
+        identity.did(),
+        "logical-session",
+        None,
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    let receipt = crate::goal::resume_goal_request(
+        &crate::ConfigAccess::Local(node.clone()),
+        &identity,
+        identity.did(),
+        "logical-session",
+        "graph-logical-root",
+    )
+    .await
+    .unwrap();
+    assert!(receipt.created);
+    let after = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(after.update_generation, before.update_generation + 1);
+    assert_eq!(after.status, "running");
+    assert!(after.error.is_none());
+    let rows = persisted_requests(&node).await;
+    assert_eq!(rows.len(), 2);
+    let parent = rows
+        .iter()
+        .find(|row| row.request_id == "graph-logical-root")
+        .unwrap();
+    let child = rows
+        .iter()
+        .find(|row| row.request_id == receipt.request_id)
+        .unwrap();
+    crate::goal::verify_goal_continuation_edge(
+        identity.did(),
+        "logical-session",
+        &goal.goal_id,
+        parent,
+        child,
+    )
+    .unwrap();
+    let resumed = crate::goal::load_goal_by_id(&node, identity.did(), &goal.goal_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(resumed.parsed_status(), Some(GoalStatus::Active));
+    assert_eq!(resumed.continuation_sequence(), 1);
+    // Acknowledgment retry must not acquire another graph generation.
+    let repeated = crate::goal::resume_goal_request(
+        &crate::ConfigAccess::Local(node.clone()),
+        &identity,
+        identity.did(),
+        "logical-session",
+        "graph-logical-root",
+    )
+    .await
+    .unwrap();
+    assert!(!repeated.created);
+    assert_eq!(repeated.request_id, receipt.request_id);
+    assert_eq!(
+        load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            .await
+            .unwrap()
+            .update_generation,
+        after.update_generation
+    );
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn automatic_claimed_publication_obeys_graph_fence() {
+    for cancel in [false, true] {
+        let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+        // A persisted successful claim, before automatic child publication.
+        execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ continuation_sequence: 1, last_continued_from_request_id: "graph-logical-root" }}) {{ _docID }} }}"#, goal.doc_id)).await;
+        let observed = crate::goal::load_goal_by_id(&node, identity.did(), &goal.goal_id)
+            .await
+            .unwrap()
+            .unwrap();
+        if cancel {
+            request_graph_run_cancellation(
+                &node,
+                None,
+                "did:key:owner",
+                &run.run_id,
+                Some("stop before publication"),
+            )
+            .await
+            .unwrap();
+        }
+        let before = publication_state(&node).await;
+        let result = crate::goal::publish_claimed_continuation(
+            &node,
+            &observed,
+            "graph-logical-root",
+            "Finish the report",
+            false,
+        )
+        .await;
+        if cancel {
+            let error = result.expect_err("cancelled graph must reject automatic publication");
+            assert!(
+                error.to_string().contains("graph run"),
+                "unexpected pre-fence rejection: {error:#}"
+            );
+            assert_eq!(publication_state(&node).await, before);
+        } else {
+            let receipt = result.unwrap().expect("live claimed publication");
+            assert!(receipt.created);
+            let after = publication_state(&node).await;
+            assert_eq!(
+                after["GraphRun"][0]["update_generation"].as_i64().unwrap(),
+                before["GraphRun"][0]["update_generation"].as_i64().unwrap() + 1
+            );
+            assert_eq!(after["AgentRequest"].as_array().unwrap().len(), 2);
+            assert_eq!(after["Goal"][0]["continuation_sequence"], 1);
+            let rows = persisted_requests(&node).await;
+            let parent = rows
+                .iter()
+                .find(|row| row.request_id == "graph-logical-root")
+                .unwrap();
+            let child = rows
+                .iter()
+                .find(|row| row.request_id == receipt.request_id)
+                .unwrap();
+            crate::goal::verify_goal_continuation_edge(
+                identity.did(),
+                "logical-session",
+                &goal.goal_id,
+                parent,
+                child,
+            )
+            .unwrap();
+        }
+        node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn fresh_goal_on_closed_rooted_session_rolls_back() {
+    let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+    set_goal(
+        &node,
+        identity.did(),
+        "logical-session",
+        None,
+        Some(GoalStatus::Paused),
+        None,
+    )
+    .await
+    .unwrap();
+    let closed = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(closed.status, "failed");
+    execute(
+        &node,
+        &format!(
+            r#"mutation {{ delete_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+            goal.doc_id
+        ),
+    )
+    .await;
+    let before = publication_state(&node).await;
+    assert!(before["Goal"].as_array().unwrap().is_empty());
+    let error = set_goal(
+        &node,
+        identity.did(),
+        "logical-session",
+        Some("Finish the report"),
+        Some(GoalStatus::Active),
+        Some(Some(1000)),
+    )
+    .await
+    .expect_err("closed graph cannot acquire a fresh continuation obligation");
+    assert!(
+        error.to_string().contains("graph run"),
+        "unexpected pre-fence rejection: {error:#}"
+    );
+    assert_eq!(publication_state(&node).await, before);
+    node.shutdown().await;
+}
+
+async fn root_trigger_lineage(
+    node: &defra_node::EmbeddedNode,
+) -> (crate::lifecycle::TriggerLineage, String) {
+    let rows = persisted_requests(node).await;
+    let root = rows
+        .iter()
+        .find(|row| row.request_id == "graph-logical-root")
+        .unwrap();
+    (
+        crate::lifecycle::TriggerLineage {
+            trigger_id: root.caused_by_trigger_id.clone(),
+            trigger_kind: root.caused_by_trigger_kind.clone(),
+            source_doc_id: root.caused_by_source_doc_id.clone(),
+            correlation: root.caused_by_correlation.clone(),
+            trigger_context: root.caused_by_trigger_context.clone(),
+        },
+        root.caused_by_trigger_doc_id.clone().unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn plain_graph_root_factory_fences_publication_and_cancellation() {
+    let (node, run, _goal, identity, _temp) = signed_invocation_fixture(4).await;
+    assert_eq!(
+        run.run_id, run.correlation,
+        "actual graph producer correlation identifies its run"
+    );
+    let (lineage, trigger_doc) = root_trigger_lineage(&node).await;
+    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    let receipt = crate::lifecycle::materialize::write_pending_agent_request_with_lineage_workspace_and_conversation_title(
+        &node, identity.did(), "test-behavior", "Plain graph root", crate::lifecycle::ExecutionOrigin::Scheduled,
+        lineage.clone(), None, None, Some("plain-factory-root"), None, Some(&trigger_doc),
+    ).await.unwrap();
+    let rows = persisted_requests(&node).await;
+    assert_eq!(rows.len(), 2);
+    let row = rows
+        .iter()
+        .find(|row| row.request_id == receipt.request_id)
+        .unwrap();
+    crate::request_admission::verify_request_receipt_signature(row).unwrap();
+    assert_eq!(row.doc_id.as_deref(), Some(receipt.doc_id.as_str()));
+    assert_eq!(
+        row.caused_by_correlation.as_deref(),
+        Some(run.run_id.as_str())
+    );
+    assert_eq!(
+        row.caused_by_trigger_doc_id.as_deref(),
+        Some(trigger_doc.as_str())
+    );
+    assert_eq!(
+        row.caused_by_source_doc_id.as_deref(),
+        Some(run.seed_doc_id.as_str())
+    );
+    let published = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(published.update_generation, before.update_generation + 1);
+    assert_eq!(
+        published.requests.len(),
+        2,
+        "factory row is an authenticated graph root"
+    );
+    // Emulate a durable executor observation before cancellation, without a
+    // provider or synthetic lease owner in this publication-boundary test.
+    execute(&node, r#"mutation { update_AgentRequest(filter: { request_id: { _eq: "plain-factory-root" } }, input: { lifecycle_state: "completed" }) { _docID } }"#).await;
+    request_graph_run_cancellation(
+        &node,
+        None,
+        "did:key:owner",
+        &run.run_id,
+        Some("stop new roots"),
+    )
+    .await
+    .unwrap();
+    let closed = publication_state(&node).await;
+    let error = crate::lifecycle::materialize::write_pending_agent_request_with_lineage_workspace_and_conversation_title(
+        &node, identity.did(), "test-behavior", "Too late", crate::lifecycle::ExecutionOrigin::Scheduled,
+        lineage, None, None, Some("denied-plain-factory-root"), None, Some(&trigger_doc),
+    ).await.expect_err("cancelled graph rejects the actual root factory");
+    assert!(
+        error.to_string().contains("graph run"),
+        "unexpected factory failure: {error:#}"
+    );
+    assert_eq!(publication_state(&node).await, closed);
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn goal_backed_graph_root_factory_rolls_back_after_cancellation() {
+    let (node, run, _goal, identity, _temp) = signed_invocation_fixture(4).await;
+    assert_eq!(run.run_id, run.correlation);
+    let (lineage, trigger_doc) = root_trigger_lineage(&node).await;
+    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    let create = crate::lifecycle::materialize::build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+        identity.did(), "test-behavior", "Goal-backed graph root", crate::lifecycle::ExecutionOrigin::Scheduled,
+        lineage.clone(), None, None, "goal-backed-factory-root", "goal-backed-factory-session", Some("goal-backed-factory-key"), None, Some(&trigger_doc),
+    ).await.unwrap();
+    let receipt = crate::goal::submit_goal_backed_request_local(
+        &node,
+        identity.did(),
+        &create.session_id,
+        "Finish the extra stage",
+        Some(1000),
+        &create,
+    )
+    .await
+    .unwrap();
+    let rows = persisted_requests(&node).await;
+    let row = rows
+        .iter()
+        .find(|row| row.request_id == receipt.request_id)
+        .unwrap();
+    crate::request_admission::verify_request_receipt_signature(row).unwrap();
+    assert_eq!(
+        row.caused_by_correlation.as_deref(),
+        Some(run.run_id.as_str())
+    );
+    let published = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(published.update_generation, before.update_generation + 1);
+    assert_eq!(published.requests.len(), 2);
+    let obligations = execute(
+        &node,
+        "{ Goal { session_id } GoalCreationClaim { session_id } }",
+    )
+    .await;
+    assert!(obligations["Goal"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|row| row["session_id"] == create.session_id));
+    assert!(obligations["GoalCreationClaim"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|row| row["session_id"] == create.session_id));
+    execute(&node, r#"mutation { update_AgentRequest(filter: { request_id: { _eq: "goal-backed-factory-root" } }, input: { lifecycle_state: "completed" }) { _docID } }"#).await;
+    request_graph_run_cancellation(
+        &node,
+        None,
+        "did:key:owner",
+        &run.run_id,
+        Some("close before next goal"),
+    )
+    .await
+    .unwrap();
+    let closed = publication_state(&node).await;
+    let claims = execute(&node, "{ GoalCreationClaim { _docID session_id } }").await;
+    let denied = crate::lifecycle::materialize::build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
+        identity.did(), "test-behavior", "Too late goal", crate::lifecycle::ExecutionOrigin::Scheduled,
+        lineage, None, None, "denied-goal-backed-root", "denied-goal-backed-session", Some("denied-goal-backed-key"), None, Some(&trigger_doc),
+    ).await.unwrap();
+    let error = crate::goal::submit_goal_backed_request_local(
+        &node,
+        identity.did(),
+        &denied.session_id,
+        "Do not create this obligation",
+        Some(1000),
+        &denied,
+    )
+    .await
+    .expect_err("closed graph rejects atomic root and Goal publication");
+    assert!(
+        error.to_string().contains("graph run"),
+        "unexpected submission failure: {error:#}"
+    );
+    assert_eq!(publication_state(&node).await, closed);
+    assert_eq!(
+        execute(&node, "{ GoalCreationClaim { _docID session_id } }").await,
+        claims
+    );
+    node.shutdown().await;
+}

--- a/crates/gents/src/graph_pipeline/mod.rs
+++ b/crates/gents/src/graph_pipeline/mod.rs
@@ -14,7 +14,7 @@ pub use compiler::{
     bind_package_plan, compile_graph, graph_plan_digest, verify_graph_plan_digest, CompilerPolicy,
     GraphCompileError,
 };
-pub(crate) use run::run_graph_run_reconciler;
+pub(crate) use run::{graph_binding_for_request_in_txn, run_graph_run_reconciler};
 pub use run::{
     load_graph_run_result_view_with_access, load_graph_run_view, load_graph_run_view_with_access,
     reconcile_graph_run, reconcile_graph_run_with_access, reconcile_owned_graph_runs,
@@ -30,8 +30,8 @@ pub use runtime::{
     MaterializedRevision, PublishedGraph, RevisionGateDecision,
 };
 pub(crate) use runtime::{
-    graph_artifact_is_reserved, graph_artifact_is_visible, graph_materialization_denial,
-    load_visible_package_artifact_ids,
+    fence_graph_publication_in_txn, fence_graph_root_request_in_txn, graph_artifact_is_reserved,
+    graph_artifact_is_visible, graph_materialization_denial, load_visible_package_artifact_ids,
 };
 pub use tools::{
     CompileGraphArgs, CompileGraphResponse, CompileGraphTool, GraphPipelineToolError,
@@ -48,3 +48,6 @@ pub use types::{
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod logical_invocation_contract_tests;

--- a/crates/gents/src/graph_pipeline/publication_contract_tests.rs
+++ b/crates/gents/src/graph_pipeline/publication_contract_tests.rs
@@ -1,0 +1,324 @@
+//! The GraphRun publication fence composes with signed request staging in one
+//! transaction. Goal claim eligibility has its separate production consumer.
+use super::*;
+use crate::graph_pipeline::logical_invocation_contract_tests::{
+    execute, prepare_signed_child, signed_invocation_fixture,
+};
+use serde::Deserialize;
+
+fn assert_created_request(response: &Value) {
+    let data = response.get("data").unwrap_or(response);
+    let result = data
+        .get("create_AgentRequest")
+        .or_else(|| data.get("add_AgentRequest"))
+        .unwrap_or_else(|| panic!("missing created request: {response:?}"));
+    let row = if let Some(rows) = result.as_array() {
+        assert_eq!(rows.len(), 1);
+        &rows[0]
+    } else {
+        result
+    };
+    assert!(
+        row["_docID"].as_str().is_some(),
+        "missing created document ID: {response:?}"
+    );
+}
+
+#[derive(Deserialize)]
+struct Contracts {
+    graph_invocation_publication_cases: Vec<Trace>,
+}
+#[derive(Deserialize)]
+struct Trace {
+    name: String,
+    initial: Observation,
+    events: Vec<Event>,
+    expected: Vec<Observation>,
+}
+#[derive(Deserialize)]
+struct Event {
+    kind: String,
+    expected_generation: Option<i64>,
+    cause: Option<u64>,
+}
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+struct Observation {
+    status: String,
+    cancellation_requested: bool,
+    generation: i64,
+    primary: Option<u64>,
+    may_interrupt_for_failure: bool,
+    children: usize,
+}
+async fn observe(node: &EmbeddedNode, run_id: &str, initial_generation: i64) -> Observation {
+    let view = load_graph_run_view(node, "did:key:owner", run_id)
+        .await
+        .unwrap();
+    let primary = view.error.as_ref().map(|error| {
+        assert_eq!(error["request_id"], "graph-logical-root");
+        90
+    });
+    let value = execute(node, "{ AgentRequest { request_id } }").await;
+    let children = value["AgentRequest"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|row| row["request_id"] != "graph-logical-root")
+        .count();
+    Observation {
+        may_interrupt_for_failure: view.status == "running"
+            && view.cancellation_requested_at.is_none()
+            && primary.is_some(),
+        status: view.status,
+        cancellation_requested: view.cancellation_requested_at.is_some(),
+        generation: view.update_generation - initial_generation,
+        primary,
+        children,
+    }
+}
+
+#[tokio::test]
+async fn generated_graph_invocation_publication_traces_drive_real_transactions() {
+    let contracts: Contracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    assert_eq!(contracts.graph_invocation_publication_cases.len(), 5);
+    for trace in contracts.graph_invocation_publication_cases {
+        let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+        execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "paused" }}) {{ _docID }} }}"#, goal.doc_id)).await;
+        let cause = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            cause.failure_evidence.as_ref().unwrap()["request_id"],
+            "graph-logical-root"
+        );
+        let initial_generation = cause.update_generation;
+        let child = prepare_signed_child(&node, &identity, &goal, "valid").await;
+        assert_eq!(
+            observe(&node, &run.run_id, initial_generation).await,
+            trace.initial,
+            "{} initial",
+            trace.name
+        );
+        assert_eq!(trace.events.len(), trace.expected.len());
+        for (event, expected) in trace.events.iter().zip(trace.expected.iter()) {
+            let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+                .await
+                .unwrap();
+            let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+            match event.kind.as_str() {
+                "publish" => {
+                    assert_eq!(
+                        event.expected_generation.unwrap() + initial_generation,
+                        before.update_generation
+                    );
+                    let result = crate::graph_pipeline::fence_graph_publication_in_txn(
+                        &txn,
+                        &run.run_id,
+                        &run.revision_digest,
+                    )
+                    .await;
+                    if result.is_ok() {
+                        let response = txn
+                            .execute(&child.graphql_mutation().unwrap())
+                            .await
+                            .unwrap();
+                        assert_created_request(&response);
+                        txn.commit().await.unwrap();
+                    } else {
+                        assert!(
+                            before.status != "running"
+                                || before.cancellation_requested_at.is_some()
+                                || before.error.is_some(),
+                            "unexpected fence error: {result:?}"
+                        );
+                        txn.discard().await.unwrap();
+                    }
+                }
+                "capture" | "finish" => {
+                    assert_eq!(event.cause, Some(90));
+                    // Preserve the real earlier observation through publication;
+                    // changing only its generation would not test stale evidence.
+                    let mut observed = cause.clone();
+                    observed.update_generation =
+                        initial_generation + event.expected_generation.unwrap();
+                    let result = if event.kind == "capture" {
+                        capture_failure_txn(txn, &observed).await.map(|_| ())
+                    } else {
+                        commit_terminal_txn(txn, &observed, "failed")
+                            .await
+                            .map(|_| ())
+                    };
+                    if let Err(error) = result {
+                        assert_ne!(
+                            before.update_generation, observed.update_generation,
+                            "unexpected owner error: {error:#}"
+                        );
+                    }
+                }
+                "cancel" => {
+                    persist_cancellation_intent(
+                        txn,
+                        "did:key:owner",
+                        &run.run_id,
+                        Some("generated publication cancellation"),
+                    )
+                    .await
+                    .unwrap();
+                }
+                kind => panic!("unknown event {kind}"),
+            }
+            assert_eq!(
+                &observe(&node, &run.run_id, initial_generation).await,
+                expected,
+                "{} {}",
+                trace.name,
+                event.kind
+            );
+        }
+        node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn discarding_graph_publication_rolls_back_generation_and_signed_child() {
+    let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        .await
+        .unwrap();
+    let child = prepare_signed_child(&node, &identity, &goal, "valid").await;
+    let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+    crate::graph_pipeline::fence_graph_publication_in_txn(&txn, &run.run_id, &run.revision_digest)
+        .await
+        .unwrap();
+    txn.execute(&child.graphql_mutation().unwrap())
+        .await
+        .unwrap();
+    let staged = txn
+        .execute("{ GraphRun { update_generation } AgentRequest { request_id } }")
+        .await
+        .unwrap();
+    assert_eq!(
+        staged["data"]["GraphRun"][0]["update_generation"],
+        before.update_generation + 1
+    );
+    assert_eq!(staged["data"]["AgentRequest"].as_array().unwrap().len(), 2);
+    txn.discard().await.unwrap();
+    assert_eq!(
+        observe(&node, &run.run_id, before.update_generation).await,
+        Observation {
+            status: "running".into(),
+            cancellation_requested: false,
+            generation: 0,
+            primary: None,
+            may_interrupt_for_failure: false,
+            children: 0,
+        }
+    );
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn overlapping_native_graph_publication_and_closure_conflict_atomically() {
+    async fn native(node: &EmbeddedNode, handle: &query::TransactionHandle, query: &str) -> Value {
+        let response = node
+            .execute_request_in_txn(defra_node::QueryRequest::new(query), handle)
+            .await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        response.data.unwrap()
+    }
+    for publication_first in [false, true] {
+        let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+        execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "paused" }}) {{ _docID }} }}"#, goal.doc_id)).await;
+        let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            .await
+            .unwrap();
+        let child = prepare_signed_child(&node, &identity, &goal, "valid").await;
+        // Intentionally use two actual native handles: ConfigApplyTxn's local
+        // mutex would serialize begin and never exercise storage conflict checks.
+        let publication = node.runner().begin_txn(false).await.unwrap();
+        let closure = node.runner().begin_txn(false).await.unwrap();
+        let read = format!(
+            r#"{{ GraphRun(filter: {{ run_id: {{ _eq: "{}" }} }}) {{ _docID status update_generation }} }}"#,
+            run.run_id
+        );
+        let left = native(&node, &publication, &read).await;
+        let right = native(&node, &closure, &read).await;
+        assert_eq!(
+            left, right,
+            "both native handles must observe the same snapshot"
+        );
+        assert_eq!(left["GraphRun"][0]["status"], "running");
+        let next = before.update_generation.checked_add(1).unwrap();
+        let filter = format!(
+            r#"{{ run_id: {{ _eq: "{}" }}, status: {{ _eq: "running" }}, update_generation: {{ _eq: {} }} }}"#,
+            run.run_id, before.update_generation
+        );
+        let touch = format!(
+            r#"mutation {{ update_GraphRun(filter: {filter}, input: {{ update_generation: {next} }}) {{ _docID }} }}"#
+        );
+        assert_eq!(
+            native(&node, &publication, &touch).await["update_GraphRun"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        let staged_child = native(&node, &publication, &child.graphql_mutation().unwrap()).await;
+        assert_created_request(&staged_child);
+        let terminal = gents_protocol::graphql::graphql_input_literal(&serde_json::json!({
+            "status": "failed",
+            "update_generation": next,
+            "error": before.failure_evidence.as_ref().unwrap().to_string(),
+            "completed_at": chrono::Utc::now().to_rfc3339(),
+        }))
+        .unwrap();
+        let finish = format!(
+            "mutation {{ update_GraphRun(filter: {filter}, input: {terminal}) {{ _docID }} }}"
+        );
+        assert_eq!(
+            native(&node, &closure, &finish).await["update_GraphRun"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        // Both conditional mutations already matched. Only the overlapping
+        // native commit boundary can reject the second writer now.
+        let (winner, loser) = if publication_first {
+            (&publication, &closure)
+        } else {
+            (&closure, &publication)
+        };
+        node.runner().commit_txn(winner).await.unwrap();
+        let conflict = node
+            .runner()
+            .commit_txn(loser)
+            .await
+            .expect_err("overlapping native writes must not both commit");
+        assert!(
+            conflict.to_string().contains("transaction conflict"),
+            "expected storage conflict, got: {conflict}"
+        );
+        let durable = execute(
+            &node,
+            "{ GraphRun { status update_generation } AgentRequest { request_id } }",
+        )
+        .await;
+        assert_eq!(durable["GraphRun"][0]["update_generation"], next);
+        assert_eq!(
+            durable["GraphRun"][0]["status"],
+            if publication_first {
+                "running"
+            } else {
+                "failed"
+            }
+        );
+        let rows = durable["AgentRequest"].as_array().unwrap();
+        assert_eq!(rows.len(), if publication_first { 2 } else { 1 });
+        assert_eq!(
+            rows.iter().any(|row| row["request_id"] == child.request_id),
+            publication_first
+        );
+        node.shutdown().await;
+    }
+}

--- a/crates/gents/src/graph_pipeline/run.rs
+++ b/crates/gents/src/graph_pipeline/run.rs
@@ -24,11 +24,18 @@ use super::{
 };
 
 const GRAPH_RUN_VIEW_VERSION: u32 = 1;
+
+#[path = "logical_invocation.rs"]
+mod logical_invocation;
 const MAX_CANCEL_REASON_BYTES: usize = 1_024;
 
 #[cfg(test)]
 #[path = "attribution_contract_tests.rs"]
 mod attribution_contract_tests;
+
+#[cfg(test)]
+#[path = "publication_contract_tests.rs"]
+mod publication_contract_tests;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GraphResultRef {
@@ -110,6 +117,11 @@ pub struct GraphRunView {
     pub persisted_result_refs: Vec<GraphResultRef>,
     pub active_request_count: usize,
     pub terminal_request_count: usize,
+    /// Derived from physical ancestry and the canonical Goal; never persisted.
+    #[serde(default)]
+    pub outstanding_invocation_count: usize,
+    #[serde(default)]
+    pub terminal_stages_completed: bool,
     pub result_contract_satisfied: bool,
     pub failure_evidence: Option<Value>,
 }
@@ -253,63 +265,6 @@ fn planned_trigger_nodes(plan: &GraphPlan) -> Result<BTreeMap<String, String>> {
         anyhow::bail!("pinned graph plan has no materialized trigger routes");
     }
     Ok(nodes_by_trigger)
-}
-
-async fn load_requests(
-    executor: &(impl GraphRunQuery + ?Sized),
-    correlation: &str,
-    plan: &GraphPlan,
-) -> Result<Vec<GraphRunRequestView>> {
-    let nodes_by_trigger = planned_trigger_nodes(plan)?;
-    let trigger_ids = nodes_by_trigger.keys().cloned().collect::<Vec<_>>();
-    // Terminalization must observe every correlated request. The pinned
-    // invocation limit supplies failure evidence; it is not a safe query cap
-    // because work beyond that cap may still be active and require draining.
-    let response = executor
-        .execute_graph_query(&format!(
-            r#"{{
-                AgentRequest(
-                    filter: {{
-                        caused_by_correlation: {{ _eq: "{}" }},
-                        caused_by_trigger_id: {{ _in: {} }}
-                    }},
-                    order: {{ created_at: ASC }}
-                ) {{
-                    request_id session_id behavior_id caused_by_trigger_id lifecycle_state failure_reason
-                }}
-            }}"#,
-            escape_graphql_string(correlation),
-            graphql_string_list_literal(&trigger_ids),
-        ))
-        .await?;
-    let mut requests = rows(&response, "AgentRequest")
-        .iter()
-        .map(|row| {
-            let row = serde_json::from_value::<AgentRequestRow>((*row).clone())
-                .context("decoding graph-run AgentRequest row")?;
-            let lifecycle_state = row.lifecycle_state;
-            Ok(GraphRunRequestView {
-                request_id: row.request_id,
-                session_id: row
-                    .session_id
-                    .as_deref()
-                    .filter(|value| !value.trim().is_empty())
-                    .map(ToOwned::to_owned),
-                node_id: row
-                    .caused_by_trigger_id
-                    .as_deref()
-                    .and_then(|trigger_id| nodes_by_trigger.get(trigger_id))
-                    .cloned(),
-                behavior_id: row.behavior_id.unwrap_or_default(),
-                terminal: lifecycle_state.is_some_and(RequestLifecycleState::is_terminal),
-                succeeded: lifecycle_state == Some(RequestLifecycleState::Completed),
-                lifecycle_state: lifecycle_state.map(|state| state.as_str().to_string()),
-                failure_reason: row.failure_reason,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    requests.sort_by(|left, right| left.request_id.cmp(&right.request_id));
-    Ok(requests)
 }
 
 async fn load_groups(
@@ -490,7 +445,17 @@ async fn load_graph_run_view_with(
     let revision_digest = required_string(&run, "revision_digest")?;
     let plan = load_plan(executor, revision_digest).await?;
     let correlation = required_string(&run, "correlation")?;
-    let requests = load_requests(executor, correlation, &plan).await?;
+    let logical = logical_invocation::load(executor, correlation, &plan).await?;
+    let requests = logical.requests;
+    let outstanding_invocation_count = logical
+        .invocations
+        .iter()
+        .filter(|invocation| invocation.outstanding)
+        .count();
+    let invalid_invocation = logical
+        .invocations
+        .iter()
+        .find(|invocation| invocation.invalid);
     let groups = load_groups(executor, correlation, &plan).await?;
     let mut results = Vec::with_capacity(plan.results.len());
     for result in &plan.results {
@@ -527,9 +492,14 @@ async fn load_graph_run_view_with(
     let active_request_count = requests.iter().filter(|request| !request.terminal).count();
     let terminal_request_count = requests.len() - active_request_count;
     let unknown_request = requests.iter().find(|request| request.node_id.is_none());
-    let failed_request = requests
-        .iter()
-        .find(|request| request.terminal && !request.succeeded);
+    let failed_invocation = logical.invocations.iter().find(|invocation| {
+        !invocation.outstanding
+            && !invocation.invalid
+            && invocation
+                .tip
+                .as_ref()
+                .is_some_and(|tip| tip.terminal && !tip.succeeded)
+    });
     let over_limit = requests.len() > plan.limits.max_total_invocations as usize;
     let invalid_group = groups.iter().find(|group| group.quiesced_at.is_some());
     let started_at = run
@@ -554,10 +524,14 @@ async fn load_graph_run_view_with(
         .collect::<BTreeSet<_>>();
     let terminal_stages_completed = !terminal_nodes.is_empty()
         && terminal_nodes.iter().all(|node_id| {
-            requests.iter().any(|request| {
-                request.node_id.as_deref() == Some(*node_id)
-                    && request.terminal
-                    && request.succeeded
+            logical.invocations.iter().any(|invocation| {
+                invocation.node_id == *node_id
+                    && !invocation.outstanding
+                    && !invocation.invalid
+                    && invocation
+                        .tip
+                        .as_ref()
+                        .is_some_and(|tip| tip.terminal && tip.succeeded)
             })
         });
     let failure_evidence = if let Some(group) = invalid_group {
@@ -569,8 +543,14 @@ async fn load_graph_run_view_with(
     } else if let Some(request) = unknown_request {
         Some(json!({
             "version": 1, "code": "contract_drift",
-            "message": "correlated request behavior is not in the pinned graph plan",
+            "message": "pinned graph request lacks authenticated route binding",
             "request_id": request.request_id, "behavior_id": request.behavior_id,
+        }))
+    } else if let Some(invocation) = invalid_invocation {
+        Some(json!({
+            "version": 1, "code": "contract_drift",
+            "message": "graph invocation has ambiguous or cyclic authenticated ancestry",
+            "root_request_id": invocation.root_request_id,
         }))
     } else if over_limit {
         Some(json!({
@@ -586,14 +566,23 @@ async fn load_graph_run_view_with(
             "max_runtime_secs": plan.limits.max_runtime_secs,
             "deadline_at": deadline.map(|value| value.to_rfc3339()),
         }))
-    } else if let Some(request) = failed_request {
+    } else if let Some(invocation) = failed_invocation {
+        let request = invocation
+            .tip
+            .as_ref()
+            .expect("failed invocation has a tip");
         Some(json!({
             "version": 1, "code": "required_request_failed",
             "message": request.failure_reason.as_deref().unwrap_or("required graph request did not complete successfully"),
             "request_id": request.request_id,
+            "root_request_id": invocation.root_request_id,
             "lifecycle_state": request.lifecycle_state,
         }))
-    } else if active_request_count == 0 && terminal_stages_completed && !result_contract_satisfied {
+    } else if active_request_count == 0
+        && outstanding_invocation_count == 0
+        && terminal_stages_completed
+        && !result_contract_satisfied
+    {
         Some(json!({
             "version": 1,
             "code": "result_contract_unsatisfied",
@@ -683,9 +672,92 @@ async fn load_graph_run_view_with(
         persisted_result_refs,
         active_request_count,
         terminal_request_count,
+        outstanding_invocation_count,
+        terminal_stages_completed,
         result_contract_satisfied,
         failure_evidence,
     })
+}
+
+/// Authenticated derived association used by the existing publication transaction.
+/// This is not stored and does not authorize a new request by itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GraphInvocationBinding {
+    pub run_id: String,
+    pub revision_digest: String,
+}
+
+pub(crate) async fn graph_binding_for_request_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    parent_doc_id: &str,
+) -> Result<Option<GraphInvocationBinding>> {
+    // Correlation is only a discovery hint. Walk original physical ancestry so
+    // a historical child with omitted optional correlation remains discoverable.
+    let mut next = Some(parent_doc_id.to_owned());
+    let mut seen = BTreeSet::new();
+    let mut correlations = BTreeSet::new();
+    while let Some(doc_id) = next {
+        if !seen.insert(doc_id.clone()) {
+            break;
+        }
+        let response = txn
+            .execute(&format!(
+                r#"{{ AgentRequest(filter: {{ _docID: {{ _eq: "{}" }} }}) {{
+                _docID caused_by_parent_request_doc_id caused_by_correlation caused_by_trigger_id
+            }} }}"#,
+                escape_graphql_string(&doc_id),
+            ))
+            .await?;
+        let Some(row) = rows(&response, "AgentRequest").first() else {
+            break;
+        };
+        let graph_route_hint = row
+            .get("caused_by_trigger_id")
+            .and_then(Value::as_str)
+            .is_some_and(super::runtime::graph_artifact_is_reserved);
+        if let Some(correlation) = row
+            .get("caused_by_correlation")
+            .and_then(Value::as_str)
+            .filter(|s| graph_route_hint && !s.is_empty())
+        {
+            correlations.insert(correlation.to_owned());
+        }
+        next = row
+            .get("caused_by_parent_request_doc_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+    if correlations.is_empty() {
+        return Ok(None);
+    }
+    let response = txn.execute(&format!(
+        r#"{{ GraphRun(filter: {{ correlation: {{ _in: {} }} }}) {{ run_id revision_digest correlation }} }}"#,
+        graphql_string_list_literal(&correlations.into_iter().collect::<Vec<_>>()),
+    )).await?;
+    let mut bindings = Vec::new();
+    for run in rows(&response, "GraphRun") {
+        let digest = required_string(run, "revision_digest")?;
+        let plan = load_plan(txn, digest).await?;
+        let projection =
+            logical_invocation::load(txn, required_string(run, "correlation")?, &plan).await?;
+        for invocation in projection.invocations {
+            if invocation.member_doc_ids.contains(parent_doc_id) {
+                anyhow::ensure!(
+                    !invocation.invalid,
+                    "cannot publish into ambiguous graph invocation ancestry"
+                );
+                bindings.push(GraphInvocationBinding {
+                    run_id: required_string(run, "run_id")?.to_owned(),
+                    revision_digest: digest.to_owned(),
+                });
+            }
+        }
+    }
+    anyhow::ensure!(
+        bindings.len() <= 1,
+        "request belongs to multiple authenticated graph invocations"
+    );
+    Ok(bindings.pop())
 }
 
 /// Reconstruct one durable graph execution from its pinned revision and the
@@ -956,7 +1028,7 @@ async fn capture_failure_txn(txn: ConfigApplyTxn<'_>, view: &GraphRunView) -> Re
         let current = query_run(&txn, &view.run_id).await?;
         let input = json!({
             "error": serde_json::to_string(&primary)?,
-            "update_generation": fresh.update_generation.saturating_add(1),
+            "update_generation": fresh.update_generation.checked_add(1).context("graph run generation exhausted")?,
         });
         txn.execute(&format!(
             "mutation {{ update_GraphRun(docID: \"{}\", input: {}) {{ _docID }} }}",
@@ -993,7 +1065,9 @@ async fn commit_terminal_txn(
         let decision = graph_run_terminal_decision(
             &fresh.status,
             fresh.cancellation_requested_at.is_some(),
-            fresh.result_contract_satisfied,
+            fresh.result_contract_satisfied
+                && fresh.terminal_stages_completed
+                && fresh.outstanding_invocation_count == 0,
             fresh.active_request_count == 0,
             fresh.failure_evidence.is_some(),
         );
@@ -1017,7 +1091,7 @@ async fn commit_terminal_txn(
             "status": status,
             "error": error.map(serde_json::to_string).transpose()?,
             "result_refs_json": result_refs.as_ref().map(serde_json::to_string).transpose()?,
-            "update_generation": current_generation.saturating_add(1),
+            "update_generation": current_generation.checked_add(1).context("graph run generation exhausted")?,
             "completed_at": chrono::Utc::now().to_rfc3339(),
         });
         let mutation = format!(
@@ -1052,6 +1126,8 @@ fn terminal_projection(
     } else if !view.requests.is_empty()
         && view.active_request_count == 0
         && view.result_contract_satisfied
+        && view.terminal_stages_completed
+        && view.outstanding_invocation_count == 0
     {
         Some(("succeeded", None, Some(view.successful_result_refs())))
     } else {
@@ -1209,7 +1285,7 @@ async fn persist_cancellation_intent(
             "cancel_requested_at": chrono::Utc::now().to_rfc3339(),
             "cancel_requested_by": actor_did,
             "cancel_reason": reason,
-            "update_generation": generation.saturating_add(1),
+            "update_generation": generation.checked_add(1).context("graph run generation exhausted")?,
         });
         txn.execute(&format!(
             "mutation {{ update_GraphRun(docID: \"{}\", input: {}) {{ _docID }} }}",
@@ -1315,6 +1391,8 @@ mod tests {
             persisted_result_refs: vec![],
             active_request_count: 0,
             terminal_request_count: 1,
+            outstanding_invocation_count: 0,
+            terminal_stages_completed: true,
             result_contract_satisfied: false,
             failure_evidence,
         }

--- a/crates/gents/src/graph_pipeline/runtime.rs
+++ b/crates/gents/src/graph_pipeline/runtime.rs
@@ -383,7 +383,7 @@ pub(crate) async fn graph_materialization_denial(
         .execute(&format!(
             r#"{{
                 GraphRun(filter: {{ run_id: {{ _eq: "{}" }} }}, limit: 2) {{
-                    revision_digest status cancel_requested_at
+                    revision_digest status cancel_requested_at error
                 }}
             }}"#,
             escape_graphql_string(correlation),
@@ -396,29 +396,93 @@ pub(crate) async fn graph_materialization_denial(
         );
     }
     let data = json!({ "data": response.data.unwrap_or(Value::Null) });
-    let found = rows(&data, "GraphRun");
-    if found.len() != 1 {
-        return Ok(Some(
-            "graph trigger correlation does not resolve to exactly one durable run".to_owned(),
-        ));
-    }
-    let run = &found[0];
-    if run.get("revision_digest").and_then(Value::as_str) != Some(trigger_digest.as_str()) {
-        return Ok(Some(
-            "graph trigger revision does not match the pinned run revision".to_owned(),
-        ));
+    Ok(graph_publication_denial(rows(&data, "GraphRun"), &trigger_digest).map(str::to_owned))
+}
+
+/// Preflight and transactional publication consume the same admission policy.
+/// Only the transaction's read plus generation write authorizes publication.
+fn graph_publication_denial(runs: &[Value], revision_digest: &str) -> Option<&'static str> {
+    let [run] = runs else {
+        return Some("graph publication requires exactly one durable run");
+    };
+    if run.get("revision_digest").and_then(Value::as_str) != Some(revision_digest) {
+        return Some("graph publication revision does not match the pinned run");
     }
     if run.get("status").and_then(Value::as_str) != Some("running") {
-        return Ok(Some("graph run is terminal".to_owned()));
+        return Some("graph run is terminal");
     }
     if run
         .get("cancel_requested_at")
-        .and_then(Value::as_str)
-        .is_some()
+        .is_some_and(|value| !value.is_null())
     {
-        return Ok(Some("graph run cancellation is requested".to_owned()));
+        return Some("graph run cancellation is requested");
     }
-    Ok(None)
+    if run.get("error").is_some_and(|value| !value.is_null()) {
+        return Some("graph run has a definitive failure latch");
+    }
+    None
+}
+
+/// Root publication knows its immutable graph route before the request exists.
+/// Continuations instead resolve their authenticated physical predecessor.
+pub(crate) async fn fence_graph_root_request_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    request: &gents_protocol::request_admission::AgentRequestCreate,
+) -> Result<()> {
+    let Some(digest) = request
+        .caused_by_trigger_id
+        .as_deref()
+        .and_then(graph_artifact_revision_digest)
+    else {
+        return Ok(());
+    };
+    let run_id = request
+        .caused_by_correlation
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .context("graph root publication requires a durable run correlation")?;
+    fence_graph_publication_in_txn(txn, run_id, &digest).await
+}
+
+/// Serialize publication with the existing GraphRun completion owner. The caller
+/// stages its request/Goal writes in this same native transaction; rollback
+/// therefore removes both publication and this generation change.
+pub(crate) async fn fence_graph_publication_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    run_id: &str,
+    revision_digest: &str,
+) -> Result<()> {
+    let response = txn
+        .execute(&format!(
+            r#"{{ GraphRun(filter: {{ run_id: {{ _eq: "{}" }} }}, limit: 2) {{
+            _docID revision_digest status cancel_requested_at error update_generation
+        }} }}"#,
+            escape_graphql_string(run_id),
+        ))
+        .await?;
+    let found = rows(&response, "GraphRun");
+    if let Some(reason) = graph_publication_denial(found, revision_digest) {
+        anyhow::bail!(reason);
+    }
+    let run = &found[0];
+    let generation = run
+        .get("update_generation")
+        .and_then(Value::as_i64)
+        .context("graph run is missing its publication generation")?;
+    let next = generation
+        .checked_add(1)
+        .context("graph run publication generation exhausted")?;
+    let doc_id = run
+        .get("_docID")
+        .and_then(Value::as_str)
+        .context("graph run is missing its document ID")?;
+    txn.execute(&format!(
+        "mutation {{ update_GraphRun(docID: \"{}\", input: {}) {{ _docID }} }}",
+        escape_graphql_string(doc_id),
+        graphql_input_literal(&json!({ "update_generation": next }))?,
+    ))
+    .await?;
+    Ok(())
 }
 
 fn revision_id(plan: &GraphPlan) -> String {
@@ -1371,7 +1435,7 @@ async fn start_run_in_txn(
 }
 
 #[cfg(test)]
-pub(super) use tests::attribution_test_fixture;
+pub(super) use tests::{attribution_test_fixture, seed_signed_graph_request};
 
 #[cfg(test)]
 mod tests {
@@ -1795,6 +1859,8 @@ mod tests {
             gents_protocol::schemas::GRAPH_REVISION,
             gents_protocol::schemas::GRAPH_RUN,
             gents_protocol::schemas::AGENT_REQUEST,
+            gents_protocol::schemas::GOAL,
+            gents_protocol::schemas::GOAL_CREATION_CLAIM,
             gents_protocol::schemas::EVENT_TRIGGER_GROUP_STATE,
             gents_protocol::schemas::TASK,
             gents_protocol::schemas::EVENT_TRIGGER,
@@ -2009,59 +2075,30 @@ mod tests {
         assert_eq!(switched.generation, 2);
 
         let now = chrono::Utc::now().to_rfc3339();
-        let completed_requests = node
-            .execute(&format!(
-                r#"mutation {{
-                    first: create_AgentRequest(input: {{
-                        request_id: "completed-request-1", agent_did: "did:key:worker",
-                        requester_did: "did:key:owner", behavior_id: "worker-v1",
-                        lifecycle_state: "completed",
-                        caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                        created_at: "2026-08-25T00:00:00Z"
-                    }}) {{ _docID }}
-                    second: create_AgentRequest(input: {{
-                        request_id: "completed-request-2", agent_did: "did:key:worker",
-                        requester_did: "did:key:owner", behavior_id: "worker-v1",
-                        lifecycle_state: "completed",
-                        caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                        created_at: "2026-08-25T00:00:01Z"
-                    }}) {{ _docID }}
-                    third: create_AgentRequest(input: {{
-                        request_id: "completed-request-3", agent_did: "did:key:worker",
-                        requester_did: "did:key:owner", behavior_id: "worker-v1",
-                        lifecycle_state: "completed",
-                        caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                        created_at: "2026-08-25T00:00:02Z"
-                    }}) {{ _docID }}
-                }}"#,
-                escape_graphql_string(&materialized.trigger_ids[0]),
-                escape_graphql_string(&run.correlation),
-                escape_graphql_string(&materialized.trigger_ids[0]),
-                escape_graphql_string(&run.correlation),
-                escape_graphql_string(&materialized.trigger_ids[0]),
-                escape_graphql_string(&run.correlation),
-            ))
+        for request_id in [
+            "completed-request-1",
+            "completed-request-2",
+            "completed-request-3",
+        ] {
+            seed_signed_graph_request(
+                &node,
+                &run,
+                &materialized.trigger_ids[0],
+                request_id,
+                "completed",
+                "",
+            )
             .await;
-        assert!(
-            !completed_requests.has_errors(),
-            "{:?}",
-            completed_requests.errors
-        );
-        let request = node
-            .execute(&format!(
-                r#"mutation {{ create_AgentRequest(input: {{
-                    request_id: "cancel-recovery-request", agent_did: "did:key:worker",
-                    requester_did: "did:key:owner", behavior_id: "worker-v1",
-                    lifecycle_state: "processing",
-                    caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                    created_at: "{}"
-                }}) {{ _docID }} }}"#,
-                escape_graphql_string(&materialized.trigger_ids[0]),
-                escape_graphql_string(&run.correlation),
-                escape_graphql_string(&now),
-            ))
-            .await;
-        assert!(!request.has_errors(), "{:?}", request.errors);
+        }
+        seed_signed_graph_request(
+            &node,
+            &run,
+            &materialized.trigger_ids[0],
+            "cancel-recovery-request",
+            "processing",
+            "",
+        )
+        .await;
         let cancel_intent = node
             .execute(&format!(
                 r#"mutation {{ update_GraphRun(
@@ -2137,6 +2174,8 @@ mod tests {
             gents_protocol::schemas::GRAPH_REVISION,
             gents_protocol::schemas::GRAPH_RUN,
             gents_protocol::schemas::AGENT_REQUEST,
+            gents_protocol::schemas::GOAL,
+            gents_protocol::schemas::GOAL_CREATION_CLAIM,
             gents_protocol::schemas::EVENT_TRIGGER_GROUP_STATE,
             gents_protocol::schemas::TASK,
             gents_protocol::schemas::EVENT_TRIGGER,
@@ -2179,21 +2218,8 @@ mod tests {
         .unwrap();
         let now = chrono::Utc::now().to_rfc3339();
         let entry_trigger_id = graph_trigger_id(&plan.digest, "entry:input:worker:input").unwrap();
-        let request = node
-            .execute(&format!(
-                r#"mutation {{ create_AgentRequest(input: {{
-                    request_id: "request-1", agent_did: "did:key:worker",
-                    requester_did: "did:key:owner", behavior_id: "worker-v1",
-                    lifecycle_state: "completed",
-                    caused_by_trigger_id: "{}",
-                    caused_by_correlation: "{}", created_at: "{}"
-                }}) {{ _docID }} }}"#,
-                escape_graphql_string(&entry_trigger_id),
-                escape_graphql_string(&run.correlation),
-                escape_graphql_string(&now),
-            ))
+        seed_signed_graph_request(&node, &run, &entry_trigger_id, "request-1", "completed", "")
             .await;
-        assert!(!request.has_errors(), "{:?}", request.errors);
         let unsatisfied = super::super::load_graph_run_view(&node, "did:key:owner", &run.run_id)
             .await
             .unwrap();
@@ -2386,6 +2412,60 @@ mod tests {
     // Drives the real GraphRun transaction/interrupt owners. Request fixture
     // state changes emulate executor terminal observations, not a second graph
     // coordinator. No provider or wall-clock sleep is needed.
+    /// Seed a real authenticated route receipt, then set its mutable lifecycle.
+    pub(in crate::graph_pipeline) async fn seed_signed_graph_request(
+        node: &EmbeddedNode,
+        run: &GraphRunReceipt,
+        trigger: &str,
+        request_id: &str,
+        lifecycle: &str,
+        reason: &str,
+    ) {
+        use crate::identity::{AgentIdentity, KeyIdentity};
+        use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
+        let temp = tempfile::tempdir().unwrap();
+        let identity =
+            KeyIdentity::load_or_create(temp.path().join("graph-worker.key"), None).unwrap();
+        let mut create = AgentRequestCreate::base(
+            request_id,
+            identity.did(),
+            identity.did(),
+            "worker-v1",
+            &format!("session-{request_id}"),
+            "Execute the pinned graph stage",
+            "scheduled",
+            "2026-08-25T00:00:00Z",
+            AgentRequestAdmissionRecord::runtime_automated_trigger(identity.did(), trigger),
+        );
+        let triggers = node
+            .execute(&format!(
+                r#"{{ EventTrigger(filter: {{ trigger_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#,
+                escape_graphql_string(trigger),
+            ))
+            .await;
+        assert!(!triggers.has_errors(), "{:?}", triggers.errors);
+        create.caused_by_trigger_doc_id = Some(
+            triggers.data.unwrap()["EventTrigger"][0]["_docID"]
+                .as_str()
+                .unwrap()
+                .into(),
+        );
+        create.caused_by_trigger_id = Some(trigger.into());
+        create.caused_by_trigger_kind = Some("event".into());
+        create.caused_by_correlation = Some(run.correlation.clone());
+        create.caused_by_source_doc_id = Some(run.seed_doc_id.clone());
+        crate::sign_agent_request_create(&identity, &mut create)
+            .await
+            .unwrap();
+        let created = node.execute(&create.graphql_mutation().unwrap()).await;
+        assert!(!created.has_errors(), "{:?}", created.errors);
+        let updated = node.execute(&format!(
+            r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, input: {{ lifecycle_state: "{}", failure_reason: "{}" }}) {{ _docID }} }}"#,
+            escape_graphql_string(request_id), escape_graphql_string(lifecycle), escape_graphql_string(reason),
+        )).await;
+        assert!(!updated.has_errors(), "{:?}", updated.errors);
+    }
+
     pub(in crate::graph_pipeline) async fn attribution_test_fixture(
         max_invocations: u32,
     ) -> (Arc<EmbeddedNode>, GraphRunReceipt, String) {
@@ -2395,6 +2475,8 @@ mod tests {
             gents_protocol::schemas::GRAPH_REVISION,
             gents_protocol::schemas::GRAPH_RUN,
             gents_protocol::schemas::AGENT_REQUEST,
+            gents_protocol::schemas::GOAL,
+            gents_protocol::schemas::GOAL_CREATION_CLAIM,
             gents_protocol::schemas::EVENT_TRIGGER_GROUP_STATE,
             gents_protocol::schemas::TASK,
             gents_protocol::schemas::EVENT_TRIGGER,
@@ -2446,32 +2528,8 @@ mod tests {
     ) {
         let (node, run, trigger) = attribution_test_fixture(2).await;
         let original_reason = "MaxTurnError: maximum 250 turns exceeded";
-        let seeded = node
-            .execute(&format!(
-                r#"mutation {{
-            cause: create_AgentRequest(input: {{
-                request_id: "{}", agent_did: "did:key:worker", requester_did: "did:key:owner",
-                behavior_id: "worker-v1", lifecycle_state: "failed", failure_reason: "{}",
-                caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                created_at: "2026-08-25T00:00:00Z"
-            }}) {{ _docID }}
-            sibling: create_AgentRequest(input: {{
-                request_id: "{}", agent_did: "did:key:worker", requester_did: "did:key:owner",
-                behavior_id: "worker-v1", lifecycle_state: "processing",
-                caused_by_trigger_id: "{}", caused_by_correlation: "{}",
-                created_at: "2026-08-25T00:00:01Z"
-            }}) {{ _docID }}
-        }}"#,
-                escape_graphql_string(cause_id),
-                escape_graphql_string(original_reason),
-                escape_graphql_string(&trigger),
-                escape_graphql_string(&run.correlation),
-                escape_graphql_string(sibling_id),
-                escape_graphql_string(&trigger),
-                escape_graphql_string(&run.correlation),
-            ))
-            .await;
-        assert!(!seeded.has_errors(), "{:?}", seeded.errors);
+        seed_signed_graph_request(&node, &run, &trigger, cause_id, "failed", original_reason).await;
+        seed_signed_graph_request(&node, &run, &trigger, sibling_id, "processing", "").await;
 
         let first = reconcile_failure_fixture(&node, &run.run_id, via_access).await;
         assert_eq!(first.status, "running");

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -38,6 +38,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) goal_request_head_cases: Vec<serde_json::Value>,
     pub(crate) goal_operator_resume_cases: Vec<serde_json::Value>,
     pub(crate) goal_config_reactivation_cases: Vec<serde_json::Value>,
+    pub(crate) graph_logical_invocation_cases: Vec<serde_json::Value>,
+    pub(crate) graph_invocation_publication_cases: Vec<serde_json::Value>,
     pub(crate) graph_failure_attribution_traces: Vec<serde_json::Value>,
     pub(crate) request_transition_cases: Vec<LeanLifecycleTransitionCase>,
     pub(crate) process_transition_cases: Vec<LeanLifecycleTransitionCase>,

--- a/crates/gents/src/lifecycle/materialize.rs
+++ b/crates/gents/src/lifecycle/materialize.rs
@@ -1,4 +1,5 @@
 use super::*;
+use anyhow::Context;
 
 #[derive(Debug, Clone)]
 pub struct EnqueuedAgentRequest {
@@ -138,6 +139,13 @@ pub(crate) async fn write_pending_agent_request_with_lineage_workspace_and_conve
         trigger_doc_id,
     )
     .await?;
+    if create
+        .caused_by_trigger_id
+        .as_deref()
+        .is_some_and(crate::graph_pipeline::graph_artifact_is_reserved)
+    {
+        return publish_graph_root_request(node, &create).await;
+    }
     let escaped_request_id = escape_graphql_string(&request_id);
     let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
 
@@ -165,6 +173,61 @@ pub(crate) async fn write_pending_agent_request_with_lineage_workspace_and_conve
         request_id,
         session_id,
     })
+}
+
+/// Retry the complete graph publication transaction on native conflicts. A
+/// first-seen trigger event cannot be replayed, so retrying only its row create
+/// would either lose the stage or bypass a newly committed graph closure.
+async fn publish_graph_root_request(
+    node: &EmbeddedNode,
+    create: &gents_protocol::request_admission::AgentRequestCreate,
+) -> Result<EnqueuedAgentRequest> {
+    let mutation = create.graphql_mutation().map_err(anyhow::Error::msg)?;
+    for attempt in 0..=crate::graphql::DEFRA_DB_CONFLICT_MAX_RETRIES {
+        let txn = crate::config_client::ConfigApplyTxn::begin_local(node, None).await?;
+        let staged = async {
+            crate::graph_pipeline::fence_graph_root_request_in_txn(&txn, create).await?;
+            let response = txn.execute(&mutation).await?;
+            let child = response
+                .pointer("/data/create_AgentRequest")
+                .or_else(|| response.pointer("/data/add_AgentRequest"))
+                .context("graph root create omitted result")?;
+            let doc_id = child
+                .get("_docID")
+                .or_else(|| child.get(0).and_then(|row| row.get("_docID")))
+                .and_then(serde_json::Value::as_str)
+                .context("graph root create omitted document ID")?
+                .to_owned();
+            Ok::<_, anyhow::Error>(doc_id)
+        }
+        .await;
+        let result = match staged {
+            Ok(doc_id) => txn.commit().await.map(|()| doc_id),
+            Err(error) => {
+                let _ = txn.discard().await;
+                Err(error)
+            }
+        };
+        match result {
+            Ok(doc_id) => {
+                return Ok(EnqueuedAgentRequest {
+                    doc_id,
+                    request_id: create.request_id.clone(),
+                    session_id: create.session_id.clone(),
+                })
+            }
+            Err(error)
+                if attempt < crate::graphql::DEFRA_DB_CONFLICT_MAX_RETRIES
+                    && crate::graphql::is_defradb_transaction_conflict_text(&format!(
+                        "{error:#}"
+                    )) =>
+            {
+                tokio::time::sleep(crate::graphql::defradb_conflict_retry_backoff(attempt)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("bounded publication retry returns on its final attempt")
 }
 
 /// Build and sign the canonical pending request used by trigger materialization.

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -542,6 +542,18 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "GoalClaimedPublicationCases".to_string(),
         ));
     }
+    if !snapshot.graph_logical_invocation_cases.is_empty() {
+        emitted.insert((
+            "graph_logical_invocation_cases".to_string(),
+            "GraphLogicalInvocationCases".to_string(),
+        ));
+    }
+    if !snapshot.graph_invocation_publication_cases.is_empty() {
+        emitted.insert((
+            "graph_invocation_publication_cases".to_string(),
+            "GraphInvocationPublicationCases".to_string(),
+        ));
+    }
     if !snapshot.goal_request_head_cases.is_empty() {
         emitted.insert((
             "goal_request_head_cases".to_string(),
@@ -1307,6 +1319,8 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "goal_request_head_cases",
         "goal_operator_resume_cases",
         "goal_config_reactivation_cases",
+        "graph_logical_invocation_cases",
+        "graph_invocation_publication_cases",
         "graph_failure_attribution_traces",
         "graph_pipeline_validation_cases",
         "graph_pipeline_revision_gate_cases",

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -56,6 +56,20 @@ impl ConformanceConsumer {
 pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
     &[
         ConformanceConsumer::RustTest {
+            id: "graph_pipeline::run::publication_contract_tests::generated_graph_invocation_publication_traces_drive_real_transactions",
+            package: "gents",
+            source_path: "crates/gents/src/graph_pipeline/publication_contract_tests.rs",
+            module_path: "graph_pipeline::run::publication_contract_tests",
+            function: "generated_graph_invocation_publication_traces_drive_real_transactions",
+        },
+        ConformanceConsumer::RustTest {
+            id: "graph_pipeline::logical_invocation_contract_tests::generated_graph_logical_invocations_drive_persisted_run_projection",
+            package: "gents",
+            source_path: "crates/gents/src/graph_pipeline/logical_invocation_contract_tests.rs",
+            module_path: "graph_pipeline::logical_invocation_contract_tests",
+            function: "generated_graph_logical_invocations_drive_persisted_run_projection",
+        },
+        ConformanceConsumer::RustTest {
             id: "goal::request_head::tests::generated_goal_request_head_cases_drive_signed_row_selector",
             package: "gents",
             source_path: "crates/gents/src/goal/request_head_tests.rs",


### PR DESCRIPTION
A failed graph request previously latched a run failure even when its Goal still owned a continuation. The run now follows authenticated physical Goal ancestry: an active obligation keeps the invocation open, and a successful final child plus the declared results can complete it. Physical attempts still determine invocation limits and cancellation/failure draining; definitive failure preserves the final causal request and its original reason.

Root factories, typed resume, automatic continuation, and fresh Goal opening now participate in the existing GraphRun generation transaction before publishing new work. Publication and closure cannot both commit against the same database snapshot. Exact receipt recovery remains idempotent. There is no new persisted invocation table, lifecycle, or transaction mechanism. CLI progress includes outstanding invocations.

The Lean model drives 15 persisted projection cases and five publication traces. Additional real caller tests cover both root factories, resume, automatic publication, and Goal creation; overlapping native handles verify storage conflicts and atomic rollback in both commit orders. A second regression covers same-second historical children after canonical Goal replacement.

Validation:

- `lake build`: 1,049 targets passed; no sorry/admit/axiom in the new models.
- `cargo test -p gents`: 2,743 passed, three existing ignored.
- CLI graph tests: 4 passed; Goal unit tests: 21 passed; real CLI Goal tests: 2 passed; Codex Goal persistence: 1 passed.
- `cargo check --workspace --all-targets`: passed; existing `Matcher.description` warning remains.
- Independent internal review completed; Opus findings checked against complete producer/canonical-owner contracts, with no remaining blocker.

The concurrency guarantee applies to cooperating transactions on the same DefraDB instance. Initial graph root/Goal publication is atomic; arbitrary independent pre-root Goal insertion and ordering across replicas are not claimed (see proof README). Final real-inference E2E results and completed disposable-clone review graph `315587bb-2553-46c7-b566-8cb540714dd5` at `98f1bccbf` are reported in #1413.

Closes #1357. Stacked on #1384 in native stack #1381.

Review correction in #1395: roots must match the verified GraphRun/revision owner DID, existing signed receipt, and pinned route. Foreign signed rows are excluded before attribution and interruption targeting; fresh publication uses the existing generation transaction. DefraDB ACP remains the access-control owner, with no new live Task/AgentBehavior permission layer. Mutable task metadata cannot erase historical work, and unrelated interactive session rows no longer erase the invocation’s Goal obligation. Final-tip validation is reported in #1413.
