### PR TITLE
fix(graph): preserve installed tool execution policy

### DIFF
--- a/crates/gents/src/graph_package/install.rs
+++ b/crates/gents/src/graph_package/install.rs
@@ -374,13 +374,6 @@ fn rewrite_selection(
         Value::String(principal_did.to_owned()),
     );
     object.insert("file_tool_root".to_owned(), Value::Null);
-    if object.get("enable_bash").and_then(Value::as_bool) == Some(true) {
-        object.insert("bash_mode".to_owned(), Value::String("ReadOnly".to_owned()));
-        object.insert(
-            "command_execution_policy".to_owned(),
-            Value::String("read_only".to_owned()),
-        );
-    }
     object.insert(
         "command_network_mode".to_owned(),
         Value::String("disabled".to_owned()),
@@ -1105,6 +1098,14 @@ mod tests {
             4,
             "active package datastore tool surfaces must be visible"
         );
+        let tool_root = tempfile::tempdir().unwrap();
+        let ceiling = crate::tool_surface::ToolCeiling::readwrite(tool_root.path());
+        let surfaces = active_view
+            .datastore_tool_surfaces
+            .values()
+            .map(|record| record.value.clone())
+            .collect::<Vec<_>>();
+        let mut artifact_selections = 0;
         for selection in active_view
             .tool_selections
             .values()
@@ -1120,7 +1121,36 @@ mod tests {
                 "package ToolSelection {} must retain its surface links",
                 selection.value.selection_id
             );
+            let config = crate::tool_surface::BehaviorToolConfig::from_tool_selection_document_with_surfaces(
+                &selection.value.selection_id,
+                &selection.value,
+                &surfaces,
+                &[],
+                &ceiling,
+                Vec::new(),
+            )
+            .unwrap();
+            if config.static_policy().bash.execution_mode
+                == crate::toolset::CommandExecutionMode::ArtifactWrite
+            {
+                artifact_selections += 1;
+                assert!(config
+                    .host_tools()
+                    .is_backgroundable_tool_name("bash_unrestricted"));
+                assert_eq!(
+                    config.static_policy().file,
+                    crate::tool_surface::FileToolMode::ReadOnly
+                );
+                assert_eq!(
+                    config.static_policy().bash.network_mode,
+                    crate::toolset::CommandNetworkMode::Disabled
+                );
+            }
         }
+        assert_eq!(
+            artifact_selections, 1,
+            "installed verifier must retain its artifact policy"
+        );
         let run = start_graph_run(
             &node,
             None,


### PR DESCRIPTION
The bundled code-review verifier could not become ready: package installation replaced its declared `Unrestricted` / `artifact_write` configuration with `ReadOnly` / `read_only`, while retaining `bash_unrestricted` in its background tool list. The real runtime builder then rejected the installed selection.

Remove the installer’s duplicate bash-policy override. Bundled configuration now reaches the existing runtime host-ceiling meet and per-request artifact-grant owner intact. Root removal, disabled networking, identity remapping, and selection validation are retained. No new policy, ACL, or transaction mechanism is introduced. Production change: seven lines deleted.

The existing installed-package regression now resolves persisted, activated selections through `BehaviorToolConfig` with their real datastore surfaces. It reproduced the exact live readiness rejection before the fix and passes after it, verifying one artifact verifier with read-only file tools, disabled networking, and its registered background tool. Existing artifact/ceiling conformance tests retain authority coverage; this configuration plumbing correction changes no formal transition or policy rule.

Closes #1407. Refs #1358 and #1298. Based on #1406 in native stack #1381.

Validated from integrated tip `98f1bccbfb14ff2f6f6700d2d01839e6b751463f`, based on main `1da8b9293cf6daeeb95e4b8f0b0a9032f8a652e2`:

- `cargo test -p gents`: 2,831 passed, zero failed, five ignored; workspace all-target check and Lean build (1,061 jobs) passed.
- CLI graph 3, CLI Goal 2, desktop Goal 1, offline artifact compiler 2, real GLM compiler 1, and live CLI 3 passed.
- Live graph `315587bb-2553-46c7-b566-8cb540714dd5` succeeded: four areas, four scans, three candidates/verdicts/Cleanup findings, seven completed Goals and seven completed requests. Saved-trace validation confirms all 57 evidence pages for each scanner, exact packet reconstruction, and unchanged source.

Live inference used `http://workstation-2:8000/v1`, `GLM-5.3-Flash-NVFP4`, temperature 1, top-p 0.95, without an API key. Cleanup findings are model judgments, not independent merge approval. Compiler execution is established by the separate compiler checks, not inferred from graph completion. The complete trace was revalidated after harness corrections; runtime results were not altered. Final reruns passed: queue 24, generated R6 consumer 1 (41 cases), Goal controller 41, and package catalog/install 13. Do not merge yet.
