### PR TITLE
Bound invalid tool attempts in the owned completion loop

### DIFF
--- a/crates/gents/proofs/Proofs.lean
+++ b/crates/gents/proofs/Proofs.lean
@@ -70,3 +70,5 @@ import Proofs.GraphPipeline.LogicalInvocation
 import Proofs.EthSubmission
 import Proofs.PeerRegistryDiscovery.DirectoryProjection
 import Proofs.PeerRegistryDiscovery.PersonaRequest
+
+import Proofs.Conformance.InvalidToolProgress

--- a/crates/gents/proofs/Proofs/CompletionRetry.lean
+++ b/crates/gents/proofs/Proofs/CompletionRetry.lean
@@ -4,3 +4,4 @@ import Proofs.CompletionRetry.Executable
 import Proofs.CompletionRetry.Properties
 import Proofs.CompletionRetry.Contracts
 import Proofs.CompletionRetry.OutputObligation
+import Proofs.CompletionRetry.InvalidToolProgress

--- a/crates/gents/proofs/Proofs/CompletionRetry/InvalidToolProgress.lean
+++ b/crates/gents/proofs/Proofs/CompletionRetry/InvalidToolProgress.lean
@@ -1,0 +1,81 @@
+import Proofs.CompletionRetry.State
+
+/-! Request-execution-local accounting in the existing owned completion loop.
+`recordDurable` is called only after the outcome has been persisted/threaded.
+It does not terminalize a request: exhaustion asks the existing stream error path
+and execution lease owner to do so. The abstraction assumes serialized dispatch;
+a stream containing several calls must check eligibility before each dispatch.
+-/
+namespace CompletionRetry.InvalidToolProgress
+
+def limit : Nat := 8
+
+inductive Outcome
+  | invalidArguments | policyDenied | unknownTool
+  | success | ordinaryFailure | skipped | backgroundCompletion
+  deriving DecidableEq, Repr
+
+def invalid : Outcome → Bool
+  | .invalidArguments | .policyDenied | .unknownTool => true
+  | _ => false
+
+structure State where
+  invalidUsed : Nat := 0
+  deriving DecidableEq, Repr
+
+def canDispatch (s : State) : Bool := s.invalidUsed < limit
+
+def recordDurable (s : State) (outcome : Outcome) : State :=
+  if canDispatch s && invalid outcome then ⟨s.invalidUsed + 1⟩ else s
+
+def exhausted (s : State) : Bool := !canDispatch s
+
+def run (s : State) : List Outcome → State
+  | [] => s
+  | outcome :: tail => run (recordDurable s outcome) tail
+
+theorem bounded_step (s : State) (o : Outcome) (h : s.invalidUsed ≤ limit) :
+    (recordDurable s o).invalidUsed ≤ limit := by
+  unfold recordDurable canDispatch
+  split <;> simp_all <;> omega
+
+theorem bounded_trace (s : State) (outcomes : List Outcome) (h : s.invalidUsed ≤ limit) :
+    (run s outcomes).invalidUsed ≤ limit := by
+  induction outcomes generalizing s with
+  | nil => exact h
+  | cons o tail ih => exact ih _ (bounded_step s o h)
+
+theorem no_reset (s : State) (o : Outcome) :
+    s.invalidUsed ≤ (recordDurable s o).invalidUsed := by
+  unfold recordDurable
+  split <;> simp_all
+
+theorem uncharged_stutters (s : State) (o : Outcome) (h : invalid o = false) :
+    recordDurable s o = s := by simp [recordDurable, h]
+
+theorem terminal_absorbing (s : State) (o : Outcome) (h : exhausted s = true) :
+    recordDurable s o = s := by simp_all [exhausted, recordDurable]
+
+theorem invalid_spends_one (s : State) (o : Outcome)
+    (h : canDispatch s = true) (hi : invalid o = true) :
+    (recordDurable s o).invalidUsed = s.invalidUsed + 1 := by
+  simp [recordDurable, h, hi]
+
+/-- A strict natural-valued rank decreases on every accepted invalid outcome.
+Valid outcomes cannot replenish it. This bounds invalid churn even when valid
+calls are interspersed; it does not claim termination of infinite valid work. -/
+theorem invalid_rank_decreases (s : State) (o : Outcome)
+    (h : canDispatch s = true) (hi : invalid o = true) :
+    limit - (recordDurable s o).invalidUsed < limit - s.invalidUsed := by
+  rw [invalid_spends_one s o h hi]
+  simp [canDispatch] at h
+  omega
+
+theorem eighth_invalid_stops (o : Outcome) (h : invalid o = true) :
+    exhausted (recordDurable ⟨7⟩ o) = true := by
+  simp [recordDurable, canDispatch, limit, h, exhausted]
+
+theorem eight_invalids_exhaust :
+    run ⟨0⟩ (List.replicate 8 .invalidArguments) = ⟨8⟩ := by decide
+
+end CompletionRetry.InvalidToolProgress

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -1,3 +1,4 @@
+import Proofs.Conformance.InvalidToolProgress
 import Proofs.Conformance.ArtifactAuthority
 import Proofs.Conformance.WorkspacePathCapability
 import Proofs.Conformance.Contracts.Json.Core
@@ -272,6 +273,8 @@ def snapshotJson : String :=
     ++ "\"cancel_propagation_cases\":"
       ++ jsonArray
         (cancelPropagationCases.map cancelPropagationCaseJson) ++ ","
+    ++ "\"invalid_tool_progress_cases\":"
+      ++ Conformance.InvalidToolProgressContracts.casesJson ++ ","
     ++ "\"workspace_path_capability_cases\":"
       ++ Conformance.WorkspacePathCapabilityContracts.casesJson ++ ","
     ++ "\"workspace_path_alias_cases\":"

--- a/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/gents/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -875,6 +875,11 @@ def caseCoverage : List CoverageEntry :=
       "gents_migration::workspace_path_capability::generated_workspace_capability_migrations_drive_real_lens_and_current_rows")
       "isolated-workspaces" [Surface.runtimeInternal]
   , tagged (consumerCoverage
+      "invalid_tool_progress_cases"
+      "InvalidToolProgressCases"
+      "agent::loop_stream::tests::generated_invalid_tool_progress_cases_drive_owned_loop")
+      "completion-retry" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "workspace_path_alias_cases"
       "WorkspacePathAliasCases"
       "workspace::tests::path_alias_contract::generated_workspace_path_alias_cases_drive_real_git_delta")

--- a/crates/gents/proofs/Proofs/Conformance/InvalidToolProgress.lean
+++ b/crates/gents/proofs/Proofs/Conformance/InvalidToolProgress.lean
@@ -1,0 +1,61 @@
+import Proofs.CompletionRetry.InvalidToolProgress
+import Proofs.Conformance.Contracts.Json.Helpers
+
+namespace Conformance.InvalidToolProgressContracts
+open CompletionRetry.InvalidToolProgress Conformance.Contracts
+
+structure Case where
+  name : String
+  outcomes : List Outcome
+  expectedInvalidUsed : Nat
+  expectedExhausted : Bool
+  expectedObservedOutcomes : Nat
+  deriving Repr
+
+/-- Prefix observed by the loop; no suffix can be dispatched after exhaustion. -/
+def observed (s : State) : List Outcome → Nat
+  | [] => 0
+  | o :: rest => if canDispatch s then 1 + observed (recordDurable s o) rest else 0
+
+def cases : List Case :=
+  [ ⟨"empty", [], 0, false, 0⟩
+  , ⟨"invalid_arguments_charged", [.invalidArguments], 1, false, 1⟩
+  , ⟨"policy_denial_charged", [.policyDenied], 1, false, 1⟩
+  , ⟨"unknown_tool_charged", [.unknownTool], 1, false, 1⟩
+  , ⟨"ordinary_failure_uncharged", List.replicate 12 .ordinaryFailure, 0, false, 12⟩
+  , ⟨"seven_invalids_allow_next", List.replicate 7 .policyDenied, 7, false, 7⟩
+  , ⟨"eighth_invalid_exhausts", List.replicate 8 .invalidArguments, 8, true, 8⟩
+  , ⟨"ninth_invalid_not_dispatched", List.replicate 9 .unknownTool, 8, true, 8⟩
+  , ⟨"success_does_not_reset", [.policyDenied,.success,.invalidArguments,.success,
+      .unknownTool,.success,.policyDenied,.success,.invalidArguments,.success,
+      .unknownTool,.success,.policyDenied,.success,.invalidArguments], 8, true, 15⟩
+  , ⟨"ordinary_failure_does_not_reset", [.policyDenied,.ordinaryFailure,.invalidArguments,
+      .ordinaryFailure,.unknownTool,.ordinaryFailure,.policyDenied,.ordinaryFailure,
+      .invalidArguments,.ordinaryFailure,.unknownTool,.ordinaryFailure,.policyDenied,
+      .ordinaryFailure,.invalidArguments], 8, true, 15⟩
+  , ⟨"success_after_exhaustion_not_dispatched",
+      List.replicate 8 .policyDenied ++ [.success], 8, true, 8⟩ ]
+
+theorem cases_match : ∀ c ∈ cases,
+    (run ⟨0⟩ c.outcomes).invalidUsed = c.expectedInvalidUsed ∧
+    exhausted (run ⟨0⟩ c.outcomes) = c.expectedExhausted ∧
+    observed ⟨0⟩ c.outcomes = c.expectedObservedOutcomes := by decide
+
+private def outcomeString : Outcome → String
+  | .invalidArguments => "invalidArguments"
+  | .policyDenied => "policyDenied"
+  | .unknownTool => "unknownTool"
+  | .success => "success"
+  | .ordinaryFailure => "ordinaryFailure"
+  | .skipped => "skipped"
+  | .backgroundCompletion => "backgroundCompletion"
+
+private def caseJson (c : Case) : String :=
+  "{\"name\":" ++ jsonString c.name ++
+  ",\"outcomes\":" ++ jsonArray (c.outcomes.map (jsonString ∘ outcomeString)) ++
+  ",\"expected_invalid_used\":" ++ toString c.expectedInvalidUsed ++
+  ",\"expected_exhausted\":" ++ (if c.expectedExhausted then "true" else "false") ++
+  ",\"expected_observed_outcomes\":" ++ toString c.expectedObservedOutcomes ++ "}"
+
+def casesJson := jsonArray (cases.map caseJson)
+end Conformance.InvalidToolProgressContracts

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -1269,3 +1269,20 @@ The model consumes checked seal/owner/incarnation/root/platform observations; it
 does not prove filesystem canonicalization, symlink/hardlink or race safety,
 Seatbelt implementation, compiler behavior, or isolation from unsandboxed host
 actors. Real host containment and compiler QA remain separate acceptance gates.
+
+### Invalid tool progress (#1298)
+
+`CompletionRetry.InvalidToolProgress` models a cumulative allowance of eight
+invalid-arguments, policy-denied, or unknown-tool outcomes per owned request
+execution. Success and ordinary failures do not reset it; skips and background
+completion do not charge it. The eighth outcome is durably observed before the
+existing stream failure path delegates terminalization to the execution lease
+owner. No ninth tool dispatch is permitted, including within a multi-call turn.
+
+The model proves bounded counts over arbitrary finite traces, monotonic usage,
+a strictly decreasing remaining allowance on accepted invalid outcomes, and
+absorbing exhaustion. This bounds invalid churn, not infinite valid work or
+storage/provider availability. Outcome classification and persistence ordering
+remain runtime consumer obligations. Eleven generated traces in
+`invalid_tool_progress_cases` are follow-up coverage until actual owned-loop
+consumers verify them; the model is not a second lifecycle or permission owner.

--- a/crates/gents/src/agent/loop_stream.rs
+++ b/crates/gents/src/agent/loop_stream.rs
@@ -47,6 +47,7 @@ use crate::truncation::{tool_result_truncation_mode, truncate_text, TruncationLi
 
 mod aggregate_budget;
 mod contract;
+mod invalid_tool_progress;
 mod one_shot;
 mod request_assembly;
 mod tool_dispatch;
@@ -125,6 +126,8 @@ where
         // prompt (mirrors Lean `PromptAssembly.Template.assembleWithContext`).
         let mut new_messages: Vec<Message> =
             assemble_new_messages(config.context_message.clone(), prompt);
+        // Request-local and cumulative across turns, retries, and compaction.
+        let mut invalid_tool_progress = invalid_tool_progress::InvalidToolProgress::default();
         let mut aggregated_usage = Usage::new();
         let aggregate_token_budget = config.aggregate_token_budget.clone();
         let mut current_turn: usize = config.initial_turn_index;
@@ -651,6 +654,10 @@ where
                                         )))?;
                                     }
                                 }
+                                // Charge only after the hook has accepted the outcome.
+                                // Default fail-closed persistence aborts above on failure;
+                                // explicit fail-open callers retain their existing policy.
+                                invalid_tool_progress.record(&outcome);
                                 // The typed outcome's model-facing accessor is
                                 // the only text that may thread to the model.
                                 let (bounded, _, _) = truncate_text(
@@ -663,6 +670,22 @@ where
                         };
 
                         pending_results.push((rig_compat::from_rig_tool_call(&tool_call), internal_call_id, bounded_result));
+                        if invalid_tool_progress.exhausted() {
+                            // Deliver the eighth result before failing. Do not await another
+                            // provider item: it could stall or contain a ninth tool call.
+                            for item in close_streaming_turn(
+                                &mut new_messages,
+                                &mut accumulator,
+                                stream.message_id.clone(),
+                                pending_results,
+                            ) {
+                                yield item;
+                            }
+                            Err(StreamingError::Completion(CompletionError::ProviderError(
+                                invalid_tool_progress.exhaustion_reason(),
+                            )))?;
+                            unreachable!("invalid tool budget exhaustion ends the stream");
+                        }
                     }
                     StreamedAssistantContent::ToolCallDelta { .. } => {
                     }

--- a/crates/gents/src/agent/loop_stream/invalid_tool_progress.rs
+++ b/crates/gents/src/agent/loop_stream/invalid_tool_progress.rs
@@ -1,0 +1,40 @@
+//! Refinement of CompletionRetry.InvalidToolProgress. This is an execution-local
+//! dispatch budget, not a request lifecycle or tool permission owner.
+
+use crate::tool_call_lifecycle::{FailureClass, ToolOutcome};
+
+const INVALID_TOOL_CALL_LIMIT: u8 = 8;
+
+#[derive(Default)]
+pub(super) struct InvalidToolProgress {
+    invalid_used: u8,
+}
+
+impl InvalidToolProgress {
+    /// Called after the existing hook accepts a dispatched outcome. Skipped
+    /// calls and asynchronous background notifications do not use this seam.
+    pub(super) fn record(&mut self, outcome: &ToolOutcome) {
+        if !self.exhausted()
+            && matches!(
+                outcome,
+                ToolOutcome::Failed {
+                    class: FailureClass::ArgumentInvalid | FailureClass::PolicyDenied,
+                    ..
+                }
+            )
+        {
+            self.invalid_used += 1;
+        }
+    }
+
+    pub(super) fn exhausted(&self) -> bool {
+        self.invalid_used >= INVALID_TOOL_CALL_LIMIT
+    }
+
+    pub(super) fn exhaustion_reason(&self) -> String {
+        format!(
+            "invalid_tool_call_budget_exhausted: limit={}, used={}; repeated invalid arguments, unknown tools, or policy-denied calls exhausted this execution's allowance",
+            INVALID_TOOL_CALL_LIMIT, self.invalid_used,
+        )
+    }
+}

--- a/crates/gents/src/agent/loop_stream/tests/invalid_tool_progress.rs
+++ b/crates/gents/src/agent/loop_stream/tests/invalid_tool_progress.rs
@@ -1,0 +1,372 @@
+struct InvalidProgressProbe;
+
+impl ToolDyn for InvalidProgressProbe {
+    fn name(&self) -> String {
+        "invalid_progress_probe".into()
+    }
+    fn definition<'a>(&'a self, _prompt: String) -> BoxFuture<'a, ToolDefinition> {
+        Box::pin(async {
+            ToolDefinition {
+                name: "invalid_progress_probe".into(),
+                description: "typed outcome fixture".into(),
+                parameters: serde_json::json!({"type":"object","properties":{"outcome":{"type":"string"}},"required":["outcome"]}),
+            }
+        })
+    }
+    fn call<'a>(&'a self, args: String) -> BoxFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move {
+            use crate::tool_call_lifecycle::FailureClass;
+            let value: serde_json::Value = serde_json::from_str(&args).unwrap();
+            let class = match value["outcome"].as_str().unwrap() {
+                "invalidArguments" => FailureClass::ArgumentInvalid,
+                "policyDenied" => FailureClass::PolicyDenied,
+                "ordinaryFailure" => FailureClass::ToolReturnedError,
+                // Successful arbitrary output must never impersonate typed failure.
+                "success" => return Ok(r#"{"failure_class":"policyDenied","ok":false}"#.into()),
+                other => panic!("unknown fixture outcome {other}"),
+            };
+            Err(ToolError::ReportedFailure {
+                class,
+                text: format!("fixture {}", class.as_str()),
+            })
+        })
+    }
+}
+
+fn invalid_progress_call(index: usize, outcome: &str) -> RawStreamingChoice<()> {
+    RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+        format!("invalid-progress-{index}"),
+        if outcome == "unknownTool" {
+            "missing"
+        } else {
+            "invalid_progress_probe"
+        }
+        .into(),
+        serde_json::json!({"outcome":outcome}),
+    ))
+}
+
+#[tokio::test]
+async fn generated_invalid_tool_progress_cases_drive_owned_loop() {
+    let cases = &crate::lean_vocab_test::lean_contract_snapshot().invalid_tool_progress_cases;
+    assert_eq!(cases.len(), 11);
+    for case in cases {
+        let (node, hook) = test_hook().await;
+        let outcomes = case["outcomes"].as_array().unwrap();
+        let mut turns = outcomes
+            .iter()
+            .enumerate()
+            .map(|(index, outcome)| {
+                vec![
+                    invalid_progress_call(index, outcome.as_str().unwrap()),
+                    RawStreamingChoice::FinalResponse(()),
+                ]
+            })
+            .collect::<Vec<_>>();
+        turns.push(vec![
+            RawStreamingChoice::Message("done".into()),
+            RawStreamingChoice::FinalResponse(()),
+        ]);
+        let model = ScriptedModel::new_turns(turns);
+        let stream = run_loop_stream(
+            model.clone(),
+            Some(hook),
+            Message::user("exercise typed outcomes"),
+            Vec::new(),
+            Arc::new(vec![Box::new(InvalidProgressProbe) as Box<dyn ToolDyn>]),
+            config(64),
+        );
+        futures::pin_mut!(stream);
+        let mut error = None;
+        let mut yielded_results = 0;
+        while let Some(item) = stream.next().await {
+            match item {
+                Err(value) => {
+                    error = Some(value.to_string());
+                    break;
+                }
+                Ok(LoopStreamItem::Item(MultiTurnStreamItem::StreamUserItem(
+                    StreamedUserContent::ToolResult { .. },
+                ))) => yielded_results += 1,
+                _ => {}
+            }
+        }
+        let exhausted = case["expected_exhausted"].as_bool().unwrap();
+        assert_eq!(error.is_some(), exhausted, "{}: {error:?}", case["name"]);
+        if let Some(error) = error {
+            assert!(
+                error.contains("invalid_tool_call_budget_exhausted:"),
+                "{error}"
+            );
+        }
+        let observed = case["expected_observed_outcomes"].as_u64().unwrap() as usize;
+        assert_eq!(
+            yielded_results, observed,
+            "{} must emit the last result before failing",
+            case["name"]
+        );
+        assert_eq!(
+            model.seen_requests().await.len(),
+            observed + usize::from(!exhausted),
+            "{} must not dispatch a suffix",
+            case["name"]
+        );
+        let response = node
+            .execute("{ AgentToolCall { lifecycle_state tool_failure_class result } }")
+            .await;
+        assert!(!response.has_errors(), "{:?}", response.errors);
+        let data = response.data.unwrap();
+        let rows = data["AgentToolCall"].as_array().unwrap();
+        assert_eq!(rows.len(), observed, "{} durable outcomes", case["name"]);
+        assert!(rows.iter().all(|row| matches!(
+            row["lifecycle_state"].as_str(),
+            Some("completed" | "failed")
+        )));
+        let charged = rows
+            .iter()
+            .filter(|row| {
+                matches!(
+                    row["tool_failure_class"].as_str(),
+                    Some("argumentInvalid" | "policyDenied")
+                )
+            })
+            .count();
+        assert_eq!(
+            charged as u64,
+            case["expected_invalid_used"].as_u64().unwrap(),
+            "{} typed outcome mapping",
+            case["name"]
+        );
+        assert!(rows
+            .iter()
+            .all(|row| row["result"].as_str().is_some_and(|text| !text.is_empty())));
+        node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn invalid_tool_budget_closes_eighth_result_before_stalling_or_batched_ninth() {
+    for batched in [false, true] {
+        let (node, hook) = test_hook().await;
+        let mut chunks = (0..8)
+            .map(|index| invalid_progress_call(index, "policyDenied"))
+            .collect::<Vec<_>>();
+        if batched {
+            chunks.push(invalid_progress_call(8, "success"));
+        }
+        // No final usage/EOF: exhaustion must not wait for the provider to close.
+        let model = ScriptedModel::new_stalling(chunks);
+        let stream = run_loop_stream(
+            model.clone(),
+            Some(hook),
+            Message::user("bound invalid batch"),
+            Vec::new(),
+            Arc::new(vec![Box::new(InvalidProgressProbe) as Box<dyn ToolDyn>]),
+            config(500),
+        );
+        futures::pin_mut!(stream);
+        let (count, error) = tokio::time::timeout(Duration::from_secs(10), async {
+            let mut count = 0;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Err(error) => return (count, error.to_string()),
+                    Ok(LoopStreamItem::Item(MultiTurnStreamItem::StreamUserItem(
+                        StreamedUserContent::ToolResult { .. },
+                    ))) => count += 1,
+                    _ => {}
+                }
+            }
+            panic!("invalid batch unexpectedly completed")
+        })
+        .await
+        .expect("must terminate without waiting for provider EOF");
+        assert_eq!(count, 8);
+        assert!(
+            error.contains("invalid_tool_call_budget_exhausted:"),
+            "{error}"
+        );
+        assert_eq!(model.seen_requests().await.len(), 1);
+        let response = node
+            .execute("{ AgentToolCall { lifecycle_state result } }")
+            .await;
+        assert!(!response.has_errors());
+        let data = response.data.unwrap();
+        let rows = data["AgentToolCall"].as_array().unwrap();
+        assert_eq!(
+            rows.len(),
+            8,
+            "no ninth effect, even within a provider batch"
+        );
+        assert!(rows.iter().all(|row| row["lifecycle_state"] == "failed"
+            && row["result"].as_str().is_some_and(|s| !s.is_empty())));
+        node.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn malformed_bash_feedback_reaches_next_request_and_corrected_argv_succeeds() {
+    let (node, hook) = test_hook().await;
+    let root = tempfile::tempdir().unwrap();
+    std::fs::create_dir(root.path().join("crates")).unwrap();
+    std::fs::write(root.path().join("crates/visible-proof.txt"), "fixture").unwrap();
+    let calls = [
+        serde_json::json!({"command":"ls crates"}),
+        serde_json::json!({"command":"ls","args":["crates"]}),
+    ];
+    let mut turns = calls
+        .into_iter()
+        .enumerate()
+        .map(|(index, args)| {
+            vec![
+                RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+                    format!("bash-format-{index}"),
+                    "bash".into(),
+                    args,
+                )),
+                RawStreamingChoice::FinalResponse(()),
+            ]
+        })
+        .collect::<Vec<_>>();
+    turns.push(vec![
+        RawStreamingChoice::Message("reviewed".into()),
+        RawStreamingChoice::FinalResponse(()),
+    ]);
+    let model = ScriptedModel::new_turns(turns);
+    let tools = crate::toolset::ToolSet::builder()
+        .read_root(root.path())
+        .bash_read_only()
+        .build()
+        .build_native_tools()
+        .unwrap();
+    let stream = run_loop_stream(
+        model.clone(),
+        Some(hook),
+        Message::user("inspect crates"),
+        Vec::new(),
+        Arc::new(tools),
+        config(10),
+    );
+    futures::pin_mut!(stream);
+    while let Some(item) = stream.next().await {
+        item.expect("corrected arguments must allow completion");
+    }
+    let requests = model.seen_requests().await;
+    assert_eq!(requests.len(), 3);
+    let feedback = serde_json::to_string(
+        &requests[1]
+            .chat_history
+            .iter()
+            .map(rig_compat::from_rig_message)
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    assert!(
+        feedback.contains("bash-format-0"),
+        "feedback must match the first call ID"
+    );
+    assert!(
+        feedback.contains("executable") && feedback.contains("args"),
+        "{feedback}"
+    );
+    let corrected = serde_json::to_string(
+        &requests[2]
+            .chat_history
+            .iter()
+            .map(rig_compat::from_rig_message)
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    assert!(
+        corrected.contains("visible-proof.txt"),
+        "successful corrected result must reach provider"
+    );
+    let bash = requests[1]
+        .tools
+        .iter()
+        .find(|tool| tool.name == "bash")
+        .unwrap();
+    assert!(bash.parameters["properties"]["command"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("executable"));
+    let response = node
+        .execute("{ AgentToolCall { tool_call_id lifecycle_state tool_failure_class result } }")
+        .await;
+    assert!(!response.has_errors());
+    let data = response.data.unwrap();
+    let rows = data["AgentToolCall"].as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(rows
+        .iter()
+        .any(|row| row["lifecycle_state"] == "failed"
+            && row["tool_failure_class"] == "argumentInvalid"));
+    assert!(rows.iter().any(|row| row["lifecycle_state"] == "completed"
+        && row["result"]
+            .as_str()
+            .unwrap()
+            .contains("visible-proof.txt")));
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn empty_bash_arguments_exhaust_owned_loop_without_side_effects() {
+    for arguments in [serde_json::json!({}), serde_json::json!("")] {
+        let (node, hook) = test_hook().await;
+        let root = tempfile::tempdir().unwrap();
+        let mut turns = (0..9)
+            .map(|index| {
+                vec![
+                    RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+                        format!("empty-bash-{index}"),
+                        "bash".into(),
+                        arguments.clone(),
+                    )),
+                    RawStreamingChoice::FinalResponse(()),
+                ]
+            })
+            .collect::<Vec<_>>();
+        turns.push(vec![
+            RawStreamingChoice::Message("unreached".into()),
+            RawStreamingChoice::FinalResponse(()),
+        ]);
+        let model = ScriptedModel::new_turns(turns);
+        let tools = crate::toolset::ToolSet::builder()
+            .read_root(root.path())
+            .bash_read_only()
+            .build()
+            .build_native_tools()
+            .unwrap();
+        let stream = run_loop_stream(
+            model.clone(),
+            Some(hook),
+            Message::user("inspect source"),
+            Vec::new(),
+            Arc::new(tools),
+            config(500),
+        );
+        futures::pin_mut!(stream);
+        let mut error = None;
+        while let Some(item) = stream.next().await {
+            if let Err(value) = item {
+                error = Some(value.to_string());
+                break;
+            }
+        }
+        assert!(error
+            .unwrap()
+            .contains("invalid_tool_call_budget_exhausted:"));
+        assert_eq!(model.seen_requests().await.len(), 8);
+        let response = node
+            .execute("{ AgentToolCall { lifecycle_state tool_failure_class result } }")
+            .await;
+        assert!(!response.has_errors());
+        let data = response.data.unwrap();
+        let rows = data["AgentToolCall"].as_array().unwrap();
+        assert_eq!(rows.len(), 8);
+        assert!(rows.iter().all(|row| row["lifecycle_state"] == "failed"
+            && row["tool_failure_class"] == "argumentInvalid"
+            && row["result"].as_str().is_some_and(|s| !s.is_empty())));
+        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 0);
+        node.shutdown().await;
+    }
+}

--- a/crates/gents/src/agent/loop_stream/tests/mod.rs
+++ b/crates/gents/src/agent/loop_stream/tests/mod.rs
@@ -30,3 +30,5 @@ include!("request_assembly.rs");
 include!("retry.rs");
 include!("streaming.rs");
 include!("tool_execution.rs");
+
+include!("invalid_tool_progress.rs");

--- a/crates/gents/src/agent/loop_stream/tool_dispatch.rs
+++ b/crates/gents/src/agent/loop_stream/tool_dispatch.rs
@@ -16,7 +16,13 @@ pub(crate) async fn dispatch_tool(
 ) -> ToolOutcome {
     let Some(tool) = tools.iter().find(|tool| tool.name() == name) else {
         // An unresolved name is a typed dispatch failure, not completed output.
-        return ToolOutcome::from_tool_call_error(&format!("error: unknown tool '{name}'"));
+        return ToolOutcome::from_dispatch(
+            name,
+            Err(crate::llm::tool::ToolError::ReportedFailure {
+                class: crate::tool_call_lifecycle::FailureClass::ArgumentInvalid,
+                text: format!("error: unknown tool '{name}'"),
+            }),
+        );
     };
 
     let Some(scope) = current_tool_runtime_context() else {

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -41,6 +41,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) graph_logical_invocation_cases: Vec<serde_json::Value>,
     pub(crate) workspace_path_capability_cases: Vec<serde_json::Value>,
     pub(crate) workspace_path_alias_cases: Vec<serde_json::Value>,
+    pub(crate) invalid_tool_progress_cases: Vec<serde_json::Value>,
     pub(crate) workspace_capability_migration_cases: Vec<serde_json::Value>,
     pub(crate) graph_invocation_publication_cases: Vec<serde_json::Value>,
     pub(crate) graph_failure_attribution_traces: Vec<serde_json::Value>,

--- a/crates/gents/src/toolset/bash_tools.rs
+++ b/crates/gents/src/toolset/bash_tools.rs
@@ -11,6 +11,31 @@ use super::shared::{
 };
 use super::BACKGROUND_COMMAND_TIMEOUT_SECS;
 
+/// Add corrective argv guidance only after the existing authority rejects the
+/// literal executable. Admitted filenames containing spaces remain unchanged.
+fn validate_read_only_bash_input(
+    command: &str,
+    args: &[String],
+    policy: &CommandExecutionPolicy,
+) -> Result<(), ToolError> {
+    validate_command_policy(command, args, policy).map_err(|error| {
+        if command.chars().any(char::is_whitespace)
+            && matches!(
+                &error,
+                ToolError::PolicyDenial(denial)
+                    if matches!(&denial.reason, super::denial::DenialReason::ReadOnlyCommandNotAllowlisted { .. })
+            )
+        {
+            ToolError::reported_failure(
+                crate::tool_call_lifecycle::FailureClass::ArgumentInvalid,
+                r#"Invalid bash command argument: this tool accepts one allowed executable name or path in `command`, with separate arguments in `args`; it does not interpret shell command strings. For example, use {"command":"ls","args":["crates"]}. The supplied literal executable was rejected; do not repeat the same unchanged call."#.to_owned(),
+            )
+        } else {
+            error
+        }
+    })
+}
+
 fn timeout_secs_schema(default_timeout: Duration, max_timeout: Duration) -> serde_json::Value {
     let max_secs = max_timeout.as_secs().max(default_timeout.as_secs());
     serde_json::json!({
@@ -116,7 +141,7 @@ impl Tool for ReadOnlyBashTool {
                 "properties": {
                     "command": {
                         "type": "string",
-                        "description": "Executable name or path from the read-only command allowlist."
+                        "description": "One executable name or path from the read-only allowlist, not a shell command string. Example: {\"command\":\"ls\",\"args\":[\"crates\"]}."
                     },
                     "args": {
                         "type": "array",
@@ -143,7 +168,7 @@ impl Tool for ReadOnlyBashTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let policy = crate::toolset::effective_command_policy(&self.policy);
-        validate_command_policy(&args.command, &args.args, &policy)?;
+        validate_read_only_bash_input(&args.command, &args.args, &policy)?;
         run_command(
             &self.context,
             Self::NAME,
@@ -249,5 +274,70 @@ impl Tool for UnrestrictedBashTool {
 
     fn into_dyn_error(error: Self::Error) -> crate::llm::tool::ToolError {
         error.into_dispatch_error()
+    }
+}
+
+#[cfg(test)]
+mod input_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_only_bash_malformed_command_reports_corrective_invalid_argument() {
+        let root = tempfile::tempdir().unwrap();
+        let tool = ReadOnlyBashTool::new(
+            ToolContext::new(root.path().to_path_buf(), false).unwrap(),
+            Duration::from_secs(10),
+            vec!["ls".into()],
+        );
+        let error = Tool::call(
+            &tool,
+            BashArgs {
+                command: "ls crates".into(),
+                args: Vec::new(),
+                cwd: None,
+                timeout_secs: None,
+                raw_json: false,
+            },
+        )
+        .await
+        .unwrap_err()
+        .into_dispatch_error();
+        match error {
+            crate::llm::tool::ToolError::ReportedFailure { class, text } => {
+                assert_eq!(
+                    class,
+                    crate::tool_call_lifecycle::FailureClass::ArgumentInvalid
+                );
+                assert!(text.contains(r#"{"command":"ls","args":["crates"]}"#));
+                assert!(text.contains("does not interpret shell command strings"));
+            }
+            other => panic!("expected typed invalid input, got {other:?}"),
+        }
+        let definition = Tool::definition(&tool, String::new()).await;
+        assert!(
+            definition.parameters["properties"]["command"]["description"]
+                .as_str()
+                .unwrap()
+                .contains(r#"{"command":"ls","args":["crates"]}"#)
+        );
+    }
+
+    #[test]
+    fn read_only_bash_guidance_preserves_literal_and_denied_authority() {
+        let mut policy = CommandExecutionPolicy::read_only(vec!["ls".into()]);
+        assert!(validate_read_only_bash_input("ls", &["crates".into()], &policy).is_ok());
+        assert!(matches!(
+            validate_read_only_bash_input("rm", &[], &policy),
+            Err(ToolError::PolicyDenial(_))
+        ));
+        // Explicitly admitted literal executable names are never split or rejected.
+        policy.allowed_argv_prefixes = vec![vec!["literal executable".into()]];
+        assert!(validate_command_policy("literal executable", &[], &policy).is_ok());
+        assert!(validate_read_only_bash_input("literal executable", &[], &policy).is_ok());
+        policy.forbidden_argv_prefixes = vec![vec!["literal executable".into()]];
+        assert!(matches!(
+            validate_read_only_bash_input("literal executable", &[], &policy),
+            Err(ToolError::PolicyDenial(_))
+        ));
     }
 }

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -564,6 +564,11 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             &snapshot.workspace_path_capability_cases,
         ),
         (
+            "invalid_tool_progress_cases",
+            "InvalidToolProgressCases",
+            &snapshot.invalid_tool_progress_cases,
+        ),
+        (
             "workspace_path_alias_cases",
             "WorkspacePathAliasCases",
             &snapshot.workspace_path_alias_cases,
@@ -1366,6 +1371,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "graph_pipeline_run_terminal_cases",
         "workspace_path_capability_cases",
         "workspace_path_alias_cases",
+        "invalid_tool_progress_cases",
         "workspace_capability_migration_cases",
         "workspace_cases",
         "workspace_binding_cases",

--- a/crates/gents/tests/support/conformance_consumers.rs
+++ b/crates/gents/tests/support/conformance_consumers.rs
@@ -84,6 +84,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_workspace_path_capability_cases_drive_real_git_executor",
         },
         ConformanceConsumer::RustTest {
+            id: "agent::loop_stream::tests::generated_invalid_tool_progress_cases_drive_owned_loop",
+            package: "gents",
+            source_path: "crates/gents/src/agent/loop_stream/tests/invalid_tool_progress.rs",
+            module_path: "agent::loop_stream::tests",
+            function: "generated_invalid_tool_progress_cases_drive_owned_loop",
+        },
+        ConformanceConsumer::RustTest {
             id: "workspace::tests::path_alias_contract::generated_workspace_path_alias_cases_drive_real_git_delta",
             package: "gents",
             source_path: "crates/gents/src/workspace/tests/path_alias_contract.rs",


### PR DESCRIPTION
A live code-review graph repeatedly submitted malformed read-only bash arguments until the broad 500-turn limit, consuming over 45 million input tokens without producing scan documents. This change gives the existing owned completion loop a cumulative allowance of eight typed invalid-argument, unknown-tool, or policy-denied dispatch outcomes. The final failed tool result is persisted and emitted before the loop propagates an error through the existing request terminal owner, including when the provider stalls or batches a ninth call.

Read-only bash now explains the executable/args split after the existing policy validator denies a malformed command. It does not parse shell strings or expand command permissions. Successful output text and ordinary tool failures do not consume the allowance.

Refs #1298. Stacked on #1395 in #1381. The allowance covers foreground dispatched outcomes; skipped hook actions and later asynchronous background completions are outside its scope.

Eleven Lean-generated traces drive the actual loop with a persistence hook. The allowance survives turns and internal retries within one execution; it is not a persisted request counter or a cross-Goal budget. Broader asynchronous/per-stage behavior remains outside this PR’s scope.

Validated from integrated tip `98f1bccbfb14ff2f6f6700d2d01839e6b751463f`, based on main `1da8b9293cf6daeeb95e4b8f0b0a9032f8a652e2`:

- `cargo test -p gents`: 2,831 passed, zero failed, five ignored; workspace all-target check and Lean build (1,061 jobs) passed.
- CLI graph 3, CLI Goal 2, desktop Goal 1, offline artifact compiler 2, real GLM compiler 1, and live CLI 3 passed.
- Live graph `315587bb-2553-46c7-b566-8cb540714dd5` succeeded: four areas, four scans, three candidates/verdicts/Cleanup findings, seven completed Goals and seven completed requests. Saved-trace validation confirms all 57 evidence pages for each scanner, exact packet reconstruction, and unchanged source.

Live inference used `http://workstation-2:8000/v1`, `GLM-5.3-Flash-NVFP4`, temperature 1, top-p 0.95, without an API key. Cleanup findings are model judgments, not independent merge approval. Compiler execution is established by the separate compiler checks, not inferred from graph completion. The complete trace was revalidated after harness corrections; runtime results were not altered. Final reruns passed: queue 24, generated R6 consumer 1 (41 cases), Goal controller 41, and package catalog/install 13. Do not merge yet.
