### PR TITLE
feat(claude): first-party claude-login, credential-expiry health probe for OAuth backends, diagnose and runnability gate

### DIFF
--- a/.github/scripts/compile-rust-ci-suite.sh
+++ b/.github/scripts/compile-rust-ci-suite.sh
@@ -33,7 +33,7 @@ case "${suite}" in
     separate_package="gents-desktop-tauri"
     ;;
   support)
-    # gents-chatgpt-login and gents-codex-protocol live here (not in `cli`)
+    # gents-chatgpt-login, gents-claude-login and gents-codex-protocol live here (not in `cli`)
     # because the support shard is where their tests RUN on every event; the
     # compile fence must cover what the test step executes. They are still
     # built on the cli shard as ordinary gents-cli dependencies.
@@ -48,6 +48,7 @@ case "${suite}" in
       gents-protocol
       gents-schemas
       gents-chatgpt-login
+      gents-claude-login
       gents-codex-protocol
     )
     ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
             -p gents-schemas \
             -p gents-codex-protocol \
             -p gents-chatgpt-login \
+            -p gents-claude-login \
             -p gents-fs-runner \
             -p gents-lean-contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ Plumbing and tooling need no proof change when they preserve semantics. The
 - Rig is a provider client behind `llm::rig_compat` and `provider_input`.
   Persisted messages remain native. DefraDB is the pinned public dependency in
   the workspace `Cargo.toml`; investigate node, schema, identity, and
-  transaction behavior there.
+  transaction behavior there. Claude subscriptions use Anthropic Messages HTTP
+  with an agent-scoped `OAuthCredential` written by `gents claude-login` and
+  refreshed by gents; the `claude` binary is not a dependency.
 
 ## Repository rules
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,6 +3833,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gents-claude-login"
+version = "0.15.0"
+dependencies = [
+ "base64 0.22.1",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tiny_http",
+ "tokio",
+ "tracing",
+ "url",
+ "webbrowser",
+]
+
+[[package]]
 name = "gents-cli"
 version = "0.15.0"
 dependencies = [
@@ -3850,6 +3867,7 @@ dependencies = [
  "futures-util",
  "gents",
  "gents-chatgpt-login",
+ "gents-claude-login",
  "gents-codex-protocol",
  "gents-desktop-core",
  "gents-fs-runner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/fixture-domain-plugin",
     "crates/gents",
     "crates/gents-chatgpt-login",
+    "crates/gents-claude-login",
     "crates/gents-cli",
     "crates/gents-codex-protocol",
     "crates/gents-desktop",
@@ -33,6 +34,7 @@ default-members = [
     "crates/fixture-domain-plugin",
     "crates/gents",
     "crates/gents-chatgpt-login",
+    "crates/gents-claude-login",
     "crates/gents-cli",
     "crates/gents-codex-protocol",
     "crates/gents-desktop",
@@ -65,6 +67,7 @@ crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e10
 defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
+gents-claude-login = { path = "crates/gents-claude-login" }
 gents-codex-protocol = { path = "crates/gents-codex-protocol" }
 gents-schemas = { path = "crates/gents-schemas" }
 gents-desktop-core = { path = "crates/gents-desktop-core" }

--- a/crates/gents-claude-login/Cargo.toml
+++ b/crates/gents-claude-login/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gents-claude-login"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Minimal Claude subscription OAuth login flows for Gents"
+
+[dependencies]
+base64.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tiny_http = "0.12"
+tokio.workspace = true
+tracing.workspace = true
+url = "2"
+webbrowser = "1"

--- a/crates/gents-claude-login/src/lib.rs
+++ b/crates/gents-claude-login/src/lib.rs
@@ -1,0 +1,617 @@
+//! Claude subscription OAuth login (PKCE) used by `gents claude-login`.
+//!
+//! Owns only the browser/loopback and manual-paste code exchanges. Tokens go
+//! back to the caller for immediate persistence in DefraDB. Client constants
+//! mirror `gents::claude_oauth`; keep both in sync (a gents-cli unit test pins it).
+
+use std::collections::HashMap;
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+use std::thread;
+
+use base64::Engine;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tiny_http::{Header, Response, Server, StatusCode as TinyStatusCode};
+use tokio::sync::{mpsc, Notify};
+use url::Url;
+
+pub const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+pub const AUTHORIZE_URL: &str = "https://claude.com/cai/oauth/authorize";
+pub const TOKEN_URL: &str = "https://platform.claude.com/v1/oauth/token";
+pub const MANUAL_REDIRECT_URL: &str = "https://platform.claude.com/oauth/code/callback";
+pub const SCOPES: &str =
+    "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoginOptions {
+    pub client_id: String,
+    pub authorize_url: String,
+    pub token_url: String,
+    pub open_browser: bool,
+    /// Test hook for deterministic callback-state checks.
+    pub force_state: Option<String>,
+}
+
+impl Default for LoginOptions {
+    fn default() -> Self {
+        Self {
+            client_id: CLIENT_ID.to_string(),
+            authorize_url: AUTHORIZE_URL.to_string(),
+            token_url: TOKEN_URL.to_string(),
+            open_browser: true,
+            force_state: None,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct LoginTokens {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in: Option<i64>,
+    pub scope: Option<String>,
+}
+
+impl fmt::Debug for LoginTokens {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LoginTokens")
+            .field("access_token", &"<redacted>")
+            .field("refresh_token", &"<redacted>")
+            .field("expires_in", &self.expires_in)
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ShutdownHandle {
+    notify: Arc<Notify>,
+}
+
+impl ShutdownHandle {
+    pub fn shutdown(&self) {
+        self.notify.notify_one();
+    }
+}
+
+pub struct LoginServer {
+    pub auth_url: String,
+    pub actual_port: u16,
+    task: tokio::task::JoinHandle<io::Result<LoginTokens>>,
+    shutdown: ShutdownHandle,
+}
+
+impl LoginServer {
+    pub async fn block_until_done(self) -> io::Result<LoginTokens> {
+        self.task
+            .await
+            .map_err(|error| io::Error::other(format!("login callback task failed: {error}")))?
+    }
+
+    pub fn cancel_handle(&self) -> ShutdownHandle {
+        self.shutdown.clone()
+    }
+}
+
+/// Loopback PKCE login: binds an ephemeral localhost port, prints/opens the
+/// authorize URL, accepts one `/callback`, exchanges the code.
+pub fn run_loopback_login(options: LoginOptions) -> io::Result<LoginServer> {
+    let pkce = generate_pkce();
+    let state = options.force_state.clone().unwrap_or_else(generate_state);
+    let server = Server::http("127.0.0.1:0").map_err(io::Error::other)?;
+    let actual_port = server
+        .server_addr()
+        .to_ip()
+        .map(|address| address.port())
+        .ok_or_else(|| io::Error::other("login callback server did not expose an IP port"))?;
+    let server = Arc::new(server);
+    let redirect_uri = format!("http://localhost:{actual_port}/callback");
+    let auth_url = build_authorize_url(&options, &redirect_uri, &pkce, &state)?;
+
+    if options.open_browser {
+        if let Err(error) = webbrowser::open(&auth_url) {
+            tracing::warn!(%error, "could not open the Claude login URL in a browser");
+        }
+    }
+
+    let (sender, mut receiver) = mpsc::channel(8);
+    let receive_server = server.clone();
+    thread::spawn(move || {
+        while let Ok(request) = receive_server.recv() {
+            if sender.blocking_send(request).is_err() {
+                break;
+            }
+        }
+    });
+
+    let notify = Arc::new(Notify::new());
+    let task_notify = notify.clone();
+    let task_server = server.clone();
+    let task = tokio::spawn(async move {
+        let result = loop {
+            tokio::select! {
+                _ = task_notify.notified() => break Err(io::Error::other("Claude login was cancelled")),
+                request = receiver.recv() => {
+                    let Some(request) = request else {
+                        break Err(io::Error::other("Claude login callback server stopped"));
+                    };
+                    let outcome =
+                        handle_callback_request(request.url(), &options, &redirect_uri, &pkce, &state)
+                            .await;
+                    let (status, body, completed) = outcome.into_parts();
+                    let response = text_response(status, body);
+                    let _ = tokio::task::spawn_blocking(move || request.respond(response)).await;
+                    if let Some(result) = completed {
+                        break result;
+                    }
+                }
+            }
+        };
+        task_server.unblock();
+        result
+    });
+
+    Ok(LoginServer {
+        auth_url,
+        actual_port,
+        task,
+        shutdown: ShutdownHandle { notify },
+    })
+}
+
+/// Manual-paste login for hosts without a browser: prints the authorize URL
+/// (redirect = Anthropic's code page), the caller supplies the pasted
+/// `code#state` string, we exchange it.
+pub async fn run_manual_login(
+    options: LoginOptions,
+    read_pasted: impl FnOnce(&str) -> io::Result<String>,
+) -> io::Result<LoginTokens> {
+    let pkce = generate_pkce();
+    let state = options.force_state.clone().unwrap_or_else(generate_state);
+    let auth_url = build_authorize_url(&options, MANUAL_REDIRECT_URL, &pkce, &state)?;
+    let pasted = read_pasted(&auth_url)?;
+    let code = parse_manual_code(pasted.trim(), &state)?;
+    exchange_code(&options, MANUAL_REDIRECT_URL, &pkce, &code, &state).await
+}
+
+pub(crate) fn parse_manual_code(pasted: &str, expected_state: &str) -> io::Result<String> {
+    let (code, state) = pasted.split_once('#').ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "expected the pasted value to look like code#state",
+        )
+    })?;
+    if state != expected_state {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "OAuth state mismatch; restart sign-in",
+        ));
+    }
+    if code.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "authorization code was empty",
+        ));
+    }
+    Ok(code.to_string())
+}
+
+enum CallbackOutcome {
+    Continue {
+        status: u16,
+        body: String,
+    },
+    Complete {
+        status: u16,
+        body: String,
+        result: io::Result<LoginTokens>,
+    },
+}
+
+impl CallbackOutcome {
+    fn into_parts(self) -> (u16, String, Option<io::Result<LoginTokens>>) {
+        match self {
+            Self::Continue { status, body } => (status, body, None),
+            Self::Complete {
+                status,
+                body,
+                result,
+            } => (status, body, Some(result)),
+        }
+    }
+}
+
+async fn handle_callback_request(
+    request_target: &str,
+    options: &LoginOptions,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    expected_state: &str,
+) -> CallbackOutcome {
+    let Ok(parsed) = Url::parse(&format!("http://localhost{request_target}")) else {
+        return CallbackOutcome::Continue {
+            status: 400,
+            body: "Invalid callback request.".into(),
+        };
+    };
+    if parsed.path() != "/callback" {
+        return CallbackOutcome::Continue {
+            status: 404,
+            body: "Not found.".into(),
+        };
+    }
+    let params: HashMap<String, String> = parsed.query_pairs().into_owned().collect();
+    if params.get("state").map(String::as_str) != Some(expected_state) {
+        tracing::warn!("rejected Claude OAuth callback with mismatched state");
+        return CallbackOutcome::Continue {
+            status: 400,
+            body: "OAuth state mismatch. Return to the terminal and retry sign-in.".into(),
+        };
+    }
+    if let Some(error) = params.get("error") {
+        let message = params
+            .get("error_description")
+            .map(String::as_str)
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or(error);
+        return CallbackOutcome::Complete {
+            status: 400,
+            body: "Claude sign-in was not completed. Return to Gents for details.".into(),
+            result: Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("Claude authorization failed: {message}"),
+            )),
+        };
+    }
+    let Some(code) = params
+        .get("code")
+        .map(String::as_str)
+        .filter(|v| !v.is_empty())
+    else {
+        return CallbackOutcome::Continue {
+            status: 400,
+            body: "The callback omitted its authorization code.".into(),
+        };
+    };
+    match exchange_code(options, redirect_uri, pkce, code, expected_state).await {
+        Ok(tokens) => CallbackOutcome::Complete {
+            status: 200,
+            body: "Claude sign-in complete. You may close this window.".into(),
+            result: Ok(tokens),
+        },
+        Err(error) => CallbackOutcome::Complete {
+            status: 502,
+            body: "Claude token exchange failed. Return to Gents for details.".into(),
+            result: Err(error),
+        },
+    }
+}
+
+fn text_response(status: u16, body: String) -> Response<std::io::Cursor<Vec<u8>>> {
+    let mut response = Response::from_string(body).with_status_code(TinyStatusCode(status));
+    if let Ok(header) = Header::from_bytes("Content-Type", "text/plain; charset=utf-8") {
+        response.add_header(header);
+    }
+    response
+}
+
+#[derive(Clone)]
+pub(crate) struct PkceCodes {
+    pub(crate) verifier: String,
+    pub(crate) challenge: String,
+}
+
+impl fmt::Debug for PkceCodes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PkceCodes")
+            .field("verifier", &"<redacted>")
+            .field("challenge", &self.challenge)
+            .finish()
+    }
+}
+
+pub(crate) fn generate_pkce() -> PkceCodes {
+    let mut bytes = [0u8; 64];
+    rand::rng().fill_bytes(&mut bytes);
+    let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(Sha256::digest(verifier.as_bytes()));
+    PkceCodes {
+        verifier,
+        challenge,
+    }
+}
+
+fn generate_state() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub(crate) fn build_authorize_url(
+    options: &LoginOptions,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    state: &str,
+) -> io::Result<String> {
+    let mut url = Url::parse(&options.authorize_url)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+    url.query_pairs_mut()
+        .append_pair("code", "true")
+        .append_pair("client_id", &options.client_id)
+        .append_pair("response_type", "code")
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("scope", SCOPES)
+        .append_pair("code_challenge", &pkce.challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("state", state);
+    Ok(url.into())
+}
+
+#[derive(Serialize)]
+struct ExchangeRequest<'a> {
+    grant_type: &'static str,
+    code: &'a str,
+    redirect_uri: &'a str,
+    client_id: &'a str,
+    code_verifier: &'a str,
+    state: &'a str,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: String,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+pub(crate) async fn exchange_code(
+    options: &LoginOptions,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    code: &str,
+    state: &str,
+) -> io::Result<LoginTokens> {
+    let request = ExchangeRequest {
+        grant_type: "authorization_code",
+        code,
+        redirect_uri,
+        client_id: &options.client_id,
+        code_verifier: &pkce.verifier,
+        state,
+    };
+    let response = reqwest::Client::new()
+        .post(&options.token_url)
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(redacted_transport_error)?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let detail = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_string))
+            .unwrap_or_else(|| "no error code".to_string());
+        return Err(io::Error::other(format!(
+            "Claude token endpoint returned HTTP {status}: {detail}"
+        )));
+    }
+    let tokens = response
+        .json::<TokenResponse>()
+        .await
+        .map_err(|error| io::Error::other(format!("decoding Claude OAuth tokens: {error}")))?;
+    Ok(LoginTokens {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_in: tokens.expires_in,
+        scope: tokens.scope,
+    })
+}
+
+fn redacted_transport_error(error: reqwest::Error) -> io::Error {
+    let kind = if error.is_timeout() {
+        "timed out"
+    } else if error.is_connect() {
+        "could not connect"
+    } else {
+        "failed"
+    };
+    io::Error::other(format!("Claude token exchange {kind}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> LoginOptions {
+        LoginOptions {
+            open_browser: false,
+            force_state: Some("state-1".into()),
+            ..LoginOptions::default()
+        }
+    }
+
+    #[test]
+    fn authorize_url_carries_claude_code_query_shape() {
+        let pkce = generate_pkce();
+        let url = build_authorize_url(
+            &options(),
+            "http://localhost:4242/callback",
+            &pkce,
+            "state-1",
+        )
+        .unwrap();
+        let parsed = url::Url::parse(&url).unwrap();
+        assert_eq!(parsed.origin().ascii_serialization(), "https://claude.com");
+        assert_eq!(parsed.path(), "/cai/oauth/authorize");
+        let q: std::collections::HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        assert_eq!(q["code"], "true");
+        assert_eq!(q["client_id"], CLIENT_ID);
+        assert_eq!(q["response_type"], "code");
+        assert_eq!(q["redirect_uri"], "http://localhost:4242/callback");
+        assert_eq!(q["scope"], SCOPES);
+        assert_eq!(q["code_challenge"], pkce.challenge);
+        assert_eq!(q["code_challenge_method"], "S256");
+        assert_eq!(q["state"], "state-1");
+    }
+
+    #[test]
+    fn pkce_challenge_is_s256_of_verifier() {
+        let pkce = generate_pkce();
+        let expected = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(Sha256::digest(pkce.verifier.as_bytes()));
+        assert_eq!(pkce.challenge, expected);
+        assert!(pkce.verifier.len() >= 43);
+    }
+
+    #[test]
+    fn debug_output_redacts_secrets() {
+        let tokens = LoginTokens {
+            access_token: "access-SECRET".into(),
+            refresh_token: "refresh-SECRET".into(),
+            expires_in: Some(60),
+            scope: Some("user:inference".into()),
+        };
+        let rendered = format!("{tokens:?}");
+        assert!(!rendered.contains("SECRET"), "{rendered}");
+        assert!(rendered.contains("expires_in: Some(60)"), "{rendered}");
+        let pkce = generate_pkce();
+        let rendered = format!("{pkce:?}");
+        assert!(!rendered.contains(&pkce.verifier), "{rendered}");
+    }
+
+    #[test]
+    fn manual_code_parsing_requires_matching_state() {
+        assert_eq!(parse_manual_code("abc#state-1", "state-1").unwrap(), "abc");
+        assert!(parse_manual_code("abc#state-2", "state-1").is_err());
+        assert!(parse_manual_code("abc", "state-1").is_err());
+        assert!(parse_manual_code("", "state-1").is_err());
+    }
+
+    #[tokio::test]
+    async fn callback_with_wrong_state_is_rejected_and_keeps_waiting() {
+        let pkce = generate_pkce();
+        let outcome = handle_callback_request(
+            "/callback?code=abc&state=wrong",
+            &options(),
+            "http://localhost:1/callback",
+            &pkce,
+            "state-1",
+        )
+        .await;
+        let (status, _, completed) = outcome.into_parts();
+        assert_eq!(status, 400);
+        assert!(completed.is_none());
+    }
+
+    #[tokio::test]
+    async fn exchange_posts_json_with_state_and_verifier() {
+        let (url, handle) = one_shot_server(200, r#"{"access_token":"access-NEW","refresh_token":"refresh-NEW","expires_in":28800,"scope":"user:inference"}"#).await;
+        let opts = LoginOptions {
+            token_url: url,
+            ..options()
+        };
+        let pkce = generate_pkce();
+        let tokens = exchange_code(
+            &opts,
+            "http://localhost:1/callback",
+            &pkce,
+            "code-1",
+            "state-1",
+        )
+        .await
+        .unwrap();
+        let request = handle.await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_str(request.split("\r\n\r\n").nth(1).unwrap()).unwrap();
+        assert_eq!(body["grant_type"], "authorization_code");
+        assert_eq!(body["code"], "code-1");
+        assert_eq!(body["redirect_uri"], "http://localhost:1/callback");
+        assert_eq!(body["client_id"], CLIENT_ID);
+        assert_eq!(body["code_verifier"], pkce.verifier);
+        assert_eq!(body["state"], "state-1");
+        assert!(
+            request.contains("content-type: application/json"),
+            "{request}"
+        );
+        assert_eq!(tokens.access_token, "access-NEW");
+        assert_eq!(tokens.refresh_token, "refresh-NEW");
+        assert_eq!(tokens.expires_in, Some(28800));
+    }
+
+    #[tokio::test]
+    async fn exchange_error_never_echoes_the_code() {
+        let (url, _handle) = one_shot_server(401, r#"{"error":"invalid_grant"}"#).await;
+        let opts = LoginOptions {
+            token_url: url,
+            ..options()
+        };
+        let pkce = generate_pkce();
+        let err = exchange_code(
+            &opts,
+            "http://localhost:1/callback",
+            &pkce,
+            "code-SECRET",
+            "state-1",
+        )
+        .await
+        .unwrap_err();
+        assert!(!err.to_string().contains("code-SECRET"), "{err}");
+        assert!(err.to_string().contains("401"), "{err}");
+    }
+
+    /// One-shot HTTP responder (no extra dependency): accepts one request, returns it, answers with `status` + `body`.
+    async fn one_shot_server(
+        status: u16,
+        body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<String>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let url = format!("http://{}/v1/oauth/token", listener.local_addr().unwrap());
+        let handle = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            loop {
+                let n = socket.read(&mut chunk).await.expect("read");
+                buf.extend_from_slice(&chunk[..n]);
+                let text = String::from_utf8_lossy(&buf);
+                if let Some(idx) = text.find("\r\n\r\n") {
+                    let content_length: usize = text[..idx]
+                        .lines()
+                        .find_map(|line| {
+                            line.strip_prefix("content-length: ")
+                                .or_else(|| line.strip_prefix("Content-Length: "))
+                        })
+                        .and_then(|value| value.trim().parse().ok())
+                        .unwrap_or(0);
+                    if buf.len() >= idx + 4 + content_length {
+                        break;
+                    }
+                }
+                if n == 0 {
+                    break;
+                }
+            }
+            let request = String::from_utf8_lossy(&buf).into_owned();
+            let response = format!(
+                "HTTP/1.1 {status} X\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.expect("write");
+            socket.shutdown().await.ok();
+            request
+        });
+        (url, handle)
+    }
+}

--- a/crates/gents-cli/Cargo.toml
+++ b/crates/gents-cli/Cargo.toml
@@ -37,6 +37,7 @@ chrono.workspace = true
 ciborium = "0.2"
 clap.workspace = true
 gents-chatgpt-login.workspace = true
+gents-claude-login.workspace = true
 gents-codex-protocol.workspace = true
 gents = { path = "../gents" }
 gents-fs-runner = { path = "../gents-fs-runner" }

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -81,6 +81,12 @@ pub(crate) enum Command {
         about = "Probe a DefraDB-backed Grok / xAI OAuth credential (read-only)"
     )]
     GrokAuthProbe(GrokAuthProbeArgs),
+    #[command(
+        name = "claude-login",
+        about = "Sign in with the Claude subscription (OAuth) and store credentials in DefraDB",
+        after_help = "Default: opens the browser and listens on a localhost callback. Use --manual on hosts without a browser: open the printed URL anywhere, then paste the code shown on Anthropic's page."
+    )]
+    ClaudeLogin(ClaudeLoginArgs),
     #[command(name = "__native-fs-runner", hide = true)]
     NativeFsRunner(NativeFsRunnerArgs),
     #[command(about = "Inspect and control live P2P runtime connectivity", after_help = P2P_AFTER_HELP)]
@@ -468,6 +474,34 @@ pub(crate) struct GrokLoginArgs {
     pub(crate) agent_did: Option<String>,
     #[arg(long, default_value = "xai-oauth")]
     pub(crate) provider: String,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct ClaudeLoginArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.gents")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint for the target gents node")]
+    pub(crate) graphql: Option<String>,
+    #[arg(long, help = "Agent DID that owns the OAuthCredential document")]
+    pub(crate) agent_did: Option<String>,
+    #[arg(long, default_value = "claude-subscription")]
+    pub(crate) provider: String,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Manual-paste login (no localhost callback, no browser)"
+    )]
+    pub(crate) manual: bool,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Print the login URL instead of opening a browser"
+    )]
+    pub(crate) no_browser: bool,
+    #[arg(long, help = "OAuth client ID override for testing")]
+    pub(crate) client_id: Option<String>,
+    #[arg(long, help = "OAuth token endpoint override for testing")]
+    pub(crate) token_url: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -1161,6 +1161,12 @@ pub(crate) enum BackendPresetArg {
     ChatGptCodex,
     #[value(name = "xai-oauth")]
     XaiGrokOAuth,
+    #[value(
+        name = "claude-cli-subscription",
+        alias = "claude-subscription",
+        alias = "claude-cli"
+    )]
+    ClaudeCliSubscription,
     #[value(name = "ollama")]
     Ollama,
     #[value(name = "vllm")]
@@ -1177,6 +1183,7 @@ impl BackendPresetArg {
             Self::OpenRouter => "openrouter",
             Self::ChatGptCodex => "chatgpt-codex",
             Self::XaiGrokOAuth => "xai-oauth",
+            Self::ClaudeCliSubscription => "claude-cli-subscription",
             Self::Ollama => "ollama",
             Self::Vllm => "vllm",
             Self::LlamaCpp => "llama-cpp",
@@ -1188,6 +1195,7 @@ impl BackendPresetArg {
             Self::OpenRouter => BackendProviderKind::OpenRouter,
             Self::ChatGptCodex => BackendProviderKind::ChatGptCodex,
             Self::XaiGrokOAuth => BackendProviderKind::XaiGrokOAuth,
+            Self::ClaudeCliSubscription => BackendProviderKind::ClaudeCliSubscription,
             Self::GenericOpenAiCompatible
             | Self::OpenAi
             | Self::Ollama
@@ -1203,6 +1211,9 @@ impl BackendPresetArg {
             Self::OpenRouter => Some("https://openrouter.ai/api/v1"),
             Self::ChatGptCodex => Some(gents::chatgpt_codex::default_backend_endpoint()),
             Self::XaiGrokOAuth => Some(gents::xai_grok_oauth::default_backend_endpoint()),
+            Self::ClaudeCliSubscription => {
+                Some(gents::claude_subscription::default_backend_endpoint())
+            }
             Self::Ollama => Some(crate::DEFAULT_OLLAMA_ENDPOINT),
             Self::Vllm => Some("http://127.0.0.1:8000/v1"),
             Self::LlamaCpp => Some("http://127.0.0.1:8080/v1"),
@@ -1219,6 +1230,7 @@ impl BackendPresetArg {
             Self::LlamaCpp => Some(crate::DEFAULT_INIT_MODEL_NAME),
             Self::ChatGptCodex => Some(crate::DEFAULT_CHATGPT_CODEX_MODEL_NAME),
             Self::XaiGrokOAuth => Some(crate::DEFAULT_XAI_GROK_OAUTH_MODEL_NAME),
+            Self::ClaudeCliSubscription => Some(gents::claude_subscription::default_model_name()),
             Self::GenericOpenAiCompatible | Self::OpenAi | Self::OpenRouter | Self::Vllm => None,
         }
     }
@@ -1230,6 +1242,7 @@ impl BackendPresetArg {
             Self::GenericOpenAiCompatible
             | Self::ChatGptCodex
             | Self::XaiGrokOAuth
+            | Self::ClaudeCliSubscription
             | Self::Ollama
             | Self::Vllm
             | Self::LlamaCpp => None,
@@ -1243,6 +1256,7 @@ impl BackendPresetArg {
             | Self::OpenRouter
             | Self::ChatGptCodex
             | Self::XaiGrokOAuth
+            | Self::ClaudeCliSubscription
             | Self::Ollama
             | Self::Vllm
             | Self::LlamaCpp => None,

--- a/crates/gents-cli/src/cli/args/tests.rs
+++ b/crates/gents-cli/src/cli/args/tests.rs
@@ -951,3 +951,34 @@ fn goal_resume_request_rejects_caller_supplied_lineage_flags() {
         );
     }
 }
+
+#[test]
+fn claude_login_parses_oauth_flags_and_rejects_seat_flags() {
+    let cli = Cli::try_parse_from([
+        "gents",
+        "claude-login",
+        "--agent-did",
+        "did:key:z6MkTest",
+        "--manual",
+        "--no-browser",
+    ])
+    .expect("parse");
+    let Command::ClaudeLogin(args) = cli.command else {
+        panic!("expected claude-login")
+    };
+    assert_eq!(args.agent_did.as_deref(), Some("did:key:z6MkTest"));
+    assert!(args.manual && args.no_browser);
+    assert_eq!(args.provider, "claude-subscription");
+    for removed in [
+        "--config-dir",
+        "--claude-bin",
+        "--dry-run",
+        "--claude-write-approved",
+        "--email",
+    ] {
+        assert!(
+            Cli::try_parse_from(["gents", "claude-login", removed, "x"]).is_err(),
+            "{removed} must be gone"
+        );
+    }
+}

--- a/crates/gents-cli/src/commands/claude_login.rs
+++ b/crates/gents-cli/src/commands/claude_login.rs
@@ -1,0 +1,181 @@
+//! First-party Claude subscription OAuth login. Tokens are stored as an
+//! `OAuthCredential` document for the agent DID, exactly like `codex-login`
+//! and `grok-login`; the `claude` binary is not involved.
+
+use std::io::{self, BufRead, Write};
+
+use anyhow::{Context, Result};
+use gents_claude_login::{run_loopback_login, run_manual_login, LoginOptions};
+use serde_json::{json, Value};
+
+use crate::cli::args::ClaudeLoginArgs;
+use crate::config_writes::ConfigAccess;
+use crate::{print_json, resolve_agent_did, resolve_config_access};
+
+pub(crate) struct ClaudeLoginOptions {
+    pub(crate) provider: String,
+    pub(crate) manual: bool,
+    pub(crate) open_browser: bool,
+    pub(crate) client_id: Option<String>,
+    pub(crate) token_url: Option<String>,
+}
+
+pub(crate) struct ClaudeLoginOutcome {
+    pub(crate) doc_id: String,
+    pub(crate) credential: gents::oauth_credential::OAuthCredential,
+}
+
+pub(crate) async fn claude_login(args: ClaudeLoginArgs) -> Result<()> {
+    let (access, home_dir) =
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref()).await?;
+    let agent_did = resolve_agent_did(Some(&home_dir), args.agent_did.as_deref())?;
+    let outcome = run_claude_login(
+        &access,
+        &agent_did,
+        &ClaudeLoginOptions {
+            provider: args.provider,
+            manual: args.manual,
+            open_browser: !args.no_browser,
+            client_id: args.client_id,
+            token_url: args.token_url,
+        },
+    )
+    .await?;
+    print_json(&claude_login_result_json(&outcome))?;
+    Ok(())
+}
+
+pub(crate) async fn run_claude_login(
+    access: &ConfigAccess,
+    agent_did: &str,
+    opts: &ClaudeLoginOptions,
+) -> Result<ClaudeLoginOutcome> {
+    let provider = gents::claude_oauth::normalize_provider(&opts.provider);
+    let mut login_options = LoginOptions {
+        open_browser: opts.open_browser,
+        ..LoginOptions::default()
+    };
+    if let Some(client_id) = opts
+        .client_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        login_options.client_id = client_id.to_string();
+    }
+    if let Some(token_url) = opts
+        .token_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        login_options.token_url = token_url.to_string();
+    }
+
+    let tokens = if opts.manual {
+        run_manual_login(login_options, |auth_url| {
+            eprintln!(
+                "Open this URL to sign in with Claude:\n{auth_url}\n\nPaste the code shown on the success page (code#state) and press Enter:"
+            );
+            io::stderr().flush()?;
+            let mut line = String::new();
+            io::stdin().lock().read_line(&mut line)?;
+            Ok(line)
+        })
+        .await
+        .context("Claude manual login failed")?
+    } else {
+        let server =
+            run_loopback_login(login_options).context("starting Claude login callback server")?;
+        eprintln!("Open this URL to sign in with Claude:\n{}", server.auth_url);
+        server
+            .block_until_done()
+            .await
+            .context("Claude browser login failed")?
+    };
+
+    let login_tokens = gents::claude_oauth::ClaudeLoginTokens {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_in: tokens.expires_in,
+        scope: tokens.scope,
+    };
+    let credential = gents::claude_oauth::credential_from_login_tokens(
+        agent_did,
+        &provider,
+        &login_tokens,
+        chrono::Utc::now(),
+    );
+    let mutation = gents::oauth_credential::oauth_credential_upsert_mutation(&credential);
+    let response = access.execute(&mutation).await?;
+    let doc_id = gents_protocol::graphql::extract_mutation_doc_id(&response, "OAuthCredential")?;
+    Ok(ClaudeLoginOutcome { doc_id, credential })
+}
+
+pub(crate) fn claude_login_result_json(outcome: &ClaudeLoginOutcome) -> Value {
+    let credential = &outcome.credential;
+    json!({
+        "login": "completed",
+        "doc_id": outcome.doc_id,
+        "credential_id": credential.credential_id,
+        "agent_did": credential.agent_did,
+        "provider": credential.provider,
+        "access_token_expires_at": credential.access_token_expires_at,
+        "last_refresh": credential.last_refresh,
+        "enabled": credential.enabled,
+        "access_token": "<redacted>",
+        "refresh_token": "<redacted>",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn login_and_runtime_constants_match() {
+        assert_eq!(
+            gents_claude_login::CLIENT_ID,
+            gents::claude_oauth::CLAUDE_OAUTH_CLIENT_ID
+        );
+        assert_eq!(
+            gents_claude_login::AUTHORIZE_URL,
+            gents::claude_oauth::CLAUDE_OAUTH_AUTHORIZE_URL
+        );
+        assert_eq!(
+            gents_claude_login::TOKEN_URL,
+            gents::claude_oauth::CLAUDE_OAUTH_TOKEN_URL
+        );
+        assert_eq!(
+            gents_claude_login::MANUAL_REDIRECT_URL,
+            gents::claude_oauth::CLAUDE_OAUTH_MANUAL_REDIRECT_URL
+        );
+        assert_eq!(
+            gents_claude_login::SCOPES,
+            gents::claude_oauth::CLAUDE_OAUTH_SCOPES
+        );
+    }
+
+    #[test]
+    fn result_json_redacts_tokens() {
+        let credential = gents::claude_oauth::credential_from_login_tokens(
+            "did:key:z6MkTest",
+            "claude-subscription",
+            &gents::claude_oauth::ClaudeLoginTokens {
+                access_token: "access-SECRET".into(),
+                refresh_token: "refresh-SECRET".into(),
+                expires_in: Some(60),
+                scope: None,
+            },
+            chrono::Utc::now(),
+        );
+        let json = claude_login_result_json(&ClaudeLoginOutcome {
+            doc_id: "bae-1".into(),
+            credential,
+        });
+        let text = json.to_string();
+        assert!(!text.contains("SECRET"), "{text}");
+        assert_eq!(json["access_token"], "<redacted>");
+        assert_eq!(json["login"], "completed");
+    }
+}

--- a/crates/gents-cli/src/commands/config/backend.rs
+++ b/crates/gents-cli/src/commands/config/backend.rs
@@ -381,3 +381,57 @@ fn resolve_backend_api_key_env_var(
             .map(ToOwned::to_owned)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    /// `backend set` validates the document before writing (#1331). The
+    /// claude-cli-subscription preset must pass that gate on its own: a
+    /// non-empty placeholder endpoint, no api_key, positive max_*.
+    #[test]
+    fn config_backend_claude_cli_subscription_preset_passes_validation() {
+        let cli = Cli::try_parse_from([
+            "gents",
+            "config",
+            "backend",
+            "set",
+            "--graphql",
+            "http://127.0.0.1:1/graphql",
+            "--backend-id",
+            "claude-max",
+            "--name",
+            "Claude Max",
+            "--backend-preset",
+            "claude-cli-subscription",
+            "--max-concurrent",
+            "1",
+        ])
+        .expect("parse");
+        let Command::Config {
+            command:
+                ConfigCommand::Backend {
+                    command: BackendCommand::Set(args),
+                },
+        } = cli.command
+        else {
+            panic!("expected config backend set")
+        };
+        let backend = resolve_backend_upsert_config(&args).expect("resolve preset");
+        assert_eq!(
+            backend.provider_kind,
+            BackendProviderKind::ClaudeCliSubscription
+        );
+        assert_eq!(
+            backend.endpoint,
+            gents::claude_subscription::default_backend_endpoint()
+        );
+        assert_eq!(backend.api_key, None);
+        assert_eq!(backend.api_key_env_var, None);
+        to_document_backend(&args, &backend)
+            .validate(None)
+            .expect("preset document validates");
+    }
+}

--- a/crates/gents-cli/src/commands/diagnose/backends.rs
+++ b/crates/gents-cli/src/commands/diagnose/backends.rs
@@ -122,6 +122,7 @@ async fn diagnose_backend(backend: &Value, required_models: Vec<String>) -> Valu
         .map(ToOwned::to_owned);
     let mut ok = gents::document_configured_from_fields(enabled, &probe_status);
     let mut error = None::<String>;
+    let mut note = None::<&'static str>;
     let mut discovered_models = Vec::<String>::new();
 
     let api_key = match (raw_api_key.as_ref(), api_key_env_var.as_deref()) {
@@ -172,7 +173,12 @@ async fn diagnose_backend(backend: &Value, required_models: Vec<String>) -> Valu
                 });
             }
         };
-        if !provider_kind.is_agent_scoped_oauth() {
+        // Mirrors the runtime prober (`backend_health`): agent-scoped OAuth
+        // kinds are not discovered here (no credential is loaded); discovery is
+        // the explicit `gents config backend discover-models`.
+        if provider_kind.is_agent_scoped_oauth() {
+            note = Some(OAUTH_CREDENTIAL_DISCOVERY_NOTE);
+        } else {
             match discover_backend_models(
                 &client,
                 provider_kind,
@@ -221,6 +227,36 @@ async fn diagnose_backend(backend: &Value, required_models: Vec<String>) -> Valu
         "api_key_env_var": api_key_env_var,
         "required_models": required_models,
         "discovered_models": discovered_models,
+        "note": note,
         "error": error,
     })
+}
+
+const OAUTH_CREDENTIAL_DISCOVERY_NOTE: &str =
+    "OAuth credential backend: diagnose skips discovery (use `gents config backend discover-models`); health is the credential-expiry probe";
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn oauth_backend_skips_discovery_and_stays_ok() {
+        let backend = json!({
+            "backend_id": "claude-max",
+            "provider_kind": "ClaudeCliSubscription",
+            "endpoint": "claude-cli://subscription",
+            "enabled": true,
+            "probe_status": "healthy",
+        });
+        let report = diagnose_backend(&backend, vec!["claude-sonnet-5".to_string()]).await;
+        assert_eq!(report["ok"], Value::Bool(true), "{report}");
+        assert_eq!(report["error"], Value::Null, "{report}");
+        assert_eq!(
+            report["note"],
+            Value::String(OAUTH_CREDENTIAL_DISCOVERY_NOTE.to_string())
+        );
+        assert_eq!(report["discovered_models"], json!([]));
+    }
 }

--- a/crates/gents-cli/src/commands/diagnose/backends.rs
+++ b/crates/gents-cli/src/commands/diagnose/backends.rs
@@ -170,6 +170,7 @@ async fn diagnose_backend(backend: &Value, required_models: Vec<String>) -> Valu
                     "required_models": required_models,
                     "discovered_models": discovered_models,
                     "error": error,
+                    "note": null,
                 });
             }
         };

--- a/crates/gents-cli/src/commands/diagnose/mod.rs
+++ b/crates/gents-cli/src/commands/diagnose/mod.rs
@@ -293,6 +293,51 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
         }),
     };
 
+    let claude_provider = gents::claude_oauth::CLAUDE_OAUTH_PROVIDER;
+    let claude_auth_check = match crate::commands::grok_auth_probe::load_oauth_credential(
+        &access,
+        &agent_did,
+        claude_provider,
+    )
+    .await
+    {
+        Ok(Some(credential))
+            if gents::oauth_credential::token_is_fresh(credential.access_token_expires_at) =>
+        {
+            json!({
+                "ok": true,
+                "credential_id": credential.credential_id,
+                "provider": credential.provider,
+                "expires_at": credential.access_token_expires_at,
+            })
+        }
+        Ok(Some(credential)) => json!({
+            "ok": false,
+            "credential_id": credential.credential_id,
+            "provider": credential.provider,
+            "expires_at": credential.access_token_expires_at,
+            "guidance": gents::claude_oauth::classify_claude_auth_error(
+                &agent_did,
+                claude_provider,
+                &gents::oauth_credential::OAuthAuthProblem::Expired,
+            ),
+        }),
+        Ok(None) => json!({
+            "ok": false,
+            "provider": claude_provider,
+            "guidance": gents::claude_oauth::classify_claude_auth_error(
+                &agent_did,
+                claude_provider,
+                &gents::oauth_credential::OAuthAuthProblem::Missing,
+            ),
+        }),
+        Err(error) => json!({
+            "ok": false,
+            "provider": claude_provider,
+            "error": error.to_string(),
+        }),
+    };
+
     // An auth failure only degrades overall health when an OAuth backend is actually
     // configured and enabled — deployments that don't use that backend have no credential
     // and must still report `ok`.
@@ -312,6 +357,13 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
     let xai_auth_ok =
         !xai_backend_configured || xai_auth_check.get("ok").and_then(Value::as_bool) == Some(true);
 
+    let claude_backend_configured = backend_reports.iter().any(|report| {
+        report.get("provider_kind").and_then(Value::as_str)
+            == Some(gents::backend_provider::BackendProviderKind::ClaudeCliSubscription.as_str())
+            && report.get("enabled").and_then(Value::as_bool) == Some(true)
+    });
+    let claude_auth_ok = claude_auth_gate(claude_backend_configured, &claude_auth_check);
+
     let status = if schemas_ok
         && principal_present
         && default_behavior_ok
@@ -319,6 +371,7 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
         && backends_ok
         && chatgpt_auth_ok
         && xai_auth_ok
+        && claude_auth_ok
         && p2p_ok
         && runtime_behavior_readiness_ok
         && config_load_error.is_none()
@@ -350,6 +403,7 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
             "tool_ceiling": tool_ceiling_check,
             "chatgpt_auth": chatgpt_auth_check,
             "xai_auth": xai_auth_check,
+            "claude_auth": claude_auth_check,
             "backends": backend_reports,
             "p2p": {
                 "ok": p2p_ok,
@@ -375,4 +429,43 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
     }
     print_json(&output)?;
     Ok(())
+}
+
+/// `checks.claude_auth.ok` reports token freshness, but a stale access token
+/// alone does not degrade the overall status: the prober counts such a
+/// credential healthy and the next request refreshes it. Only a credential
+/// that could not be read at all (missing, or a decode error) degrades — the
+/// agent snapshot gate refuses the behavior in that case.
+fn claude_auth_gate(backend_configured: bool, check: &Value) -> bool {
+    !backend_configured || check.get("credential_id").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::claude_auth_gate;
+
+    #[test]
+    fn claude_auth_degrades_status_only_when_no_credential_can_be_read() {
+        let fresh = json!({"ok": true, "credential_id": "claude-subscription:did:key:z6MkT"});
+        let stale = json!({
+            "ok": false,
+            "credential_id": "claude-subscription:did:key:z6MkT",
+            "guidance": "expired or revoked",
+        });
+        let missing = json!({"ok": false, "guidance": "run gents claude-login"});
+        let read_error = json!({"ok": false, "error": "querying OAuthCredential returned errors"});
+        assert!(claude_auth_gate(true, &fresh));
+        assert!(
+            claude_auth_gate(true, &stale),
+            "staleness alone must not degrade: the next request refreshes"
+        );
+        assert!(!claude_auth_gate(true, &missing));
+        assert!(!claude_auth_gate(true, &read_error));
+        assert!(
+            claude_auth_gate(false, &missing),
+            "no enabled Claude backend: the check is not folded in"
+        );
+    }
 }

--- a/crates/gents-cli/src/commands/mod.rs
+++ b/crates/gents-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod background;
 pub(crate) mod chain;
 pub(crate) mod chat;
+pub(crate) mod claude_login;
 pub(crate) mod codex;
 pub(crate) mod codex_auth_probe;
 pub(crate) mod codex_login;

--- a/crates/gents-cli/src/commands/serve.rs
+++ b/crates/gents-cli/src/commands/serve.rs
@@ -947,6 +947,7 @@ pub(crate) async fn serve_with_control(
             &probe_client,
             &backend_health,
             &probe_options,
+            identity.did(),
         )
         .await;
         tracing::debug!(

--- a/crates/gents-cli/src/lib.rs
+++ b/crates/gents-cli/src/lib.rs
@@ -422,6 +422,7 @@ async fn async_main() -> Result<()> {
         Command::CodexAuthProbe(args) => commands::codex_auth_probe::codex_auth_probe(args).await,
         Command::GrokLogin(args) => commands::grok_login::grok_login(args).await,
         Command::GrokAuthProbe(args) => commands::grok_auth_probe::grok_auth_probe(args).await,
+        Command::ClaudeLogin(args) => commands::claude_login::claude_login(args).await,
         Command::P2p { command } => commands::p2p::dispatch(command).await,
         Command::Schema { command } => commands::schema::dispatch(command).await,
         Command::Trace { command } => commands::trace::dispatch(command).await,

--- a/crates/gents-cli/src/resolve_helpers.rs
+++ b/crates/gents-cli/src/resolve_helpers.rs
@@ -34,7 +34,13 @@ pub(crate) fn resolve_backend_config_with_preset(
 
     let endpoint = resolve_backend_endpoint(explicit_endpoint, preset, mode)?;
     let provider_kind = resolve_backend_provider_kind(explicit_provider_kind, preset)?;
-    let openai_wire_api = resolve_openai_wire_api(explicit_openai_wire_api, preset);
+    let openai_wire_api = if provider_kind == BackendProviderKind::ClaudeCliSubscription {
+        // Claude is not an OpenAI-wire provider. Never persist a sticky wire
+        // value when migrating an existing OpenAiCompatible backend.
+        None
+    } else {
+        resolve_openai_wire_api(explicit_openai_wire_api, preset)
+    };
     let api_key_env_var =
         resolve_backend_api_key_env_var(explicit_api_key_env_var, api_key.is_some(), preset);
 
@@ -199,6 +205,29 @@ mod tests {
         assert_eq!(
             resolved.openai_wire_api,
             Some(OpenAiWireApi::ChatCompletions)
+        );
+    }
+
+    #[test]
+    fn claude_cli_subscription_drops_sticky_openai_wire_api() {
+        let resolved = resolve_backend_config_with_preset(
+            Some(BackendPresetArg::ClaudeCliSubscription),
+            None,
+            None,
+            Some(OpenAiWireApiArg::ChatCompletions),
+            None,
+            None,
+            BackendResolutionMode::ConfigWrite,
+        )
+        .expect("resolve claude preset");
+
+        assert_eq!(
+            resolved.provider_kind,
+            BackendProviderKind::ClaudeCliSubscription
+        );
+        assert_eq!(
+            resolved.openai_wire_api, None,
+            "Claude migration must not persist sticky openai_wire_api"
         );
     }
 }

--- a/crates/gents/proofs/Proofs/PromptAssembly/ClaudeMap.lean
+++ b/crates/gents/proofs/Proofs/PromptAssembly/ClaudeMap.lean
@@ -173,8 +173,9 @@ inductive Msg where
   | other (tag : String)
   deriving DecidableEq, Repr
 
-/-- The Claude Code identity block. `system[0]` on every request; the agent's subscription credential's
-oat routes on it. Checked against Rust `CLAUDE_CODE_IDENTITY` by the vocab test. -/
+/-- The Claude Code identity block. `system[0]` on every request; the agent's
+subscription credential routes on it. Checked against Rust `CLAUDE_CODE_IDENTITY`
+by the vocab test. -/
 def identity : String := "You are Claude Code, Anthropic's official CLI for Claude."
 
 /-- Pull `System` rows out in order; everything else is untouched. Rust also

--- a/crates/gents/proofs/Proofs/PromptAssembly/ClaudeMap.lean
+++ b/crates/gents/proofs/Proofs/PromptAssembly/ClaudeMap.lean
@@ -5,7 +5,7 @@ import Proofs.Transcript.State
 
 Anthropic Messages HTTP is the only Claude wire. Its `tool_use` /
 `tool_result` content blocks are mapped here onto existing `ToolCallId`s /
-`MessageKind` rows. This file does not model the HTTP transport, the seat
+`MessageKind` rows. This file does not model the HTTP transport, the agent's subscription credential
 token read, or oat.
 
 Unmapped names (including Claude-native `Bash`) and `tool_use` on an empty
@@ -173,7 +173,7 @@ inductive Msg where
   | other (tag : String)
   deriving DecidableEq, Repr
 
-/-- The Claude Code identity block. `system[0]` on every request; the seat's
+/-- The Claude Code identity block. `system[0]` on every request; the agent's subscription credential's
 oat routes on it. Checked against Rust `CLAUDE_CODE_IDENTITY` by the vocab test. -/
 def identity : String := "You are Claude Code, Anthropic's official CLI for Claude."
 

--- a/crates/gents/proofs/Proofs/RenderedCapture.lean
+++ b/crates/gents/proofs/Proofs/RenderedCapture.lean
@@ -7,7 +7,7 @@ The owned completion loop assembles a provider request, arms this attempt's
 capture (`on_rendered_request`, `crates/gents/src/agent/loop_stream.rs`), and
 the innermost HTTP transport then persists the body it is about to post before
 it posts it (`crates/gents/src/rendered_request/transport.rs`). Every provider,
-the Claude subscription seat included, posts through that one HTTP transport, so
+the agent's Claude subscription credential included, posts through that one HTTP transport, so
 `CaptureSeam::TransportBody` is the only seam version 1 emits; `CanonicalRequest`
 stays opaque. This model fences the *order*: a provider send is legal only after
 the matching `(capture key, canonical request)` pair is durable, and one

--- a/crates/gents/proofs/Proofs/RenderedCapture.lean
+++ b/crates/gents/proofs/Proofs/RenderedCapture.lean
@@ -7,7 +7,7 @@ The owned completion loop assembles a provider request, arms this attempt's
 capture (`on_rendered_request`, `crates/gents/src/agent/loop_stream.rs`), and
 the innermost HTTP transport then persists the body it is about to post before
 it posts it (`crates/gents/src/rendered_request/transport.rs`). Every provider,
-the agent's Claude subscription credential included, posts through that one HTTP transport, so
+the Claude subscription included, posts through that one HTTP transport, so
 `CaptureSeam::TransportBody` is the only seam version 1 emits; `CanonicalRequest`
 stays opaque. This model fences the *order*: a provider send is legal only after
 the matching `(capture key, canonical request)` pair is durable, and one

--- a/crates/gents/src/agent/document_view/snapshot.rs
+++ b/crates/gents/src/agent/document_view/snapshot.rs
@@ -208,6 +208,21 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
                     ),
                 ));
             }
+            if backend.provider_kind
+                == crate::backend_provider::BackendProviderKind::ClaudeCliSubscription
+                && !view.has_enabled_oauth_credential(crate::claude_oauth::CLAUDE_OAUTH_PROVIDER)
+            {
+                let agent_did = view.principal.value.agent_did.as_str();
+                return Err(BehaviorResolutionError::new(
+                    BehaviorReadinessUnavailableReason::CredentialsRequired,
+                    anyhow!(
+                        "behavior {} ClaudeCliSubscription backend {} has no enabled OAuthCredential for agent \
+                         {agent_did}; run `gents claude-login --agent-did {agent_did}`",
+                        behavior.behavior_id,
+                        backend.backend_id,
+                    ),
+                ));
+            }
             let profile_id = behavior
                 .inference_profile_id
                 .as_deref()

--- a/crates/gents/src/agent/document_view/tests.rs
+++ b/crates/gents/src/agent/document_view/tests.rs
@@ -1506,6 +1506,129 @@ async fn chatgpt_codex_behavior_with_enabled_credential_is_runnable() {
     );
 }
 
+async fn bind_default_behavior_claude_backend(
+    node: &defra_node::EmbeddedNode,
+    agent_did: &str,
+    backend_id: &str,
+) {
+    let bootstrap = crate::ensure_agent_principal(node, agent_did)
+        .await
+        .unwrap();
+    let escaped_backend_id = escape_graphql_string(backend_id);
+    let escaped_endpoint =
+        escape_graphql_string(crate::claude_subscription::default_backend_endpoint());
+    let mutation = format!(
+        r#"mutation {{
+            upsert_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{escaped_backend_id}" }} }},
+                add: {{
+                    backend_id: "{escaped_backend_id}",
+                    name: "{escaped_backend_id}",
+                    provider_kind: "ClaudeCliSubscription",
+                    endpoint: "{escaped_endpoint}",
+                    max_concurrent: 1,
+                    enabled: true,
+                    models: ["default"],
+                    probe_status: "healthy"
+                }},
+                update: {{
+                    name: "{escaped_backend_id}",
+                    provider_kind: "ClaudeCliSubscription",
+                    enabled: true,
+                    probe_status: "healthy"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "upsert ClaudeCliSubscription InferenceBackend failed: {:?}",
+        response.errors
+    );
+
+    let mut default_behavior =
+        crate::load_agent_behavior(node, &bootstrap.default_behavior.behavior_id)
+            .await
+            .unwrap()
+            .expect("default behavior document");
+    default_behavior.backend_id = Some(backend_id.to_string());
+    crate::upsert_agent_behavior(node, &default_behavior)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn claude_subscription_behavior_requires_enabled_credential() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let identity = Arc::new(test_identity("document-view-claude-cred"));
+    bind_default_behavior_claude_backend(node.as_ref(), identity.did(), "backend-claude-cred")
+        .await;
+    let default_behavior_id = crate::default_behavior_id_for_agent(identity.did());
+    let resolve_context = DocumentResolveContext {
+        identity: identity.clone(),
+        tool_ceiling: ToolCeiling::readonly(),
+        backend_health: crate::backend_health::BackendHealthMap::new(),
+    };
+
+    let view = load_document_runtime_view(node.as_ref(), identity.did())
+        .await
+        .expect("document view");
+    let snapshot =
+        resolve_document_runtime_snapshot_from_view(node.as_ref(), &resolve_context, &view)
+            .await
+            .expect("snapshot");
+    assert!(
+        !snapshot.behaviors.contains_key(&default_behavior_id),
+        "a ClaudeCliSubscription behavior without an OAuthCredential must not be runnable"
+    );
+    let reason = snapshot
+        .unavailable_behaviors
+        .get(&default_behavior_id)
+        .expect("behavior should be reported unavailable");
+    assert_eq!(
+        reason.public_reason,
+        gents_protocol::row::BehaviorReadinessUnavailableReason::CredentialsRequired
+    );
+    assert!(
+        reason.diagnostic.contains(&format!(
+            "run `gents claude-login --agent-did {}`",
+            identity.did()
+        )),
+        "unavailable reason should point at claude-login: {}",
+        reason.diagnostic
+    );
+
+    let credential = crate::claude_oauth::credential_from_login_tokens(
+        identity.did(),
+        crate::claude_oauth::CLAUDE_OAUTH_PROVIDER,
+        &crate::claude_oauth::ClaudeLoginTokens {
+            access_token: "access-token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            expires_in: Some(3600),
+            scope: None,
+        },
+        chrono::Utc::now(),
+    );
+    crate::oauth_credential::upsert_oauth_credential(node.as_ref(), &credential)
+        .await
+        .expect("upsert credential");
+
+    let view = load_document_runtime_view(node.as_ref(), identity.did())
+        .await
+        .expect("document view");
+    let snapshot =
+        resolve_document_runtime_snapshot_from_view(node.as_ref(), &resolve_context, &view)
+            .await
+            .expect("snapshot");
+    assert!(
+        snapshot.behaviors.contains_key(&default_behavior_id),
+        "a ClaudeCliSubscription behavior with an enabled OAuthCredential must be runnable; unavailable: {:?}",
+        snapshot.unavailable_behaviors
+    );
+}
+
 #[tokio::test]
 async fn apply_control_update_admits_chatgpt_behavior_when_credential_added() {
     let node = test_node().await;

--- a/crates/gents/src/agent/runtime/startup.rs
+++ b/crates/gents/src/agent/runtime/startup.rs
@@ -538,6 +538,7 @@ async fn run_agent_owned(
         agent.backend_prober_options.clone(),
         backend_health_events_tx,
         cancel.child_token(),
+        agent.agent_did().to_string(),
     );
 
     let runtime_snapshot_observer_handle =

--- a/crates/gents/src/backend_health.rs
+++ b/crates/gents/src/backend_health.rs
@@ -220,18 +220,96 @@ pub struct ProbeCycleOutcome {
     pub promotable: Vec<String>,
 }
 
+/// Node + principal used to read agent-scoped OAuth credentials during a probe cycle.
+pub struct OAuthProbeContext<'a> {
+    pub node: &'a EmbeddedNode,
+    pub principal_did: &'a str,
+}
+
+async fn probe_oauth_credential(
+    context: &OAuthProbeContext<'_>,
+    backend: &InferenceBackend,
+) -> (ProbeEvent, Option<String>) {
+    let Some(provider) = backend.provider_kind.oauth_provider() else {
+        return (
+            ProbeEvent::ProbeFail,
+            Some("backend kind has no OAuth provider".to_string()),
+        );
+    };
+    match crate::oauth_credential::lookup_oauth_credential(
+        context.node,
+        context.principal_did,
+        provider,
+    )
+    .await
+    {
+        Ok(Some(credential))
+            if crate::oauth_credential::token_is_fresh(credential.access_token_expires_at) =>
+        {
+            tracing::debug!(
+                backend_id = %backend.backend_id,
+                provider,
+                expires_at = %credential.access_token_expires_at.to_rfc3339(),
+                "oauth credential probe ok"
+            );
+            (ProbeEvent::ProbeSuccess, None)
+        }
+        // A stale access token is not a liveness failure: every decoded
+        // credential carries a refresh token (the decoder rejects blank ones),
+        // the request path refreshes on next use, and demoting here would veto
+        // routing, so nothing would ever make that request.
+        Ok(Some(credential)) => {
+            tracing::debug!(
+                backend_id = %backend.backend_id,
+                provider,
+                expires_at = %credential.access_token_expires_at.to_rfc3339(),
+                "oauth credential probe ok: access token stale, refreshes on next use"
+            );
+            (ProbeEvent::ProbeSuccess, None)
+        }
+        Ok(None) => (
+            ProbeEvent::ProbeFail,
+            Some(backend.provider_kind.oauth_auth_guidance(
+                context.principal_did,
+                provider,
+                &crate::oauth_credential::OAuthAuthProblem::Missing,
+            )),
+        ),
+        Err(error) => (
+            ProbeEvent::ProbeFail,
+            Some(format!("reading OAuthCredential: {error:#}")),
+        ),
+    }
+}
+
 pub async fn probe_backends_cycle(
     client: &reqwest::Client,
     backends: &[InferenceBackend],
     now: DateTime<Utc>,
     health_map: &BackendHealthMap,
     options: &BackendProberOptions,
+    oauth: Option<OAuthProbeContext<'_>>,
 ) -> ProbeCycleOutcome {
     let mut outcome = ProbeCycleOutcome::default();
     let mut probed_ids = HashSet::new();
 
     for backend in backends {
         if backend.provider_kind.is_agent_scoped_oauth() {
+            let Some(context) = oauth.as_ref() else {
+                continue;
+            };
+            probed_ids.insert(backend.backend_id.clone());
+            let (event, error_text) = probe_oauth_credential(context, backend).await;
+            record_probe_event(
+                backend,
+                event,
+                error_text,
+                now,
+                health_map,
+                options,
+                &mut outcome,
+            )
+            .await;
             continue;
         }
         probed_ids.insert(backend.backend_id.clone());
@@ -259,51 +337,72 @@ pub async fn probe_backends_cycle(
             }
         };
 
-        let previous = health_map.get_model(&backend.backend_id).await;
-        let next = step_backend(previous, event, options.failure_threshold_k);
-        let veto_flipped = previous.0.blocks_routing() != next.0.blocks_routing();
-
-        if veto_flipped {
-            tracing::warn!(
-                backend_id = %backend.backend_id,
-                endpoint = %backend.endpoint,
-                previous_state = %previous.0.as_str(),
-                next_state = %next.0.as_str(),
-                failure_count = next.1,
-                error = error_text.as_deref().unwrap_or(""),
-                "backend probe: measured health crossed the routing threshold"
-            );
-            outcome.flipped.push(backend.backend_id.clone());
-        } else if event == ProbeEvent::ProbeFail {
-            tracing::debug!(
-                backend_id = %backend.backend_id,
-                endpoint = %backend.endpoint,
-                state = %next.0.as_str(),
-                failure_count = next.1,
-                error = error_text.as_deref().unwrap_or(""),
-                "backend probe failed"
-            );
-        }
-
-        if event == ProbeEvent::ProbeSuccess && backend.probe_status == UNKNOWN_PROBE_STATUS {
-            outcome.promotable.push(backend.backend_id.clone());
-        }
-
-        health_map
-            .set_entry(
-                backend.backend_id.clone(),
-                BackendHealthEntry {
-                    state: next.0,
-                    failure_count: next.1,
-                    last_probe_at: now,
-                    last_error: error_text,
-                },
-            )
-            .await;
+        record_probe_event(
+            backend,
+            event,
+            error_text,
+            now,
+            health_map,
+            options,
+            &mut outcome,
+        )
+        .await;
     }
 
     health_map.retain_backends(&probed_ids).await;
     outcome
+}
+
+async fn record_probe_event(
+    backend: &InferenceBackend,
+    event: ProbeEvent,
+    error_text: Option<String>,
+    now: DateTime<Utc>,
+    health_map: &BackendHealthMap,
+    options: &BackendProberOptions,
+    outcome: &mut ProbeCycleOutcome,
+) {
+    let previous = health_map.get_model(&backend.backend_id).await;
+    let next = step_backend(previous, event, options.failure_threshold_k);
+    let veto_flipped = previous.0.blocks_routing() != next.0.blocks_routing();
+
+    if veto_flipped {
+        tracing::warn!(
+            backend_id = %backend.backend_id,
+            endpoint = %backend.endpoint,
+            previous_state = %previous.0.as_str(),
+            next_state = %next.0.as_str(),
+            failure_count = next.1,
+            error = error_text.as_deref().unwrap_or(""),
+            "backend probe: measured health crossed the routing threshold"
+        );
+        outcome.flipped.push(backend.backend_id.clone());
+    } else if event == ProbeEvent::ProbeFail {
+        tracing::debug!(
+            backend_id = %backend.backend_id,
+            endpoint = %backend.endpoint,
+            state = %next.0.as_str(),
+            failure_count = next.1,
+            error = error_text.as_deref().unwrap_or(""),
+            "backend probe failed"
+        );
+    }
+
+    if event == ProbeEvent::ProbeSuccess && backend.probe_status == UNKNOWN_PROBE_STATUS {
+        outcome.promotable.push(backend.backend_id.clone());
+    }
+
+    health_map
+        .set_entry(
+            backend.backend_id.clone(),
+            BackendHealthEntry {
+                state: next.0,
+                failure_count: next.1,
+                last_probe_at: now,
+                last_error: error_text,
+            },
+        )
+        .await;
 }
 
 pub async fn run_backend_probe_cycle(
@@ -311,6 +410,7 @@ pub async fn run_backend_probe_cycle(
     client: &reqwest::Client,
     health_map: &BackendHealthMap,
     options: &BackendProberOptions,
+    principal_did: &str,
 ) -> ProbeCycleOutcome {
     let backends = match list_enabled_backends(node).await {
         Ok(backends) => backends,
@@ -321,7 +421,18 @@ pub async fn run_backend_probe_cycle(
     };
 
     let now = Utc::now();
-    let outcome = probe_backends_cycle(client, &backends, now, health_map, options).await;
+    let outcome = probe_backends_cycle(
+        client,
+        &backends,
+        now,
+        health_map,
+        options,
+        Some(OAuthProbeContext {
+            node,
+            principal_did,
+        }),
+    )
+    .await;
 
     for backend_id in &outcome.promotable {
         match set_backend_probe_status_with_last_probe(node, backend_id, "healthy", now).await {
@@ -346,6 +457,7 @@ pub fn spawn_backend_prober(
     options: BackendProberOptions,
     health_events_tx: mpsc::Sender<()>,
     cancel: CancellationToken,
+    principal_did: String,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let client = match reqwest::Client::builder()
@@ -369,9 +481,14 @@ pub fn spawn_backend_prober(
                     return;
                 }
                 _ = ticker.tick() => {
-                    let outcome =
-                        run_backend_probe_cycle(node.as_ref(), &client, &health_map, &options)
-                            .await;
+                    let outcome = run_backend_probe_cycle(
+                        node.as_ref(),
+                        &client,
+                        &health_map,
+                        &options,
+                        &principal_did,
+                    )
+                    .await;
                     if !outcome.flipped.is_empty() {
                         let _ = health_events_tx.try_send(());
                     }
@@ -389,6 +506,9 @@ mod tests {
     use super::*;
     use crate::backend_registry::DEFAULT_MAX_QUEUE_DEPTH;
     use crate::lean_vocab_test::lean_backend_health_cases;
+    use crate::oauth_credential::test_support::{
+        seed_credential, seed_credential_with_refresh_token, test_node,
+    };
 
     fn state_from_lean(name: &str, state: &str) -> BackendHealthState {
         match state {
@@ -548,7 +668,8 @@ mod tests {
         let endpoint = listener.endpoint();
         let backends = vec![backend("spark", endpoint.clone(), "healthy")];
         let now = Utc::now();
-        let outcome = probe_backends_cycle(&client, &backends, now, &health_map, &options).await;
+        let outcome =
+            probe_backends_cycle(&client, &backends, now, &health_map, &options, None).await;
         assert!(outcome.flipped.is_empty());
         let snap = health_map.get("spark").await.expect("entry after probe");
         assert_eq!(snap.state, BackendHealthState::Healthy);
@@ -561,7 +682,8 @@ mod tests {
         for cycle in 1..=3u32 {
             let cycle_now = Utc::now();
             let outcome =
-                probe_backends_cycle(&client, &backends, cycle_now, &health_map, &options).await;
+                probe_backends_cycle(&client, &backends, cycle_now, &health_map, &options, None)
+                    .await;
             let snap = health_map.get("spark").await.expect("entry");
             assert_eq!(snap.failure_count, cycle, "consecutive failures accumulate");
             assert_eq!(
@@ -584,7 +706,7 @@ mod tests {
         let recovered = ModelsListener::start();
         let backends = vec![backend("spark", recovered.endpoint(), "healthy")];
         let outcome =
-            probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options).await;
+            probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options, None).await;
         assert_eq!(
             outcome.flipped,
             vec!["spark".to_string()],
@@ -606,13 +728,13 @@ mod tests {
 
         let backends = vec![backend("late-arrival", listener.endpoint(), "unknown")];
         let outcome =
-            probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options).await;
+            probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options, None).await;
         assert_eq!(outcome.promotable, vec!["late-arrival".to_string()]);
 
         // Already-promoted docs are not re-written.
         let backends = vec![backend("late-arrival", listener.endpoint(), "healthy")];
         let outcome =
-            probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options).await;
+            probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options, None).await;
         assert!(outcome.promotable.is_empty());
     }
 
@@ -627,10 +749,227 @@ mod tests {
         let mut codex = backend("codex", "http://127.0.0.1:1/v1".to_string(), "healthy");
         codex.provider_kind = crate::backend_provider::BackendProviderKind::ChatGptCodex;
         let outcome =
-            probe_backends_cycle(&client, &[codex], Utc::now(), &health_map, &options).await;
+            probe_backends_cycle(&client, &[codex], Utc::now(), &health_map, &options, None).await;
         assert!(outcome.flipped.is_empty());
         assert!(health_map.get("codex").await.is_none(), "no measured entry");
         assert!(!health_map.measured_blocks_routing("codex").await);
+    }
+
+    fn claude_backend() -> InferenceBackend {
+        let mut claude = backend(
+            "claude",
+            crate::claude_subscription::DEFAULT_BACKEND_ENDPOINT.to_string(),
+            "healthy",
+        );
+        claude.provider_kind = crate::backend_provider::BackendProviderKind::ClaudeCliSubscription;
+        claude
+    }
+
+    fn oauth_backend(
+        kind: crate::backend_provider::BackendProviderKind,
+        id: &str,
+        endpoint: &str,
+    ) -> InferenceBackend {
+        let mut backend = backend(id, endpoint.to_string(), "healthy");
+        backend.provider_kind = kind;
+        backend
+    }
+
+    #[tokio::test]
+    async fn oauth_kinds_probe_the_credential_document_fresh_is_healthy_and_promotes() {
+        let node = test_node().await;
+        let did = "did:key:z6MkProbe";
+        seed_credential(
+            &node,
+            did,
+            crate::claude_oauth::CLAUDE_OAUTH_PROVIDER,
+            Utc::now() + chrono::Duration::hours(8),
+        )
+        .await;
+        let (options, client, health_map) = (
+            probe_options(),
+            reqwest::Client::new(),
+            BackendHealthMap::new(),
+        );
+        let mut claude = claude_backend();
+        claude.probe_status = "unknown".to_string();
+        let outcome = probe_backends_cycle(
+            &client,
+            &[claude],
+            Utc::now(),
+            &health_map,
+            &options,
+            Some(OAuthProbeContext {
+                node: &node,
+                principal_did: did,
+            }),
+        )
+        .await;
+        assert_eq!(outcome.promotable, vec!["claude".to_string()]);
+        let snap = health_map.get("claude").await.expect("entry");
+        assert_eq!(snap.state, BackendHealthState::Healthy);
+        assert!(snap.last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn oauth_kinds_stale_credential_with_refresh_token_stays_healthy_and_promotes() {
+        let node = test_node().await;
+        let did = "did:key:z6MkProbe";
+        seed_credential(
+            &node,
+            did,
+            crate::xai_grok_oauth::XAI_OAUTH_PROVIDER,
+            Utc::now() - chrono::Duration::minutes(1),
+        )
+        .await;
+        let (options, client, health_map) = (
+            probe_options(),
+            reqwest::Client::new(),
+            BackendHealthMap::new(),
+        );
+        let mut grok = oauth_backend(
+            crate::backend_provider::BackendProviderKind::XaiGrokOAuth,
+            "grok",
+            "https://cli-chat-proxy.grok.com/v1",
+        );
+        grok.probe_status = "unknown".to_string();
+        for _ in 0..3 {
+            let outcome = probe_backends_cycle(
+                &client,
+                std::slice::from_ref(&grok),
+                Utc::now(),
+                &health_map,
+                &options,
+                Some(OAuthProbeContext {
+                    node: &node,
+                    principal_did: did,
+                }),
+            )
+            .await;
+            assert!(outcome.flipped.is_empty());
+            assert_eq!(outcome.promotable, vec!["grok".to_string()]);
+            let snap = health_map.get("grok").await.expect("entry");
+            assert_eq!(snap.state, BackendHealthState::Healthy);
+            assert_eq!(snap.failure_count, 0);
+            assert!(snap.last_error.is_none(), "{:?}", snap.last_error);
+        }
+        assert!(health_map.vetoed_backend_ids().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn oauth_kinds_stale_credential_without_refresh_token_still_demotes_after_k() {
+        let node = test_node().await;
+        let did = "did:key:z6MkProbe";
+        seed_credential_with_refresh_token(
+            &node,
+            did,
+            crate::xai_grok_oauth::XAI_OAUTH_PROVIDER,
+            Utc::now() - chrono::Duration::minutes(1),
+            "",
+        )
+        .await;
+        let (options, client, health_map) = (
+            probe_options(),
+            reqwest::Client::new(),
+            BackendHealthMap::new(),
+        );
+        let grok = oauth_backend(
+            crate::backend_provider::BackendProviderKind::XaiGrokOAuth,
+            "grok",
+            "https://cli-chat-proxy.grok.com/v1",
+        );
+        for cycle in 1..=3u32 {
+            let outcome = probe_backends_cycle(
+                &client,
+                std::slice::from_ref(&grok),
+                Utc::now(),
+                &health_map,
+                &options,
+                Some(OAuthProbeContext {
+                    node: &node,
+                    principal_did: did,
+                }),
+            )
+            .await;
+            assert!(outcome.promotable.is_empty());
+            let snap = health_map.get("grok").await.expect("entry");
+            assert_eq!(snap.failure_count, cycle);
+            let err = snap.last_error.clone().unwrap_or_default();
+            assert!(err.contains("missing refresh_token"), "{err}");
+            if cycle == 3 {
+                assert_eq!(snap.state, BackendHealthState::Unhealthy);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn oauth_kinds_missing_credential_fails_with_login_hint() {
+        let node = test_node().await;
+        let (options, client, health_map) = (
+            probe_options(),
+            reqwest::Client::new(),
+            BackendHealthMap::new(),
+        );
+        let codex = oauth_backend(
+            crate::backend_provider::BackendProviderKind::ChatGptCodex,
+            "codex",
+            "https://chatgpt.com/backend-api/codex",
+        );
+        probe_backends_cycle(
+            &client,
+            &[codex],
+            Utc::now(),
+            &health_map,
+            &options,
+            Some(OAuthProbeContext {
+                node: &node,
+                principal_did: "did:key:z6MkNobody",
+            }),
+        )
+        .await;
+        let snap = health_map.get("codex").await.expect("entry");
+        assert_eq!(snap.state, BackendHealthState::Degraded);
+        assert!(snap
+            .last_error
+            .clone()
+            .unwrap_or_default()
+            .contains("gents codex-login --agent-did did:key:z6MkNobody"));
+    }
+
+    #[tokio::test]
+    async fn oauth_kinds_are_skipped_without_a_probe_context() {
+        let (options, client, health_map) = (
+            probe_options(),
+            reqwest::Client::new(),
+            BackendHealthMap::new(),
+        );
+        let outcome = probe_backends_cycle(
+            &client,
+            &[claude_backend()],
+            Utc::now(),
+            &health_map,
+            &options,
+            None,
+        )
+        .await;
+        assert!(outcome.promotable.is_empty());
+        assert!(
+            health_map.get("claude").await.is_none(),
+            "no measurement without a node"
+        );
+    }
+
+    #[test]
+    fn provider_kind_oauth_provider_names() {
+        use crate::backend_provider::BackendProviderKind as K;
+        assert_eq!(
+            K::ClaudeCliSubscription.oauth_provider(),
+            Some("claude-subscription")
+        );
+        assert_eq!(K::XaiGrokOAuth.oauth_provider(), Some("xai-oauth"));
+        assert_eq!(K::ChatGptCodex.oauth_provider(), Some("chatgpt-codex"));
+        assert_eq!(K::OpenAiCompatible.oauth_provider(), None);
+        assert!(K::ClaudeCliSubscription.is_agent_scoped_oauth());
     }
 
     #[tokio::test]
@@ -644,7 +983,7 @@ mod tests {
 
         let listener = ModelsListener::start();
         let backends = vec![backend("current", listener.endpoint(), "healthy")];
-        probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options).await;
+        probe_backends_cycle(&client, &backends, Utc::now(), &health_map, &options, None).await;
 
         assert!(health_map.get("retired").await.is_none());
         assert!(health_map.get("current").await.is_some());

--- a/crates/gents/src/oauth_credential.rs
+++ b/crates/gents/src/oauth_credential.rs
@@ -18,6 +18,11 @@ use tokio::sync::Mutex;
 
 const OAUTH_CREDENTIAL_FIELDS: &str = "_docID credential_id agent_did provider access_token refresh_token id_token account_id chatgpt_plan_type is_fedramp access_token_expires_at last_refresh enabled";
 const REFRESH_SKEW: Duration = Duration::minutes(5);
+/// After a failed refresh the bearer serves that failure again for this long
+/// instead of POSTing the provider's token endpoint on every request. A
+/// re-login is still picked up at once: the database is re-read before the
+/// cooldown is consulted.
+const REFRESH_FAILURE_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Product copy used when classifying auth failures for operators.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -549,7 +554,9 @@ pub struct DbCredentialBearer {
     credential_id: String,
     http: reqwest::Client,
     cache: Mutex<Option<OAuthCredential>>,
-    refresh_lock: Mutex<()>,
+    /// Single-flight refresh lock. It also holds the last refresh failure, so
+    /// the cooldown check and the refresh share one critical section.
+    refresh_lock: Mutex<Option<(std::time::Instant, OAuthAuthProblem)>>,
     is_owner: bool,
     force_refresh: AtomicBool,
     refresh_kind: OAuthRefreshKind,
@@ -596,7 +603,7 @@ impl DbCredentialBearer {
             credential_id: credential_id.into(),
             http: reqwest::Client::new(),
             cache: Mutex::new(cache_seed),
-            refresh_lock: Mutex::new(()),
+            refresh_lock: Mutex::new(None),
             is_owner,
             force_refresh: AtomicBool::new(false),
             refresh_kind,
@@ -696,7 +703,7 @@ impl BearerSource for DbCredentialBearer {
             }
         }
 
-        let _guard = self.refresh_lock.lock().await;
+        let mut last_failure = self.refresh_lock.lock().await;
 
         let forced = self.force_refresh.load(Ordering::SeqCst);
 
@@ -734,10 +741,23 @@ impl BearerSource for DbCredentialBearer {
             }
         }
 
-        let refreshed = self
-            .refresh_tokens(&credential.refresh_token)
-            .await
-            .map_err(|problem| self.auth_error(&problem))?;
+        if let Some((failed_at, problem)) = last_failure.as_ref() {
+            if failed_at.elapsed() < REFRESH_FAILURE_COOLDOWN {
+                self.force_refresh.store(false, Ordering::SeqCst);
+                return Err(self.auth_error(problem));
+            }
+        }
+
+        let refreshed = match self.refresh_tokens(&credential.refresh_token).await {
+            Ok(refreshed) => refreshed,
+            Err(problem) => {
+                let error = self.auth_error(&problem);
+                *last_failure = Some((std::time::Instant::now(), problem));
+                self.force_refresh.store(false, Ordering::SeqCst);
+                return Err(error);
+            }
+        };
+        *last_failure = None;
         apply_refreshed_tokens(&mut credential, refreshed);
 
         self.cache_credential(&credential).await;
@@ -957,6 +977,51 @@ mod tests {
             "tier gate should not push re-login as the fix: {msg}"
         );
         assert!(msg.contains("api.x.ai"), "{msg}");
+    }
+}
+
+#[cfg(test)]
+mod cooldown_tests {
+    use super::test_support::{one_shot_token_server, seed_credential, test_node};
+    use super::*;
+
+    /// A failed refresh is served from the cooldown on the next call instead
+    /// of POSTing the token endpoint again. The one-shot server accepts one
+    /// request and is gone before the second call, so a second POST would
+    /// surface as a transport error rather than the cached "expired or
+    /// revoked" text.
+    #[tokio::test]
+    async fn failed_refresh_is_not_retried_during_the_cooldown() {
+        let node = Arc::new(test_node().await);
+        let did = "did:key:z6MkRevoked";
+        let provider = crate::xai_grok_oauth::XAI_OAUTH_PROVIDER;
+        seed_credential(&node, did, provider, Utc::now() - Duration::minutes(1)).await;
+        let (url, handle) = one_shot_token_server(401, r#"{"error":"invalid_grant"}"#).await;
+        // Process-global; no other lib test refreshes an xAI credential.
+        std::env::set_var(
+            crate::xai_oauth_refresh::XAI_OAUTH_TOKEN_URL_OVERRIDE_ENV,
+            &url,
+        );
+        let bearer = DbCredentialBearer::new(
+            node,
+            did,
+            provider,
+            oauth_credential_id(did, provider),
+            true,
+            OAuthRefreshKind::Xai,
+            XAI_OAUTH_PRODUCT,
+        );
+        let first = bearer.current_bearer().await.expect_err("revoked");
+        let request = handle.await.expect("server");
+        let second = bearer.current_bearer().await.expect_err("cooldown");
+        std::env::remove_var(crate::xai_oauth_refresh::XAI_OAUTH_TOKEN_URL_OVERRIDE_ENV);
+
+        assert!(request.contains("grant_type=refresh_token"), "{request}");
+        assert!(
+            first.to_string().contains("is expired or revoked"),
+            "{first}"
+        );
+        assert_eq!(first.to_string(), second.to_string());
     }
 }
 

--- a/crates/gents/src/oauth_credential.rs
+++ b/crates/gents/src/oauth_credential.rs
@@ -19,9 +19,10 @@ use tokio::sync::Mutex;
 const OAUTH_CREDENTIAL_FIELDS: &str = "_docID credential_id agent_did provider access_token refresh_token id_token account_id chatgpt_plan_type is_fedramp access_token_expires_at last_refresh enabled";
 const REFRESH_SKEW: Duration = Duration::minutes(5);
 /// After a failed refresh the bearer serves that failure again for this long
-/// instead of POSTing the provider's token endpoint on every request. A
-/// re-login is still picked up at once: the database is re-read before the
-/// cooldown is consulted.
+/// instead of POSTing the provider's token endpoint on every request. While
+/// the cooldown holds every call returns the classified error: no provider
+/// round-trip and no fast-path token. A re-login is picked up once the
+/// cooldown lapses, because the forced slow path re-reads the document first.
 const REFRESH_FAILURE_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Product copy used when classifying auth failures for operators.
@@ -743,7 +744,6 @@ impl BearerSource for DbCredentialBearer {
 
         if let Some((failed_at, problem)) = last_failure.as_ref() {
             if failed_at.elapsed() < REFRESH_FAILURE_COOLDOWN {
-                self.force_refresh.store(false, Ordering::SeqCst);
                 return Err(self.auth_error(problem));
             }
         }
@@ -753,7 +753,6 @@ impl BearerSource for DbCredentialBearer {
             Err(problem) => {
                 let error = self.auth_error(&problem);
                 *last_failure = Some((std::time::Instant::now(), problem));
-                self.force_refresh.store(false, Ordering::SeqCst);
                 return Err(error);
             }
         };
@@ -1017,6 +1016,46 @@ mod cooldown_tests {
         std::env::remove_var(crate::xai_oauth_refresh::XAI_OAUTH_TOKEN_URL_OVERRIDE_ENV);
 
         assert!(request.contains("grant_type=refresh_token"), "{request}");
+        assert!(
+            first.to_string().contains("is expired or revoked"),
+            "{first}"
+        );
+        assert_eq!(first.to_string(), second.to_string());
+    }
+
+    /// After `invalidate()` (a provider 401) a failed refresh must keep the
+    /// bearer forced: while the cooldown holds every call returns the
+    /// classified error instead of taking the cache fast path and re-serving
+    /// the unexpired but rejected access token.
+    #[tokio::test]
+    async fn failed_refresh_keeps_the_bearer_forced_and_never_reserves_the_bad_token() {
+        let node = Arc::new(test_node().await);
+        let did = "did:key:z6MkRejected";
+        let provider = crate::chatgpt_codex::CHATGPT_CODEX_PROVIDER;
+        seed_credential(&node, did, provider, Utc::now() + Duration::hours(1)).await;
+        let (url, handle) = one_shot_token_server(401, r#"{"error":"invalid_grant"}"#).await;
+        // Process-global; no other lib test refreshes a ChatGPT credential.
+        std::env::set_var(
+            gents_protocol::chatgpt_oauth::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR,
+            &url,
+        );
+        let bearer = DbCredentialBearer::new(
+            node,
+            did,
+            provider,
+            oauth_credential_id(did, provider),
+            true,
+            OAuthRefreshKind::ChatGpt,
+            CHATGPT_OAUTH_PRODUCT,
+        );
+        bearer.invalidate().await;
+        let first = bearer.current_bearer().await;
+        handle.await.expect("server");
+        let second = bearer.current_bearer().await;
+        std::env::remove_var(gents_protocol::chatgpt_oauth::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR);
+
+        let first = first.expect_err("rejected refresh");
+        let second = second.expect_err("cooldown must not re-serve the rejected token");
         assert!(
             first.to_string().contains("is expired or revoked"),
             "{first}"


### PR DESCRIPTION
Supersedes #1389 (same content; re-opened from a `gents-ai/gents` branch so GitHub's native stacked-PR view applies).

## Summary

Puts Claude on the same credential model Codex and Grok use, and gives all three a health probe.

- `gents claude-login` (new workspace crate `gents-claude-login`): PKCE loopback with `--manual` paste and `--no-browser`
  fallbacks; writes an agent-scoped `OAuthCredential` (`provider = claude-subscription`,
  `credential_id = claude-subscription:<agent_did>`). The `claude` binary is not involved anywhere.
- `--backend-preset claude-cli-subscription` for `gents init` / `gents config backend set`.
- Credential-expiry health probe for agent-scoped OAuth kinds, a 60 s refresh-failure cooldown on the shared bearer,
  `checks.claude_auth` in `gents diagnose`, and a `CredentialsRequired` runnability gate.

Commits (stacked on PR1):

| commit | what |
|---|---|
| 4a08ba8b | `gents-claude-login` crate, `gents claude-login`, preset variant, CLI arg test |
| 420e83a6 | credential-expiry probe for agent-scoped OAuth kinds; stale-but-refreshable stays routable; 60 s cooldown; startup threads the principal DID into the prober |
| cf16d1ab | `checks.claude_auth` diagnose + gate; runnability gate in main's `CredentialsRequired` shape; preset validation |
| cd939e0a | Lean doc comments: credential, not seat |
| c678e2f5 | fix: a failed refresh keeps the bearer forced; the cooldown returns the classified error, never the stale token (all three kinds) |
| 0cecb1a1 | review minors: diagnose early return carries the `note` key; Lean wording |
| fed2d559 | ci: register `gents-claude-login` in the support suite (package-coverage guard) |

## Notes

This PR changes shared behaviour for Codex and Grok.

- **Health probe now covers agent-scoped OAuth kinds.** On `main` the prober skips them (`backend_health.rs:234`,
  `continue`). Now `ChatGptCodex`, `XaiGrokOAuth` and `ClaudeCliSubscription` are probed by reading their credential document:
  an enabled credential with a refresh token counts healthy even when the access token is stale (it refreshes on next use;
  "Option A"); a missing or disabled credential is a `ProbeFail` and demotes after K failures, with a login hint. The probe
  never refreshes and never calls the provider. Net effect: Codex/Grok backends gain a health signal they did not have, and a
  Codex/Grok backend with no credential now demotes where it previously stayed unprobed.
- **Refresh-failure cooldown, all three kinds.** After a failed refresh the bearer returns the classified error for 60 s
  without another token-endpoint POST (`REFRESH_FAILURE_COOLDOWN`). c678e2f5 keeps the bearer *forced* through the failure and
  the cooldown so it never re-serves the rejected, clock-fresh token; the RED-first test
  `failed_refresh_keeps_the_bearer_forced_and_never_reserves_the_bad_token` returned the bad token before the fix.
- **Runnability gate is Claude-only.** A behavior whose backend is `ClaudeCliSubscription` with no enabled credential is
  `CredentialsRequired` at startup, in the same error shape main uses. Codex/Grok gates are untouched.
- **Diagnose asymmetry (known, left as is).** `claude_auth` degrades `status` only when no credential can be read;
  `chatgpt_auth` / `xai_auth` still degrade on a stale token while the prober treats all three alike. Follow-up: apply the same
  gate to all three.
- **Containment.** Tokens are redacted on every `Debug` surface (hand-written `Debug` for `ClaudeLoginTokens`); no Keychain;
  the login server is loopback-only; `GENTS_CLAUDE_OAUTH_TOKEN_URL` is a test-only override.
- **Cargo.** One new in-repo workspace member; `Cargo.lock` +2 hunks; zero new external dependencies.
- **Before the discovery PR lands** a Claude backend's `models[]` stays at the single id the preset seeds
  (`claude-sonnet-5`), and `gents config backend discover-models` against it fails with the internal-sounding
  `load_oauth_credential_for_discovery called for non-OAuth provider` (main's loader only knows Codex and Grok; PR 3 adds the
  arm). Acceptable for the PR1+PR2 window, but say so in the merge note if PR 3 does not follow quickly.

## Verification

- Opus review (T3+T4 trees): approved, 0 Critical / 0 Important; the whole-branch review's one Important (the `force_refresh`
  regression) is fixed here (c678e2f5) and re-reviewed Ready.
- Unit: `oauth_credential` cooldown + forced-bearer tests; `backend_health` Option A tests (stale with refresh token stays
  healthy and promotes; stale without refresh token demotes after K); diagnose gate test; `gents-claude-login` 7/7;
  `gents-protocol` 143/143. On this exact tip (2026-09-05 split gate): `cargo check -p gents -p gents-cli -p gents-claude-login` 0; targeted lib tests (oauth_credential, claude_subscription, backend_health) 31/31; gents-cli `diagnose` + `claude_login` tests 9/9; `gents-claude-login` 7/7.
- Live (dev machine, Claude Max seat): login end to end (`login: completed`, expiry +8 h); refresh on the request path after a
  restart with a stale row (`last_refresh` rotated, no 401); disable → diagnose degraded with the login hint, enable → ok;
  login + tool turn again on the final re-ported binary.
- Desktop caveat as in PR 1 (iroh P2P names; CI is the authority).

## Known gaps / follow-ups (not in this PR)

- A **revoked** refresh token never demotes health: only request-path failures see it, each bounded by the cooldown;
  re-login is the fix. Revisit before the retry consumer lands.
- `probe_oauth_credential` has no timeout (the HTTP arm does); the startup probe still skips agent-scoped kinds until the first
  cycle; the loopback login listener has no timeout.
- The three diagnose auth blocks are near-identical; `gents-chatgpt-login` still derives `Debug` over its tokens
  (pre-existing, same class as the one fixed here).
- `gents init` reseeds `models[]` to one on every run.

