### PR TITLE
fix(runtime): resolve graph reliability stack review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3764,6 +3764,7 @@ dependencies = [
  "gents-lean-contract",
  "gents-migration",
  "gents-protocol",
+ "hmac",
  "hostname",
  "identity",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
+hmac = "0.12"
 subtle = "2.6"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -74,6 +74,7 @@ serde_json.workspace = true
 regex = "1"
 schemars = "1"
 sha2.workspace = true
+hmac.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/crates/gents/proofs/Proofs/CommandPolicy/ArtifactAuthority.lean
+++ b/crates/gents/proofs/Proofs/CommandPolicy/ArtifactAuthority.lean
@@ -86,6 +86,11 @@ theorem admitted_explicit {m : ExecutionMode} {c : Option ArtifactBinding}
 theorem missing_binding_denied (m : ExecutionMode) : admitArtifact m none = false := by
   simp [admitArtifact]
 
+/-- Host eligibility is an admission premise, not merely a later spawn check. -/
+theorem unsupported_host_denied (m : ExecutionMode) (c : ArtifactBinding)
+    (h : c.sandboxEnforced = false) : admitArtifact m (some c) = false := by
+  simp [admitArtifact, ArtifactBinding.eligible, h]
+
 theorem admitted_checks {m : ExecutionMode} {c : ArtifactBinding}
     (h : admitArtifact m (some c) = true) :
     c.authority = .readOnly ∧ c.state = .sealed ∧ c.sealMatches = true ∧

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -274,6 +274,8 @@ def snapshotJson : String :=
         (cancelPropagationCases.map cancelPropagationCaseJson) ++ ","
     ++ "\"workspace_path_capability_cases\":"
       ++ Conformance.WorkspacePathCapabilityContracts.casesJson ++ ","
+    ++ "\"workspace_path_alias_cases\":"
+      ++ Conformance.WorkspacePathCapabilityContracts.aliasCasesJson ++ ","
     ++ "\"workspace_capability_migration_cases\":"
       ++ Conformance.WorkspacePathCapabilityContracts.migrationCasesJson ++ ","
     ++ "\"workspace_cases\":"

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -875,6 +875,11 @@ def caseCoverage : List CoverageEntry :=
       "gents_migration::workspace_path_capability::generated_workspace_capability_migrations_drive_real_lens_and_current_rows")
       "isolated-workspaces" [Surface.runtimeInternal]
   , tagged (consumerCoverage
+      "workspace_path_alias_cases"
+      "WorkspacePathAliasCases"
+      "workspace::tests::path_alias_contract::generated_workspace_path_alias_cases_drive_real_git_delta")
+      "isolated-workspaces" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "graph_logical_invocation_cases"
       "GraphLogicalInvocationCases"
       "graph_pipeline::logical_invocation_contract_tests::generated_graph_logical_invocations_drive_persisted_run_projection")

--- a/crates/gents/proofs/Proofs/Conformance/GoalOperatorResume.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GoalOperatorResume.lean
@@ -84,10 +84,14 @@ def requestJson (x : Request) : String :=
   ",\"authorized\":" ++ b x.authorized ++ ",\"parent_belongs_to_goal\":" ++ b x.parentBelongsToGoal ++
   ",\"terminal_parent\":" ++ b x.terminalParent ++ ",\"session_idle\":" ++ b x.sessionIdle ++
   ",\"binding\":" ++ bindingJson x.binding ++ "}"
+theorem historical_receipt_can_report_paused :
+  receiptStatus (resume later request true) = some .paused := by decide
+
 def caseJson (c : ResumeCase) : String :=
   "{\"name\":" ++ jsonString c.name ++ ",\"before\":" ++ snapshotJson c.before ++
   ",\"request\":" ++ requestJson c.request ++ ",\"commit\":" ++ b c.commit ++
-  ",\"expected\":" ++ snapshotJson c.expected ++ ",\"outcome\":" ++ jsonString (outcome c.outcome) ++ "}"
+  ",\"expected\":" ++ snapshotJson c.expected ++ ",\"outcome\":" ++ jsonString (outcome c.outcome) ++
+  ",\"goal_status\":" ++ (match receiptStatus (c.expected, c.outcome) with | none => "null" | some value => status value) ++ "}"
 def resumeCasesJson : String := jsonArray (resumeCases.map caseJson)
 def configCasesJson : String := jsonArray (configCases.map fun c =>
   "{\"current\":" ++ status c.1 ++ ",\"target\":" ++ status c.2.1 ++ ",\"allowed\":" ++ b c.2.2 ++ "}")

--- a/crates/gents/proofs/Proofs/Conformance/GraphFailureAttribution.lean
+++ b/crates/gents/proofs/Proofs/Conformance/GraphFailureAttribution.lean
@@ -32,10 +32,11 @@ def traceCases : List TraceCase :=
       expected := [⟨.running, false, 1, some 90, true⟩,
                    ⟨.running, false, 1, some 90, true⟩, ⟨.failed, false, 2, some 90, false⟩] }
   , { name := "reversed_lexical_order_keeps_cause"
-      -- A later higher-ID failure does not displace the already observed
-      -- lower-ID candidate in the runtime's lexical evidence projection.
-      events := [.capture 0 (some 10), .capture 1 (some 10), .finish 1 true (some 10)]
+      -- Explicitly introduce the second physical failure before recapture.
+      events := [.capture 0 (some 10), .observedFailure 90,
+                 .capture 1 (some 10), .finish 1 true (some 10)]
       expected := [⟨.running, false, 1, some 10, true⟩,
+                   ⟨.running, false, 1, some 10, true⟩,
                    ⟨.running, false, 1, some 10, true⟩, ⟨.failed, false, 2, some 10, false⟩] }
   , { name := "concurrent_stale_capture_loses"
       events := [.capture 0 (some 90), .capture 0 (some 10), .finish 1 true (some 10)]
@@ -88,6 +89,8 @@ private def statusJson : RunStatus → String
   | .cancelled => jsonString "cancelled"
 
 def eventJson : Event → String
+  | .observedFailure cause =>
+      "{\"kind\":\"observed_failure\",\"witness\":" ++ causeJson (some cause) ++ "}"
   | .capture expected witness =>
       "{\"kind\":\"capture\",\"expected_generation\":" ++ toString expected ++
       ",\"witness\":" ++ causeJson witness ++ "}"

--- a/crates/gents/proofs/Proofs/Conformance/WorkspacePathCapability.lean
+++ b/crates/gents/proofs/Proofs/Conformance/WorkspacePathCapability.lean
@@ -143,4 +143,57 @@ private def migrationCaseJson (c : MigrationCase) :=
   "{\"name\":" ++ jsonString c.name ++ ",\"legacy_source\":" ++ boolString c.legacySource ++
   ",\"stored\":" ++ optionalCapJson c.stored ++ ",\"expected\":" ++ optionalCapJson c.expected ++ "}"
 def migrationCasesJson := jsonArray (migrationCases.map migrationCaseJson)
+
+structure AliasCase where
+  name : String
+  changedPaths : List String
+  basePaths : List String
+  treePaths : List String
+  changedPrefixes : List (String × String)
+  basePrefixes : List (String × String)
+  treePrefixes : List (String × String)
+  expected : Bool
+  deriving DecidableEq, Repr
+
+def aliasCases : List AliasCase :=
+  [ ⟨"unrelated_exotic_and_colliding_entries_unchanged",
+      ["allowed.rs"], ["allowed.rs","odd:name","[draft]","Old/a","old/b"],
+      ["allowed.rs","odd:name","[draft]","Old/a","old/b"],
+      [("allowed.rs","allowed.rs")],
+      [("allowed.rs","allowed.rs"),("odd:name","odd:name"),("[draft]","[draft]"),
+       ("Old","old"),("Old/a","old/a"),("old","old"),("old/b","old/b")],
+      [("allowed.rs","allowed.rs"),("odd:name","odd:name"),("[draft]","[draft]"),
+       ("Old","old"),("Old/a","old/a"),("old","old"),("old/b","old/b")], true⟩
+  , ⟨"changed_file_alias_denied", ["allowed.rs"], ["Allowed.rs"],
+      ["Allowed.rs","allowed.rs"], [("allowed.rs","allowed.rs")],
+      [("Allowed.rs","allowed.rs")],[("Allowed.rs","allowed.rs"),("allowed.rs","allowed.rs")], false⟩
+  , ⟨"changed_directory_alias_denied", ["src/new.rs"], ["Src/other.rs"],
+      ["Src/other.rs","src/new.rs"], [("src","src"),("src/new.rs","src/new.rs")],
+      [("Src","src"),("Src/other.rs","src/other.rs")],
+      [("Src","src"),("Src/other.rs","src/other.rs"),("src","src"),("src/new.rs","src/new.rs")], false⟩
+  , ⟨"exact_shared_directory_allowed", ["src/new.rs"], ["src/other.rs"],
+      ["src/other.rs","src/new.rs"], [("src","src"),("src/new.rs","src/new.rs")],
+      [("src","src"),("src/other.rs","src/other.rs")],
+      [("src","src"),("src/other.rs","src/other.rs"),("src","src"),("src/new.rs","src/new.rs")], true⟩
+  , ⟨"empty_delta_ignores_existing_aliases", [], ["Old","old"], ["Old","old"], [],
+      [("Old","old"),("old","old")], [("Old","old"),("old","old")], true⟩ ]
+
+theorem alias_cases_replay : ∀ c ∈ aliasCases,
+    (changedAliasesCanonical c.changedPrefixes c.basePrefixes &&
+     changedAliasesCanonical c.changedPrefixes c.treePrefixes) = c.expected := by decide
+
+private def pathsJson (paths : List String) := jsonArray (paths.map jsonString)
+private def prefixesJson (prefixes : List (String × String)) :=
+  jsonArray (prefixes.map fun p => jsonArray [jsonString p.1, jsonString p.2])
+private def aliasCaseJson (c : AliasCase) :=
+  "{\"name\":" ++ jsonString c.name ++
+  ",\"changed_paths\":" ++ pathsJson c.changedPaths ++
+  ",\"base_paths\":" ++ pathsJson c.basePaths ++
+  ",\"tree_paths\":" ++ pathsJson c.treePaths ++
+  ",\"changed_prefixes\":" ++ prefixesJson c.changedPrefixes ++
+  ",\"base_prefixes\":" ++ prefixesJson c.basePrefixes ++
+  ",\"tree_prefixes\":" ++ prefixesJson c.treePrefixes ++
+  ",\"expected\":" ++ boolString c.expected ++ "}"
+def aliasCasesJson := jsonArray (aliasCases.map aliasCaseJson)
+
 end Conformance.WorkspacePathCapabilityContracts

--- a/crates/gents/proofs/Proofs/GoalAutomation/OperatorResume.lean
+++ b/crates/gents/proofs/Proofs/GoalAutomation/OperatorResume.lean
@@ -179,4 +179,23 @@ theorem config_cannot_reactivate (current : Goals.Status) (h : current ≠ .acti
 
 theorem active_config_remains_allowed : configMaySetStatus .active .active = true := rfl
 
+/-- Receipt status observes the transaction result, not a claim that a historical
+acknowledgment reactivated the Goal. This does not change resume transitions. -/
+def receiptStatus (result : Snapshot × Outcome) : Option Goals.Status :=
+  match result.2 with
+  | .created | .recovered => some result.1.goal.status
+  | _ => none
+
+theorem recovered_receipt_observes_current_status (s : Snapshot) (r : Request) (commit : Bool)
+    (h : (resume s r commit).2 = .recovered) :
+    receiptStatus (resume s r commit) = some s.goal.status := by
+  have same := recovered_is_noop s r commit h
+  simp [receiptStatus, h, same]
+
+theorem created_receipt_reports_active (s : Snapshot) (r : Request) (commit : Bool)
+    (h : (resume s r commit).2 = .created) :
+    receiptStatus (resume s r commit) = some .active := by
+  have active := (created_publishes_atomically s r commit h).1
+  simp [receiptStatus, h, active]
+
 end GoalAutomation.OperatorResume

--- a/crates/gents/proofs/Proofs/GraphPipeline/FailureAttribution.lean
+++ b/crates/gents/proofs/Proofs/GraphPipeline/FailureAttribution.lean
@@ -74,6 +74,24 @@ theorem losing_capture_is_noop (s : Snapshot) (expected : Nat) (witness : Option
     (h : s.generation ≠ expected) : capture s expected witness = s := by
   simp [capture, h]
 
+/-- Compose the actual generation-fenced capture with its ensuing interruption
+projection. The snapshot supplied here is the durable transaction/reload view. -/
+def captureAndObserve (s : Snapshot) (expected : Nat) (witness : Option Cause) :
+    Snapshot × Bool :=
+  let next := capture s expected witness
+  (next, mayInterruptForFailure next)
+
+theorem capture_loser_observes_winner (durable : Snapshot) (expected : Nat)
+    (witness : Option Cause) (h : durable.generation ≠ expected) :
+    captureAndObserve durable expected witness = (durable, mayInterruptForFailure durable) := by
+  simp [captureAndObserve, losing_capture_is_noop durable expected witness h]
+
+theorem cancelled_capture_never_requests_failure_interrupt (durable : Snapshot)
+    (expected : Nat) (witness : Option Cause)
+    (h : durable.run.cancellationRequested = true) :
+    captureAndObserve durable expected witness = (durable, false) := by
+  simp [captureAndObserve, capture, mayInterruptForFailure, h]
+
 theorem first_capture_records_witness (s : Snapshot) (cause : Cause)
     (h_running : s.run.status = .running)
     (h_cancel : s.run.cancellationRequested = false) (h_empty : s.primary = none) :
@@ -122,12 +140,15 @@ theorem terminal_snapshot_cannot_change (s : Snapshot)
   simp [capture, requestCancel, finish, h]
 
 inductive Event where
+  /-- Another durable request failed; observing it does not write the GraphRun latch. -/
+  | observedFailure (cause : Cause)
   | capture (expected : Nat) (witness : Option Cause)
   | cancel
   | finish (expected : Nat) (allTerminal : Bool) (witness : Option Cause)
   deriving DecidableEq, Repr
 
 def step (s : Snapshot) : Event → Snapshot
+  | .observedFailure _ => s
   | .capture expected witness => capture s expected witness
   | .cancel => requestCancel s
   | .finish expected allTerminal witness => finish s expected allTerminal witness

--- a/crates/gents/proofs/Proofs/GraphPipeline/LogicalInvocation.lean
+++ b/crates/gents/proofs/Proofs/GraphPipeline/LogicalInvocation.lean
@@ -6,6 +6,25 @@ import Proofs.GraphPipeline.FailureAttribution
    identity or Goal policy is introduced. Finite safety, not scheduler liveness. -/
 namespace GraphPipeline.LogicalInvocation
 abbrev Doc := Nat
+/-- Existing graph ownership: receipt verification and a pinned route must
+resolve to the GraphRun/revision owner DID. DefraDB ACP and existing request
+admission own task/behavior permissions; this is not another ACL projector. -/
+structure RootAuthorization where
+  receiptValid : Bool
+  routePinned : Bool
+  principalMatches : Bool
+  deriving DecidableEq, Repr
+
+def RootAuthorization.admitted (a : RootAuthorization) : Bool :=
+  a.receiptValid && a.routePinned && a.principalMatches
+
+theorem foreign_signed_root_denied (route : Bool) :
+    RootAuthorization.admitted ⟨true, route, false⟩ = false := by
+  cases route <;> rfl
+
+theorem unpinned_owner_signed_root_denied :
+    RootAuthorization.admitted ⟨true, false, true⟩ = false := rfl
+
 structure Attempt where
   doc : Doc
   pinnedRoot : Bool
@@ -75,7 +94,7 @@ def project (rows : List Attempt) (edges : List Edge) (root : Doc)
       else .failed tip.doc
   | _ => .invalid
 
-/-- Historical ancestry survives Goal replacement. Only matching current head
+/-- Historical ancestry survives Goal replacement. Only matching invocation-local causal head
 binding grants the canonical Goal's continuation obligation. -/
 def associatedGoal (goal : Option GoalEvidence) (headBindingMatches : Bool) : Option GoalEvidence :=
   if headBindingMatches then goal else none
@@ -114,6 +133,12 @@ private def complete : GoalEvidence := { active with status := .complete }
 
 theorem active_goal_defers_failed_root :
     project [root] [] 10 (some active) false = .outstanding := by decide
+
+/-- Actual rooted projection excludes an unrelated interactive physical row;
+its presence does not discharge the existing active Goal obligation. -/
+theorem unrelated_interactive_row_preserves_active_goal :
+    project [root, ⟨30, false, some .completed⟩] [] 10 (some active) false =
+      project [root] [] 10 (some active) false := by decide
 
 theorem claimed_gap_stays_outstanding :
     project [root] [] 10 (some {active with phase := .claimed}) false = .outstanding := by decide

--- a/crates/gents/proofs/Proofs/InferenceCall/Registry.lean
+++ b/crates/gents/proofs/Proofs/InferenceCall/Registry.lean
@@ -1,7 +1,11 @@
 import Proofs.InferenceCall.ControllerBookkeeping
 
 /-! One backend's serial-drain registry refinement. `key` is the canonical
-resource configuration, excluding display/catalog metadata. Counts represent
+resource configuration, including queue capacity and credential identity but
+excluding display/catalog metadata. Rust's queue-depth equality is therefore
+part of key equality, not an omitted admission parameter. The keyed digest is
+a runtime representation of this identity, not a cryptographic theorem here.
+Counts represent
 real in-flight controller ownership, not persisted InferenceCall rows. -/
 namespace InferenceCall.Registry
 

--- a/crates/gents/proofs/Proofs/Workspace/PathCapability.lean
+++ b/crates/gents/proofs/Proofs/Workspace/PathCapability.lean
@@ -17,6 +17,21 @@ structure Change where
   canonical : Bool := true
   deriving DecidableEq, Repr
 
+/-- Host supplies literal component prefixes and their compatibility alias keys.
+Only prefixes of changed paths must be unambiguous against both full trees;
+unchanged entries are observations, never newly admitted capability paths. -/
+def changedAliasesCanonical (changed tree : List (String × String)) : Bool :=
+  changed.all fun wanted => tree.all fun existing =>
+    wanted.2 != existing.2 || wanted.1 == existing.1
+
+theorem empty_delta_ignores_tree_aliases (tree : List (String × String)) :
+    changedAliasesCanonical [] tree = true := rfl
+
+theorem changed_alias_collision_rejected (left right key : String)
+    (different : left ≠ right) :
+    changedAliasesCanonical [(left,key)] [(right,key)] = false := by
+  simp [changedAliasesCanonical, different]
+
 def deltaAuthorized (cap : WorkspacePathCapability) (delta : List Change) : Bool :=
   match cap with
   | .unrestrictedCompatibility => true

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -1120,6 +1120,13 @@ later Goal progress. Seven configuration cases prevent the ordinary setter
 from reactivating a Goal without its continuation. Usage and budget remain
 unchanged; status and sequence fence stale controller writes.
 
+Resume receipts also report the Goal status observed in their transaction.
+Recovering an old child while the Goal is paused returns that child with
+`created: false` and `goal_status: paused`; it does not silently claim reactivation.
+Separate native overlapping-write tests bypass the process-local mutation gate.
+InputRequired and WorkspaceBindingPending remain unfinished requests: a resume
+cannot duplicate work that already waits for input or workspace placement.
+
 `GoalAutomation/RequestHead.lean` preserves canonical request ordering among
 causal heads while excluding an authenticated continuation's physical parent.
 Fifteen generated cases drive the production selector with signed request
@@ -1148,6 +1155,13 @@ does not duplicate GoalSource retry/activity/budget decisions. An unsuccessful
 tip cannot succeed merely because results exist. Physical descendants still
 count individually. Authentication booleans in the model must be discharged by
 real signed-row consumers, including physical parent, owner and pinned route.
+
+DefraDB ACP remains the access-control owner. Root attribution reuses the
+verified GraphRun/revision owner DID and existing signed receipt; it does not
+recompute Task/behavior permissions from mutable configuration. Foreign roots
+cannot contribute counts or failure witnesses. Unrelated interactive session
+rows do not erase an invocation's Goal obligation; authenticated replacement
+Goal chains retain their distinct association semantics.
 
 Publication and terminal/failure transactions write the existing GraphRun key.
 This refinement assumes same-native-store write conflict validation; scans do
@@ -1205,6 +1219,12 @@ Operation cases cover legacy fresh denial, identity recovery, empty exact sets, 
 symlink/gitlink denial, immutable-base/snapshot mismatch, denied receipt repair,
 authorized integration, absent-checkout receipt recovery and capability tampering.
 
+Five additional generated alias cases drive actual Git trees. Only changed paths
+need valid grant syntax; unrelated historical spellings do not become grants.
+Changed component spellings are checked against both full trees, including valid
+ancestor prefixes of opaque filenames. Case/Unicode aliases involving a changed
+path still fail closed.
+
 Migration always stamps predecessor-schema rows with explicit compatibility,
 even if untrusted input injects an exact capability field absent from that source
 schema. Current-schema values are preserved. This is a source-version migration
@@ -1236,6 +1256,9 @@ workspace binding, managed launch and pre-pool LSP denial. The ledger records th
 injected unavailable-host observation and explicitly scoped background task as
 bounded coverage, separately from durable background-bridge and OS behavior.
 Sandbox cases additionally cover available and unavailable artifact enforcement.
+The unavailable-host admission case drives the production workspace resolver
+with an injected host observation, rather than only testing a later launch
+selector. Unsupported hosts reject before binding or provider dispatch.
 The contextual requested mode is already met with behavior and operator ceilings;
 an active binding and current live, uncanceled execution are constructor
 preconditions. Persistent LSP starts are initially denied before pool lookup in

--- a/crates/gents/src/admission/config.rs
+++ b/crates/gents/src/admission/config.rs
@@ -1,12 +1,39 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
 
 use anyhow::Result;
-use sha2::{Digest, Sha256};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 
 use crate::backend_registry::{InferenceBackend, HEALTHY_PROBE_STATUS};
 
 /// Domain and version of the canonical resource identity encoding.
 const BACKEND_CONFIG_FINGERPRINT_TAG: &str = "gents-backend-admission-config-v1";
+const PUBLIC_FINGERPRINT_PREFIX: &str = "hmac-sha256:process-v1:";
+
+// Equality is needed only within a live registry. Never persist this key: a
+// public salt or unkeyed digest would let readers test candidate credentials.
+// Restarting changes attribution fingerprints; runtime_instance_id already
+// scopes the associated controller ownership to that runtime.
+static FINGERPRINT_KEY: OnceLock<[u8; 32]> = OnceLock::new();
+
+fn keyed_fingerprint(encoded: &[u8], key: &[u8; 32]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC accepts a 32-byte key");
+    mac.update(encoded);
+    format!(
+        "{PUBLIC_FINGERPRINT_PREFIX}{:x}",
+        mac.finalize().into_bytes()
+    )
+}
+
+/// Only the current non-secret attribution format may leave the timeline.
+/// Legacy Debug values contain inline credentials; older SHA-256 values permit
+/// candidate-key confirmation. Repair of persisted history is tracked in #1394.
+pub(crate) fn exportable_backend_fingerprint(value: Option<&str>) -> Option<String> {
+    let value = value?;
+    let digest = value.strip_prefix(PUBLIC_FINGERPRINT_PREFIX)?;
+    (digest.len() == 64 && digest.bytes().all(|b| b.is_ascii_hexdigit())).then(|| value.to_owned())
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BackendAdmissionConfig {
@@ -45,7 +72,8 @@ impl BackendAdmissionConfig {
         // Reuse the effective provider mapping and hash its resource fields
         // in a versioned, unambiguous encoding. Display/catalog metadata does
         // not replace controllers; availability remains separately owned.
-        // Only the digest, never credential values, enters persisted call rows.
+        // Only a process-keyed digest enters persisted call rows. Preserve key
+        // rotation in equality without exposing an offline credential oracle.
         let fields = backend.backend_fields();
         let fingerprint_inputs = (
             BACKEND_CONFIG_FINGERPRINT_TAG,
@@ -59,8 +87,10 @@ impl BackendAdmissionConfig {
             backend.max_queue_depth,
         );
         let encoded = serde_json::to_vec(&fingerprint_inputs)?;
-        let digest = Sha256::digest(&encoded);
-        let config_fingerprint = format!("sha256:{digest:x}");
+        let config_fingerprint = keyed_fingerprint(
+            &encoded,
+            FINGERPRINT_KEY.get_or_init(rand::random::<[u8; 32]>),
+        );
 
         Ok(Self {
             backend_id: backend.backend_id.clone(),
@@ -144,6 +174,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn attribution_is_process_keyed_and_legacy_values_are_not_exported() {
+        let bytes = b"synthetic-credential-and-config";
+        let first = keyed_fingerprint(bytes, &[1; 32]);
+        assert_eq!(first, keyed_fingerprint(bytes, &[1; 32]));
+        assert_ne!(first, keyed_fingerprint(bytes, &[2; 32]));
+        assert_ne!(
+            first,
+            keyed_fingerprint(b"rotated-synthetic-credential", &[1; 32])
+        );
+        assert_eq!(exportable_backend_fingerprint(Some(&first)), Some(first));
+        for legacy in [
+            "InferenceBackend { api_key: Some(\"synthetic-secret\") }",
+            "sha256:abc",
+            "hmac-sha256:process-v1:synthetic-secret",
+            "",
+        ] {
+            assert_eq!(exportable_backend_fingerprint(Some(legacy)), None);
+        }
+    }
+
+    #[test]
     fn resource_identity_normalizes_wire_defaults_and_protects_credentials() {
         let mut backend = InferenceBackend::from_value(&serde_json::json!({
             "backend_id": "resource-identity",
@@ -169,6 +220,13 @@ mod tests {
         let rotated = BackendAdmissionConfig::from_backend(&backend).unwrap();
         assert_ne!(implicit.config_fingerprint, rotated.config_fingerprint);
         assert!(!rotated.config_fingerprint.contains("fixture-only-secret"));
+
+        // Lean Registry.Config.key includes queue capacity. Its separately
+        // modeled capacity is the semaphore, not the entire resource identity.
+        backend.max_queue_depth = 3;
+        let resized_queue = BackendAdmissionConfig::from_backend(&backend).unwrap();
+        assert_ne!(rotated.config_fingerprint, resized_queue.config_fingerprint);
+        assert_eq!(rotated.max_concurrent, resized_queue.max_concurrent);
     }
 
     fn config(

--- a/crates/gents/src/admission/mod.rs
+++ b/crates/gents/src/admission/mod.rs
@@ -14,6 +14,7 @@ pub(crate) use client::{
     terminal_failure_reason_observer, AdmissionCallContext, AdmittedCompletionClient, CallKind,
 };
 pub(crate) use config::backend_admission_configs_from_backends;
+pub(crate) use config::exportable_backend_fingerprint;
 pub(crate) use config::BackendAvailability;
 pub use config::{document_configured_from_fields, BackendAdmissionConfig};
 pub use recovery::{InferenceCall, InferenceCallRecoveryReport};

--- a/crates/gents/src/callback/run.rs
+++ b/crates/gents/src/callback/run.rs
@@ -105,7 +105,12 @@ pub fn plan_from_binding(
                 .projected_fields()
                 .map_err(|error| error.to_string())?;
             for field in ["path_capability", "owned_files"] {
-                if source.get(field).is_some() && !admitted.iter().any(|name| name == field) {
+                // Empty projection means the schema's full safe field set in
+                // fetch_source_doc; an explicit list remains restrictive.
+                if !admitted.is_empty()
+                    && source.get(field).is_some()
+                    && !admitted.iter().any(|name| name == field)
+                {
                     return Err(format!("workspace capability source `{field}` is not admitted by this callback binding"));
                 }
             }
@@ -791,6 +796,33 @@ mod path_capability_tests {
             ])
             .unwrap()
         );
+    }
+
+    #[test]
+    fn builtin_empty_source_projection_retains_explicit_manifest_requirement() {
+        for projection in [None, Some(""), Some("[]")] {
+            let mut binding: CallbackBindingDoc = serde_json::from_value(json!({
+                "binding_id": "path-contract", "source_collection": "WorkUnit", "event_kind": "created",
+                "principal_did": "did:key:writer", "owner_deployment_id": "local", "builtin_emitter": "create_workspace"
+            })).unwrap();
+            binding.source_fields = projection.map(str::to_owned);
+            assert!(binding.projected_fields().unwrap().is_empty());
+            let source = json!({"work_unit_id": "unit", "repository_id": "repo", "base_sha": "base", "branch": "branch", "owned_files": "[\"src/a.rs\"]"});
+            let plan = plan_from_binding(&binding, &source, None).unwrap();
+            let HostAction::CreateWorkspace(action) = &plan.actions[0] else {
+                panic!("expected workspace")
+            };
+            assert_eq!(
+                action.path_capability,
+                crate::workspace::WorkspacePathCapability::exact_paths(vec!["src/a.rs".into()])
+                    .unwrap()
+            );
+            let mut missing = source.clone();
+            missing.as_object_mut().unwrap().remove("owned_files");
+            assert!(plan_from_binding(&binding, &missing, None).is_err());
+            missing["path_capability"] = json!({"mode":"unrestrictedCompatibility"});
+            assert!(plan_from_binding(&binding, &missing, None).is_err());
+        }
     }
 
     #[test]

--- a/crates/gents/src/goal/claimed_publication.rs
+++ b/crates/gents/src/goal/claimed_publication.rs
@@ -130,6 +130,7 @@ async fn stage_claimed_continuation(
             "claimed continuation receipt conflicts with the observed publication"
         );
         return Ok(Some(GoalResumeReceipt {
+            goal_status: goal.parsed_status().context("goal has an unknown status")?,
             goal_id: goal.goal_id,
             request_id: child.request_id.clone(),
             doc_id: child
@@ -209,6 +210,7 @@ async fn stage_claimed_continuation(
         .and_then(serde_json::Value::as_str)
         .context("claimed child create omitted document ID")?;
     Ok(Some(GoalResumeReceipt {
+        goal_status: goal.parsed_status().context("goal has an unknown status")?,
         goal_id: goal.goal_id,
         request_id: create.request_id,
         doc_id: child_doc.to_owned(),

--- a/crates/gents/src/goal/operator_resume.rs
+++ b/crates/gents/src/goal/operator_resume.rs
@@ -13,6 +13,8 @@ pub struct GoalResumeReceipt {
     pub request_id: String,
     pub doc_id: String,
     pub created: bool,
+    /// Goal status observed in this transaction; a historical receipt need not be active.
+    pub goal_status: GoalStatus,
 }
 
 /// Resume the canonical goal and publish its continuation atomically.
@@ -111,6 +113,7 @@ async fn stage_resume(
     if let Some(child) = children.first() {
         super::request_head::verify_goal_continuation_receipt(&goal, parent_row, child)?;
         return Ok(GoalResumeReceipt {
+            goal_status: goal.parsed_status().context("goal has an unknown status")?,
             goal_id: goal.goal_id,
             request_id: child.request_id.clone(),
             doc_id: child
@@ -212,6 +215,7 @@ async fn stage_resume(
         .context("continuation create omitted document ID")?
         .to_owned();
     Ok(GoalResumeReceipt {
+        goal_status: post.status,
         goal_id: goal.goal_id,
         request_id: create.request_id,
         doc_id,

--- a/crates/gents/src/goal/operator_resume/contract_tests.rs
+++ b/crates/gents/src/goal/operator_resume/contract_tests.rs
@@ -92,6 +92,14 @@ async fn generated_goal_operator_resume_cases_drive_real_transactions() {
                 "created" | "recovered" => {
                     let receipt = result.unwrap();
                     assert_eq!(receipt.created, case.outcome == "created");
+                    assert_eq!(
+                        Some(receipt.goal_status.as_str()),
+                        case.goal_status.as_deref()
+                    );
+                    if case.name == "retry_after_later_progress" {
+                        assert_eq!(receipt.goal_status, GoalStatus::Paused);
+                        assert!(!receipt.created);
+                    }
                     let expected = goal_continuation_identity(&f.goal.goal_id, PARENT, 1).unwrap();
                     assert_eq!(receipt.request_id, expected.request_id);
                     assert_eq!(receipt.goal_id, f.goal.goal_id);
@@ -185,6 +193,132 @@ async fn generated_goal_config_reactivation_cases_drive_transactional_setter() {
             expected["status"] = json!(case.target);
         }
         assert_eq!(f.observe().await, expected);
+        f.node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn waiting_requests_keep_resume_idle_guard_closed_without_duplicate_children() {
+    let contracts: Contracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    let initial = &contracts
+        .goal_operator_resume_cases
+        .iter()
+        .find(|case| case.name == "atomic_publication")
+        .unwrap()
+        .before;
+    for state in [
+        RequestLifecycleState::InputRequired,
+        RequestLifecycleState::WorkspaceBindingPending,
+    ] {
+        assert!(!state.is_terminal());
+        let f = Fixture::new(initial).await;
+        f.other_request("waiting-existing", "2019-01-01T00:00:00Z", state.as_str())
+            .await;
+        let before = f.observe().await;
+        let rows_before = serde_json::to_value(request_rows(&f.node).await).unwrap();
+        let error = resume_goal_request(
+            &crate::ConfigAccess::Local(f.node.clone()),
+            f.identity.as_ref(),
+            f.identity.did(),
+            SESSION,
+            PARENT,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("unfinished requests"),
+            "{state:?}: {error}"
+        );
+        assert_eq!(f.observe().await, before);
+        assert_eq!(
+            serde_json::to_value(request_rows(&f.node).await).unwrap(),
+            rows_before,
+            "{state:?}: resume duplicated existing work"
+        );
+        f.node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn overlapping_resume_and_native_goal_write_conflict_atomically() {
+    async fn native(
+        node: &EmbeddedNode,
+        handle: &query::TransactionHandle,
+        query: &str,
+    ) -> serde_json::Value {
+        let result = node
+            .execute_request_in_txn(defra_node::QueryRequest::new(query), handle)
+            .await;
+        assert!(!result.has_errors(), "{:?}", result.errors);
+        result.data.unwrap()
+    }
+    let contracts: Contracts = gents_lean_contract::load_contract_snapshot().unwrap();
+    let initial = &contracts
+        .goal_operator_resume_cases
+        .iter()
+        .find(|case| case.name == "atomic_publication")
+        .unwrap()
+        .before;
+    for resume_first in [false, true] {
+        let f = Fixture::new(initial).await;
+        // Remote/native writes do not participate in ConfigApplyTxn's local
+        // mutation mutex. Keep both storage snapshots open deliberately.
+        let remote = f.node.runner().begin_txn(false).await.unwrap();
+        let goal_id = escape_graphql_string(&f.goal.goal_id);
+        let query = format!(
+            r#"{{ Goal(filter: {{ goal_id: {{ _eq: "{goal_id}" }} }}) {{ _docID status continuation_sequence updated_at }} }}"#
+        );
+        let before = native(&f.node, &remote, &query).await;
+        assert_eq!(before["Goal"][0]["status"], "paused");
+        let local = ConfigApplyTxn::begin_local(&f.node, None).await.unwrap();
+        let receipt = stage_resume(
+            &local,
+            f.identity.as_ref(),
+            f.identity.did(),
+            SESSION,
+            PARENT,
+        )
+        .await
+        .unwrap();
+        assert!(receipt.created);
+        let update = format!(
+            r#"mutation {{ update_Goal(filter: {{ goal_id: {{ _eq: "{goal_id}" }}, status: {{ _eq: "paused" }}, continuation_sequence: {{ _eq: 0 }} }}, input: {{ status: "paused", updated_at: "2031-01-01T00:00:00Z" }}) {{ _docID }} }}"#
+        );
+        assert_eq!(
+            native(&f.node, &remote, &update).await["update_Goal"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        let conflict = if resume_first {
+            local.commit().await.unwrap();
+            f.node
+                .runner()
+                .commit_txn(&remote)
+                .await
+                .unwrap_err()
+                .to_string()
+        } else {
+            f.node.runner().commit_txn(&remote).await.unwrap();
+            local.commit().await.unwrap_err().to_string()
+        };
+        assert!(conflict.contains("transaction conflict"), "{conflict}");
+        let _ = f.node.runner().rollback_txn(&remote).await;
+        let observed = f.observe().await;
+        assert_eq!(
+            observed["status"],
+            if resume_first { "active" } else { "paused" }
+        );
+        assert_eq!(observed["sequence"], if resume_first { 1 } else { 0 });
+        assert_eq!(
+            request_rows(&f.node)
+                .await
+                .iter()
+                .filter(|row| row.request_id == receipt.request_id)
+                .count(),
+            usize::from(resume_first)
+        );
         f.node.shutdown().await;
     }
 }

--- a/crates/gents/src/goal/operator_resume/support.rs
+++ b/crates/gents/src/goal/operator_resume/support.rs
@@ -14,6 +14,11 @@ pub(super) struct ResumeCase {
     pub commit: bool,
     pub expected: Value,
     pub outcome: String,
+    #[serde(default)]
+    // This fixture is also compiled by claimed_publication; only the operator
+    // resume consumer checks this emitted receipt observation.
+    #[allow(dead_code)]
+    pub goal_status: Option<String>,
 }
 
 pub(super) const SESSION: &str = "contract-session";

--- a/crates/gents/src/graph_pipeline/attribution_contract_tests.rs
+++ b/crates/gents/src/graph_pipeline/attribution_contract_tests.rs
@@ -1,5 +1,6 @@
 //! Generated attribution traces consumed by the actual GraphRun transaction owners.
 use super::*;
+use crate::graph_pipeline::runtime::graph_test_owner;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -68,7 +69,7 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
     assert_eq!(snapshot.graph_failure_attribution_traces.len(), 10);
     for trace in snapshot.graph_failure_attribution_traces {
         let (node, run, trigger) = super::super::runtime::attribution_test_fixture(3).await;
-        let initial = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let initial = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         let initial_generation = initial.update_generation;
@@ -96,7 +97,7 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
         }
         assert_eq!(trace.events.len(), trace.expected.len());
         for (index, (event, expected)) in trace.events.iter().zip(&trace.expected).enumerate() {
-            let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
             if !before.is_terminal() {
@@ -123,18 +124,26 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
                     ) {{ _docID }} }}"#, escape_graphql_string(&run.correlation))).await;
                 }
             }
-            let mut observed = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            let mut observed = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
             // Check emitted witness against durable facts independently of the
             // latched error, which correctly stops changing after capture.
             if let Some(witness) = event.witness {
-                let candidate = observed
-                    .requests
-                    .iter()
-                    .filter(|request| request.terminal && !request.succeeded)
-                    .min_by_key(|request| request.request_id.as_str())
-                    .unwrap();
+                let candidate = if event.kind == "observed_failure" {
+                    observed.requests.iter().find(|request| {
+                        request.request_id == cause_id(witness)
+                            && request.terminal
+                            && !request.succeeded
+                    })
+                } else {
+                    observed
+                        .requests
+                        .iter()
+                        .filter(|request| request.terminal && !request.succeeded)
+                        .min_by_key(|request| request.request_id.as_str())
+                }
+                .expect("the emitted failure must be a real durable terminal request");
                 assert_eq!(
                     candidate.request_id,
                     cause_id(witness),
@@ -155,6 +164,7 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
                 observed.update_generation = initial_generation + generation;
             }
             match event.kind.as_str() {
+                "observed_failure" => {} // The durable fixture transition above is the observation.
                 "capture" => {
                     let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
                     let result = capture_failure_txn(txn, &observed).await;
@@ -171,7 +181,7 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
                     let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
                     persist_cancellation_intent(
                         txn,
-                        "did:key:owner",
+                        graph_test_owner(),
                         &run.run_id,
                         Some("generated cancellation"),
                     )
@@ -199,7 +209,7 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
                 }
                 other => panic!("unknown generated action {other}"),
             }
-            let durable = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            let durable = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
             assert_eq!(
@@ -211,4 +221,152 @@ async fn generated_graph_failure_attribution_traces_drive_real_transactions() {
         }
         node.shutdown().await;
     }
+}
+
+// FailureAttribution.capture_loser_observes_winner: two real observers load the
+// same generation; a cancellation committed between them must remain visible.
+#[tokio::test]
+async fn failure_capture_loser_reloads_cancellation_winner() {
+    let (node, run, trigger) = super::super::runtime::attribution_test_fixture(2).await;
+    super::super::runtime::seed_signed_graph_request(
+        &node,
+        &run,
+        &trigger,
+        "failed",
+        "failed",
+        "first cause",
+    )
+    .await;
+    super::super::runtime::seed_signed_graph_request(
+        &node,
+        &run,
+        &trigger,
+        "live",
+        "processing",
+        "",
+    )
+    .await;
+    let stale = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    execute_fixture(&node, format!(r#"mutation {{ update_GraphRun(filter: {{ run_id: {{ _eq: "{}" }} }}, input: {{ cancel_requested_at: "2026-09-05T00:00:00Z", update_generation: {} }}) {{ _docID }} }}"#, escape_graphql_string(&run.run_id), stale.update_generation + 1)).await;
+    let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+    capture_failure_txn(txn, &stale).await.unwrap();
+    let fresh = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert!(fresh.cancellation_requested_at.is_some());
+    assert!(fresh.error.is_none());
+    assert_eq!(fresh.update_generation, stale.update_generation + 1);
+}
+
+#[tokio::test]
+async fn future_failure_code_remains_observable_and_cancellable() {
+    let (node, run, _) = super::super::runtime::attribution_test_fixture(2).await;
+    let opaque = json!({"version": 1, "code": "future_owner_failure", "message": "Opaque diagnostic", "future_details": {"counter": 9}});
+    execute_fixture(&node, format!(r#"mutation {{ update_GraphRun(filter: {{ run_id: {{ _eq: "{}" }} }}, input: {{ error: "{}" }}) {{ _docID }} }}"#, escape_graphql_string(&run.run_id), escape_graphql_string(&opaque.to_string()))).await;
+    let observed = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(observed.error, Some(opaque));
+    let cancelled = request_graph_run_cancellation(
+        &node,
+        None,
+        graph_test_owner(),
+        &run.run_id,
+        Some("operator cancellation"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(cancelled.status, "cancelled");
+}
+
+#[tokio::test]
+async fn competing_failure_observers_reload_single_committed_cause() {
+    let (node, run, trigger) = super::super::runtime::attribution_test_fixture(2).await;
+    super::super::runtime::seed_signed_graph_request(
+        &node,
+        &run,
+        &trigger,
+        "cause",
+        "failed",
+        "durable cause",
+    )
+    .await;
+    super::super::runtime::seed_signed_graph_request(
+        &node,
+        &run,
+        &trigger,
+        "live",
+        "processing",
+        "",
+    )
+    .await;
+    let first = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    let second = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    let first_txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+    capture_failure_txn(first_txn, &first).await.unwrap();
+    let second_txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+    capture_failure_txn(second_txn, &second).await.unwrap();
+    let access = ConfigAccess::Local(Arc::clone(&node));
+    let fresh = reconcile_graph_run_with_access(&access, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(fresh.update_generation, first.update_generation + 1);
+    assert_eq!(fresh.error.as_ref().unwrap()["request_id"], "cause");
+    let persisted = node.execute(r#"{ AgentRequest(filter: { request_id: { _eq: "live" } }) { interrupt_requested_at } }"#).await;
+    assert!(!persisted.has_errors());
+    assert!(persisted.data.unwrap()["AgentRequest"][0]["interrupt_requested_at"].is_string());
+}
+
+#[tokio::test]
+async fn native_failure_capture_conflict_reloads_cancellation_winner() {
+    let (node, run, trigger) = super::super::runtime::attribution_test_fixture(2).await;
+    super::super::runtime::seed_signed_graph_request(
+        &node,
+        &run,
+        &trigger,
+        "cause",
+        "failed",
+        "durable cause",
+    )
+    .await;
+    super::super::runtime::seed_signed_graph_request(
+        &node,
+        &run,
+        &trigger,
+        "live",
+        "processing",
+        "",
+    )
+    .await;
+    let stale = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+    let initial = load_graph_run_view_with(&txn, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(initial.update_generation, stale.update_generation);
+    // The direct node operation is an independent native transaction, deliberately
+    // bypassing the local ConfigApplyTxn serialization mutex for this storage race.
+    execute_fixture(&node, format!(r#"mutation {{ update_GraphRun(filter: {{ run_id: {{ _eq: "{}" }} }}, input: {{ cancel_requested_at: "2026-09-05T00:00:00Z", update_generation: {} }}) {{ _docID }} }}"#, escape_graphql_string(&run.run_id), stale.update_generation + 1)).await;
+    let snapshot = load_graph_run_view_with(&txn, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert!(
+        snapshot.cancellation_requested_at.is_none(),
+        "must exercise an overlapping native snapshot, not merely sequential CAS loss"
+    );
+    capture_failure_txn(txn, &stale).await.unwrap();
+    let fresh = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert!(fresh.cancellation_requested_at.is_some());
+    assert!(fresh.error.is_none());
+    assert_eq!(fresh.update_generation, stale.update_generation + 1);
 }

--- a/crates/gents/src/graph_pipeline/logical_invocation.rs
+++ b/crates/gents/src/graph_pipeline/logical_invocation.rs
@@ -34,11 +34,12 @@ fn request_view(row: &AgentRequestRow, node_id: Option<String>) -> GraphRunReque
     }
 }
 
-fn authentic_root(row: &AgentRequestRow) -> bool {
+fn authentic_root(row: &AgentRequestRow, owner_did: &str) -> bool {
     let Some(target) = row.agent_did.as_deref().filter(|s| !s.is_empty()) else {
         return false;
     };
-    verify_request_receipt_signature(row).is_ok()
+    target == owner_did
+        && verify_request_receipt_signature(row).is_ok()
         && row.doc_id.as_deref().is_some_and(|id| !id.is_empty())
         && row.session_id.as_deref().is_some_and(|id| !id.is_empty())
         && row.admission_kind.as_deref() == Some("runtime-internal")
@@ -57,6 +58,7 @@ pub(super) async fn load(
     executor: &(impl GraphRunQuery + ?Sized),
     correlation: &str,
     plan: &GraphPlan,
+    owner_did: &str,
 ) -> Result<Projection> {
     let routes = planned_trigger_nodes(plan)?;
     let response = executor
@@ -77,13 +79,9 @@ pub(super) async fn load(
             .get(root.caused_by_trigger_id.as_deref().unwrap_or_default())
             .context("selected graph route is absent from pinned plan")?
             .clone();
-        if !authentic_root(root) {
-            physical.insert(
-                root.doc_id
-                    .clone()
-                    .unwrap_or_else(|| root.request_id.clone()),
-                request_view(root, None),
-            );
+        if !authentic_root(root, owner_did) {
+            // Owner DID comes from the verified GraphRun/revision, never the
+            // candidate row or mutable Task/AgentBehavior configuration.
             continue;
         }
         let owner = root.agent_did.as_deref().unwrap();
@@ -177,12 +175,43 @@ pub(super) async fn load(
             let open = goal
                 .state()
                 .is_some_and(crate::goal::GoalState::has_continuation_obligation);
-            open && crate::goal::latest_authenticated_session_request(owner, session, requests)
-                .is_some_and(|head| {
-                    head.doc_id.as_ref().is_some_and(|id| members.contains(id))
-                        && (head.caused_by_trigger_kind.as_deref() != Some("goal")
-                            || head.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str()))
+            // Keep invocation ancestry and other authenticated Goal chains as
+            // association evidence. Ordinary interactive rows cannot erase an
+            // obligation; a replacement Goal on another chain cannot acquire it.
+            let invocation_rows = requests
+                .iter()
+                .filter(|row| {
+                    if row.doc_id.as_ref().is_some_and(|id| members.contains(id)) {
+                        return true;
+                    }
+                    let Some(goal_id) = row
+                        .caused_by_trigger_id
+                        .as_deref()
+                        .filter(|_| row.caused_by_trigger_kind.as_deref() == Some("goal"))
+                    else {
+                        return false;
+                    };
+                    let Some(parent) = requests.iter().find(|parent| {
+                        parent.doc_id.is_some()
+                            && parent.doc_id == row.caused_by_parent_request_doc_id
+                    }) else {
+                        return false;
+                    };
+                    crate::goal::verify_goal_continuation_edge(owner, session, goal_id, parent, row)
+                        .is_ok()
                 })
+                .cloned()
+                .collect::<Vec<_>>();
+            open && crate::goal::latest_authenticated_session_request(
+                owner,
+                session,
+                &invocation_rows,
+            )
+            .is_some_and(|head| {
+                head.doc_id.as_ref().is_some_and(|id| members.contains(id))
+                    && (head.caused_by_trigger_kind.as_deref() != Some("goal")
+                        || head.caused_by_trigger_id.as_deref() == Some(goal.goal_id.as_str()))
+            })
         });
         let outstanding = obligation || physically_active;
         for row in &member_rows {

--- a/crates/gents/src/graph_pipeline/logical_invocation_contract_tests.rs
+++ b/crates/gents/src/graph_pipeline/logical_invocation_contract_tests.rs
@@ -1,6 +1,7 @@
 //! Real persisted graph invocations; request signatures use the actual target key.
 use super::*;
 use crate::goal::{set_goal, GoalStatus};
+use crate::graph_pipeline::runtime::graph_test_owner;
 use crate::identity::{AgentIdentity, KeyIdentity};
 use crate::request_admission::SIGNED_REQUEST_FIELDS;
 use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
@@ -22,7 +23,7 @@ pub(super) async fn signed_invocation_fixture(
 ) {
     let (node, run, trigger) = runtime::attribution_test_fixture(max_invocations).await;
     let temp = tempfile::tempdir().unwrap();
-    let identity = KeyIdentity::load_or_create(temp.path().join("worker.key"), None).unwrap();
+    let identity = runtime::graph_test_identity();
     let goal = set_goal(
         &node,
         identity.did(),
@@ -81,7 +82,7 @@ pub(super) async fn signed_invocation_fixture(
 #[tokio::test]
 async fn failed_graph_root_with_active_goal_remains_running_without_failure_latch() {
     let (node, run, goal, _identity, _temp) = signed_invocation_fixture(3).await;
-    let view = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+    let view = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(
@@ -195,7 +196,7 @@ async fn successful_signed_goal_child_completes_graph_invocation() {
     let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
     let child = signed_child(&node, &identity, &goal, "valid", Some("completed")).await;
     execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "complete" }}) {{ _docID }} create_PipelineResult(input: {{ graph_run_id: "{}", report: "finished" }}) {{ _docID }} }}"#, goal.doc_id, run.correlation)).await;
-    let view = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+    let view = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(view.status, "succeeded");
@@ -221,7 +222,7 @@ async fn paused_goal_failure_uses_authenticated_tip_cause() {
     let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
     let child = signed_child(&node, &identity, &goal, "valid", Some("failed")).await;
     execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "paused" }}) {{ _docID }} }}"#, goal.doc_id)).await;
-    let view = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+    let view = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(view.status, "failed");
@@ -230,7 +231,7 @@ async fn paused_goal_failure_uses_authenticated_tip_cause() {
         view.error.as_ref().unwrap()["root_request_id"],
         "graph-logical-root"
     );
-    let repeated = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+    let repeated = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(repeated.error, view.error);
@@ -369,7 +370,7 @@ async fn generated_graph_logical_invocations_drive_persisted_run_projection() {
         if case.result_satisfied {
             execute(&node, &format!(r#"mutation {{ create_PipelineResult(input: {{ graph_run_id: "{}", report: "finished" }}) {{ _docID }} }}"#, run.correlation)).await;
         }
-        let view = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let view = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         assert_eq!(
@@ -433,7 +434,7 @@ async fn generated_graph_logical_invocations_drive_persisted_run_projection() {
             ),
             other => panic!("unknown outcome {other}"),
         }
-        let terminal = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+        let terminal = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         let status = match expected {
@@ -468,14 +469,14 @@ async fn typed_resume_obeys_cancelled_or_failed_graph_fence() {
             request_graph_run_cancellation(
                 &node,
                 None,
-                "did:key:owner",
+                graph_test_owner(),
                 &run.run_id,
                 Some("operator cancelled"),
             )
             .await
             .unwrap()
         } else {
-            let closed = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+            let closed = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
             assert_eq!(closed.status, "failed");
@@ -526,7 +527,7 @@ async fn typed_resume_advances_graph_generation_with_signed_child() {
     )
     .await
     .unwrap();
-    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     let receipt = crate::goal::resume_goal_request(
@@ -539,7 +540,7 @@ async fn typed_resume_advances_graph_generation_with_signed_child() {
     .await
     .unwrap();
     assert!(receipt.created);
-    let after = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let after = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(after.update_generation, before.update_generation + 1);
@@ -582,7 +583,7 @@ async fn typed_resume_advances_graph_generation_with_signed_child() {
     assert!(!repeated.created);
     assert_eq!(repeated.request_id, receipt.request_id);
     assert_eq!(
-        load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap()
             .update_generation,
@@ -605,7 +606,7 @@ async fn automatic_claimed_publication_obeys_graph_fence() {
             request_graph_run_cancellation(
                 &node,
                 None,
-                "did:key:owner",
+                graph_test_owner(),
                 &run.run_id,
                 Some("stop before publication"),
             )
@@ -673,7 +674,7 @@ async fn fresh_goal_on_closed_rooted_session_rolls_back() {
     )
     .await
     .unwrap();
-    let closed = reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+    let closed = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(closed.status, "failed");
@@ -733,7 +734,7 @@ async fn plain_graph_root_factory_fences_publication_and_cancellation() {
         "actual graph producer correlation identifies its run"
     );
     let (lineage, trigger_doc) = root_trigger_lineage(&node).await;
-    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     let receipt = crate::lifecycle::materialize::write_pending_agent_request_with_lineage_workspace_and_conversation_title(
@@ -760,7 +761,7 @@ async fn plain_graph_root_factory_fences_publication_and_cancellation() {
         row.caused_by_source_doc_id.as_deref(),
         Some(run.seed_doc_id.as_str())
     );
-    let published = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let published = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(published.update_generation, before.update_generation + 1);
@@ -775,7 +776,7 @@ async fn plain_graph_root_factory_fences_publication_and_cancellation() {
     request_graph_run_cancellation(
         &node,
         None,
-        "did:key:owner",
+        graph_test_owner(),
         &run.run_id,
         Some("stop new roots"),
     )
@@ -799,7 +800,7 @@ async fn goal_backed_graph_root_factory_rolls_back_after_cancellation() {
     let (node, run, _goal, identity, _temp) = signed_invocation_fixture(4).await;
     assert_eq!(run.run_id, run.correlation);
     let (lineage, trigger_doc) = root_trigger_lineage(&node).await;
-    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     let create = crate::lifecycle::materialize::build_signed_pending_agent_request_with_lineage_workspace_and_conversation_title(
@@ -826,7 +827,7 @@ async fn goal_backed_graph_root_factory_rolls_back_after_cancellation() {
         row.caused_by_correlation.as_deref(),
         Some(run.run_id.as_str())
     );
-    let published = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let published = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     assert_eq!(published.update_generation, before.update_generation + 1);
@@ -850,7 +851,7 @@ async fn goal_backed_graph_root_factory_rolls_back_after_cancellation() {
     request_graph_run_cancellation(
         &node,
         None,
-        "did:key:owner",
+        graph_test_owner(),
         &run.run_id,
         Some("close before next goal"),
     )
@@ -882,4 +883,438 @@ async fn goal_backed_graph_root_factory_rolls_back_after_cancellation() {
         claims
     );
     node.shutdown().await;
+}
+
+#[tokio::test]
+async fn signed_foreign_graph_roots_cannot_change_invocation_or_failure() {
+    let (node, run, _goal, _identity, _temp) = signed_invocation_fixture(1).await;
+    let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    let root = persisted_requests(&node).await.remove(0);
+    let temp = tempfile::tempdir().unwrap();
+    let foreign = KeyIdentity::load_or_create(temp.path().join("foreign.key"), None).unwrap();
+    for (name, signer, behavior, state) in [
+        ("foreign-completed", &foreign, "test-behavior", "completed"),
+        ("foreign-failed", &foreign, "test-behavior", "failed"),
+    ] {
+        let trigger = root.caused_by_trigger_id.as_deref().unwrap();
+        let mut create = AgentRequestCreate::base(
+            name,
+            signer.did(),
+            signer.did(),
+            behavior,
+            "foreign-session",
+            "Copied graph route",
+            "scheduled",
+            "2026-08-26T00:00:00Z",
+            AgentRequestAdmissionRecord::runtime_automated_trigger(signer.did(), trigger),
+        );
+        create.caused_by_trigger_id = root.caused_by_trigger_id.clone();
+        create.caused_by_trigger_doc_id = root.caused_by_trigger_doc_id.clone();
+        create.caused_by_trigger_kind = root.caused_by_trigger_kind.clone();
+        create.caused_by_correlation = root.caused_by_correlation.clone();
+        create.caused_by_source_doc_id = root.caused_by_source_doc_id.clone();
+        crate::sign_agent_request_create(signer, &mut create)
+            .await
+            .unwrap();
+        // The actual publication fence rejects the correctly signed foreign
+        // target; direct DB seeding below models a replicated untrusted row.
+        let txn = crate::config_client::ConfigApplyTxn::begin_local(&node, None)
+            .await
+            .unwrap();
+        assert!(runtime::fence_graph_root_request_in_txn(&txn, &create)
+            .await
+            .is_err());
+        txn.discard().await.unwrap();
+        execute(&node, &create.graphql_mutation().unwrap()).await;
+        execute(&node, &format!(r#"mutation {{ update_AgentRequest(filter: {{ request_id: {{ _eq: "{name}" }} }}, input: {{ lifecycle_state: "{state}" }}) {{ _docID }} }}"#)).await;
+    }
+    for row in persisted_requests(&node)
+        .await
+        .into_iter()
+        .filter(|row| row.request_id != "graph-logical-root")
+    {
+        crate::request_admission::verify_request_receipt_signature(&row).unwrap();
+        let txn = crate::config_client::ConfigApplyTxn::begin_local(&node, None)
+            .await
+            .unwrap();
+        assert!(
+            graph_binding_for_request_in_txn(&txn, row.doc_id.as_deref().unwrap())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        txn.discard().await.unwrap();
+    }
+    let after = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(after.requests, before.requests);
+    assert_eq!(after.outstanding_invocation_count, 1);
+    assert_eq!(after.status, "running");
+    assert!(after.error.is_none());
+    assert!(after.failure_evidence.is_none());
+    assert_eq!(after.update_generation, before.update_generation);
+}
+
+#[tokio::test]
+async fn unrelated_interactive_head_preserves_graph_goal_obligation() {
+    let (node, run, _goal, identity, _temp) = signed_invocation_fixture(3).await;
+    let mut interactive = AgentRequestCreate::base(
+        "later-interactive",
+        identity.did(),
+        identity.did(),
+        "test-behavior",
+        "logical-session",
+        "Unrelated question",
+        "interactive",
+        "2026-08-27T00:00:00Z",
+        AgentRequestAdmissionRecord::local_self(identity.did()),
+    );
+    crate::sign_agent_request_create(&identity, &mut interactive)
+        .await
+        .unwrap();
+    execute(&node, &interactive.graphql_mutation().unwrap()).await;
+    execute(&node, r#"mutation { update_AgentRequest(filter: { request_id: { _eq: "later-interactive" } }, input: { lifecycle_state: "completed" }) { _docID } }"#).await;
+    let view = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(view.outstanding_invocation_count, 1);
+    assert_eq!(view.status, "running");
+    assert!(view.error.is_none());
+    assert!(view.failure_evidence.is_none());
+}
+
+#[tokio::test]
+async fn malformed_reserved_graph_trigger_cannot_publish() {
+    let (node, run, _goal, identity, _temp) = signed_invocation_fixture(3).await;
+    let mut create = AgentRequestCreate::base(
+        "malformed-route",
+        identity.did(),
+        identity.did(),
+        "test-behavior",
+        "logical-session",
+        "Malformed reserved route",
+        "scheduled",
+        "2026-08-27T00:00:00Z",
+        AgentRequestAdmissionRecord::runtime_automated_trigger(
+            identity.did(),
+            "graph-trigger-malformed",
+        ),
+    );
+    create.caused_by_trigger_id = Some("graph-trigger-malformed".into());
+    create.caused_by_correlation = Some(run.correlation.clone());
+    let txn = crate::config_client::ConfigApplyTxn::begin_local(&node, None)
+        .await
+        .unwrap();
+    assert!(runtime::fence_graph_root_request_in_txn(&txn, &create)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("malformed reserved"));
+    txn.discard().await.unwrap();
+    assert!(runtime::graph_materialization_denial(
+        &node,
+        "graph-trigger-malformed",
+        Some(&run.correlation)
+    )
+    .await
+    .unwrap()
+    .is_some());
+}
+
+#[tokio::test]
+async fn bundled_package_root_binding_survives_task_metadata_changes() {
+    use crate::config_client::{ConfigAccess, ConfigApplyTxn};
+    use crate::graph_package::{install_bundled_graph_package, GraphPackageInstallBindings};
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+    crate::ensure_runtime_schemas(&node).await.unwrap();
+    let identity = runtime::graph_test_identity();
+    crate::document_config::ensure_agent_principal(&node, identity.did())
+        .await
+        .unwrap();
+    for mutation in [
+        r#"mutation { create_HostDeployment(input: { deployment_id: "graph-test-host", display_name: "Graph test" }) { _docID } }"#,
+        r#"mutation { create_InferenceBackend(input: { backend_id: "graph-test-backend", name: "Graph test", provider_kind: "OpenAiCompatible", endpoint: "http://127.0.0.1:1/v1", max_concurrent: 4, enabled: true, models: ["test-model"] }) { _docID } }"#,
+        r#"mutation { create_InferenceProfile(input: { profile_id: "graph-test-profile", display_name: "Graph test", max_turns: 8 }) { _docID } }"#,
+    ] {
+        execute(&node, mutation).await;
+    }
+    let role = PackageRoleBinding {
+        principal_did: identity.did().into(),
+        deployment_id: "graph-test-host".into(),
+        backend_id: Some("graph-test-backend".into()),
+        profile_id: Some("graph-test-profile".into()),
+        model_name: Some("test-model".into()),
+    };
+    let bindings = GraphPackageInstallBindings {
+        owner_did: identity.did().into(),
+        roles: BTreeMap::from([
+            ("coordinator".into(), role.clone()),
+            ("reviewer".into(), role),
+        ]),
+    };
+    let access = ConfigAccess::Local(node.clone());
+    let installed =
+        install_bundled_graph_package(&access, identity.did(), "code-review", &bindings)
+            .await
+            .unwrap();
+    activate_graph_revision(
+        &node,
+        None,
+        identity.did(),
+        &installed.graph_id,
+        &installed.revision_digest,
+        None,
+    )
+    .await
+    .unwrap();
+    let run = start_graph_run(&node, None, identity.did(), &installed.graph_id, None, "review",
+        serde_json::json!({"repository_path": "/tmp/repo", "base_ref": "base-sha", "head_ref": "head-sha", "lens_count": "4", "lens_min": "4", "lens_max": "4", "focus": "authorization"})).await.unwrap();
+    let trigger =
+        runtime::graph_trigger_id(&installed.revision_digest, "entry:review:recon:job").unwrap();
+    let route = execute(
+        &node,
+        &format!(
+            r#"{{ EventTrigger(filter: {{ trigger_id: {{ _eq: "{}" }} }}) {{ _docID task_id }} }}"#,
+            crate::graphql::escape_graphql_string(&trigger)
+        ),
+    )
+    .await;
+    let task_id = route["EventTrigger"][0]["task_id"].as_str().unwrap();
+    let task = execute(
+        &node,
+        &format!(
+            r#"{{ Task(filter: {{ task_id: {{ _eq: "{}" }} }}) {{ behavior_id }} }}"#,
+            crate::graphql::escape_graphql_string(task_id)
+        ),
+    )
+    .await;
+    let behavior = task["Task"][0]["behavior_id"].as_str().unwrap();
+    let mut request = AgentRequestCreate::base(
+        "bundled-root",
+        identity.did(),
+        identity.did(),
+        behavior,
+        "bundled-session",
+        "Inspect repository",
+        "scheduled",
+        "2026-08-27T00:00:00Z",
+        AgentRequestAdmissionRecord::runtime_automated_trigger(identity.did(), &trigger),
+    );
+    request.caused_by_trigger_id = Some(trigger.clone());
+    request.caused_by_trigger_doc_id =
+        Some(route["EventTrigger"][0]["_docID"].as_str().unwrap().into());
+    request.caused_by_trigger_kind = Some("event".into());
+    request.caused_by_correlation = Some(run.correlation.clone());
+    request.caused_by_source_doc_id = Some(run.seed_doc_id.clone());
+    crate::sign_agent_request_create(&identity, &mut request)
+        .await
+        .unwrap();
+    let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
+    runtime::fence_graph_root_request_in_txn(&txn, &request)
+        .await
+        .unwrap();
+    txn.execute(&request.graphql_mutation().unwrap())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    let admitted = load_graph_run_view(&node, identity.did(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(admitted.requests.len(), 1);
+    assert_eq!(admitted.requests[0].node_id.as_deref(), Some("recon"));
+    assert!(admitted.failure_evidence.is_none());
+    execute(&node, &format!(r#"mutation {{ update_Task(filter: {{ task_id: {{ _eq: "{}" }} }}, input: {{ enabled: false }}) {{ _docID }} }}"#, crate::graphql::escape_graphql_string(task_id))).await;
+    let disabled = load_graph_run_view(&node, identity.did(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(disabled.requests, admitted.requests);
+    assert!(
+        disabled.failure_evidence.is_none(),
+        "disable cannot erase a historical root's identity"
+    );
+    execute(&node, &format!(r#"mutation {{ update_Task(filter: {{ task_id: {{ _eq: "{}" }} }}, input: {{ behavior_id: "unapproved-task-target" }}) {{ _docID }} }}"#, crate::graphql::escape_graphql_string(task_id))).await;
+    let changed = load_graph_run_view(&node, identity.did(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        changed.requests, admitted.requests,
+        "mutable Task metadata cannot erase owner-signed history"
+    );
+    assert!(changed.failure_evidence.is_none());
+    let cancelling = request_graph_run_cancellation(
+        &node,
+        None,
+        identity.did(),
+        &run.run_id,
+        Some("operator can still cancel after config changes"),
+    )
+    .await
+    .unwrap();
+    assert!(cancelling.cancellation_requested_at.is_some());
+    drop(access);
+    Arc::try_unwrap(node)
+        .unwrap_or_else(|_| panic!("retained fixture node"))
+        .shutdown()
+        .await;
+}
+
+#[tokio::test]
+async fn replacement_goal_on_other_authenticated_chain_does_not_attach_to_old_root() {
+    let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
+    let mut parent = AgentRequestCreate::base(
+        "other-goal-parent",
+        identity.did(),
+        identity.did(),
+        "test-behavior",
+        "logical-session",
+        "A different goal",
+        "interactive",
+        "2026-08-28T00:00:00Z",
+        AgentRequestAdmissionRecord::local_self(identity.did()),
+    );
+    crate::sign_agent_request_create(&identity, &mut parent)
+        .await
+        .unwrap();
+    execute(&node, &parent.graphql_mutation().unwrap()).await;
+    execute(&node, r#"mutation { update_AgentRequest(filter: { request_id: { _eq: "other-goal-parent" } }, input: { lifecycle_state: "completed" }) { _docID } }"#).await;
+    let parent_row = persisted_requests(&node)
+        .await
+        .into_iter()
+        .find(|row| row.request_id == "other-goal-parent")
+        .unwrap();
+    let parent = crate::watcher::AgentRequest::try_from(parent_row).unwrap();
+    let mut child = crate::lifecycle::queue::prepare_goal_continuation(
+        &parent,
+        "test-behavior".into(),
+        "replacement-canonical-goal",
+        "Continue the unrelated goal",
+        1,
+        false,
+        "2026-08-28T00:00:00Z",
+    )
+    .unwrap();
+    crate::sign_agent_request_create(&identity, &mut child)
+        .await
+        .unwrap();
+    execute(&node, &child.graphql_mutation().unwrap()).await;
+    execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ goal_id: {{ _eq: "{}" }} }}, input: {{ goal_id: "replacement-canonical-goal", status: "active" }}) {{ _docID }} }}"#, crate::graphql::escape_graphql_string(&goal.goal_id))).await;
+    let view = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        view.outstanding_invocation_count, 0,
+        "the current Goal belongs to the other authenticated chain"
+    );
+    assert_eq!(
+        view.failure_evidence.as_ref().unwrap()["request_id"],
+        "graph-logical-root"
+    );
+}
+
+#[tokio::test]
+async fn generic_graph_foreign_roots_remain_ignored_after_reassignment_or_missing_task() {
+    for missing_task in [false, true] {
+        let (node, run, trigger) = runtime::attribution_test_fixture(1).await;
+        let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+            .await
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let foreign = KeyIdentity::load_or_create(dir.path().join("foreign.key"), None).unwrap();
+        let routes = execute(&node, &format!(r#"{{ EventTrigger(filter: {{ trigger_id: {{ _eq: "{}" }} }}) {{ _docID task_id }} }}"#, crate::graphql::escape_graphql_string(&trigger))).await;
+        if missing_task {
+            let task = routes["EventTrigger"][0]["task_id"].as_str().unwrap();
+            execute(&node, &format!(r#"mutation {{ delete_Task(filter: {{ task_id: {{ _eq: "{}" }} }}) {{ _docID }} }}"#, crate::graphql::escape_graphql_string(task))).await;
+        } else {
+            execute(&node, &format!(r#"mutation {{ update_AgentBehavior(filter: {{ behavior_id: {{ _eq: "test-behavior" }} }}, input: {{ agent_did: "{}" }}) {{ _docID }} }}"#, crate::graphql::escape_graphql_string(foreign.did()))).await;
+        }
+        let mut request = AgentRequestCreate::base(
+            "foreign-root",
+            foreign.did(),
+            foreign.did(),
+            "test-behavior",
+            "foreign-session",
+            "Copied owner route",
+            "scheduled",
+            "2026-08-28T00:00:00Z",
+            AgentRequestAdmissionRecord::runtime_automated_trigger(foreign.did(), &trigger),
+        );
+        request.caused_by_trigger_id = Some(trigger.clone());
+        request.caused_by_trigger_doc_id =
+            Some(routes["EventTrigger"][0]["_docID"].as_str().unwrap().into());
+        request.caused_by_trigger_kind = Some("event".into());
+        request.caused_by_correlation = Some(run.correlation.clone());
+        request.caused_by_source_doc_id = Some(run.seed_doc_id.clone());
+        crate::sign_agent_request_create(&foreign, &mut request)
+            .await
+            .unwrap();
+        let txn = crate::config_client::ConfigApplyTxn::begin_local(&node, None)
+            .await
+            .unwrap();
+        let denial = runtime::fence_graph_root_request_in_txn(&txn, &request)
+            .await
+            .unwrap_err();
+        assert!(
+            denial
+                .to_string()
+                .contains("principal is not its pinned owner"),
+            "{denial:#}"
+        );
+        txn.discard().await.unwrap();
+        execute(&node, &request.graphql_mutation().unwrap()).await;
+        execute(&node, r#"mutation { update_AgentRequest(filter: { request_id: { _eq: "foreign-root" } }, input: { lifecycle_state: "failed", failure_reason: "must not poison owner graph" }) { _docID } }"#).await;
+        let rows = persisted_requests(&node).await;
+        assert_eq!(rows.len(), 1);
+        crate::request_admission::verify_request_receipt_signature(&rows[0]).unwrap();
+        let after = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            after.requests, before.requests,
+            "foreign rows must be rejected before invalid-target fallback"
+        );
+        assert_eq!(after.status, "running");
+        assert_eq!(after.update_generation, before.update_generation);
+        assert!(after.error.is_none());
+        assert!(after.failure_evidence.is_none());
+    }
+}
+
+#[tokio::test]
+async fn generic_task_behavior_changes_cannot_erase_active_owner_signed_root() {
+    let (node, run, trigger) = runtime::attribution_test_fixture(2).await;
+    runtime::seed_signed_graph_request(&node, &run, &trigger, "active-root", "processing", "")
+        .await;
+    let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(before.active_request_count, 1);
+    execute(&node, &format!(r#"mutation {{ create_AgentBehavior(input: {{ behavior_id: "other-owner-behavior", agent_did: "{}", enabled: true }}) {{ _docID }} }}"#, crate::graphql::escape_graphql_string(graph_test_owner()))).await;
+    execute(&node, r#"mutation { update_Task(filter: { behavior_id: { _eq: "test-behavior" } }, input: { behavior_id: "other-owner-behavior", enabled: false, name: "renamed task" }) { _docID } }"#).await;
+    let changed = reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
+        .await
+        .unwrap();
+    assert_eq!(changed.requests, before.requests);
+    assert_eq!(changed.active_request_count, 1);
+    assert_eq!(changed.status, "running");
+    assert_eq!(changed.update_generation, before.update_generation);
+    assert!(changed.error.is_none());
+    assert!(changed.failure_evidence.is_none());
+    let cancelling = request_graph_run_cancellation(
+        &node,
+        None,
+        graph_test_owner(),
+        &run.run_id,
+        Some("still drains actual historical work"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(cancelling.requests.len(), 1);
+    assert!(cancelling.cancellation_requested_at.is_some());
+    let rows = execute(&node, r#"{ AgentRequest(filter: { request_id: { _eq: "active-root" } }) { interrupt_requested_at } }"#).await;
+    assert!(rows["AgentRequest"][0]["interrupt_requested_at"].is_string());
 }

--- a/crates/gents/src/graph_pipeline/publication_contract_tests.rs
+++ b/crates/gents/src/graph_pipeline/publication_contract_tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::graph_pipeline::logical_invocation_contract_tests::{
     execute, prepare_signed_child, signed_invocation_fixture,
 };
+use crate::graph_pipeline::runtime::graph_test_owner;
 use serde::Deserialize;
 
 fn assert_created_request(response: &Value) {
@@ -51,7 +52,7 @@ struct Observation {
     children: usize,
 }
 async fn observe(node: &EmbeddedNode, run_id: &str, initial_generation: i64) -> Observation {
-    let view = load_graph_run_view(node, "did:key:owner", run_id)
+    let view = load_graph_run_view(node, graph_test_owner(), run_id)
         .await
         .unwrap();
     let primary = view.error.as_ref().map(|error| {
@@ -84,7 +85,7 @@ async fn generated_graph_invocation_publication_traces_drive_real_transactions()
     for trace in contracts.graph_invocation_publication_cases {
         let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
         execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "paused" }}) {{ _docID }} }}"#, goal.doc_id)).await;
-        let cause = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let cause = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         assert_eq!(
@@ -101,7 +102,7 @@ async fn generated_graph_invocation_publication_traces_drive_real_transactions()
         );
         assert_eq!(trace.events.len(), trace.expected.len());
         for (event, expected) in trace.events.iter().zip(trace.expected.iter()) {
-            let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+            let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
             let txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
@@ -158,7 +159,7 @@ async fn generated_graph_invocation_publication_traces_drive_real_transactions()
                 "cancel" => {
                     persist_cancellation_intent(
                         txn,
-                        "did:key:owner",
+                        graph_test_owner(),
                         &run.run_id,
                         Some("generated publication cancellation"),
                     )
@@ -182,7 +183,7 @@ async fn generated_graph_invocation_publication_traces_drive_real_transactions()
 #[tokio::test]
 async fn discarding_graph_publication_rolls_back_generation_and_signed_child() {
     let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
-    let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+    let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
         .await
         .unwrap();
     let child = prepare_signed_child(&node, &identity, &goal, "valid").await;
@@ -229,7 +230,7 @@ async fn overlapping_native_graph_publication_and_closure_conflict_atomically() 
     for publication_first in [false, true] {
         let (node, run, goal, identity, _temp) = signed_invocation_fixture(3).await;
         execute(&node, &format!(r#"mutation {{ update_Goal(filter: {{ _docID: {{ _eq: "{}" }} }}, input: {{ status: "paused" }}) {{ _docID }} }}"#, goal.doc_id)).await;
-        let before = load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let before = load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         let child = prepare_signed_child(&node, &identity, &goal, "valid").await;

--- a/crates/gents/src/graph_pipeline/run.rs
+++ b/crates/gents/src/graph_pipeline/run.rs
@@ -217,9 +217,13 @@ async fn query_run(executor: &(impl GraphRunQuery + ?Sized), run_id: &str) -> Re
         .with_context(|| format!("GraphRun {run_id:?} does not exist"))
 }
 
-async fn load_plan(executor: &(impl GraphRunQuery + ?Sized), digest: &str) -> Result<GraphPlan> {
+async fn load_plan(
+    executor: &(impl GraphRunQuery + ?Sized),
+    digest: &str,
+    owner_did: &str,
+) -> Result<GraphPlan> {
     let response = executor.execute_graph_query(&format!(
-        r#"{{ GraphRevision(filter: {{ digest: {{ _eq: "{}" }} }}, limit: 2) {{ plan_json }} }}"#,
+        r#"{{ GraphRevision(filter: {{ digest: {{ _eq: "{}" }} }}, limit: 2) {{ plan_json owner_did graph_id }} }}"#,
         escape_graphql_string(digest),
     ))
     .await?;
@@ -233,7 +237,11 @@ async fn load_plan(executor: &(impl GraphRunQuery + ?Sized), digest: &str) -> Re
             .and_then(Value::as_str)
             .context("pinned GraphRevision is missing plan_json")?,
     )?;
-    if plan.digest != digest || !verify_graph_plan_digest(&plan) {
+    if plan.digest != digest
+        || !verify_graph_plan_digest(&plan)
+        || found[0].get("owner_did").and_then(Value::as_str) != Some(owner_did)
+        || found[0].get("graph_id").and_then(Value::as_str) != Some(plan.graph_id.as_str())
+    {
         anyhow::bail!("pinned GraphRevision plan failed immutable identity verification");
     }
     Ok(plan)
@@ -265,6 +273,27 @@ fn planned_trigger_nodes(plan: &GraphPlan) -> Result<BTreeMap<String, String>> {
         anyhow::bail!("pinned graph plan has no materialized trigger routes");
     }
     Ok(nodes_by_trigger)
+}
+
+pub(super) async fn validate_graph_root_owner_in_txn(
+    txn: &ConfigApplyTxn<'_>,
+    request: &gents_protocol::request_admission::AgentRequestCreate,
+    run_id: &str,
+    digest: &str,
+) -> Result<()> {
+    let run = query_run(txn, run_id).await?;
+    let owner = required_string(&run, "owner_did")?;
+    anyhow::ensure!(
+        request.agent_did == owner,
+        "graph request principal is not its pinned owner"
+    );
+    let plan = load_plan(txn, digest, owner).await?;
+    let routes = planned_trigger_nodes(&plan)?;
+    anyhow::ensure!(
+        routes.contains_key(request.caused_by_trigger_id.as_deref().unwrap_or_default()),
+        "graph request trigger is not a pinned route"
+    );
+    Ok(())
 }
 
 async fn load_groups(
@@ -443,9 +472,9 @@ async fn load_graph_run_view_with(
         anyhow::bail!("actor is not authorized to observe this graph run");
     }
     let revision_digest = required_string(&run, "revision_digest")?;
-    let plan = load_plan(executor, revision_digest).await?;
+    let plan = load_plan(executor, revision_digest, owner_did).await?;
     let correlation = required_string(&run, "correlation")?;
-    let logical = logical_invocation::load(executor, correlation, &plan).await?;
+    let logical = logical_invocation::load(executor, correlation, &plan, owner_did).await?;
     let requests = logical.requests;
     let outstanding_invocation_count = logical
         .invocations
@@ -612,17 +641,10 @@ async fn load_graph_run_view_with(
         anyhow::ensure!(
             primary.get("version").and_then(Value::as_u64) == Some(1)
                 && primary.get("message").and_then(Value::as_str).is_some()
-                && matches!(
-                    primary.get("code").and_then(Value::as_str),
-                    Some(
-                        "group_quiesced"
-                            | "contract_drift"
-                            | "invocation_limit_exceeded"
-                            | "run_deadline_exceeded"
-                            | "required_request_failed"
-                            | "result_contract_unsatisfied"
-                    )
-                ),
+                && primary
+                    .get("code")
+                    .and_then(Value::as_str)
+                    .is_some_and(|code| !code.trim().is_empty()),
             "invalid persisted graph failure evidence"
         );
     }
@@ -731,15 +753,20 @@ pub(crate) async fn graph_binding_for_request_in_txn(
         return Ok(None);
     }
     let response = txn.execute(&format!(
-        r#"{{ GraphRun(filter: {{ correlation: {{ _in: {} }} }}) {{ run_id revision_digest correlation }} }}"#,
+        r#"{{ GraphRun(filter: {{ correlation: {{ _in: {} }} }}) {{ run_id revision_digest correlation owner_did }} }}"#,
         graphql_string_list_literal(&correlations.into_iter().collect::<Vec<_>>()),
     )).await?;
     let mut bindings = Vec::new();
     for run in rows(&response, "GraphRun") {
         let digest = required_string(run, "revision_digest")?;
-        let plan = load_plan(txn, digest).await?;
-        let projection =
-            logical_invocation::load(txn, required_string(run, "correlation")?, &plan).await?;
+        let plan = load_plan(txn, digest, required_string(run, "owner_did")?).await?;
+        let projection = logical_invocation::load(
+            txn,
+            required_string(run, "correlation")?,
+            &plan,
+            required_string(run, "owner_did")?,
+        )
+        .await?;
         for invocation in projection.invocations {
             if invocation.member_doc_ids.contains(parent_doc_id) {
                 anyhow::ensure!(
@@ -1017,13 +1044,13 @@ async fn capture_failure_txn(txn: ConfigApplyTxn<'_>, view: &GraphRunView) -> Re
     let result = async {
         let fresh = load_graph_run_view_with(&txn, &view.owner_did, &view.run_id).await?;
         if fresh.status != "running" || fresh.update_generation != view.update_generation {
-            anyhow::bail!("graph failure capture CAS lost; reload the durable run");
+            return Ok(false);
         }
         if fresh.cancellation_requested_at.is_some() || fresh.error.is_some() {
-            return Ok(());
+            return Ok(false);
         }
         let Some(primary) = fresh.failure_evidence else {
-            return Ok(());
+            return Ok(false);
         };
         let current = query_run(&txn, &view.run_id).await?;
         let input = json!({
@@ -1036,14 +1063,30 @@ async fn capture_failure_txn(txn: ConfigApplyTxn<'_>, view: &GraphRunView) -> Re
             graphql_input_literal(&input)?,
         ))
         .await?;
-        Result::<()>::Ok(())
+        Result::<bool>::Ok(true)
     }
     .await;
     match result {
-        Ok(()) => txn.commit().await.context("commit graph failure cause"),
+        Ok(false) => txn.discard().await,
+        Ok(true) => match txn.commit().await {
+            Ok(()) => Ok(()),
+            // Reconciliation always reloads after this shared operation. A
+            // native competing winner is an observation change, not a failure
+            // that may bypass reloading or emit stale sibling interruptions.
+            Err(error)
+                if crate::graphql::is_defradb_transaction_conflict_text(&format!("{error:#}")) =>
+            {
+                Ok(())
+            }
+            Err(error) => Err(error).context("commit graph failure cause"),
+        },
         Err(error) => {
             let _ = txn.discard().await;
-            Err(error)
+            if crate::graphql::is_defradb_transaction_conflict_text(&format!("{error:#}")) {
+                Ok(())
+            } else {
+                Err(error)
+            }
         }
     }
 }

--- a/crates/gents/src/graph_pipeline/runtime.rs
+++ b/crates/gents/src/graph_pipeline/runtime.rs
@@ -372,7 +372,8 @@ pub(crate) async fn graph_materialization_denial(
     correlation: Option<&str>,
 ) -> Result<Option<String>> {
     let Some(trigger_digest) = graph_artifact_revision_digest(trigger_id) else {
-        return Ok(None);
+        return Ok(graph_artifact_is_reserved(trigger_id)
+            .then(|| "malformed reserved graph trigger ID".to_owned()));
     };
     let Some(correlation) = correlation.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(Some(
@@ -429,11 +430,14 @@ pub(crate) async fn fence_graph_root_request_in_txn(
     txn: &ConfigApplyTxn<'_>,
     request: &gents_protocol::request_admission::AgentRequestCreate,
 ) -> Result<()> {
-    let Some(digest) = request
-        .caused_by_trigger_id
-        .as_deref()
-        .and_then(graph_artifact_revision_digest)
-    else {
+    let Some(trigger_id) = request.caused_by_trigger_id.as_deref() else {
+        return Ok(());
+    };
+    let Some(digest) = graph_artifact_revision_digest(trigger_id) else {
+        anyhow::ensure!(
+            !graph_artifact_is_reserved(trigger_id),
+            "malformed reserved graph trigger ID"
+        );
         return Ok(());
     };
     let run_id = request
@@ -441,6 +445,7 @@ pub(crate) async fn fence_graph_root_request_in_txn(
         .as_deref()
         .filter(|value| !value.trim().is_empty())
         .context("graph root publication requires a durable run correlation")?;
+    super::run::validate_graph_root_owner_in_txn(txn, request, run_id, &digest).await?;
     fence_graph_publication_in_txn(txn, run_id, &digest).await
 }
 
@@ -1435,7 +1440,9 @@ async fn start_run_in_txn(
 }
 
 #[cfg(test)]
-pub(super) use tests::{attribution_test_fixture, seed_signed_graph_request};
+pub(super) use tests::{
+    attribution_test_fixture, graph_test_identity, graph_test_owner, seed_signed_graph_request,
+};
 
 #[cfg(test)]
 mod tests {
@@ -1464,10 +1471,11 @@ mod tests {
                 .execute(&format!(
                     r#"mutation {{ create_GraphRevision(input: {{
                         revision_id: "{revision_id}", graph_id: "graph", digest: "{digest}",
-                        owner_did: "did:key:owner", status: "validated",
+                        owner_did: "{owner}", status: "validated",
                         compiler_version: "test", plan_json: "{{}}",
                         artifacts_complete: {complete}, created_at: "{created_at}"
                     }}) {{ _docID }} }}"#,
+                    owner = graph_test_owner(),
                     revision_id = escape_graphql_string(revision_id),
                     digest = escape_graphql_string(digest),
                     created_at = escape_graphql_string(&created_at),
@@ -1481,10 +1489,14 @@ mod tests {
             "sha256:incomplete".to_owned(),
             "sha256:malformed".to_owned(),
         ]);
-        let visible =
-            load_visible_package_artifact_ids(&node, "did:key:owner", &digests, &BTreeSet::new())
-                .await
-                .unwrap();
+        let visible = load_visible_package_artifact_ids(
+            &node,
+            graph_test_owner(),
+            &digests,
+            &BTreeSet::new(),
+        )
+        .await
+        .unwrap();
         assert!(visible.0.is_empty());
         assert!(visible.1.is_empty());
 
@@ -1610,9 +1622,9 @@ mod tests {
                 task_id: format!("worker-{configuration}"),
                 input_ports: vec![input],
                 output_ports: vec![output],
-                allowed_callers: vec!["did:key:owner".to_owned()],
+                allowed_callers: vec![graph_test_owner().to_owned()],
             }],
-            "did:key:owner",
+            graph_test_owner(),
             &CompilerPolicy::default(),
         )
         .unwrap()
@@ -1708,7 +1720,7 @@ mod tests {
                     task_id: "producer-task".to_owned(),
                     input_ports: vec![input],
                     output_ports: vec![output],
-                    allowed_callers: vec!["did:key:owner".to_owned()],
+                    allowed_callers: vec![graph_test_owner().to_owned()],
                 },
                 StageCapability {
                     capability_id: "consumer".to_owned(),
@@ -1716,10 +1728,10 @@ mod tests {
                     task_id: "consumer-task".to_owned(),
                     input_ports: vec![grouped_input],
                     output_ports: vec![],
-                    allowed_callers: vec!["did:key:owner".to_owned()],
+                    allowed_callers: vec![graph_test_owner().to_owned()],
                 },
             ],
-            "did:key:owner",
+            graph_test_owner(),
             &CompilerPolicy::default(),
         )
         .unwrap()
@@ -1785,9 +1797,9 @@ mod tests {
                 task_id: "worker-result".to_owned(),
                 input_ports: vec![input],
                 output_ports: vec![output],
-                allowed_callers: vec!["did:key:owner".to_owned()],
+                allowed_callers: vec![graph_test_owner().to_owned()],
             }],
-            "did:key:owner",
+            graph_test_owner(),
             &CompilerPolicy::default(),
         )
         .unwrap()
@@ -1827,6 +1839,18 @@ mod tests {
     }
 
     async fn install_plan_tasks(node: &EmbeddedNode, plan: &GraphPlan) {
+        use crate::identity::AgentIdentity;
+        let identity = graph_test_identity();
+        let behavior = node.execute(r#"{ AgentBehavior(filter: { behavior_id: { _eq: "test-behavior" } }) { _docID } }"#).await;
+        assert!(!behavior.has_errors(), "{:?}", behavior.errors);
+        if behavior.data.unwrap()["AgentBehavior"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+        {
+            let result = node.execute(&format!(r#"mutation {{ create_AgentBehavior(input: {{ behavior_id: "test-behavior", agent_did: "{}", enabled: true }}) {{ _docID }} }}"#, escape_graphql_string(identity.did()))).await;
+            assert!(!result.has_errors(), "{:?}", result.errors);
+        }
         let now = chrono::Utc::now().to_rfc3339();
         for task_id in plan
             .nodes
@@ -1863,6 +1887,7 @@ mod tests {
             gents_protocol::schemas::GOAL_CREATION_CLAIM,
             gents_protocol::schemas::EVENT_TRIGGER_GROUP_STATE,
             gents_protocol::schemas::TASK,
+            gents_protocol::schemas::AGENT_BEHAVIOR,
             gents_protocol::schemas::EVENT_TRIGGER,
             r#"type PipelineInput {
                 graph_run_id: String @index(unique: true)
@@ -1878,13 +1903,13 @@ mod tests {
 
         let first = test_plan("first");
         install_plan_tasks(&node, &first).await;
-        let materialized = materialize_graph_revision(&node, None, "did:key:owner", &first)
+        let materialized = materialize_graph_revision(&node, None, graph_test_owner(), &first)
             .await
             .unwrap();
         assert_eq!(materialized.task_ids.len(), 1);
         assert_eq!(materialized.trigger_ids.len(), 1);
         assert_eq!(
-            materialize_graph_revision(&node, None, "did:key:owner", &first)
+            materialize_graph_revision(&node, None, graph_test_owner(), &first)
                 .await
                 .unwrap(),
             materialized
@@ -1901,7 +1926,7 @@ mod tests {
         let activation = activate_graph_revision(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             &first.digest,
             None,
@@ -1911,7 +1936,7 @@ mod tests {
         assert_eq!(activation.generation, 1);
         assert_eq!(activation.previous_digest, None);
         assert_eq!(
-            materialize_graph_revision(&node, None, "did:key:owner", &first)
+            materialize_graph_revision(&node, None, graph_test_owner(), &first)
                 .await
                 .unwrap(),
             materialized
@@ -1931,7 +1956,7 @@ mod tests {
         assert_eq!(active_row["artifacts_complete"], true);
 
         let read_txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
-        let loaded = load_active_graph_plan_in_txn(&read_txn, "did:key:owner", "pipeline")
+        let loaded = load_active_graph_plan_in_txn(&read_txn, graph_test_owner(), "pipeline")
             .await
             .unwrap()
             .expect("active plan");
@@ -1941,7 +1966,7 @@ mod tests {
         let disable_txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
         set_graph_enabled_in_txn(
             &disable_txn,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             false,
             "2026-08-25T00:00:00Z",
@@ -1952,7 +1977,7 @@ mod tests {
         assert!(start_graph_run(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             Some(&first.digest),
             "input",
@@ -1965,7 +1990,7 @@ mod tests {
         let enable_txn = ConfigApplyTxn::begin_local(&node, None).await.unwrap();
         set_graph_enabled_in_txn(
             &enable_txn,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             true,
             "2026-08-25T00:00:01Z",
@@ -1978,7 +2003,7 @@ mod tests {
         let stale_start = start_graph_run(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             Some(&stale_digest),
             "input",
@@ -1999,7 +2024,7 @@ mod tests {
         let run = start_graph_run(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             None,
             "input",
@@ -2044,13 +2069,13 @@ mod tests {
 
         let second = test_plan("second");
         install_plan_tasks(&node, &second).await;
-        materialize_graph_revision(&node, None, "did:key:owner", &second)
+        materialize_graph_revision(&node, None, graph_test_owner(), &second)
             .await
             .unwrap();
         let conflict = activate_graph_revision(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             &second.digest,
             None,
@@ -2061,7 +2086,7 @@ mod tests {
         let switched = activate_graph_revision(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "pipeline",
             &second.digest,
             Some(&first.digest),
@@ -2113,7 +2138,7 @@ mod tests {
         assert!(!cancel_intent.has_errors(), "{:?}", cancel_intent.errors);
 
         let recovering =
-            super::super::reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+            super::super::reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
         assert_eq!(recovering.status, "running");
@@ -2145,7 +2170,7 @@ mod tests {
             terminal_request.errors
         );
         let cancelled =
-            super::super::reconcile_graph_run(&node, None, "did:key:owner", &run.run_id)
+            super::super::reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id)
                 .await
                 .unwrap();
         assert_eq!(cancelled.status, "cancelled");
@@ -2178,6 +2203,7 @@ mod tests {
             gents_protocol::schemas::GOAL_CREATION_CLAIM,
             gents_protocol::schemas::EVENT_TRIGGER_GROUP_STATE,
             gents_protocol::schemas::TASK,
+            gents_protocol::schemas::AGENT_BEHAVIOR,
             gents_protocol::schemas::EVENT_TRIGGER,
             r#"type PipelineInput {
                 graph_run_id: String @index(unique: true)
@@ -2192,13 +2218,13 @@ mod tests {
         }
         let plan = result_test_plan();
         install_plan_tasks(&node, &plan).await;
-        materialize_graph_revision(&node, None, "did:key:owner", &plan)
+        materialize_graph_revision(&node, None, graph_test_owner(), &plan)
             .await
             .unwrap();
         activate_graph_revision(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "result-pipeline",
             &plan.digest,
             None,
@@ -2208,7 +2234,7 @@ mod tests {
         let run = start_graph_run(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "result-pipeline",
             None,
             "input",
@@ -2220,7 +2246,7 @@ mod tests {
         let entry_trigger_id = graph_trigger_id(&plan.digest, "entry:input:worker:input").unwrap();
         seed_signed_graph_request(&node, &run, &entry_trigger_id, "request-1", "completed", "")
             .await;
-        let unsatisfied = super::super::load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let unsatisfied = super::super::load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         assert_eq!(
@@ -2269,7 +2295,7 @@ mod tests {
             ))
             .await;
         assert!(!unrelated.has_errors(), "{:?}", unrelated.errors);
-        let scoped = super::super::load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let scoped = super::super::load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         assert_eq!(scoped.requests.len(), 1);
@@ -2285,12 +2311,12 @@ mod tests {
                 .contains("not authorized")
         );
         assert_eq!(
-            super::super::reconcile_owned_graph_runs(&node, "did:key:owner")
+            super::super::reconcile_owned_graph_runs(&node, graph_test_owner())
                 .await
                 .unwrap(),
             1
         );
-        let terminal = super::super::load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let terminal = super::super::load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         assert_eq!(terminal.status, "succeeded");
@@ -2298,7 +2324,7 @@ mod tests {
         assert_eq!(terminal.persisted_result_refs[0].name, "report");
         assert!(!terminal.persisted_result_refs[0].commit_cid.is_empty());
 
-        let reloaded = super::super::load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let reloaded = super::super::load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         assert_eq!(
@@ -2306,14 +2332,14 @@ mod tests {
             terminal.persisted_result_refs
         );
         assert_eq!(
-            super::super::reconcile_graph_run(&node, None, "did:key:owner", &run.run_id,)
+            super::super::reconcile_graph_run(&node, None, graph_test_owner(), &run.run_id,)
                 .await
                 .unwrap()
                 .status,
             "succeeded"
         );
         assert_eq!(
-            super::super::reconcile_owned_graph_runs(&node, "did:key:owner")
+            super::super::reconcile_owned_graph_runs(&node, graph_test_owner())
                 .await
                 .unwrap(),
             0
@@ -2340,7 +2366,7 @@ mod tests {
         let access = ConfigAccess::Local(Arc::clone(&node));
         let hydrated = super::super::load_graph_run_result_view_with_access(
             &access,
-            "did:key:owner",
+            graph_test_owner(),
             &run.run_id,
         )
         .await
@@ -2362,6 +2388,7 @@ mod tests {
             gents_protocol::schemas::GRAPH_DEFINITION,
             gents_protocol::schemas::GRAPH_REVISION,
             gents_protocol::schemas::TASK,
+            gents_protocol::schemas::AGENT_BEHAVIOR,
             gents_protocol::schemas::EVENT_TRIGGER,
         ] {
             node.add_schema(schema).await.unwrap();
@@ -2369,7 +2396,7 @@ mod tests {
 
         let plan = grouped_test_plan();
         install_plan_tasks(&node, &plan).await;
-        materialize_graph_revision(&node, None, "did:key:owner", &plan)
+        materialize_graph_revision(&node, None, graph_test_owner(), &plan)
             .await
             .unwrap();
         let response = node
@@ -2399,11 +2426,11 @@ mod tests {
     ) -> crate::graph_pipeline::GraphRunView {
         if via_access {
             let access = ConfigAccess::Local(Arc::clone(node));
-            super::super::reconcile_graph_run_with_access(&access, "did:key:owner", run_id)
+            super::super::reconcile_graph_run_with_access(&access, graph_test_owner(), run_id)
                 .await
                 .unwrap()
         } else {
-            super::super::reconcile_graph_run(node, None, "did:key:owner", run_id)
+            super::super::reconcile_graph_run(node, None, graph_test_owner(), run_id)
                 .await
                 .unwrap()
         }
@@ -2413,6 +2440,27 @@ mod tests {
     // state changes emulate executor terminal observations, not a second graph
     // coordinator. No provider or wall-clock sleep is needed.
     /// Seed a real authenticated route receipt, then set its mutable lifecycle.
+    pub(in crate::graph_pipeline) fn graph_test_owner() -> &'static str {
+        use crate::identity::AgentIdentity;
+        static OWNER: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        OWNER.get_or_init(|| graph_test_identity().did().to_owned())
+    }
+
+    pub(in crate::graph_pipeline) fn graph_test_identity() -> crate::identity::KeyIdentity {
+        use crate::identity::KeyIdentity;
+        static KEY: std::sync::OnceLock<Vec<u8>> = std::sync::OnceLock::new();
+        let key = KEY.get_or_init(|| {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("worker.key");
+            KeyIdentity::load_or_create(&path, None).unwrap();
+            std::fs::read(path).unwrap()
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("worker.key");
+        std::fs::write(&path, key).unwrap();
+        KeyIdentity::load_or_create(path, None).unwrap()
+    }
+
     pub(in crate::graph_pipeline) async fn seed_signed_graph_request(
         node: &EmbeddedNode,
         run: &GraphRunReceipt,
@@ -2421,16 +2469,14 @@ mod tests {
         lifecycle: &str,
         reason: &str,
     ) {
-        use crate::identity::{AgentIdentity, KeyIdentity};
+        use crate::identity::AgentIdentity;
         use gents_protocol::request_admission::{AgentRequestAdmissionRecord, AgentRequestCreate};
-        let temp = tempfile::tempdir().unwrap();
-        let identity =
-            KeyIdentity::load_or_create(temp.path().join("graph-worker.key"), None).unwrap();
+        let identity = graph_test_identity();
         let mut create = AgentRequestCreate::base(
             request_id,
             identity.did(),
             identity.did(),
-            "worker-v1",
+            "test-behavior",
             &format!("session-{request_id}"),
             "Execute the pinned graph stage",
             "scheduled",
@@ -2479,6 +2525,7 @@ mod tests {
             gents_protocol::schemas::GOAL_CREATION_CLAIM,
             gents_protocol::schemas::EVENT_TRIGGER_GROUP_STATE,
             gents_protocol::schemas::TASK,
+            gents_protocol::schemas::AGENT_BEHAVIOR,
             gents_protocol::schemas::EVENT_TRIGGER,
             "type PipelineInput { graph_run_id: String @index(unique: true) payload: String }",
             "type PipelineResult { graph_run_id: String @index report: String }",
@@ -2491,13 +2538,13 @@ mod tests {
         plan.limits.max_total_invocations = max_invocations;
         plan.digest = crate::graph_pipeline::graph_plan_digest(&plan);
         install_plan_tasks(&node, &plan).await;
-        materialize_graph_revision(&node, None, "did:key:owner", &plan)
+        materialize_graph_revision(&node, None, graph_test_owner(), &plan)
             .await
             .unwrap();
         activate_graph_revision(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "result-pipeline",
             &plan.digest,
             None,
@@ -2507,7 +2554,7 @@ mod tests {
         let run = start_graph_run(
             &node,
             None,
-            "did:key:owner",
+            graph_test_owner(),
             "result-pipeline",
             None,
             "input",
@@ -2536,7 +2583,7 @@ mod tests {
         assert_eq!(first.active_request_count, 1);
         // Reload from DB: asserting only failure_evidence would pass before
         // the fix because that is recomputed and is not a durable latch.
-        let latched = super::super::load_graph_run_view(&node, "did:key:owner", &run.run_id)
+        let latched = super::super::load_graph_run_view(&node, graph_test_owner(), &run.run_id)
             .await
             .unwrap();
         let primary = latched
@@ -2569,7 +2616,7 @@ mod tests {
                 let access = ConfigAccess::Local(Arc::clone(&node));
                 super::super::request_graph_run_cancellation_with_access(
                     &access,
-                    "did:key:owner",
+                    graph_test_owner(),
                     &run.run_id,
                     reason,
                 )
@@ -2579,7 +2626,7 @@ mod tests {
                 super::super::request_graph_run_cancellation(
                     &node,
                     None,
-                    "did:key:owner",
+                    graph_test_owner(),
                     &run.run_id,
                     reason,
                 )

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -40,6 +40,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) goal_config_reactivation_cases: Vec<serde_json::Value>,
     pub(crate) graph_logical_invocation_cases: Vec<serde_json::Value>,
     pub(crate) workspace_path_capability_cases: Vec<serde_json::Value>,
+    pub(crate) workspace_path_alias_cases: Vec<serde_json::Value>,
     pub(crate) workspace_capability_migration_cases: Vec<serde_json::Value>,
     pub(crate) graph_invocation_publication_cases: Vec<serde_json::Value>,
     pub(crate) graph_failure_attribution_traces: Vec<serde_json::Value>,

--- a/crates/gents/src/run_timeline.rs
+++ b/crates/gents/src/run_timeline.rs
@@ -948,7 +948,14 @@ pub fn build_run_timeline(mut rows: RunTimelineRows) -> RunTimeline {
             included_request_ids.insert(request.request_id.clone());
         }
     }
-    let inference_calls = sorted_inference_calls(rows.inference_calls, &included_request_ids);
+    let mut inference_calls = sorted_inference_calls(rows.inference_calls, &included_request_ids);
+    // The timeline serializes both these rows and derived events. Sanitize once
+    // before either representation is built, not only the event projection.
+    for call in &mut inference_calls {
+        call.backend_config_fingerprint = crate::admission::exportable_backend_fingerprint(
+            call.backend_config_fingerprint.as_deref(),
+        );
+    }
     apply_retry_summaries(&mut rows.request, &mut rows.requests, &inference_calls);
 
     let mut events = Vec::new();
@@ -1852,7 +1859,7 @@ mod tests {
                 priority: Some(7),
                 queue_depth_at_enqueue: Some(3),
                 controller_generation: Some(11),
-                backend_config_fingerprint: Some("sha256:abc".to_string()),
+                backend_config_fingerprint: Some("hmac-sha256:process-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()),
                 queued_at: Some("2026-08-14T12:00:01Z".to_string()),
                 ..Default::default()
             }],
@@ -1895,7 +1902,7 @@ mod tests {
         assert_eq!(inference.controller_generation, Some(11));
         assert_eq!(
             inference.backend_config_fingerprint.as_deref(),
-            Some("sha256:abc")
+            Some("hmac-sha256:process-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         );
 
         let approval = timeline.events.iter().find_map(|event| match event {

--- a/crates/gents/src/run_timeline_fetch.rs
+++ b/crates/gents/src/run_timeline_fetch.rs
@@ -623,7 +623,7 @@ mod tests {
                         priority: 7
                         queue_depth_at_enqueue: 3
                         controller_generation: 11
-                        backend_config_fingerprint: "sha256:abc"
+                        backend_config_fingerprint: "InferenceBackend synthetic-inline-secret"
                         prompt_tokens: 10
                         completion_tokens: 5
                         cached_input_tokens: 2
@@ -676,10 +676,10 @@ mod tests {
         assert_eq!(inference.priority, Some(7));
         assert_eq!(inference.queue_depth_at_enqueue, Some(3));
         assert_eq!(inference.controller_generation, Some(11));
-        assert_eq!(
-            inference.backend_config_fingerprint.as_deref(),
-            Some("sha256:abc")
-        );
+        assert_eq!(inference.backend_config_fingerprint, None);
+        assert!(!serde_json::to_string(&timeline)
+            .unwrap()
+            .contains("synthetic-inline-secret"));
 
         node.shutdown().await;
     }

--- a/crates/gents/src/toolset.rs
+++ b/crates/gents/src/toolset.rs
@@ -653,6 +653,3 @@ fn default_read_only_commands() -> Vec<String> {
     .map(str::to_string)
     .collect()
 }
-
-#[cfg(test)]
-pub(crate) use shared::select_sandbox_for_policy;

--- a/crates/gents/src/workspace/adapter.rs
+++ b/crates/gents/src/workspace/adapter.rs
@@ -269,13 +269,6 @@ pub(crate) fn validate_tree_delta(
     if !capability.is_exact() {
         return Ok(());
     }
-    // Check component aliases in both trees, including unchanged entries. A new
-    // spelling must not acquire authority over an existing filesystem alias.
-    for revision in [base, tree] {
-        let args = ["ls-tree", "-r", "-z", "--name-only", revision];
-        let bytes = git_output_bytes_inner(git_command(repo, &args), repo, &args)?;
-        super::WorkspacePathCapability::exact_paths(nul_paths(&bytes)?)?;
-    }
     let args = [
         "diff",
         "--raw",
@@ -291,12 +284,14 @@ pub(crate) fn validate_tree_delta(
     if fields.len() % 2 != 0 {
         bail!("malformed Git raw delta");
     }
+    let mut changed_paths = Vec::new();
     for pair in fields.chunks_exact(2) {
         let header: Vec<_> = pair[0].split_ascii_whitespace().collect();
         if header.len() != 5 {
             bail!("malformed Git raw delta header");
         }
         let path = &pair[1];
+        changed_paths.push(path.as_str());
         super::path_capability::validate_relative_path(path)?;
         if !capability.authorizes(path) {
             bail!("workspace path capability denies changed path {path:?}");
@@ -309,6 +304,31 @@ pub(crate) fn validate_tree_delta(
                 bail!("workspace path capability denies changed symlink/gitlink or unsupported mode {mode} at {path:?}");
             }
         }
+    }
+    // Unchanged entries are observations, not new capability grants. Check
+    // only aliases involving changed prefixes, against BOTH complete trees.
+    // Opaque components cannot alias admitted UTF-8 components, but their
+    // valid ancestors still participate in the alias check.
+    for revision in [base, tree] {
+        let args = ["ls-tree", "-r", "-z", "--name-only", revision];
+        let bytes = git_output_bytes_inner(git_command(repo, &args), repo, &args)?;
+        if !bytes.is_empty() && bytes.last() != Some(&0) {
+            bail!("malformed Git tree path list");
+        }
+        let paths = bytes
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .filter_map(|path| match std::str::from_utf8(path) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    // Keep complete UTF-8 ancestors before the first opaque
+                    // component (e.g. Src/<opaque> still observes Src).
+                    let valid = &path[..error.valid_up_to()];
+                    let separator = valid.iter().rposition(|byte| *byte == b'/')?;
+                    std::str::from_utf8(&valid[..separator]).ok()
+                }
+            });
+        super::path_capability::validate_changed_path_aliases(&changed_paths, paths)?;
     }
     Ok(())
 }

--- a/crates/gents/src/workspace/artifact.rs
+++ b/crates/gents/src/workspace/artifact.rs
@@ -247,6 +247,13 @@ impl ArtifactGrant {
         if checked_worktree_git_dir(&owner.source_root, &owner.workspace_id)? != owner.git_dir {
             bail!("artifact Git placement changed");
         }
+        // Hash before observing the execution lease: on a large tree this may
+        // take hundreds of milliseconds. Keep the generation/expiry observation
+        // as close to launch as possible. Fresh hashing deliberately avoids a
+        // cache whose invalidation would become another source-integrity premise.
+        if super::adapter::working_tree_hash(&owner.source_root)? != owner.seal_hash {
+            bail!("artifact source no longer matches its seal");
+        }
         let doc = escape_graphql_string(&owner.request_doc_id);
         let workspace = escape_graphql_string(&owner.workspace_id);
         let deployment = escape_graphql_string(&owner.deployment_id);
@@ -281,9 +288,6 @@ impl ArtifactGrant {
                 .ok_or_else(|| anyhow!("missing artifact query data"))?,
             Utc::now(),
         )?;
-        if super::adapter::working_tree_hash(&owner.source_root)? != owner.seal_hash {
-            bail!("artifact source no longer matches its seal");
-        }
         Ok(())
     }
 }

--- a/crates/gents/src/workspace/overlay.rs
+++ b/crates/gents/src/workspace/overlay.rs
@@ -128,6 +128,30 @@ pub(crate) async fn resolve_request_workspace_overlay(
     artifact_requested: bool,
     operator_tool_root: Option<&Path>,
 ) -> Result<Option<WorkspaceOverlay>> {
+    resolve_request_workspace_overlay_on_host(
+        node,
+        request,
+        execution_generation,
+        artifact_requested,
+        operator_tool_root,
+        workspace_write_sandbox_enforced(),
+    )
+    .await
+}
+
+async fn resolve_request_workspace_overlay_on_host(
+    node: &Arc<EmbeddedNode>,
+    request: &AgentRequest,
+    execution_generation: &str,
+    artifact_requested: bool,
+    operator_tool_root: Option<&Path>,
+    sandbox_enforced: bool,
+) -> Result<Option<WorkspaceOverlay>> {
+    // Enforce the model's host eligibility before database reads, binding,
+    // grant allocation or provider dispatch, not after a wasted model turn.
+    if artifact_requested && !sandbox_enforced {
+        bail!("artifact_write requires an enforceable artifact sandbox on this host");
+    }
     let Some(workspace_id) = optional_id(request.workspace_id.as_deref()) else {
         if artifact_requested {
             bail!("artifact_write requires a sealed ReadOnly workspace binding");
@@ -183,7 +207,7 @@ pub(crate) async fn resolve_request_workspace_overlay(
             local_deployment_id: &local_deployment_id,
             operator_tool_root,
             enabled_workspace_roots: &enabled_workspace_roots,
-            workspace_write_sandbox_enforced: workspace_write_sandbox_enforced(),
+            workspace_write_sandbox_enforced: sandbox_enforced,
             live_tree_hash: live_tree_hash.as_deref(),
         },
     )?;

--- a/crates/gents/src/workspace/overlay_tests.rs
+++ b/crates/gents/src/workspace/overlay_tests.rs
@@ -985,11 +985,21 @@ async fn generated_artifact_admission_cases_drive_live_binding_and_launch_policy
         let mode = CommandExecutionMode::parse(case["mode"].as_str().unwrap()).unwrap();
         let fx = artifact_test_fixture(&[]).await;
         if name == "unsupported_platform" {
-            // Exercise the actual selector's host observation input; this is not
-            // an assertion that the current macOS host lacks Seatbelt.
+            // Inject only the host observation into the actual admission path;
+            // do not substitute a launch-only selector for admission evidence.
             assert_eq!(case["expected_admitted"], false);
             assert!(case["expected_bound_mode"].is_null());
-            assert!(crate::toolset::select_sandbox_for_policy(mode, false).is_err());
+            let error = super::resolve_request_workspace_overlay_on_host(
+                &fx.node,
+                fx.owner.request(),
+                fx.owner.execution_generation().unwrap(),
+                true,
+                Some(fx._dir.path()),
+                false,
+            )
+            .await
+            .unwrap_err();
+            assert!(error.to_string().contains("enforceable artifact sandbox"));
             continue;
         }
         execute(&fx.node, r#"mutation { create_HostDeployment(input: { deployment_id: "artifact-deployment", display_name: "local", created_at: "2026-09-01T00:00:00Z", updated_at: "2026-09-01T00:00:00Z" }) { _docID } }"#).await;

--- a/crates/gents/src/workspace/path_capability.rs
+++ b/crates/gents/src/workspace/path_capability.rs
@@ -141,9 +141,11 @@ impl WorkspacePathCapability {
                 })? {
                     let entry = entry?;
                     let filename = entry.file_name();
-                    let spelling = filename
-                        .to_str()
-                        .context("workspace directory contains a non-UTF-8 filename")?;
+                    let Some(spelling) = filename.to_str() else {
+                        // Admitted components are UTF-8. An unrelated opaque
+                        // filename cannot alias this literal component.
+                        continue;
+                    };
                     if alias_key(spelling) != wanted_alias {
                         continue;
                     }
@@ -180,6 +182,48 @@ impl WorkspacePathCapability {
         }
         Ok(())
     }
+}
+
+/// Refine the changed-prefix observations against a complete Git tree without
+/// imposing new path-admission requirements on unrelated historical entries.
+pub(crate) fn validate_changed_path_aliases<'a>(
+    changed: &[&str],
+    tree_paths: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    let mut changed_prefixes = BTreeMap::new();
+    for path in changed {
+        validate_relative_path(path)?;
+        let mut prefix = String::new();
+        for component in path.split('/') {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(component);
+            let key = alias_key(&prefix);
+            if let Some(previous) = changed_prefixes.insert(key, prefix.clone()) {
+                ensure!(
+                    previous == prefix,
+                    "changed workspace path aliases conflict: {previous} and {prefix}"
+                );
+            }
+        }
+    }
+    for path in tree_paths {
+        let mut prefix = String::new();
+        for component in path.split('/') {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(component);
+            if let Some(changed) = changed_prefixes.get(&alias_key(&prefix)) {
+                ensure!(
+                    changed == &prefix,
+                    "changed workspace path component aliases conflict: {changed} and {prefix}"
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Compatibility caseless key, following caseless::compatibility_caseless_match
@@ -254,6 +298,25 @@ mod tests {
     use super::*;
     fn exact(paths: &[&str]) -> Result<WorkspacePathCapability> {
         WorkspacePathCapability::exact_paths(paths.iter().map(|p| (*p).into()).collect())
+    }
+
+    // macOS rejects opaque byte filenames at creation (EILSEQ); its Git-object
+    // cases still exercise opaque tree entries without impossible host files.
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn unrelated_non_utf8_sibling_does_not_reject_owned_path() {
+        use std::os::unix::ffi::OsStringExt;
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(
+            root.path().join(std::ffi::OsString::from_vec(vec![0xff])),
+            b"unchanged",
+        )
+        .unwrap();
+        std::fs::write(root.path().join("owned.rs"), b"owned").unwrap();
+        exact(&["owned.rs"])
+            .unwrap()
+            .validate_paths_at(root.path())
+            .unwrap();
     }
 
     #[test]

--- a/crates/gents/src/workspace/tests.rs
+++ b/crates/gents/src/workspace/tests.rs
@@ -2536,3 +2536,6 @@ fn generated_workspace_path_capability_cases_drive_real_git_executor() {
 
 #[path = "tests/capability_runtime.rs"]
 mod capability_runtime;
+
+#[path = "tests/path_alias_contract.rs"]
+mod path_alias_contract;

--- a/crates/gents/src/workspace/tests/path_alias_contract.rs
+++ b/crates/gents/src/workspace/tests/path_alias_contract.rs
@@ -1,0 +1,176 @@
+use super::*;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn prefixes(paths: &[String]) -> Vec<(String, String)> {
+    paths
+        .iter()
+        .flat_map(|path| {
+            let mut prefix = String::new();
+            path.split('/').map(move |component| {
+                if !prefix.is_empty() {
+                    prefix.push('/');
+                }
+                prefix.push_str(component);
+                (
+                    prefix.clone(),
+                    super::super::path_capability::alias_key(&prefix),
+                )
+            })
+        })
+        .collect()
+}
+
+fn index_tree(repo: &Path, paths: &[String], changed: &[String], old: &str, new: &str) -> String {
+    let temp = tempfile::tempdir().unwrap();
+    let index = temp.path().join("index");
+    let run = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(["-c", "core.ignorecase=false"])
+            .current_dir(repo)
+            .env("GIT_INDEX_FILE", &index)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    run(&["read-tree", "--empty"]);
+    for path in paths {
+        let blob = if changed.contains(path) { new } else { old };
+        run(&["update-index", "--add", "--cacheinfo", "100644", blob, path]);
+    }
+    run(&["write-tree"])
+}
+
+#[test]
+fn generated_workspace_path_alias_cases_drive_real_git_delta() {
+    let cases = &crate::lean_vocab_test::lean_contract_snapshot().workspace_path_alias_cases;
+    assert_eq!(cases.len(), 5, "wire every emitted alias case");
+    for case in cases {
+        let paths =
+            |key: &str| -> Vec<String> { serde_json::from_value(case[key].clone()).unwrap() };
+        let changed = paths("changed_paths");
+        let base_paths = paths("base_paths");
+        let tree_paths = paths("tree_paths");
+        for (leaf_paths, key) in [
+            (&changed, "changed_prefixes"),
+            (&base_paths, "base_prefixes"),
+            (&tree_paths, "tree_prefixes"),
+        ] {
+            // Fence the host alias observations against the actual path spellings;
+            // the Rust test does not replay the Lean decision predicate.
+            assert_eq!(
+                serde_json::to_value(prefixes(leaf_paths)).unwrap(),
+                case[key]
+            );
+        }
+        let fx = Fixture::new();
+        let old = git(&fx.repo, &["rev-parse", "HEAD:README.md"]);
+        let mut command = Command::new("git")
+            .current_dir(&fx.repo)
+            .args(["hash-object", "-w", "--stdin"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        command
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"owned delta\n")
+            .unwrap();
+        let output = command.wait_with_output().unwrap();
+        assert!(output.status.success());
+        let new = String::from_utf8(output.stdout).unwrap().trim().to_owned();
+        let base = index_tree(&fx.repo, &base_paths, &[], &old, &new);
+        let tree = index_tree(&fx.repo, &tree_paths, &changed, &old, &new);
+        let cap = WorkspacePathCapability::exact_paths(changed).unwrap();
+        let result = super::super::adapter::validate_tree_delta(&fx.repo, &base, &tree, &cap);
+        assert_eq!(
+            result.is_ok(),
+            case["expected"].as_bool().unwrap(),
+            "{}: {result:?}",
+            case["name"]
+        );
+    }
+}
+
+#[test]
+fn unchanged_non_utf8_git_entry_does_not_widen_changed_path_admission() {
+    let mut fx = Fixture::new();
+    fx.commit("other.txt", "different bytes\n");
+    let old = git(&fx.repo, &["rev-parse", "HEAD:README.md"]);
+    let other = git(&fx.repo, &["rev-parse", "HEAD:other.txt"]);
+    let tree = |owned: &str, opaque: &str| {
+        let mut bytes = format!("100644 blob {owned}\towned.rs\0").into_bytes();
+        bytes.extend_from_slice(format!("100644 blob {opaque}\t").as_bytes());
+        bytes.extend_from_slice(&[0xff, 0]);
+        let mut child = Command::new("git")
+            .current_dir(&fx.repo)
+            .args(["mktree", "-z"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child.stdin.take().unwrap().write_all(&bytes).unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    let base = tree(&old, &old);
+    let cap = WorkspacePathCapability::exact_paths(vec!["owned.rs".into()]).unwrap();
+    assert!(
+        super::super::adapter::validate_tree_delta(&fx.repo, &base, &tree(&other, &old), &cap)
+            .is_ok()
+    );
+    assert!(super::super::adapter::validate_tree_delta(
+        &fx.repo,
+        &base,
+        &tree(&other, &other),
+        &cap
+    )
+    .is_err());
+}
+
+#[test]
+fn opaque_git_basename_keeps_parent_alias_fence() {
+    let fx = Fixture::new();
+    let blob = git(&fx.repo, &["rev-parse", "HEAD:README.md"]);
+    let make_tree = |bytes: &[u8]| {
+        let mut child = Command::new("git")
+            .current_dir(&fx.repo)
+            .args(["mktree", "-z"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child.stdin.take().unwrap().write_all(bytes).unwrap();
+        let output = child.wait_with_output().unwrap();
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    let mut opaque = format!("100644 blob {blob}\t").into_bytes();
+    opaque.extend_from_slice(&[0xff, 0]);
+    let opaque_subtree = make_tree(&opaque);
+    let owned_subtree = make_tree(format!("100644 blob {blob}\towned.rs\0").as_bytes());
+    let base = make_tree(format!("040000 tree {opaque_subtree}\tSrc\0").as_bytes());
+    let tree = make_tree(
+        format!(
+            "040000 tree {opaque_subtree}\tSrc\0\
+        040000 tree {owned_subtree}\tsrc\0"
+        )
+        .as_bytes(),
+    );
+    let cap = WorkspacePathCapability::exact_paths(vec!["src/owned.rs".into()]).unwrap();
+    let error =
+        super::super::adapter::validate_tree_delta(&fx.repo, &base, &tree, &cap).unwrap_err();
+    assert!(
+        error.to_string().contains("component aliases conflict"),
+        "{error:#}"
+    );
+}

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -564,6 +564,11 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             &snapshot.workspace_path_capability_cases,
         ),
         (
+            "workspace_path_alias_cases",
+            "WorkspacePathAliasCases",
+            &snapshot.workspace_path_alias_cases,
+        ),
+        (
             "workspace_capability_migration_cases",
             "WorkspaceCapabilityMigrationCases",
             &snapshot.workspace_capability_migration_cases,
@@ -1360,6 +1365,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "graph_pipeline_revision_gate_cases",
         "graph_pipeline_run_terminal_cases",
         "workspace_path_capability_cases",
+        "workspace_path_alias_cases",
         "workspace_capability_migration_cases",
         "workspace_cases",
         "workspace_binding_cases",

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -84,6 +84,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_workspace_path_capability_cases_drive_real_git_executor",
         },
         ConformanceConsumer::RustTest {
+            id: "workspace::tests::path_alias_contract::generated_workspace_path_alias_cases_drive_real_git_delta",
+            package: "gents",
+            source_path: "crates/gents/src/workspace/tests/path_alias_contract.rs",
+            module_path: "workspace::tests::path_alias_contract",
+            function: "generated_workspace_path_alias_cases_drive_real_git_delta",
+        },
+        ConformanceConsumer::RustTest {
             id: "gents_migration::workspace_path_capability::generated_workspace_capability_migrations_drive_real_lens_and_current_rows",
             package: "gents-migration",
             source_path: "crates/gents-migration/tests/workspace_path_capability.rs",

--- a/docs/security/backend-fingerprint-remediation.md
+++ b/docs/security/backend-fingerprint-remediation.md
@@ -1,0 +1,37 @@
+# Backend fingerprint credential remediation
+
+Versions before PR #1382 used the backend's Debug representation as admission
+configuration identity. When an inline API key was configured, that representation
+included the key. It was copied to `InferenceCall.backend_config_fingerprint` and
+could appear in timeline and adapter exports. Environment-variable references did
+not embed the resolved environment value in that representation.
+
+PR #1382 stopped new plaintext writes but used an unkeyed SHA-256 digest containing
+the inline key. With the remaining inputs known, that digest allows offline
+confirmation of candidate keys. Neither change erases prior data.
+
+Current admission fingerprints use HMAC-SHA-256 with a fresh random 256-bit
+process-private key. The key is never stored with call records, serialized, or
+exported. The fingerprint remains stable within the process, so metadata edits
+reuse a controller and credential or queue-capacity changes replace it. A restart
+changes the fingerprint: it is runtime-scoped attribution, not a cross-host or
+cross-restart content identifier. Cryptographic collision resistance and host
+memory confidentiality are assumptions, not claims of the Lean registry model.
+
+Timeline construction exports only the current `hmac-sha256:process-v1:` format
+with a 64-character hexadecimal digest. Older Debug values, unkeyed hashes and
+malformed values are omitted. This prevents ordinary timeline/adapter export from
+redisclosing old values; it does not restrict administrative raw database reads.
+
+Operators with affected inline-key configurations should rotate or revoke those
+credentials at their provider. Updating a fingerprint column cannot invalidate a
+credential already copied elsewhere. Do not paste original fingerprint values into
+diagnostics, tickets or repair logs.
+
+Historical repair is tracked in [#1394](https://github.com/gents-ai/gents/issues/1394).
+It must cover current documents and separately account for DefraDB revision
+history, P2P replicas (including offline peers), backups, and exported artifacts.
+A current-row update must not be described as erasing those copies. No automatic
+historical database mutation is performed by this runtime change. Repair should
+be resumable and idempotent, report identifiers/counts only, and preserve call
+lifecycle, attribution, and usage data unrelated to the fingerprint.


### PR DESCRIPTION
Fix the review findings above #1392 while preserving DefraDB ACP as the access-control owner. Graph attribution now requires the existing signed receipt to match the verified run/revision owner DID and planned route; it adds no Task/behavior permission layer. Foreign signed rows cannot affect counts, failure capture, or cancellation, and historical owner-signed work survives configuration edits.

Other corrections:

- Replace public credential-derived SHA-256 fingerprints with process-keyed HMAC-SHA-256, preserving credential/queue-change controller replacement. Redact historical formats before both timeline rows and events are built. Fingerprints are runtime-scoped; historical database repair and affected-key remediation remain #1394.
- Validate exact workspace grants against changed paths, with alias checks against both complete trees. Unrelated historical names no longer reject a valid delta; valid ancestors of opaque filenames still participate in alias checks. Empty callback field projections now match the existing source-fetch semantics while retaining mandatory exact manifests.
- Reload after losing failure capture, preserving the existing terminal owner. Unknown nonempty v1 failure codes retain opaque evidence and remain cancellable. The reversed-order conformance trace now introduces its second physical failure explicitly.
- Report transaction-observed `goal_status` in replayed resume receipts. Preserve the existing request when it waits for input/workspace binding, and retain an invocation's Goal obligation across unrelated interactive messages.
- Reject artifact execution on unsupported hosts before binding/provider dispatch. Retain fresh source hashing and move the live lease observation after it. Four collections were already queried in one GraphQL request; no new permission cache or seal cache is introduced.

Fresh seal hashing remains a known cost; no permission or seal cache is added. Refs #1394, #1354, #1357, #1375, #1349, and #1358.

Validated from integrated tip `98f1bccbfb14ff2f6f6700d2d01839e6b751463f`, based on main `1da8b9293cf6daeeb95e4b8f0b0a9032f8a652e2`:

- `cargo test -p gents`: 2,831 passed, zero failed, five ignored; workspace all-target check and Lean build (1,061 jobs) passed.
- CLI graph 3, CLI Goal 2, desktop Goal 1, offline artifact compiler 2, real GLM compiler 1, and live CLI 3 passed.
- Live graph `315587bb-2553-46c7-b566-8cb540714dd5` succeeded: four areas, four scans, three candidates/verdicts/Cleanup findings, seven completed Goals and seven completed requests. Saved-trace validation confirms all 57 evidence pages for each scanner, exact packet reconstruction, and unchanged source.

Live inference used `http://workstation-2:8000/v1`, `GLM-5.3-Flash-NVFP4`, temperature 1, top-p 0.95, without an API key. Cleanup findings are model judgments, not independent merge approval. Compiler execution is established by the separate compiler checks, not inferred from graph completion. The complete trace was revalidated after harness corrections; runtime results were not altered. Final reruns passed: queue 24, generated R6 consumer 1 (41 cases), Goal controller 41, and package catalog/install 13. Do not merge yet.
