### PR TITLE
feat(backend): Claude model discovery via GET /v1/models, and discover-models --write

### DIFF
--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -2422,6 +2422,11 @@ pub(crate) struct BackendDiscoverModelsArgs {
         help = "Agent home directory used to resolve the local agent DID for OAuth-credential backend discovery (defaults to ~/.gents). Pass --agent-did instead to target a specific agent"
     )]
     pub(crate) home: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Replace the backend document's models[] with the discovered models (requires --backend-id; nothing is written without this flag)"
+    )]
+    pub(crate) write: bool,
 }
 
 #[derive(clap::Args)]

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -2414,12 +2414,12 @@ pub(crate) struct BackendDiscoverModelsArgs {
     pub(crate) api_key_env_var: Option<String>,
     #[arg(
         long,
-        help = "Agent DID owning the ChatGptCodex OAuth credential (defaults to the local agent). Only used for ChatGptCodex backends, whose bearer is a DefraDB document rather than an api_key"
+        help = "Agent DID owning the OAuth credential (defaults to the local agent). Only used for OAuth-credential backends (ChatGptCodex, XaiGrokOAuth, ClaudeCliSubscription), whose bearer is a DefraDB document rather than an api_key"
     )]
     pub(crate) agent_did: Option<String>,
     #[arg(
         long,
-        help = "Agent home directory used to resolve the local agent DID for ChatGptCodex discovery (defaults to ~/.gents). Pass --agent-did instead to target a specific agent"
+        help = "Agent home directory used to resolve the local agent DID for OAuth-credential backend discovery (defaults to ~/.gents). Pass --agent-did instead to target a specific agent"
     )]
     pub(crate) home: Option<PathBuf>,
 }

--- a/crates/gents-cli/src/commands/config/backend.rs
+++ b/crates/gents-cli/src/commands/config/backend.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use gents::graphql::escape_graphql_string;
 use gents::{discover_backend_models, BackendProviderKind, InferenceBackend};
+use gents_protocol::graphql::{extract_mutation_doc_id, string_list_field};
 use serde_json::{json, Value};
 
 use crate::cli::*;
@@ -88,6 +89,11 @@ pub(super) async fn backend_set(args: BackendUpsertArgs) -> Result<()> {
 }
 
 pub(super) async fn backend_discover_models(args: BackendDiscoverModelsArgs) -> Result<()> {
+    if args.write && normalize_optional_string(args.backend_id.as_deref()).is_none() {
+        anyhow::bail!(
+            "--write requires --backend-id: the discovered models are written to that backend document"
+        );
+    }
     let target = resolve_backend_discovery_target(&args).await?;
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -147,6 +153,22 @@ pub(super) async fn backend_discover_models(args: BackendDiscoverModelsArgs) -> 
         Err(error) => return Err(error),
     };
 
+    // An empty list would render `models: null` and wipe the column, so it is never written.
+    let models_written = if args.write && !discovered_models.is_empty() {
+        write_discovered_models(
+            args.graphql
+                .as_deref()
+                .expect("checked graphql when backend_id is set"),
+            target
+                .backend_id
+                .as_deref()
+                .expect("checked backend_id when --write is set"),
+            &discovered_models,
+        )
+        .await?
+    } else {
+        0
+    };
     let output = json!({
         "backend_id": target.backend_id,
         "backend_preset": target.preset.map(BackendPresetArg::as_str),
@@ -155,6 +177,9 @@ pub(super) async fn backend_discover_models(args: BackendDiscoverModelsArgs) -> 
         "api_key": target.api_key.as_ref().map(|_| "<redacted>"),
         "api_key_env_var": target.api_key_env_var,
         "discovered_models": discovered_models,
+        "models_written": models_written,
+        "write_skipped": (args.write && models_written == 0)
+            .then_some("discovery returned no models; models[] left unchanged"),
     });
     print_json(&output)?;
     Ok(())
@@ -191,6 +216,30 @@ async fn load_oauth_credential_for_discovery(
         crate::commands::codex_auth_probe::load_oauth_credential(&access, &agent_did, provider)
             .await?;
     Ok((credential, agent_did))
+}
+
+/// Rewrites `models[]` on the stored backend document and nothing else.
+async fn write_discovered_models(
+    graphql: &str,
+    backend_id: &str,
+    models: &[String],
+) -> Result<usize> {
+    let models_field = string_list_field("models", models)
+        .ok_or_else(|| anyhow::anyhow!("backend models field could not be rendered"))?;
+    let mutation = format!(
+        r#"mutation {{
+            update_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{}" }} }},
+                input: {{ {} }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(backend_id),
+        models_field,
+    );
+    let response = post_graphql(graphql, &mutation).await?;
+    extract_mutation_doc_id(&response, "InferenceBackend")
+        .with_context(|| format!("updating models on backend {backend_id}"))?;
+    Ok(models.len())
 }
 
 /// Whether a model-discovery error is an authentication failure (HTTP 401/403), so ChatGptCodex

--- a/crates/gents-cli/src/commands/config/backend.rs
+++ b/crates/gents-cli/src/commands/config/backend.rs
@@ -133,6 +133,17 @@ pub(super) async fn backend_discover_models(args: BackendDiscoverModelsArgs) -> 
             );
             anyhow::bail!("{error:#}\n{guidance}");
         }
+        Err(error)
+            if target.provider_kind == BackendProviderKind::ClaudeCliSubscription
+                && discovery_error_is_auth(&error) =>
+        {
+            let guidance = gents::claude_oauth::classify_claude_auth_error(
+                oauth_agent_did.as_deref().unwrap_or(""),
+                gents::claude_oauth::CLAUDE_OAUTH_PROVIDER,
+                &gents::oauth_credential::OAuthAuthProblem::Expired,
+            );
+            anyhow::bail!("{error:#}\n{guidance}");
+        }
         Err(error) => return Err(error),
     };
 
@@ -161,6 +172,10 @@ async fn load_oauth_credential_for_discovery(
         BackendProviderKind::XaiGrokOAuth => (
             gents::xai_grok_oauth::XAI_OAUTH_PROVIDER,
             "gents grok-login",
+        ),
+        BackendProviderKind::ClaudeCliSubscription => (
+            gents::claude_oauth::CLAUDE_OAUTH_PROVIDER,
+            "gents claude-login",
         ),
         _ => anyhow::bail!("load_oauth_credential_for_discovery called for non-OAuth provider"),
     };

--- a/crates/gents-cli/tests/suites/cli_config_backend.rs
+++ b/crates/gents-cli/tests/suites/cli_config_backend.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use serde_json::Value;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -144,24 +144,34 @@ async fn config_backend_set_preset_and_discover_models_from_backend_id() -> Resu
         discover.get("provider_kind").and_then(Value::as_str),
         Some("OpenRouter")
     );
+    assert_eq!(
+        discover.get("models_written").and_then(Value::as_u64),
+        Some(0),
+        "without --write nothing is written: {discover}"
+    );
 
-    let backend_rows = graphql_query(
-        &graphql,
-        &format!(
+    let backend_query = |id: &str| {
+        format!(
             r#"{{
-                InferenceBackend(filter: {{ backend_id: {{ _eq: "{}" }} }}, limit: 1) {{
-                    backend_id
-                    provider_kind
-                    endpoint
-                    api_key
-                    api_key_env_var
-                }}
-            }}"#,
-            escape_graphql_string(&backend_id),
-        ),
-    )
-    .await?;
+            InferenceBackend(filter: {{ backend_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                backend_id
+                name
+                provider_kind
+                endpoint
+                api_key
+                api_key_env_var
+                max_concurrent
+                enabled
+                probe_status
+                models
+            }}
+        }}"#,
+            escape_graphql_string(id),
+        )
+    };
+    let backend_rows = graphql_query(&graphql, &backend_query(&backend_id)).await?;
     let backend = first_graphql_row(&backend_rows, "InferenceBackend")?;
+    assert_eq!(backend.get("models"), Some(&json!(["default"])));
     assert_eq!(
         backend.get("provider_kind").and_then(Value::as_str),
         Some("OpenRouter")
@@ -176,6 +186,128 @@ async fn config_backend_set_preset_and_discover_models_from_backend_id() -> Resu
     );
     assert_eq!(backend.get("api_key_env_var").and_then(Value::as_str), None);
 
+    let written = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "backend",
+            "discover-models",
+            "--graphql",
+            &graphql,
+            "--backend-id",
+            &backend_id,
+            "--write",
+        ],
+    )?;
+    assert_eq!(
+        written.get("models_written").and_then(Value::as_u64),
+        Some(1),
+        "--write reports the persisted count: {written}"
+    );
+
+    let backend_rows = graphql_query(&graphql, &backend_query(&backend_id)).await?;
+    let backend = first_graphql_row(&backend_rows, "InferenceBackend")?;
+    assert_eq!(
+        backend.get("models"),
+        Some(&json!([discover_model])),
+        "--write replaces models[] with the discovered catalog: {backend}"
+    );
+    assert_eq!(
+        backend.get("name").and_then(Value::as_str),
+        Some("OpenRouter")
+    );
+    assert_eq!(
+        backend.get("endpoint").and_then(Value::as_str),
+        Some(discover_endpoint.endpoint())
+    );
+    assert_eq!(
+        backend.get("api_key").and_then(Value::as_str),
+        Some(discover_api_key)
+    );
+    assert_eq!(
+        backend.get("max_concurrent").and_then(Value::as_i64),
+        Some(2)
+    );
+    assert_eq!(backend.get("enabled").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        backend.get("probe_status").and_then(Value::as_str),
+        Some("healthy")
+    );
+
+    // Zero usable ids: the mock renders {"data":[{"id":""}]} and blank ids are
+    // dropped, so --write must not touch models[] (an empty list would render
+    // `models: null` and wipe the column).
+    let empty_endpoint = MockModelEndpoint::start("")?;
+    let empty_backend_id = format!("{agent_name}-empty");
+    run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "backend",
+            "set",
+            "--graphql",
+            &graphql,
+            "--backend-id",
+            &empty_backend_id,
+            "--name",
+            "Empty catalog",
+            "--backend-preset",
+            "openrouter",
+            "--endpoint",
+            empty_endpoint.endpoint(),
+            "--api-key",
+            "unused",
+            "--max-concurrent",
+            "1",
+        ],
+    )?;
+    let skipped = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "backend",
+            "discover-models",
+            "--graphql",
+            &graphql,
+            "--backend-id",
+            &empty_backend_id,
+            "--write",
+        ],
+    )?;
+    assert_eq!(
+        skipped.get("models_written").and_then(Value::as_u64),
+        Some(0),
+        "{skipped}"
+    );
+    assert!(
+        skipped
+            .get("write_skipped")
+            .and_then(Value::as_str)
+            .is_some(),
+        "zero ids must report write_skipped: {skipped}"
+    );
+    let backend_rows = graphql_query(&graphql, &backend_query(&empty_backend_id)).await?;
+    let backend = first_graphql_row(&backend_rows, "InferenceBackend")?;
+    assert_eq!(
+        backend.get("models"),
+        Some(&json!(["default"])),
+        "zero ids must leave models[] untouched: {backend}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn config_backend_discover_models_write_requires_backend_id() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let stderr = run_cli_failure_stderr(
+        tempdir.path(),
+        &["config", "backend", "discover-models", "--write"],
+    )?;
+    assert!(
+        stderr.contains("--write requires --backend-id"),
+        "guard must fire before any server is needed: {stderr}"
+    );
     Ok(())
 }
 

--- a/crates/gents/src/backend_provider.rs
+++ b/crates/gents/src/backend_provider.rs
@@ -118,6 +118,18 @@ fn provider_display_name(kind: BackendProviderKind) -> &'static str {
 const MODEL_DISCOVERY_PATH: &str = "/models";
 /// The Grok CLI proxy publishes its catalog at `/models-v2` (official client path).
 const XAI_GROK_MODEL_DISCOVERY_PATH: &str = "/models-v2";
+/// Claude subscription catalog base. The backend document's endpoint is the
+/// `claude-cli://subscription` placeholder; an `http(s)://` endpoint (tests)
+/// overrides this.
+const CLAUDE_MODELS_BASE: &str = "https://api.anthropic.com/v1";
+
+fn claude_models_base(endpoint: &str) -> String {
+    if endpoint.starts_with("http://") || endpoint.starts_with("https://") {
+        endpoint.trim_end_matches('/').to_string()
+    } else {
+        CLAUDE_MODELS_BASE.to_string()
+    }
+}
 
 #[derive(Deserialize)]
 struct OpenAiModelsResponse {
@@ -148,6 +160,7 @@ impl OpenAiModelRecord {
             .into_iter()
             .flatten()
             .find(|value| !value.trim().is_empty())
+            .map(|value| value.trim().to_string())
     }
 }
 
@@ -165,6 +178,7 @@ impl ChatGptCodexModelRecord {
             .into_iter()
             .flatten()
             .find(|value| !value.trim().is_empty())
+            .map(|value| value.trim().to_string())
     }
 }
 
@@ -178,6 +192,7 @@ pub async fn discover_models(
     let endpoint = match kind {
         BackendProviderKind::ChatGptCodex => crate::chatgpt_codex::normalize_endpoint(endpoint),
         BackendProviderKind::XaiGrokOAuth => crate::xai_grok_oauth::normalize_endpoint(endpoint),
+        BackendProviderKind::ClaudeCliSubscription => claude_models_base(endpoint),
         _ => endpoint.trim_end_matches('/').to_string(),
     };
     let discovery_path = if kind == BackendProviderKind::XaiGrokOAuth {
@@ -236,6 +251,21 @@ pub async fn discover_models(
                     request = request.header(name, value);
                 }
             }
+        } else if kind == BackendProviderKind::ClaudeCliSubscription {
+            let Some(credential) = oauth_credential else {
+                tracing::Span::current().record("failure_class", "auth");
+                anyhow::bail!(
+                    "Claude subscription model discovery requires an OAuthCredential document; run `gents claude-login --agent-did <did>` for the agent DID first"
+                );
+            };
+            request = request
+                .bearer_auth(&credential.access_token)
+                .header(
+                    "anthropic-version",
+                    crate::claude_messages::ANTHROPIC_VERSION,
+                )
+                .header("anthropic-beta", crate::claude_messages::OAUTH_BETA)
+                .query(&[("limit", "100")]);
         } else if let Some(api_key) = api_key {
             request = request.bearer_auth(api_key);
         }
@@ -337,7 +367,7 @@ mod tests {
     #[tokio::test]
     async fn discover_models_reads_openai_models_and_sends_api_key() {
         let (endpoint, requests) =
-            spawn_model_discovery_server(r#"{"data":[{"id":"gpt-4.1-mini"},{"id":"o3"}]}"#).await;
+            spawn_model_discovery_server(r#"{"data":[{"id":"gpt-4.1-mini"},{"id":" o3 "}]}"#).await;
 
         let models = discover_models(
             &Client::new(),
@@ -367,7 +397,7 @@ mod tests {
     #[tokio::test]
     async fn discover_models_decodes_chatgpt_codex_models_shape() {
         let (endpoint, _requests) =
-            spawn_model_discovery_server(r#"{"models":[{"slug":"codex-mini-latest"}]}"#).await;
+            spawn_model_discovery_server(r#"{"models":[{"slug":" codex-mini-latest "}]}"#).await;
 
         let models = discover_models(
             &Client::new(),
@@ -524,7 +554,132 @@ mod tests {
         );
     }
 
+    fn claude_credential() -> crate::oauth_credential::OAuthCredential {
+        crate::oauth_credential::OAuthCredential {
+            doc_id: None,
+            credential_id: "claude-subscription:did:key:zAgent".to_string(),
+            agent_did: "did:key:zAgent".to_string(),
+            provider: crate::claude_oauth::CLAUDE_OAUTH_PROVIDER.to_string(),
+            access_token: "access-token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            id_token: None,
+            account_id: None,
+            chatgpt_plan_type: None,
+            is_fedramp: false,
+            access_token_expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            last_refresh: None,
+            enabled: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn discover_models_reads_claude_models_with_oauth_headers() {
+        // Live probe: `GET https://api.anthropic.com/v1/models` with the
+        // subscription bearer returns the OpenAI-style `{"data":[{"id":...}]}`.
+        let (endpoint, requests) = spawn_model_discovery_server(
+            r#"{"data":[{"id":"claude-fable-5-1","type":"model"},{"id":"claude-opus-5","type":"model"},{"id":"claude-sonnet-5","type":"model"}],"has_more":false}"#,
+        )
+        .await;
+        let credential = claude_credential();
+
+        let models = discover_models(
+            &Client::new(),
+            BackendProviderKind::ClaudeCliSubscription,
+            &format!("{endpoint}/v1"),
+            None,
+            Some(&credential),
+        )
+        .await
+        .expect("Claude subscription model discovery should read /v1/models");
+
+        assert_eq!(
+            models,
+            vec!["claude-fable-5-1", "claude-opus-5", "claude-sonnet-5"]
+        );
+        let requests = requests.lock().expect("requests lock");
+        let request = requests
+            .first()
+            .expect("captured request")
+            .to_ascii_lowercase();
+        assert!(
+            request.starts_with("get /v1/models?limit=100 "),
+            "Claude discovery must query /v1/models?limit=100: {request}"
+        );
+        for header in [
+            "authorization: bearer access-token",
+            "anthropic-version: 2023-06-01",
+            "anthropic-beta: oauth-2025-04-20",
+        ] {
+            assert!(request.contains(header), "{header} missing from {request}");
+        }
+    }
+
+    #[tokio::test]
+    async fn discover_models_claude_401_is_an_auth_error() {
+        let (endpoint, _requests) = spawn_model_discovery_server_with_status(
+            "401 Unauthorized",
+            r#"{"type":"error","error":{"type":"authentication_error","message":"invalid bearer"}}"#,
+        )
+        .await;
+        let credential = claude_credential();
+
+        let error = discover_models(
+            &Client::new(),
+            BackendProviderKind::ClaudeCliSubscription,
+            &format!("{endpoint}/v1"),
+            None,
+            Some(&credential),
+        )
+        .await
+        .expect_err("401 from /v1/models must fail discovery");
+
+        let http = error
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<ModelDiscoveryHttpError>())
+            .expect("401 must surface as ModelDiscoveryHttpError so the CLI appends claude-login guidance");
+        assert!(http.is_auth(), "{http}");
+    }
+
+    #[tokio::test]
+    async fn discover_models_claude_without_credential_names_claude_login() {
+        let error = discover_models(
+            &Client::new(),
+            BackendProviderKind::ClaudeCliSubscription,
+            "claude-cli://subscription",
+            None,
+            None,
+        )
+        .await
+        .expect_err("Claude discovery without a credential must fail");
+
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("requires an OAuthCredential document")
+                && message.contains("--agent-did"),
+            "missing-credential error must name the login command: {message}"
+        );
+    }
+
+    #[test]
+    fn claude_models_base_ignores_the_placeholder_endpoint() {
+        assert_eq!(
+            claude_models_base("claude-cli://subscription"),
+            "https://api.anthropic.com/v1"
+        );
+        assert_eq!(
+            claude_models_base("http://127.0.0.1:8080/v1"),
+            "http://127.0.0.1:8080/v1"
+        );
+    }
+
     async fn spawn_model_discovery_server(body: &'static str) -> (String, Arc<Mutex<Vec<String>>>) {
+        spawn_model_discovery_server_with_status("200 OK", body).await
+    }
+
+    async fn spawn_model_discovery_server_with_status(
+        status: &'static str,
+        body: &'static str,
+    ) -> (String, Arc<Mutex<Vec<String>>>) {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind mock model-discovery server");
@@ -546,7 +701,8 @@ mod tests {
                 .expect("requests lock")
                 .push(request.to_string());
             let response = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status,
                 body.len(),
                 body
             );


### PR DESCRIPTION
**Stack (four PRs carved from one reviewed branch; #1388 targets `main`, each later PR targets its predecessor's branch):** #1388 wire + Lean fence → #1389 login, probe, gate → #1390 discovery → #1391 docs. This is PR 3 of 4: the diff shows only its own 2 commits; GitHub retargets it to `main` once #1389's branch is deleted on merge. #1388 and #1389 should land together.

## Summary

- Claude arm in `discover_models`: `GET https://api.anthropic.com/v1/models?limit=100` with the credential bearer,
  `anthropic-version: 2023-06-01` and `anthropic-beta: oauth-2025-04-20`; identifiers trimmed (the same `identifier()` trim now
  applies to Codex catalog records).
- `gents config backend discover-models --write` persists the discovered ids into the backend's `models[]` — for all three
  OAuth kinds. Requires `--backend-id`; a models-only mutation (name, endpoint, api_key, max_concurrent, enabled,
  probe_status untouched); skipped with `write_skipped` when discovery returns zero ids, so `models[]` is never wiped.

Commits (stacked on PR2): 7ce34b6a (discovery arm + CLI error/credential arms + help text), 28237cb9 (`--write`).

## Notes

- This is the first path that ever persists a catalog: before it, discovery only printed, and `gents init` seeds `models[]`
  with the single `--model-name`. Codex's `/model` picker reads `models[]`, so this is what makes the full Claude list appear.
- Discovery is explicit only: no login runs it, and automatic (fleet) discovery keeps skipping agent-scoped kinds.
- `--write` bypasses `InferenceBackend::validate` (same as `backend set` passing `None`); the no-lockout conjunct is opt-in.
- `has_more` is ignored: a catalog over 100 models would be truncated.
- A hand-edited `https://` endpoint on a Claude row becomes the discovery base; the placeholder `claude-cli://subscription`
  maps to the default base.
- One GET per invocation, no inference.

## Verification

- Opus review (with PR2's trees): approved, 0 Critical / 0 Important.
- Unit: `backend_provider` 10/10 (mock `/v1/models` three ways; path, `?limit=100`, both headers, trimming asserted);
  `cli_config_backend` discover tests incl. zero-ids and the `--write`-without-`--backend-id` guard. On this exact tip
  (2026-09-05 split gate): `cargo check` 0; `backend_provider` lib tests 10/10; gents-cli `discover` tests 6/6.
- Live (dev machine): `GET /v1/models` with the subscription bearer → 200, 11 ids; `--write` turned `models[]` from 1 to 11
  with every other field byte-identical, idempotent on rerun, no restart needed.

## Known gaps / follow-ups (not in this PR)

- Two Anthropic base-URL literals; duplicated auth-guidance arms across the three kinds.
- `--write` not validated (above); `has_more` truncation.


