### PR TITLE
fix(goal): honor exhausted budget before failure retries

### DIFF
--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Goal.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Goal.lean
@@ -68,6 +68,30 @@ def goalDecisionCases : List GoalDecisionCase :=
       sessionIdle := true, childExists := false, budgetReached := false, hasActivity := true,
       requestIsWrapup := false, infrastructureRetries := 2,
       wrapupRequested := false, wrapupCompleted := false }
+  , { name := "dead_below_budget_retries", status := .active, terminal := .dead,
+      sessionIdle := true, childExists := false, budgetReached := false, hasActivity := true,
+      requestIsWrapup := false, infrastructureRetries := 0,
+      wrapupRequested := false, wrapupCompleted := false }
+  , { name := "failed_exhausted_requests_wrapup", status := .active, terminal := .failed,
+      sessionIdle := true, childExists := false, budgetReached := true, hasActivity := true,
+      requestIsWrapup := false, infrastructureRetries := 0,
+      wrapupRequested := false, wrapupCompleted := false }
+  , { name := "dead_exhausted_requests_wrapup", status := .active, terminal := .dead,
+      sessionIdle := true, childExists := false, budgetReached := true, hasActivity := true,
+      requestIsWrapup := false, infrastructureRetries := 0,
+      wrapupRequested := false, wrapupCompleted := false }
+  , { name := "exhausted_failure_at_retry_bound_requests_wrapup", status := .active, terminal := .failed,
+      sessionIdle := true, childExists := false, budgetReached := true, hasActivity := true,
+      requestIsWrapup := false, infrastructureRetries := 2,
+      wrapupRequested := false, wrapupCompleted := false }
+  , { name := "exhausted_interrupt_still_pauses", status := .active, terminal := .interrupted,
+      sessionIdle := true, childExists := false, budgetReached := true, hasActivity := true,
+      requestIsWrapup := false, infrastructureRetries := 0,
+      wrapupRequested := false, wrapupCompleted := false }
+  , { name := "exhausted_supersede_still_pauses", status := .active, terminal := .superseded,
+      sessionIdle := true, childExists := false, budgetReached := true, hasActivity := true,
+      requestIsWrapup := false, infrastructureRetries := 0,
+      wrapupRequested := false, wrapupCompleted := false }
   , { name := "no_activity_pauses", status := .active, terminal := .completed,
       sessionIdle := true, childExists := false, budgetReached := false, hasActivity := false,
       requestIsWrapup := false, infrastructureRetries := 0,

--- a/crates/gents/proofs/Proofs/Goals.lean
+++ b/crates/gents/proofs/Proofs/Goals.lean
@@ -211,7 +211,9 @@ def decide
   | .active =>
       match terminal with
       | .interrupted | .superseded => .pause
-      | .failed | .dead => if infrastructureRetries < 2 then .retry else .pause
+      | .failed | .dead =>
+          if budgetReached then .wrapup
+          else if infrastructureRetries < 2 then .retry else .pause
       | .completed =>
           if !hasActivity then .pause
           else if budgetReached then .wrapup else .continue
@@ -223,6 +225,21 @@ def decide
       | .failed | .dead | .interrupted | .superseded =>
           if infrastructureRetries < 2 then .retry else .abandonWrapup
   | .paused | .blocked | .usageLimited | .complete => .none
+
+-- Exhaustion prevents another ordinary recovery attempt. Budget-limited
+-- wrap-up retries remain governed by their existing, separate bounded rule.
+theorem exhausted_active_never_retries
+    (terminal : RequestTerminal) (idle child activity wrapup : Bool)
+    (retries : Nat) (requested completed : Bool) :
+    decide .active terminal idle child true activity wrapup retries requested completed ≠ .retry := by
+  cases terminal <;> cases idle <;> cases child <;> cases activity <;> simp [decide]
+
+theorem exhausted_failure_requests_wrapup
+    (terminal : RequestTerminal) (activity wrapup : Bool)
+    (retries : Nat) (requested completed : Bool)
+    (hfailure : terminal = .failed ∨ terminal = .dead) :
+    decide .active terminal true false true activity wrapup retries requested completed = .wrapup := by
+  rcases hfailure with rfl | rfl <;> simp [decide]
 
 theorem busy_session_never_continues
     (status : Status) (terminal : RequestTerminal) (child budget activity wrapup : Bool)

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -1113,6 +1113,13 @@ operational diagnostics, TLA+ specs, or platform-specific tests.
 
 ### Goal resume and continuation publication
 
+`Goals.decide` checks the observed budget before retrying a failed or dead
+request. Exhausted active Goals enter the existing budget-limited wrap-up path;
+interruption still pauses and wrap-up retries retain their existing bound.
+The 24 generated decision cases fence the runtime decision function, and the
+GoalSource database regression checks persisted usage and wrap-up publication.
+This is a between-request budget rule, not an in-request token cap.
+
 `GoalAutomation/OperatorResume.lean` composes the existing Goal resume action
 with one signed child publication. Eleven generated cases exercise real
 transactions, including discard and recovery of an existing receipt after

--- a/crates/gents/src/goal.rs
+++ b/crates/gents/src/goal.rs
@@ -416,7 +416,9 @@ pub fn decide_goal_continuation(
                 GoalDecision::Pause
             }
             GoalRequestTerminal::Failed | GoalRequestTerminal::Dead => {
-                if infrastructure_retries.max(0) < MAX_INFRASTRUCTURE_RETRIES {
+                if budget_reached {
+                    GoalDecision::Wrapup
+                } else if infrastructure_retries.max(0) < MAX_INFRASTRUCTURE_RETRIES {
                     GoalDecision::Retry
                 } else {
                     GoalDecision::Pause

--- a/crates/gents/tests/conformance/goals.rs
+++ b/crates/gents/tests/conformance/goals.rs
@@ -31,7 +31,7 @@ fn rust_goal_status_vocabulary_and_machine_match_lean_contract() {
 #[test]
 fn generated_goal_decision_cases_fence_runtime_controller() {
     let cases = lean_goal_decision_cases();
-    assert_eq!(cases.len(), 18, "the durable-goal decision matrix drifted");
+    assert_eq!(cases.len(), 24, "the durable-goal decision matrix drifted");
     for case in cases {
         let status = GoalStatus::parse(&case.status)
             .unwrap_or_else(|| panic!("unknown status in Lean case {}", case.name));

--- a/crates/gents/tests/misc/goal_controller.rs
+++ b/crates/gents/tests/misc/goal_controller.rs
@@ -1203,6 +1203,114 @@ async fn interrupted_terminal_pauses_instead_of_self_continuing() {
 }
 
 #[tokio::test]
+async fn exhausted_budget_after_failed_or_dead_request_materializes_wrapup_not_retry() {
+    for terminal in ["failed", "dead"] {
+        let db = test_db(&format!("goal-budget-after-{terminal}")).await;
+        let parent = "parent-over-budget";
+        create_request_for_agent_with_signed_fields(
+            db.node.as_ref(),
+            db.node_identity.did(),
+            parent,
+            SESSION,
+            terminal,
+            "2026-07-15T00:00:00Z",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        let usage = format!(
+            r#"mutation {{ add_InferenceCall(input: {{
+                call_id: "over-budget-failed-call",
+                request_id: "{parent}",
+                agent_did: "{}",
+                call_seq: 1,
+                attempt: 1,
+                call_state: "failed",
+                failure_reason: "provider stream interrupted after reporting usage",
+                prompt_tokens: 100,
+                completion_tokens: 5
+            }}) {{ _docID }} }}"#,
+            gents::graphql::escape_graphql_string(db.node_identity.did()),
+        );
+        let response = db.node.execute(&usage).await;
+        assert!(!response.has_errors(), "seed usage: {:?}", response.errors);
+        assert_eq!(
+            session_token_usage(db.node.as_ref(), db.node_identity.did(), SESSION)
+                .await
+                .unwrap(),
+            105,
+        );
+        set_goal(
+            db.node.as_ref(),
+            db.node_identity.did(),
+            SESSION,
+            Some("Respect the budget even when execution fails"),
+            Some(GoalStatus::Active),
+            Some(Some(10)),
+        )
+        .await
+        .unwrap();
+
+        let (mut source, _snapshot_tx) = source(&db);
+        tokio::time::timeout(Duration::from_secs(2), source.next_fire())
+            .await
+            .expect("goal source timed out")
+            .expect("wrapup intent");
+        let goal = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            goal.parsed_status(),
+            Some(GoalStatus::BudgetLimited),
+            "{terminal}"
+        );
+        assert_eq!(goal.tokens_used, Some(105), "{terminal}");
+        assert_eq!(goal.wrapup_requested, Some(true), "{terminal}");
+        assert!(!goal.wrapup_completed.unwrap_or(false), "{terminal}");
+        assert_eq!(
+            goal.infrastructure_retry_count.unwrap_or_default(),
+            0,
+            "{terminal}"
+        );
+        let children = goal_children(&db).await;
+        assert_eq!(children.len(), 1, "{terminal}");
+        assert_eq!(
+            children[0].caused_by_parent_request_id.as_deref(),
+            Some(parent)
+        );
+        let metadata: serde_json::Value =
+            serde_json::from_str(children[0].metadata.as_deref().unwrap()).unwrap();
+        assert_eq!(metadata["goal"]["wrapup"], true, "{terminal}");
+
+        // A restart while this wrapup is pending must not publish another child
+        // or charge an ordinary infrastructure retry for the failed parent.
+        drop(source);
+        let (mut restarted, _restart_tx) = self::source(&db);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), restarted.next_fire())
+                .await
+                .is_err(),
+            "{terminal}: duplicate continuation"
+        );
+        let current = load_canonical_goal(db.node.as_ref(), db.node_identity.did(), SESSION)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(current.parsed_status(), Some(GoalStatus::BudgetLimited));
+        assert_eq!(current.tokens_used, Some(105));
+        assert_eq!(current.continuation_sequence, goal.continuation_sequence);
+        assert_eq!(current.infrastructure_retry_count.unwrap_or_default(), 0);
+        let persisted = goal_children(&db).await;
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].doc_id, children[0].doc_id);
+        drop(restarted);
+    }
+}
+
+#[tokio::test]
 async fn token_budget_materializes_one_wrapup_and_never_repeats_it() {
     let db = test_db("goal-budget-wrapup").await;
     seed_completed_request(&db, "parent-budget").await;


### PR DESCRIPTION
An exhausted durable Goal could start an ordinary retry after its physical request failed or died. The decision ignored `budget_reached` in that branch even though GoalSource had refreshed usage. Live code-review run `3133d737-fa53-477d-b155-ba4ef8e1a8be` demonstrated 2,536,410 tokens against a 250,000 budget followed by an Active retry.

Check exhaustion before the existing failure-retry rule and enter the existing BudgetLimited wrap-up path. Interrupted and superseded requests still pause; existing wrap-up retry bounds remain unchanged. No new budget ledger, terminal owner, or transaction mechanism is introduced.

Lean models the change first, with two safety theorems and six added decision cases (24 total). The generated runtime consumer failed with Retry vs Wrapup before the Rust change and passes afterward. A real GoalSource test uses persisted InferenceCall usage and both Failed/Dead predecessors, verifying one wrap-up child, no ordinary retry charge, and restart idempotency.

Closes #1409. Refs #1298 and #1396. Based on #1408 in native stack #1381.

This is a between-request budget rule, not a hard aggregate cap within an already-running physical request.

Validated from integrated tip `98f1bccbfb14ff2f6f6700d2d01839e6b751463f`, based on main `1da8b9293cf6daeeb95e4b8f0b0a9032f8a652e2`:

- `cargo test -p gents`: 2,831 passed, zero failed, five ignored; workspace all-target check and Lean build (1,061 jobs) passed.
- CLI graph 3, CLI Goal 2, desktop Goal 1, offline artifact compiler 2, real GLM compiler 1, and live CLI 3 passed.
- Live graph `315587bb-2553-46c7-b566-8cb540714dd5` succeeded: four areas, four scans, three candidates/verdicts/Cleanup findings, seven completed Goals and seven completed requests. Saved-trace validation confirms all 57 evidence pages for each scanner, exact packet reconstruction, and unchanged source.

Live inference used `http://workstation-2:8000/v1`, `GLM-5.3-Flash-NVFP4`, temperature 1, top-p 0.95, without an API key. Cleanup findings are model judgments, not independent merge approval. Compiler execution is established by the separate compiler checks, not inferred from graph completion. The complete trace was revalidated after harness corrections; runtime results were not altered. Final reruns passed: queue 24, generated R6 consumer 1 (41 cases), Goal controller 41, and package catalog/install 13. Do not merge yet.
