### PR TITLE
fix: restore mobile pairing and conversation recovery for v0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1036,6 +1036,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2056,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2117,7 +2139,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -2244,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -2395,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2410,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "anyhow",
@@ -2475,7 +2497,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2500,12 +2522,13 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "async-stream",
  "async-trait",
  "axum",
+ "axum-server",
  "base64 0.22.1",
  "cid",
  "crypto",
@@ -2520,6 +2543,7 @@ dependencies = [
  "lens",
  "query",
  "rand 0.8.5",
+ "rustls",
  "schema",
  "serde",
  "serde_json",
@@ -2535,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "anyhow",
@@ -2569,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "async-trait",
@@ -2601,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "serde",
 ]
@@ -2850,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3181,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3443,6 +3467,16 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -4913,7 +4947,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -4924,6 +4958,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "web-time",
 ]
 
 [[package]]
@@ -5627,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "async-channel",
@@ -5748,7 +5783,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6999,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "anyhow",
@@ -7841,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "acp",
  "async-graphql",
@@ -8271,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "p2p",
  "query",
@@ -8730,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "cid",
  "defra-core",
@@ -9565,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10146,7 +10181,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "tracing",
 ]
@@ -12605,7 +12640,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1249,7 +1249,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2117,7 +2117,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "anyhow",
@@ -2475,7 +2475,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "async-stream",
@@ -2535,7 +2535,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "anyhow",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "async-trait",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "serde",
 ]
@@ -2850,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4913,7 +4913,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -5627,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "async-channel",
@@ -5748,7 +5748,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "anyhow",
@@ -7841,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "acp",
  "async-graphql",
@@ -8271,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "p2p",
  "query",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "cid",
  "defra-core",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10146,7 +10146,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "tracing",
 ]
@@ -12605,7 +12605,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=03e1035f364dc0914016e9cf8bde4e4f1a000f06#03e1035f364dc0914016e9cf8bde4e4f1a000f06"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=7a0010be1e1f95b83c042c1a8b96675137c66716#7a0010be1e1f95b83c042c1a8b96675137c66716"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,13 +58,12 @@ bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 clap = { version = "4", features = ["derive", "env"] }
-# DefraDB v0.19.0 replaces the retired storage backends with Regolith and binds
-# gossip fetch obligations to transport-routable origins. Its iterative
-# parent-DAG replay remains required on iOS: a deep collection history otherwise
-# exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+# Current DefraDB includes the multiplexed Iroh protocol: upgrade clients and
+# runtimes together. Keep its iterative parent-DAG replay for deep iOS history
+# and let the database own durable replication and recovery.
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-claude-login = { path = "crates/gents-claude-login" }
@@ -75,12 +74,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -88,9 +87,9 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
-storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ clap = { version = "4", features = ["derive", "env"] }
 # gossip fetch obligations to transport-routable origins. Its iterative
 # parent-DAG replay remains required on iOS: a deep collection history otherwise
 # exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-claude-login = { path = "crates/gents-claude-login" }
@@ -75,12 +75,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -88,9 +88,9 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
-storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "03e1035f364dc0914016e9cf8bde4e4f1a000f06" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
+storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "7a0010be1e1f95b83c042c1a8b96675137c66716" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/apps/gents-desktop/tests/playwright/desktop-fleet-actions.spec.ts
+++ b/apps/gents-desktop/tests/playwright/desktop-fleet-actions.spec.ts
@@ -14,7 +14,9 @@ test.describe("fleet deployment navigation", () => {
     await expect(page.getByTestId("fleet-enrollment-pending")).toContainText(
       "enrollment-request-harness",
     );
-    await expect(page.getByRole("button", { name: "Add Agent", exact: true })).toBeEnabled();
+    await expect(
+      page.getByRole("button", { name: "Add Agent", exact: true }),
+    ).toBeEnabled();
     await page.getByRole("button", { name: "Add Agent", exact: true }).click();
     await expect(page.getByTestId("fleet-add-server-address")).toBeVisible();
     await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toHaveCount(1);

--- a/crates/gents-cli/src/commands/claude_login.rs
+++ b/crates/gents-cli/src/commands/claude_login.rs
@@ -107,7 +107,7 @@ pub(crate) async fn run_claude_login(
         chrono::Utc::now(),
     );
     let mutation = gents::oauth_credential::oauth_credential_upsert_mutation(&credential);
-    let response = access.execute(&mutation).await?;
+    let response = access.write("cli.claude_login.credential", &mutation).await?;
     let doc_id = gents_protocol::graphql::extract_mutation_doc_id(&response, "OAuthCredential")?;
     Ok(ClaudeLoginOutcome { doc_id, credential })
 }

--- a/crates/gents-cli/src/commands/claude_login.rs
+++ b/crates/gents-cli/src/commands/claude_login.rs
@@ -107,7 +107,9 @@ pub(crate) async fn run_claude_login(
         chrono::Utc::now(),
     );
     let mutation = gents::oauth_credential::oauth_credential_upsert_mutation(&credential);
-    let response = access.write("cli.claude_login.credential", &mutation).await?;
+    let response = access
+        .write("cli.claude_login.credential", &mutation)
+        .await?;
     let doc_id = gents_protocol::graphql::extract_mutation_doc_id(&response, "OAuthCredential")?;
     Ok(ClaudeLoginOutcome { doc_id, credential })
 }

--- a/crates/gents-cli/src/commands/grok_shim/projection/messages.rs
+++ b/crates/gents-cli/src/commands/grok_shim/projection/messages.rs
@@ -2518,6 +2518,7 @@ mod tests {
                     return defra_node::QueryResponse {
                         data: None,
                         errors: Vec::new(),
+                        extensions: Default::default(),
                     };
                 }
                 if query.contains("depth: 1") {

--- a/crates/gents-cli/src/config_import/tests.rs
+++ b/crates/gents-cli/src/config_import/tests.rs
@@ -241,7 +241,8 @@ async fn generic_override_recreates_a_tombstoned_tool_selection() -> Result<()> 
     let first_doc_id = tool_selection_doc_id(&access).await?;
 
     access
-        .execute(
+        .write(
+            "test.config_import.delete_tool_selection",
             r#"mutation {
                     delete_ToolSelection(filter: { selection_id: { _eq: "tools-a" } }) { _docID }
                 }"#,

--- a/crates/gents-cli/src/desired_state/tests/live/apply.rs
+++ b/crates/gents-cli/src/desired_state/tests/live/apply.rs
@@ -18,7 +18,8 @@ async fn explicit_null_clears_task_goals_and_tool_goal_capabilities() -> Result<
     let access = ConfigAccess::Local(std::sync::Arc::new(node));
 
     access
-        .execute(
+        .write(
+            "test.desired_state.seed_principal",
             r#"mutation {
                 create_AgentPrincipal(input: {
                     agent_did: "did:test:test",
@@ -130,7 +131,7 @@ async fn all_subagent_fields_persist_and_apply_is_idempotent() -> Result<()> {
         use gents::graphql::escape_graphql_string;
         let did = escape_graphql_string("did:key:test-subagent-idempotency");
         access
-                .execute(&format!(
+                .write("test.desired_state.seed_principal", &format!(
                     r#"mutation {{ create_AgentPrincipal(input: {{ agent_did: "{did}", enabled: true }}) {{ _docID }} }}"#
                 ))
                 .await?;
@@ -327,7 +328,7 @@ async fn behavior_description_and_summary_persist_and_apply_is_idempotent() -> R
         use gents::graphql::escape_graphql_string;
         let did = escape_graphql_string("did:key:test-behavior-desc-idempotency");
         access
-                .execute(&format!(
+                .write("test.desired_state.seed_principal", &format!(
                     r#"mutation {{ create_AgentPrincipal(input: {{ agent_did: "{did}", enabled: true }}) {{ _docID }} }}"#
                 ))
                 .await?;

--- a/crates/gents-cli/src/desired_state/tests/live/prune.rs
+++ b/crates/gents-cli/src/desired_state/tests/live/prune.rs
@@ -146,7 +146,8 @@ async fn prune_spares_backends_referenced_by_other_agents() -> Result<()> {
     apply_live_desired_state(&access, &bundle, &planned).await?;
 
     access
-        .execute(
+        .write(
+            "test.desired_state.seed_backend",
             r#"mutation { create_InferenceBackend(input: {
                     backend_id: "other-agent-backend",
                     name: "other-agent-backend",
@@ -159,7 +160,8 @@ async fn prune_spares_backends_referenced_by_other_agents() -> Result<()> {
         )
         .await?;
     access
-        .execute(
+        .write(
+            "test.desired_state.seed_behavior",
             r#"mutation { create_AgentBehavior(input: {
                     behavior_id: "other-agent-behavior",
                     agent_did: "did:key:some-other-agent",
@@ -169,7 +171,8 @@ async fn prune_spares_backends_referenced_by_other_agents() -> Result<()> {
         )
         .await?;
     access
-        .execute(
+        .write(
+            "test.desired_state.seed_backend",
             r#"mutation { create_InferenceBackend(input: {
                     backend_id: "stale-backend",
                     name: "stale-backend",

--- a/crates/gents-cli/src/http/fleet_slots.rs
+++ b/crates/gents-cli/src/http/fleet_slots.rs
@@ -59,6 +59,7 @@ pub(crate) struct FleetBackendAdmissionCounters {
     pub(crate) configured: bool,
     pub(crate) enabled: bool,
     pub(crate) probe_status: String,
+    /// Last reported semantic readiness, not current peer connectivity.
     pub(crate) accepting_admission: bool,
     pub(crate) running: i64,
     pub(crate) queued: i64,
@@ -406,9 +407,10 @@ fn build_fleet_slot_snapshot(
 /// behaviors currently bound to it — never from `InferenceBackend`'s
 /// `enabled`/`probe_status` (measured health stays unpersisted; see
 /// `backend_health.rs`). A backend accepts once any bound behavior's own
-/// runtime reports it `Ready`; with no such signal it fails closed to
-/// not-accepting, matching every other unconfigured/stale edge in this
-/// snapshot.
+/// runtime reports it `Ready`; with no such signal the projection is
+/// not-accepting. This is last-known capacity information, not an admission
+/// gate or a connectivity probe. The runtime's admission owner and transport
+/// health remain authoritative for live execution and reachability.
 fn backend_admission_from_readiness(
     behaviors: &BTreeMap<String, BehaviorRow>,
     readiness_by_agent: &BTreeMap<String, AgentBehaviorReadinessRow>,

--- a/crates/gents-cli/src/http/healthz.rs
+++ b/crates/gents-cli/src/http/healthz.rs
@@ -408,17 +408,14 @@ mod tests {
     }
 
     #[test]
-    fn healthz_fails_closed_when_readiness_is_stale() {
+    fn healthz_does_not_require_unchanged_readiness_to_be_rewritten() {
         let mut data = healthy_data();
         data.behavior_readiness[0].updated_at = "2026-05-13T11:59:00Z".to_string();
 
         let payload = render_healthz_payload_at(&state(), Some(&data), None, observed_at());
 
-        assert_eq!(
-            payload.get("status").and_then(Value::as_str),
-            Some("unhealthy")
-        );
-        assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(false));
+        assert_eq!(payload.get("status").and_then(Value::as_str), Some("ok"));
+        assert_eq!(payload.get("ok").and_then(Value::as_bool), Some(true));
     }
 
     #[test]

--- a/crates/gents-cli/src/http/prometheus.rs
+++ b/crates/gents-cli/src/http/prometheus.rs
@@ -1468,10 +1468,6 @@ mod tests {
                 snapshot_json: "{}".to_string(),
                 ..metrics_readiness("did:test:metrics")
             }],
-            vec![AgentBehaviorReadinessRow {
-                updated_at: "2026-08-28T23:59:00Z".to_string(),
-                ..metrics_readiness("did:test:metrics")
-            }],
         ] {
             let mut lines = Vec::new();
             push_behavior_readiness_metrics_at(
@@ -1490,6 +1486,28 @@ mod tests {
                 r#"gents_runtime_behavior_readiness_observed{agent_did="did:test:metrics"} 0"#
             ));
         }
+    }
+
+    #[test]
+    fn behavior_readiness_metrics_keep_unchanged_semantic_state_observed() {
+        let mut lines = Vec::new();
+        push_behavior_readiness_metrics_at(
+            &mut lines,
+            "did:test:metrics",
+            &[AgentBehaviorReadinessRow {
+                updated_at: "2026-08-28T23:59:00Z".to_string(),
+                ..metrics_readiness("did:test:metrics")
+            }],
+            readiness_observed_at(),
+        );
+        let rendered = lines.join("\n");
+        assert!(rendered
+            .contains(r#"gents_runtime_runnable_behaviors{agent_did="did:test:metrics"} 1"#));
+        assert!(rendered
+            .contains(r#"gents_runtime_unavailable_behaviors{agent_did="did:test:metrics"} 1"#));
+        assert!(rendered.contains(
+            r#"gents_runtime_behavior_readiness_observed{agent_did="did:test:metrics"} 1"#
+        ));
     }
 
     #[test]

--- a/crates/gents-cli/tests/cli_enrollment.rs
+++ b/crates/gents-cli/tests/cli_enrollment.rs
@@ -3,6 +3,8 @@
 //! `/status` offer, operator approve, two-leg client route — not the
 //! hand-installed replicators used by the live desktop fixture.
 
+#[path = "cli_enrollment/contract.rs"]
+mod contract;
 mod support;
 use support::*;
 
@@ -172,7 +174,7 @@ async fn status_enrollment_from_fresh_desktop_replicates_chat_without_agent_prin
                 "live inference response missing {reply_token}: {runtime_response}"
             );
 
-            wait_for_client_complete_response(&core, &request_id, &reply_token).await?;
+            wait_for_client_complete_response(&core, &session_id, &agent_did, &request_id, &reply_token).await?;
 
             let runtime_principals = graphql_query(
                 &graphql,
@@ -404,24 +406,20 @@ async fn assistant_message_text(graphql: &str, request_id: &str) -> Result<Strin
                 .is_some_and(|role| role == "assistant" || role == "agent")
         })
         .filter_map(|row| {
-            row.get("content")
-                .and_then(Value::as_str)
-                .map(str::to_owned)
+            row.get("content").and_then(Value::as_str).map(|content| {
+                gents_protocol::transcript::present_persisted_message("assistant", content)
+                    .body_markdown
+            })
         })
         .collect::<Vec<_>>()
         .join("\n"))
 }
 
 fn response_visible_text(row: &Value) -> String {
-    [
-        row.get("content")
-            .and_then(Value::as_str)
-            .unwrap_or_default(),
-        row.get("reasoning")
-            .and_then(Value::as_str)
-            .unwrap_or_default(),
-    ]
-    .join("\n")
+    row.get("content")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
 }
 
 async fn wait_for_complete_agent_response(
@@ -506,39 +504,55 @@ async fn wait_for_complete_agent_response(
 
 async fn wait_for_client_complete_response(
     core: &ClientCore,
+    session_id: &str,
+    agent_did: &str,
     request_id: &str,
     token: &str,
 ) -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(60);
     loop {
+        // Match desktop_session_snapshot: transcript rows deliberately do not
+        // live in the global observer. Read the app's bounded, scoped page.
+        core.ensure_session_hydration_started(session_id, agent_did)
+            .await?;
+        core.refresh_local_request(agent_did, request_id).await?;
+        let page = gents_desktop_core::client::load_session_transcript_page(
+            core.node(),
+            session_id,
+            Some(agent_did),
+            Some(core.principal().did()),
+            None,
+            Some(40),
+        )
+        .await?;
         let snapshot = core.store().snapshot();
         let response_text = snapshot
             .responses
             .iter()
             .filter(|row| row.request_id.as_deref() == Some(request_id))
-            .map(|row| {
-                [
-                    row.content.as_deref().unwrap_or_default(),
-                    row.reasoning.as_deref().unwrap_or_default(),
-                ]
-                .join("\n")
-            })
+            .map(|row| row.content.as_deref().unwrap_or_default())
             .collect::<Vec<_>>()
             .join("\n");
-        let message_text = snapshot
+        let message_text = page
+            .store
             .messages
             .iter()
             .filter(|row| row.request_id.as_deref() == Some(request_id))
+            .filter(|row| matches!(row.role.as_deref(), Some("assistant" | "agent")))
             .map(|row| {
-                [
+                gents_protocol::transcript::present_persisted_message(
+                    "assistant",
                     row.content.as_deref().unwrap_or_default(),
-                    row.reasoning.as_deref().unwrap_or_default(),
-                ]
-                .join("\n")
+                )
+                .body_markdown
             })
             .collect::<Vec<_>>()
             .join("\n");
-        if response_text.contains(token) || message_text.contains(token) {
+        let complete = snapshot.responses.iter().any(|row| {
+            row.request_id.as_deref() == Some(request_id)
+                && row.status.as_deref() == Some("complete")
+        });
+        if complete && (response_text.contains(token) || message_text.contains(token)) {
             return Ok(());
         }
         if snapshot.responses.iter().any(|row| {

--- a/crates/gents-cli/tests/cli_enrollment/README.md
+++ b/crates/gents-cli/tests/cli_enrollment/README.md
@@ -13,9 +13,10 @@ Success requires:
 - A completed request, response, and assistant body present in the phone database
   within 20 seconds of submitting a turn, including two seconds of deterministic
   model latency. User text, tool arguments, and reasoning do not count as replies.
-- After the app closes with a request accepted by the runtime, reopening the
+- The fake provider withholds the offline reply until the app has shut down.
+  After the app closes with a request accepted by the runtime, reopening the
   same home recovers the completed reply within 20 seconds, including startup.
-- A subsequent turn in the same session includes the earlier assistant reply
+- A subsequent turn in the same session includes both distinct earlier replies
   in the provider transcript and completes visibly within the same turn budget.
 - Enrollment identity survives reopening; `AgentPrincipal` stays on the runtime.
 
@@ -23,6 +24,10 @@ These are initial integration-test latency budgets. The independent live-model
 test exercises inference without substituting a fake provider. The deterministic
 test substitutes only inference; storage, signatures, approval, transport,
 replication, and observation remain real.
+
+The live-model test exercises the app's local refresh/display path as well.
+The deterministic contract is the stricter data-plane gate: it waits on local
+database rows without requesting recovery or refreshing the UI.
 
 The device acceptance run must additionally exercise actual iOS foreground and
 background transitions, existing production store history, and the rendered
@@ -34,6 +39,9 @@ and `updated_at`, including the unchanged snapshot field. This crosses the
 first CAR response's block limit and exercises selective continuation. New
 runtimes must not create this history: generated publisher tests advance hours
 of idle time and require no additional readiness writes.
+Enrollment must observe the final seeded readiness timestamp or a later runtime
+update, together with a usable semantic snapshot; an arbitrary historical row
+does not satisfy the aged gate. Fixture construction is outside the UX budget.
 
 Reconnect recovery must work without app-issued collection-wide replay. The
 database's durable sender markers and receiver DAG state own that recovery;
@@ -52,11 +60,14 @@ the phone's existing replica. It must not create another pairing, reset the
 session's replication progress, or request a full network replay. Data-plane
 convergence and local page ordering/completeness need separate assertions.
 
-The contract selects the session through hydration admission, then observes
-replication using local database queries only. It does not refresh the UI or
-request recovery while waiting for the reply. After reconnecting and completing
-three turns, it reads one-message local pages and checks ordering, completeness,
-and unchanged pairing/hydration intent. Untouched-session exclusion still needs
+The contract requests session selection alongside conversation delivery; the
+hydration owner may defer admission until the active request finishes. Reply
+delivery is observed through local queries, not conditioned on hydration being
+its cause. It does not refresh the UI or request recovery while waiting for the
+reply. After reconnecting and completing three turns, it waits for hydration
+completion, reads one-message local pages, and checks ordering, completeness,
+and unchanged pairing/hydration fields (including served progress, not just IDs).
+Untouched-session exclusion still needs
 its own multi-session scenario; these checks do not establish that policy.
 
 Pairing retains its existing owners: enrollment controls runtime authorization

--- a/crates/gents-cli/tests/cli_enrollment/README.md
+++ b/crates/gents-cli/tests/cli_enrollment/README.md
@@ -1,0 +1,65 @@
+# App pairing acceptance contract
+
+Run `CARGO_INCREMENTAL=0 cargo test -p gents-cli --test cli_enrollment -- --nocapture`.
+
+The runtime starts through `gents init` and `gents server`. The app starts
+through the same `ClientCore` used by desktop and iOS. Enrollment consumes the
+runtime's `/status` offer, creates a pending request, and uses operator approval.
+The test must not install replicators or pairing documents itself.
+
+Success requires:
+
+- Approved enrollment and replicated behavior/readiness within 30 seconds.
+- A completed request, response, and assistant body present in the phone database
+  within 20 seconds of submitting a turn, including two seconds of deterministic
+  model latency. User text, tool arguments, and reasoning do not count as replies.
+- After the app closes with a request accepted by the runtime, reopening the
+  same home recovers the completed reply within 20 seconds, including startup.
+- A subsequent turn in the same session includes the earlier assistant reply
+  in the provider transcript and completes visibly within the same turn budget.
+- Enrollment identity survives reopening; `AgentPrincipal` stays on the runtime.
+
+These are initial integration-test latency budgets. The independent live-model
+test exercises inference without substituting a fake provider. The deterministic
+test substitutes only inference; storage, signatures, approval, transport,
+replication, and observation remain real.
+
+The device acceptance run must additionally exercise actual iOS foreground and
+background transitions, existing production store history, and the rendered
+conversation. A passing Rust client-core test does not prove that device run.
+Capture submit, runtime completion, and client visibility times separately.
+
+The aged fixture recreates 2,500 old heartbeat updates of both `snapshot_json`
+and `updated_at`, including the unchanged snapshot field. This crosses the
+first CAR response's block limit and exercises selective continuation. New
+runtimes must not create this history: generated publisher tests advance hours
+of idle time and require no additional readiness writes.
+
+Reconnect recovery must work without app-issued collection-wide replay. The
+database's durable sender markers and receiver DAG state own that recovery;
+the app must not add a second recovery counter or infer transport liveness
+from a readiness timestamp.
+
+## Separate replication from display
+
+Session selection is data-plane intent: sessions interacted with on a phone
+should remain synchronized into that phone's database, including after a
+reconnect. An untouched session should not cause eager transcript replication
+merely because its lightweight conversation index is visible.
+
+Scrolling is a local database operation: read bounded transcript pages from
+the phone's existing replica. It must not create another pairing, reset the
+session's replication progress, or request a full network replay. Data-plane
+convergence and local page ordering/completeness need separate assertions.
+
+The contract selects the session through hydration admission, then observes
+replication using local database queries only. It does not refresh the UI or
+request recovery while waiting for the reply. After reconnecting and completing
+three turns, it reads one-message local pages and checks ordering, completeness,
+and unchanged pairing/hydration intent. Untouched-session exclusion still needs
+its own multi-session scenario; these checks do not establish that policy.
+
+Pairing retains its existing owners: enrollment controls runtime authorization
+and its outbound route; the app route manager controls the app's outbound route;
+the database owns transport and DAG recovery; the sync projection owns product
+status. Row counts and transport connectivity alone do not establish success.

--- a/crates/gents-cli/tests/cli_enrollment/contract.rs
+++ b/crates/gents-cli/tests/cli_enrollment/contract.rs
@@ -1,0 +1,406 @@
+//! Production enrollment and client-visible conversation contract.
+//!
+//! Only inference is deterministic. The CLI server, signed enrollment,
+//! operator approval, Iroh replication, and the iOS app's ClientCore/store
+//! are real. This is not a test of UIKit rendering or iOS suspension; those
+//! require the device acceptance run. Each deadline includes all work in its
+//! phase, rather than allowing each polling helper a fresh latency budget.
+
+use super::*;
+use std::sync::Arc;
+use support::mocks::fake_llm::{ChatAction, FakeLlm};
+use tokio::time::timeout;
+
+const ENROLL_BUDGET: Duration = Duration::from_secs(30);
+const TURN_BUDGET: Duration = Duration::from_secs(20);
+const RECONNECT_BUDGET: Duration = Duration::from_secs(20);
+const MODEL_DELAY: Duration = Duration::from_secs(2);
+const REPLY: &str = "PAIRING_CONTRACT_ASSISTANT_REPLY";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn app_enrollment_conversation_survives_reopen_with_bounded_latency() -> Result<()> {
+    run_contract(0).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fresh_app_pairs_with_aged_runtime_with_bounded_latency() -> Result<()> {
+    run_contract(2_500).await
+}
+
+async fn run_contract(readiness_revisions: usize) -> Result<()> {
+    let _guard = enrollment_e2e_lock().lock().await;
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "cli_enrollment=info".into()),
+        )
+        .with_test_writer()
+        .try_init();
+    let model = FakeLlm::start(
+        "pairing-contract",
+        None,
+        Arc::new(|_| {
+            tracing::info!("deterministic provider received inference request");
+            ChatAction::DelayThenSse(MODEL_DELAY, completion_text_sse(REPLY))
+        }),
+    )?;
+    let temp = tempfile::tempdir()?;
+    let runtime_home = temp.path().join("runtime");
+    let client_home = temp.path().join("app");
+    fs::create_dir_all(&runtime_home)?;
+    let home = runtime_home.to_str().context("runtime home UTF-8")?;
+    let init = run_init_json(
+        &runtime_home,
+        &[
+            "--home",
+            home,
+            "--agent-name",
+            "pairing-contract",
+            "--model-name",
+            "pairing-contract",
+            "--inference-url",
+            model.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let behavior = default_behavior_id_for_agent(&agent_did);
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let debug_filter = std::env::var("RUST_LOG").ok();
+    let server_env = debug_filter
+        .as_deref()
+        .map(|filter| ("RUST_LOG", filter))
+        .into_iter()
+        .collect::<Vec<_>>();
+    let (mut server, _) =
+        spawn_server_with_ready_json(&runtime_home, port, &["--home", home], &server_env)?;
+    wait_for_port(port, &mut server)?;
+
+    let result = server.capturing(async {
+        wait_for_runtime_ready(&graphql, &agent_did, ENROLL_BUDGET).await?;
+        seed_readiness_history(&graphql, &agent_did, readiness_revisions).await?;
+        let core = ClientCore::start_with_paths_and_options(
+            DesktopPaths::from_root(&client_home), ClientCoreOptions::local_only(),
+        ).await?;
+        core.set_selected_agent_did(Some(agent_did.clone()));
+        let enrollment_started = Instant::now();
+        let enrollment = timeout(ENROLL_BUDGET, async {
+            let (_, offer) = wait_for_enrollment_token(&format!("http://127.0.0.1:{port}")).await?;
+            let pending = core.request_status_enrollment_with_label(&offer, Some("Contract")).await?;
+            anyhow::ensure!(pending.state == "pending_approval", "unexpected initial enrollment: {pending:?}");
+            wait_for_runtime_enrollment_request(&graphql, &pending.request_id).await?;
+            run_cli_json(&runtime_home, &["p2p", "enrollment", "approve", &pending.request_id, "--home", home])?;
+            wait_for_chat_ready_enrollment(&core, &agent_did).await?;
+            wait_for_client_behavior_readiness(&core, &agent_did).await?;
+            anyhow::ensure!(query_collection_dids(core.node(), "AgentPrincipal").await?.is_empty(), "runtime principal replicated to app");
+            Ok::<_, anyhow::Error>(())
+        }).await;
+        if !matches!(enrollment, Ok(Ok(()))) {
+            let diagnostics = pairing_diagnostics(&core, &graphql).await;
+            core.shutdown().await?;
+            bail!("enroll/approve/readiness exceeded 30s or failed: {enrollment:?}; {diagnostics}");
+        }
+        tracing::info!(elapsed_ms = enrollment_started.elapsed().as_millis(), "app enrollment ready");
+
+        let session = Uuid::new_v4().to_string();
+        visible_turn(&core, &graphql, &agent_did, &behavior, &session, "First conversation turn").await?;
+
+        // A request reaches the runtime, then the app closes before inference
+        // finishes. Reopen exactly the same home: no re-enrollment, identity
+        // reset, injected desired rows, or hand-installed return replicator.
+        let records = core.peer_records().await;
+        core.submit_request(&session, &agent_did, "Reply while the app is closed", Some(&behavior)).await?;
+        let (request, _, _) = timeout(TURN_BUDGET, wait_for_runtime_agent_request(
+            &graphql, core.node(), &agent_did, "Reply while the app is closed",
+        )).await.context("second request did not reach runtime in 20s")??;
+        core.shutdown().await?;
+        drop(core);
+        wait_for_complete_agent_response(&graphql, &request, TURN_BUDGET).await?;
+
+        let reconnect_started = Instant::now();
+        let core = ClientCore::start_with_paths_and_options(
+            DesktopPaths::from_root(&client_home), ClientCoreOptions::local_only(),
+        ).await?;
+        core.set_selected_agent_did(Some(agent_did.clone()));
+        let recovered = timeout(RECONNECT_BUDGET.saturating_sub(reconnect_started.elapsed()), async {
+            wait_for_chat_ready_enrollment(&core, &agent_did).await?;
+            wait_for_client_behavior_readiness(&core, &agent_did).await?;
+            wait_for_replicated_reply(&core, &session, &agent_did, &request).await
+        }).await;
+        if !matches!(recovered, Ok(Ok(()))) {
+            let diagnostics = pairing_diagnostics(&core, &graphql).await;
+            core.shutdown().await?;
+            bail!("app reopen did not recover completed reply within 20s: {recovered:?}; {diagnostics}");
+        }
+        let reopened = core.peer_records().await;
+        anyhow::ensure!(records.len() == reopened.len() && records.iter().zip(&reopened).all(|(old, new)| old.peer_id == new.peer_id && old.enrollment_request_id == new.enrollment_request_id), "reopen changed enrollment identity");
+        tracing::info!(elapsed_ms = reconnect_started.elapsed().as_millis(), "app recovered offline reply");
+        visible_turn(&core, &graphql, &agent_did, &behavior, &session, "Continue our existing conversation").await?;
+        assert_local_pagination(&core, &session, &agent_did).await?;
+        anyhow::ensure!(query_collection_dids(core.node(), "AgentPrincipal").await?.is_empty(), "reopen replicated runtime principal");
+        core.shutdown().await?;
+        anyhow::ensure!(model.captured_chat_requests().iter().any(|request| {
+            request_contains_role_text(request, "user", "Continue our existing conversation")
+                && request_contains_role_text(request, "assistant", REPLY)
+        }), "continued conversation lost its prior assistant transcript");
+        Ok(())
+    }).await;
+    if result.is_err() {
+        let retained = temp.keep();
+        tracing::error!(path = %retained.display(), "retained failed pairing fixture for investigation");
+    }
+    result
+}
+
+async fn visible_turn(
+    core: &ClientCore,
+    graphql: &str,
+    agent: &str,
+    behavior: &str,
+    session: &str,
+    prompt: &str,
+) -> Result<()> {
+    let started = Instant::now();
+    let result = timeout(TURN_BUDGET, async {
+        core.submit_request(session, agent, prompt, Some(behavior))
+            .await?;
+        let (request, _, _) =
+            wait_for_runtime_agent_request(graphql, core.node(), agent, prompt).await?;
+        let request_arrived = started.elapsed();
+        let (selection_admitted, runtime_completed, client_visible) = tokio::try_join!(
+            async {
+                select_session(core, session, agent).await?;
+                Ok::<_, anyhow::Error>(started.elapsed())
+            },
+            async {
+                wait_for_complete_agent_response(graphql, &request, TURN_BUDGET).await?;
+                Ok::<_, anyhow::Error>(started.elapsed())
+            },
+            async {
+                wait_for_replicated_reply(core, session, agent, &request).await?;
+                Ok::<_, anyhow::Error>(started.elapsed())
+            },
+        )?;
+        tracing::info!(
+            request_delivery_ms = request_arrived.as_millis(),
+            selection_admission_ms = selection_admitted.as_millis(),
+            runtime_completion_ms = runtime_completed.as_millis(),
+            client_visible_ms = client_visible.as_millis(),
+            observed_return_lag_ms = client_visible.saturating_sub(runtime_completed).as_millis(),
+            "conversation phase timings (250ms observation resolution)",
+        );
+        let lifecycle = graphql_query(graphql, &format!(r#"{{
+            AgentRequest(filter: {{request_id: {{_eq: "{}"}}}}) {{created_at claimed_at terminalized_at}}
+            AgentResponse(filter: {{request_id: {{_eq: "{}"}}}}) {{created_at completed_at materialized_at}}
+        }}"#, escape_graphql_string(&request), escape_graphql_string(&request))).await?;
+        tracing::info!(timestamps = ?lifecycle, "runtime lifecycle timing evidence");
+        Ok::<_, anyhow::Error>(())
+    })
+    .await;
+    if !matches!(result, Ok(Ok(()))) {
+        let diagnostics = pairing_diagnostics(core, graphql).await;
+        core.shutdown().await?;
+        bail!("client-visible turn exceeded 20s or failed: {result:?}; {diagnostics}");
+    }
+    tracing::info!(
+        elapsed_ms = started.elapsed().as_millis(),
+        prompt,
+        "completed assistant reply visible in app store"
+    );
+    Ok(())
+}
+
+/// Session selection is a data-plane action, independent of UI page reads.
+async fn select_session(core: &ClientCore, session: &str, agent: &str) -> Result<()> {
+    use gents::agent::p2p_reconcile::session_hydration::ClientHydrationPhase;
+    loop {
+        core.ensure_session_hydration_started(session, agent)
+            .await?;
+        match core.session_hydration_progress(session, agent).await?.phase {
+            ClientHydrationPhase::Idle => sleep(Duration::from_millis(100)).await,
+            ClientHydrationPhase::Failed => bail!("session selection was rejected"),
+            _ => return Ok(()),
+        }
+    }
+}
+
+/// No hydration, repair, UI refresh, or remote reads here: success is a
+/// completed conversation present in the phone-side database itself.
+async fn wait_for_replicated_reply(
+    core: &ClientCore,
+    session: &str,
+    agent: &str,
+    request: &str,
+) -> Result<()> {
+    let filter = format!(
+        r#"request_id: {{_eq: "{}"}}, session_id: {{_eq: "{}"}}, agent_did: {{_eq: "{}"}}, requester_did: {{_eq: "{}"}}"#,
+        escape_graphql_string(request),
+        escape_graphql_string(session),
+        escape_graphql_string(agent),
+        escape_graphql_string(core.principal().did()),
+    );
+    let query = format!(
+        r#"{{
+        AgentRequest(filter: {{{filter}}}) {{lifecycle_state}}
+        AgentResponse(filter: {{{filter}}}) {{status content}}
+        AgentMessage(filter: {{{filter}}}) {{role content}}
+    }}"#
+    );
+    loop {
+        let result = core.node().execute(&query).await;
+        anyhow::ensure!(
+            !result.has_errors(),
+            "replica query failed: {:?}",
+            result.errors
+        );
+        let data = result.data.context("replica query missing data")?;
+        let rows = |collection: &str| {
+            data.get(collection)
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+        };
+        let requests = rows("AgentRequest");
+        let responses = rows("AgentResponse");
+        let messages = rows("AgentMessage");
+        let completed = requests
+            .iter()
+            .any(|row| row["lifecycle_state"] == "completed")
+            && responses.iter().any(|row| row["status"] == "complete");
+        let body = messages
+            .iter()
+            .filter(|row| row["role"] == "assistant")
+            .filter_map(|row| row["content"].as_str())
+            .map(|content| {
+                gents_protocol::transcript::present_persisted_message("assistant", content)
+                    .body_markdown
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if completed && body.contains(REPLY) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            !responses.iter().any(|row| row["status"] == "error"),
+            "replicated error response: {responses:?}"
+        );
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn pairing_diagnostics(core: &ClientCore, graphql: &str) -> String {
+    let query = "{ PeerPairingDesired { peer_id template source } PeerPairingApplied { peer_id } AgentBehaviorReadiness { agent_did updated_at } AgentResponse { request_id status content } }";
+    let client = core.node().execute(query).await;
+    let runtime = graphql_query(graphql, query).await;
+    let sync = core.sync_state();
+    let database_now = timeout(Duration::from_secs(3), core.p2p().sync_status()).await;
+    let runtime_database = reqwest::Client::new()
+        .get(graphql.replace("/graphql", "/p2p/sync/status"))
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await;
+    let runtime_database = match runtime_database {
+        Ok(response) => response.json::<serde_json::Value>().await.ok(),
+        Err(_) => None,
+    };
+    format!(
+        "database_now={database_now:?}; runtime_database={runtime_database:?}; database={:?}; peers={:?}; client={client:?}; runtime={runtime:?}",
+        sync.database_sync, sync.peers
+    )
+}
+
+async fn assert_local_pagination(core: &ClientCore, session: &str, agent: &str) -> Result<()> {
+    let intent_query = "{ SessionHydrationRequest { _docID } PeerPairingDesired { _docID } }";
+    let before = core.node().execute(intent_query).await;
+    anyhow::ensure!(!before.has_errors(), "local intent query failed");
+    let mut cursor = None;
+    let mut seen = std::collections::BTreeSet::new();
+    let mut last_sequence = i64::MAX;
+    loop {
+        let page = gents_desktop_core::client::load_session_transcript_page(
+            core.node(),
+            session,
+            Some(agent),
+            Some(core.principal().did()),
+            cursor.as_deref(),
+            Some(1),
+        )
+        .await?;
+        anyhow::ensure!(
+            page.store.messages.len() <= 1,
+            "local page exceeded requested message budget"
+        );
+        for message in &page.store.messages {
+            let sequence = message.sequence.context("message sequence")?;
+            let key = message.message_key.clone();
+            anyhow::ensure!(
+                sequence < last_sequence && seen.insert(key.clone()),
+                "local pagination repeated or reordered a message"
+            );
+            last_sequence = sequence;
+            cursor = Some(key);
+        }
+        if page.source_exhausted {
+            break;
+        }
+        anyhow::ensure!(
+            !page.store.messages.is_empty(),
+            "local pagination made no progress"
+        );
+    }
+    anyhow::ensure!(
+        seen.len() >= 6,
+        "three conversation turns must survive local paging: {seen:?}"
+    );
+    let after = core.node().execute(intent_query).await;
+    anyhow::ensure!(
+        !after.has_errors() && before.data == after.data,
+        "scrolling changed pairing or hydration intent"
+    );
+    Ok(())
+}
+
+/// Production Amy had about 2,500 readiness revisions when a clean mobile
+/// client enrolled. Seed real signed runtime writes before creating the app;
+/// this must not become a dependency on old history for current readiness.
+async fn seed_readiness_history(graphql: &str, agent: &str, revisions: usize) -> Result<()> {
+    if revisions == 0 {
+        return Ok(());
+    }
+    let agent = escape_graphql_string(agent);
+    let readiness = graphql_query(graphql, &format!(
+        r#"{{ AgentBehaviorReadiness(filter: {{agent_did: {{_eq: "{agent}"}}}}) {{snapshot_json}} }}"#,
+    )).await?;
+    let snapshot = readiness
+        .pointer("/data/AgentBehaviorReadiness/0/snapshot_json")
+        .and_then(Value::as_str)
+        .context("aged fixture requires runtime readiness")?;
+    let snapshot = escape_graphql_string(snapshot);
+    let started = Instant::now();
+    for batch in (0..revisions).step_by(50) {
+        let mut fields = String::new();
+        for revision in batch..(batch + 50).min(revisions) {
+            let timestamp = (Utc::now() - chrono::Duration::seconds((revisions - revision) as i64))
+                .to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+            fields.push_str(&format!(
+                // Match the removed publisher: even an unchanged snapshot was
+                // rewritten alongside its timestamp, adding another field DAG.
+                r#"r{revision}: update_AgentBehaviorReadiness(filter: {{agent_did: {{_eq: "{agent}"}}}}, input: {{snapshot_json: "{snapshot}", updated_at: "{}"}}) {{_docID}} "#,
+                escape_graphql_string(&timestamp),
+            ));
+        }
+        graphql_query(graphql, &format!("mutation {{ {fields} }}")).await?;
+    }
+    if revisions > 0 {
+        graphql_query(graphql, &format!(
+            r#"mutation {{ update_AgentBehaviorReadiness(filter: {{agent_did: {{_eq: "{agent}"}}}}, input: {{updated_at: "{}"}}) {{_docID}} }}"#,
+            escape_graphql_string(&Utc::now().to_rfc3339()),
+        )).await?;
+        tracing::info!(
+            revisions,
+            elapsed_ms = started.elapsed().as_millis(),
+            "aged runtime readiness fixture ready"
+        );
+    }
+    Ok(())
+}

--- a/crates/gents-cli/tests/cli_enrollment/contract.rs
+++ b/crates/gents-cli/tests/cli_enrollment/contract.rs
@@ -16,6 +16,10 @@ const TURN_BUDGET: Duration = Duration::from_secs(20);
 const RECONNECT_BUDGET: Duration = Duration::from_secs(20);
 const MODEL_DELAY: Duration = Duration::from_secs(2);
 const REPLY: &str = "PAIRING_CONTRACT_ASSISTANT_REPLY";
+const OFFLINE_REPLY: &str = "PAIRING_CONTRACT_OFFLINE_REPLY";
+const FOLLOWUP_REPLY: &str = "PAIRING_CONTRACT_CONTINUED_REPLY";
+const OFFLINE_PROMPT: &str = "Reply while the app is closed";
+const FOLLOWUP_PROMPT: &str = "Continue our existing conversation";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn app_enrollment_conversation_survives_reopen_with_bounded_latency() -> Result<()> {
@@ -36,12 +40,33 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         )
         .with_test_writer()
         .try_init();
+    let offline_gate = Arc::new(tokio::sync::Semaphore::new(0));
+    let model_gate = Arc::clone(&offline_gate);
     let model = FakeLlm::start(
         "pairing-contract",
         None,
-        Arc::new(|_| {
+        Arc::new(move |request| {
             tracing::info!("deterministic provider received inference request");
-            ChatAction::DelayThenSse(MODEL_DELAY, completion_text_sse(REPLY))
+            let latest = request
+                .get("messages")
+                .and_then(Value::as_array)
+                .and_then(|messages| {
+                    messages
+                        .iter()
+                        .rev()
+                        .find(|message| message["role"] == "user")
+                });
+            let latest = serde_json::json!({"messages": [latest]});
+            if request_contains_role_text(&latest, "user", OFFLINE_PROMPT) {
+                ChatAction::WaitThenSse(Arc::clone(&model_gate), completion_text_sse(OFFLINE_REPLY))
+            } else {
+                let reply = if request_contains_role_text(&latest, "user", FOLLOWUP_PROMPT) {
+                    FOLLOWUP_REPLY
+                } else {
+                    REPLY
+                };
+                ChatAction::DelayThenSse(MODEL_DELAY, completion_text_sse(reply))
+            }
         }),
     )?;
     let temp = tempfile::tempdir()?;
@@ -78,7 +103,7 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
 
     let result = server.capturing(async {
         wait_for_runtime_ready(&graphql, &agent_did, ENROLL_BUDGET).await?;
-        seed_readiness_history(&graphql, &agent_did, readiness_revisions).await?;
+        let readiness_timestamp = seed_readiness_history(&graphql, &agent_did, readiness_revisions).await?;
         let core = ClientCore::start_with_paths_and_options(
             DesktopPaths::from_root(&client_home), ClientCoreOptions::local_only(),
         ).await?;
@@ -92,6 +117,9 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
             run_cli_json(&runtime_home, &["p2p", "enrollment", "approve", &pending.request_id, "--home", home])?;
             wait_for_chat_ready_enrollment(&core, &agent_did).await?;
             wait_for_client_behavior_readiness(&core, &agent_did).await?;
+            if let Some(expected) = readiness_timestamp.as_deref() {
+                wait_for_readiness_revision(&core, &agent_did, expected).await?;
+            }
             anyhow::ensure!(query_collection_dids(core.node(), "AgentPrincipal").await?.is_empty(), "runtime principal replicated to app");
             Ok::<_, anyhow::Error>(())
         }).await;
@@ -109,12 +137,13 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         // finishes. Reopen exactly the same home: no re-enrollment, identity
         // reset, injected desired rows, or hand-installed return replicator.
         let records = core.peer_records().await;
-        core.submit_request(&session, &agent_did, "Reply while the app is closed", Some(&behavior)).await?;
+        core.submit_request(&session, &agent_did, OFFLINE_PROMPT, Some(&behavior)).await?;
         let (request, _, _) = timeout(TURN_BUDGET, wait_for_runtime_agent_request(
-            &graphql, core.node(), &agent_did, "Reply while the app is closed",
+            &graphql, core.node(), &agent_did, OFFLINE_PROMPT,
         )).await.context("second request did not reach runtime in 20s")??;
         core.shutdown().await?;
         drop(core);
+        offline_gate.add_permits(1);
         wait_for_complete_agent_response(&graphql, &request, TURN_BUDGET).await?;
 
         let reconnect_started = Instant::now();
@@ -125,7 +154,7 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         let recovered = timeout(RECONNECT_BUDGET.saturating_sub(reconnect_started.elapsed()), async {
             wait_for_chat_ready_enrollment(&core, &agent_did).await?;
             wait_for_client_behavior_readiness(&core, &agent_did).await?;
-            wait_for_replicated_reply(&core, &session, &agent_did, &request).await
+            wait_for_replicated_reply(&core, &session, &agent_did, &request, OFFLINE_REPLY).await
         }).await;
         if !matches!(recovered, Ok(Ok(()))) {
             let diagnostics = pairing_diagnostics(&core, &graphql).await;
@@ -135,13 +164,14 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         let reopened = core.peer_records().await;
         anyhow::ensure!(records.len() == reopened.len() && records.iter().zip(&reopened).all(|(old, new)| old.peer_id == new.peer_id && old.enrollment_request_id == new.enrollment_request_id), "reopen changed enrollment identity");
         tracing::info!(elapsed_ms = reconnect_started.elapsed().as_millis(), "app recovered offline reply");
-        visible_turn(&core, &graphql, &agent_did, &behavior, &session, "Continue our existing conversation").await?;
+        visible_turn(&core, &graphql, &agent_did, &behavior, &session, FOLLOWUP_PROMPT).await?;
         assert_local_pagination(&core, &session, &agent_did).await?;
         anyhow::ensure!(query_collection_dids(core.node(), "AgentPrincipal").await?.is_empty(), "reopen replicated runtime principal");
         core.shutdown().await?;
         anyhow::ensure!(model.captured_chat_requests().iter().any(|request| {
-            request_contains_role_text(request, "user", "Continue our existing conversation")
+            request_contains_role_text(request, "user", FOLLOWUP_PROMPT)
                 && request_contains_role_text(request, "assistant", REPLY)
+                && request_contains_role_text(request, "assistant", OFFLINE_REPLY)
         }), "continued conversation lost its prior assistant transcript");
         Ok(())
     }).await;
@@ -177,7 +207,8 @@ async fn visible_turn(
                 Ok::<_, anyhow::Error>(started.elapsed())
             },
             async {
-                wait_for_replicated_reply(core, session, agent, &request).await?;
+                let expected = if prompt == FOLLOWUP_PROMPT { FOLLOWUP_REPLY } else { REPLY };
+                wait_for_replicated_reply(core, session, agent, &request, expected).await?;
                 Ok::<_, anyhow::Error>(started.elapsed())
             },
         )?;
@@ -231,6 +262,7 @@ async fn wait_for_replicated_reply(
     session: &str,
     agent: &str,
     request: &str,
+    expected_reply: &str,
 ) -> Result<()> {
     let filter = format!(
         r#"request_id: {{_eq: "{}"}}, session_id: {{_eq: "{}"}}, agent_did: {{_eq: "{}"}}, requester_did: {{_eq: "{}"}}"#,
@@ -277,7 +309,7 @@ async fn wait_for_replicated_reply(
             })
             .collect::<Vec<_>>()
             .join("\n");
-        if completed && body.contains(REPLY) {
+        if completed && body.contains(expected_reply) {
             return Ok(());
         }
         anyhow::ensure!(
@@ -310,7 +342,19 @@ async fn pairing_diagnostics(core: &ClientCore, graphql: &str) -> String {
 }
 
 async fn assert_local_pagination(core: &ClientCore, session: &str, agent: &str) -> Result<()> {
-    let intent_query = "{ SessionHydrationRequest { _docID } PeerPairingDesired { _docID } }";
+    timeout(TURN_BUDGET, async {
+        use gents::agent::p2p_reconcile::session_hydration::ClientHydrationPhase;
+        loop {
+            match core.session_hydration_progress(session, agent).await?.phase {
+                ClientHydrationPhase::Complete => return Ok::<_, anyhow::Error>(()),
+                ClientHydrationPhase::Failed => bail!("session hydration failed before pagination"),
+                _ => sleep(Duration::from_millis(100)).await,
+            }
+        }
+    })
+    .await
+    .context("session hydration did not settle before pagination")??;
+    let intent_query = "{ SessionHydrationRequest { _docID request_key status status_detail served_doc_count served_manifest_json processed_at outcome_signer_did outcome_signature } PeerPairingDesired { _docID peer_id collections profiles template source enrollment_request_digest enrollment_authorization_sequence enrollment_authorization_expires_at updated_at } }";
     let before = core.node().execute(intent_query).await;
     anyhow::ensure!(!before.has_errors(), "local intent query failed");
     let mut cursor = None;
@@ -363,9 +407,13 @@ async fn assert_local_pagination(core: &ClientCore, session: &str, agent: &str) 
 /// Production Amy had about 2,500 readiness revisions when a clean mobile
 /// client enrolled. Seed real signed runtime writes before creating the app;
 /// this must not become a dependency on old history for current readiness.
-async fn seed_readiness_history(graphql: &str, agent: &str, revisions: usize) -> Result<()> {
+async fn seed_readiness_history(
+    graphql: &str,
+    agent: &str,
+    revisions: usize,
+) -> Result<Option<String>> {
     if revisions == 0 {
-        return Ok(());
+        return Ok(None);
     }
     let agent = escape_graphql_string(agent);
     let readiness = graphql_query(graphql, &format!(
@@ -391,10 +439,11 @@ async fn seed_readiness_history(graphql: &str, agent: &str, revisions: usize) ->
         }
         graphql_query(graphql, &format!("mutation {{ {fields} }}")).await?;
     }
+    let final_timestamp = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
     if revisions > 0 {
         graphql_query(graphql, &format!(
             r#"mutation {{ update_AgentBehaviorReadiness(filter: {{agent_did: {{_eq: "{agent}"}}}}, input: {{updated_at: "{}"}}) {{_docID}} }}"#,
-            escape_graphql_string(&Utc::now().to_rfc3339()),
+            escape_graphql_string(&final_timestamp),
         )).await?;
         tracing::info!(
             revisions,
@@ -402,5 +451,45 @@ async fn seed_readiness_history(graphql: &str, agent: &str, revisions: usize) ->
             "aged runtime readiness fixture ready"
         );
     }
-    Ok(())
+    Ok(Some(final_timestamp))
+}
+
+async fn wait_for_readiness_revision(core: &ClientCore, agent: &str, expected: &str) -> Result<()> {
+    let query = format!(
+        r#"{{ AgentBehaviorReadiness(filter: {{agent_did: {{_eq: "{}"}}}}) {{agent_did snapshot_json updated_at}} }}"#,
+        escape_graphql_string(agent)
+    );
+    loop {
+        let result = core.node().execute(&query).await;
+        anyhow::ensure!(
+            !result.has_errors(),
+            "readiness convergence query failed: {:?}",
+            result.errors
+        );
+        if let Some(row) = result
+            .data
+            .as_ref()
+            .and_then(|data| data["AgentBehaviorReadiness"].as_array())
+            .and_then(|rows| rows.first())
+        {
+            let row: gents_protocol::row::AgentBehaviorReadinessRow =
+                serde_json::from_value(row.clone())?;
+            let actual = chrono::DateTime::parse_from_rfc3339(&row.updated_at)?;
+            if actual >= chrono::DateTime::parse_from_rfc3339(expected)? {
+                anyhow::ensure!(
+                    matches!(
+                        gents_protocol::row::project_behavior_readiness_summary(
+                            Some(&row),
+                            agent,
+                            Utc::now()
+                        ),
+                        gents_protocol::row::ProjectedBehaviorReadinessSummary::Observed(_)
+                    ),
+                    "latest readiness revision is not a usable semantic snapshot"
+                );
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
 }

--- a/crates/gents-cli/tests/support/mocks/fake_llm.rs
+++ b/crates/gents-cli/tests/support/mocks/fake_llm.rs
@@ -27,6 +27,7 @@ use tokio::sync::{oneshot, Notify};
 pub enum ChatAction {
     Sse(String),
     DelayThenSse(Duration, String),
+    WaitThenSse(Arc<tokio::sync::Semaphore>, String),
     Hang,
 }
 
@@ -210,6 +211,26 @@ async fn handle_chat(
             let _ = tokio::time::timeout(delay, state.stop.notified()).await;
             sse_response(body)
         }
+        ChatAction::WaitThenSse(gate, body) => loop {
+            if state.stopped.load(Ordering::Relaxed) {
+                return json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    r#"{"error":"shutting down"}"#.to_string(),
+                );
+            }
+            if let Ok(permit) =
+                tokio::time::timeout(Duration::from_millis(50), gate.acquire()).await
+            {
+                if let Ok(permit) = permit {
+                    permit.forget();
+                    return sse_response(body);
+                }
+                return json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    r#"{"error":"gate closed"}"#.to_string(),
+                );
+            }
+        },
         ChatAction::Hang => {
             while !state.stopped.load(Ordering::Relaxed) {
                 let _ =

--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -13,12 +13,9 @@ use super::super::paths::DesktopPaths;
 use super::super::peer_directory::{PeerDirectory, PeerRecord};
 use super::super::principal_identity::PrincipalIdentity;
 use super::super::query::load_full_snapshot_with_peer_records;
-use super::super::schema::{
-    client_recovery_collection_names, ensure_runtime_schemas, subscribe_all_collections,
-};
+use super::super::schema::{ensure_runtime_schemas, subscribe_all_collections};
 use super::p2p_ops::{
     p2p_connect_peer, p2p_connected_peers, p2p_listen_addresses, p2p_local_peer_id,
-    p2p_sync_branchable_collection,
 };
 use super::route_manager::{is_enrollment_peer, ClientRouteManager};
 use super::supervisor::spawn_p2p_supervisor_task;
@@ -338,33 +335,6 @@ pub(super) async fn force_connect_peer_with_retry_until(
             }
         }
     }
-}
-
-pub(super) async fn request_client_recovery_sync(
-    node: &EmbeddedNode,
-    p2p: &Arc<dyn P2POps>,
-) -> Result<Vec<String>> {
-    if p2p_connected_peers(p2p).await?.is_empty() {
-        anyhow::bail!("no connected peers available for session index request");
-    }
-
-    let resolve_id = |collection_name| -> Result<String> {
-        let collection = node
-            .get_collection(collection_name)
-            .map_err(|error| {
-                anyhow::anyhow!("loading collection id for {collection_name}: {error}")
-            })?
-            .ok_or_else(|| anyhow::anyhow!("collection {collection_name} not found"))?;
-        Ok(collection.collection_id)
-    };
-    let mut requested = Vec::new();
-    for collection_name in client_recovery_collection_names() {
-        let collection_id = resolve_id(collection_name)?;
-        p2p_sync_branchable_collection(p2p, &collection_id).await?;
-        requested.push(collection_name.to_string());
-    }
-
-    Ok(requested)
 }
 
 pub(super) async fn is_connected_peer(p2p: &Arc<dyn P2POps>, peer_id: &str) -> Result<bool> {

--- a/crates/gents-desktop-core/src/client/core/p2p_ops.rs
+++ b/crates/gents-desktop-core/src/client/core/p2p_ops.rs
@@ -95,22 +95,3 @@ pub(super) async fn p2p_remove_replicator(
         Err(_) => anyhow::bail!("timed out removing desktop P2P replicator for {addr}"),
     }
 }
-
-pub(super) async fn p2p_sync_branchable_collection(
-    p2p: &Arc<dyn P2POps>,
-    collection_id: &str,
-) -> Result<()> {
-    match timeout(
-        P2P_OPERATION_TIMEOUT,
-        p2p.sync_branchable_collection(collection_id),
-    )
-    .await
-    {
-        Ok(result) => result
-            .map_err(anyhow::Error::msg)
-            .with_context(|| format!("syncing desktop P2P branchable collection {collection_id}")),
-        Err(_) => {
-            anyhow::bail!("timed out syncing desktop P2P branchable collection {collection_id}")
-        }
-    }
-}

--- a/crates/gents-desktop-core/src/client/core/supervisor.rs
+++ b/crates/gents-desktop-core/src/client/core/supervisor.rs
@@ -15,10 +15,7 @@ use tokio::time::{Instant, MissedTickBehavior};
 
 use super::super::peer_directory::PeerRecord;
 use super::super::principal_identity::PrincipalIdentity;
-use super::bootstrap::{
-    connect_peer_with_retry, force_connect_peer_with_retry, is_connected_peer,
-    request_client_recovery_sync,
-};
+use super::bootstrap::{connect_peer_with_retry, force_connect_peer_with_retry, is_connected_peer};
 use super::p2p_ops::{
     p2p_connected_peers, p2p_get_replicators, p2p_listen_addresses, p2p_local_peer_id,
     p2p_notify_network_change, p2p_sync_status,
@@ -62,7 +59,6 @@ pub(super) fn spawn_p2p_supervisor_task(
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(P2P_SUPERVISOR_INTERVAL);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        let mut recovery_requests = BTreeMap::new();
         let mut route_reconciled_at = BTreeMap::new();
         let mut removal_retries = BTreeMap::new();
 
@@ -113,14 +109,12 @@ pub(super) fn spawn_p2p_supervisor_task(
                 };
             run_pending_removal_cleanup(&sync_state, &route_manager, &mut removal_retries).await;
             run_saved_peer_repair_cycle(
-                &node,
                 &p2p,
                 &sync_state,
                 &remote_admin_actor,
                 &route_manager,
                 install_replicators_on_bootstrap,
                 manual_repair,
-                &mut recovery_requests,
                 &mut route_reconciled_at,
                 &enrollment_authority,
             )
@@ -226,24 +220,16 @@ fn removal_retry_delay(failures: u32) -> Duration {
 }
 
 async fn run_saved_peer_repair_cycle(
-    node: &Arc<EmbeddedNode>,
     p2p: &Arc<dyn P2POps>,
     sync_state: &ClientSyncStateOwner,
     remote_admin_actor: &Arc<PrincipalIdentity>,
     route_manager: &Arc<ClientRouteManager>,
     install_replicators_on_bootstrap: bool,
     force_repair: bool,
-    recovery_requests: &mut BTreeMap<String, PeerRecord>,
     route_reconciled_at: &mut BTreeMap<String, (RouteReconcileFence, Instant)>,
     enrollment_authority: &BTreeMap<String, super::enrollment::EnrollmentAuthorizationGeneration>,
 ) {
     let records = sync_state.records();
-    let saved_peer_ids = records
-        .iter()
-        .map(|record| record.peer_id.clone())
-        .collect::<BTreeSet<_>>();
-    recovery_requests
-        .retain(|peer_id, expected| expected.peer_id == *peer_id && records.contains(expected));
     route_reconciled_at.retain(|peer_id, (expected, _)| {
         expected.record.peer_id == *peer_id
             && records.contains(&expected.record)
@@ -255,7 +241,6 @@ async fn run_saved_peer_repair_cycle(
             saved_record,
             enrollment_authority,
         ) {
-            recovery_requests.remove(&saved_record.peer_id);
             route_reconciled_at.remove(&saved_record.peer_id);
             continue;
         }
@@ -296,7 +281,6 @@ async fn run_saved_peer_repair_cycle(
             .iter()
             .any(|candidate| candidate.peer_id == record.peer_id);
         if needs_repair {
-            recovery_requests.remove(&record.peer_id);
             let updated = repair_saved_peer(
                 p2p,
                 &record,
@@ -352,73 +336,6 @@ async fn run_saved_peer_repair_cycle(
                     route_reconcile_fence(&record, enrollment_authority),
                     Instant::now(),
                 ),
-            );
-        }
-    }
-
-    if install_replicators_on_bootstrap {
-        request_client_recovery_for_ready_peers(
-            node,
-            p2p,
-            sync_state,
-            &saved_peer_ids,
-            recovery_requests,
-        )
-        .await;
-    }
-}
-
-pub(super) async fn request_client_recovery_for_ready_peers(
-    node: &Arc<EmbeddedNode>,
-    p2p: &Arc<dyn P2POps>,
-    sync_state: &ClientSyncStateOwner,
-    saved_peer_ids: &BTreeSet<String>,
-    requested_for: &mut BTreeMap<String, PeerRecord>,
-) {
-    let snapshot = sync_state.snapshot();
-    let pending = snapshot
-        .directory
-        .iter()
-        .filter(|record| {
-            snapshot
-                .peers
-                .iter()
-                .find(|status| status.peer_id == record.peer_id)
-                .is_some_and(|status| {
-                    saved_peer_ids.contains(&record.peer_id)
-                        && status.dial_succeeded
-                        && status.last_error.is_none()
-                        && requested_for.get(&record.peer_id) != Some(record)
-                })
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    if pending.is_empty() {
-        return;
-    }
-
-    match request_client_recovery_sync(node.as_ref(), p2p).await {
-        Ok(collections) => {
-            let current = sync_state.records();
-            requested_for.extend(
-                pending
-                    .iter()
-                    .filter(|expected| current.contains(expected))
-                    .map(|record| (record.peer_id.clone(), record.clone())),
-            );
-            tracing::info!(
-                target: "gents_desktop_core::peer_maintenance",
-                requested_collections = ?collections,
-                "client recovery sync request dispatched; merges continue asynchronously"
-            );
-        }
-        Err(error) => {
-            let message = format!("client recovery sync request failed: {error}");
-            sync_state.set_last_error_for_records(&pending, message);
-            tracing::warn!(
-                target: "gents_desktop_core::peer_maintenance",
-                error = %error,
-                "client recovery sync request failed; supervisor will retry after repair"
             );
         }
     }

--- a/crates/gents-desktop-core/src/client/core/sync_state.rs
+++ b/crates/gents-desktop-core/src/client/core/sync_state.rs
@@ -306,27 +306,6 @@ impl ClientSyncStateOwner {
         });
     }
 
-    pub(super) fn set_last_error_for_records(
-        &self,
-        expected_records: &[PeerRecord],
-        message: String,
-    ) -> bool {
-        self.tx.send_if_modified(|state| {
-            let previous = state.peers.clone();
-            for expected in expected_records {
-                if !state.directory.iter().any(|record| record == expected) {
-                    continue;
-                }
-                if let Some(status) = state.peers.iter_mut().find(|status| {
-                    status.peer_id == expected.peer_id && status.addr == expected.addr
-                }) {
-                    status.last_error = Some(message.clone());
-                }
-            }
-            state.peers != previous
-        })
-    }
-
     /// Patch one diagnostic only while both the durable peer generation and
     /// the previously observed diagnostic still match. Delayed projection
     /// work cannot use this path to overwrite newer supervisor state.
@@ -692,27 +671,6 @@ mod tests {
         .await
         .expect("offline initializer may write after live owner exits");
         assert_eq!(initialized.agent_did, "did:key:other");
-    }
-
-    #[tokio::test]
-    async fn stale_index_failure_cannot_tag_a_new_peer_generation() {
-        let old = record("a");
-        let (_tempdir, owner) =
-            ClientSyncStateOwner::for_test(vec![old.clone()], vec![peer("a")]).await;
-        let mut repaired = old.clone();
-        repaired.pairing_network_id = Some("network-new".to_string());
-        owner
-            .replace_record(&old, repaired.clone())
-            .await
-            .unwrap()
-            .expect("replace generation");
-
-        assert!(!owner.set_last_error_for_records(&[old], "stale index failure".to_string()));
-        assert_eq!(
-            owner.snapshot().directory[0].pairing_network_id,
-            repaired.pairing_network_id
-        );
-        assert_eq!(owner.snapshot().peers[0].last_error, None);
     }
 
     #[tokio::test]

--- a/crates/gents-desktop-core/src/client/core/tests.rs
+++ b/crates/gents-desktop-core/src/client/core/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::RwLock as StdRwLock;
@@ -12,10 +12,7 @@ use defra_p2p_adapter::{
 use tokio::sync::Notify;
 
 use super::route_manager::cleanup_saved_peer_p2p;
-use super::supervisor::{
-    probe_p2p_health, repair_saved_peer, request_client_recovery_for_ready_peers,
-    saved_peer_needs_repair,
-};
+use super::supervisor::{probe_p2p_health, repair_saved_peer, saved_peer_needs_repair};
 use super::*;
 use crate::client::{PeerDirectory, PeerRecord};
 
@@ -31,7 +28,6 @@ struct RecordingP2P {
     connect_error: StdRwLock<Option<String>>,
     connect_gate: StdRwLock<Option<Arc<Notify>>>,
     add_replicator_calls: StdRwLock<Vec<String>>,
-    sync_branchable_calls: StdRwLock<Vec<String>>,
     cleanup_calls: StdRwLock<Vec<String>>,
     replicators: StdRwLock<Vec<ReplicatorInfo>>,
     replicators_error: StdRwLock<Option<String>>,
@@ -123,13 +119,6 @@ impl RecordingP2P {
         self.add_replicator_calls
             .read()
             .expect("add replicator calls lock poisoned")
-            .clone()
-    }
-
-    fn sync_branchable_calls(&self) -> Vec<String> {
-        self.sync_branchable_calls
-            .read()
-            .expect("sync branchable calls lock poisoned")
             .clone()
     }
 
@@ -337,12 +326,10 @@ impl P2POps for RecordingP2P {
         Ok(())
     }
 
-    async fn sync_branchable_collection(&self, collection_id: &str) -> P2PResult<()> {
-        self.sync_branchable_calls
-            .write()
-            .expect("sync branchable calls lock poisoned")
-            .push(collection_id.to_string());
-        Ok(())
+    async fn sync_branchable_collection(&self, _collection_id: &str) -> P2PResult<()> {
+        panic!(
+            "client repair must use database-owned delivery recovery, not collection-wide replay"
+        )
     }
 
     async fn sync_collection_versions(&self, _version_ids: Vec<String>) -> P2PResult<()> {
@@ -476,160 +463,6 @@ async fn expired_enrollment_is_persistently_demoted_before_submit_can_write() {
         .await
         .unwrap();
     assert!(!persisted[0].pairing_ready);
-
-    core.shutdown().await.expect("shutdown");
-}
-
-#[tokio::test]
-async fn recovery_sync_targets_the_session_index_and_runtime_readiness() {
-    use crate::client::paths::DesktopPaths;
-
-    let tmp = tempfile::TempDir::new().expect("tmpdir");
-    let core = ClientCore::start_with_paths_and_options(
-        DesktopPaths::from_root(tmp.path().to_path_buf()),
-        ClientCoreOptions::local_only(),
-    )
-    .await
-    .expect("client core");
-    let recording = Arc::new(RecordingP2P::default());
-    recording.set_connected_peers(vec!["peer-alpha".to_string()]);
-    let p2p: Arc<dyn P2POps> = recording.clone();
-
-    let requested = super::bootstrap::request_client_recovery_sync(core.node(), &p2p)
-        .await
-        .expect("request index sync");
-    assert_eq!(
-        requested,
-        [
-            "AgentConversation",
-            "AgentSession",
-            "MailboxItem",
-            "AgentBehaviorReadiness"
-        ]
-    );
-
-    let mut expected = crate::client::schema::client_recovery_collection_names()
-        .into_iter()
-        .map(|name| {
-            core.node()
-                .get_collection(name)
-                .expect("get collection")
-                .expect("collection exists")
-                .collection_id
-        })
-        .collect::<Vec<_>>();
-    let mut actual = recording.sync_branchable_calls();
-    expected.sort();
-    actual.sort();
-    assert_eq!(actual, expected);
-
-    core.shutdown().await.expect("shutdown");
-}
-
-#[tokio::test]
-async fn supervisor_requests_index_for_new_and_reconnected_peers_and_surfaces_failures() {
-    use crate::client::paths::DesktopPaths;
-
-    let tmp = tempfile::TempDir::new().expect("tmpdir");
-    let core = ClientCore::start_with_paths_and_options(
-        DesktopPaths::from_root(tmp.path().to_path_buf()),
-        ClientCoreOptions::local_only(),
-    )
-    .await
-    .expect("client core");
-    let recording = Arc::new(RecordingP2P::default());
-    recording.set_connected_peers(vec!["peer-alpha".to_string()]);
-    let p2p: Arc<dyn P2POps> = recording.clone();
-    let node = core.node_arc();
-    let mut saved_record = PeerRecord::new("Alpha", "peer-alpha", "did:key:alpha");
-    saved_record.peer_id = "saved-alpha".to_string();
-    let (_sync_tempdir, sync_state) = sync_state::ClientSyncStateOwner::for_test(
-        vec![saved_record],
-        vec![ClientPeerStatus {
-            peer_id: "saved-alpha".to_string(),
-            label: "Alpha".to_string(),
-            agent_did: "did:key:alpha".to_string(),
-            addr: "peer-alpha".to_string(),
-            dial_succeeded: true,
-            last_error: None,
-            pairing: Vec::new(),
-            routes: Vec::new(),
-        }],
-    )
-    .await;
-    let mut saved = BTreeSet::from(["saved-alpha".to_string()]);
-    let mut requested_for = BTreeMap::new();
-    let recovery_collection_count = crate::client::schema::client_recovery_collection_names().len();
-
-    request_client_recovery_for_ready_peers(&node, &p2p, &sync_state, &saved, &mut requested_for)
-        .await;
-    assert_eq!(
-        recording.sync_branchable_calls().len(),
-        recovery_collection_count
-    );
-    assert_eq!(
-        requested_for.keys().cloned().collect::<BTreeSet<_>>(),
-        saved
-    );
-
-    request_client_recovery_for_ready_peers(&node, &p2p, &sync_state, &saved, &mut requested_for)
-        .await;
-    assert_eq!(
-        recording.sync_branchable_calls().len(),
-        recovery_collection_count
-    );
-
-    let mut beta_record = PeerRecord::new("Beta", "peer-beta", "did:key:beta");
-    beta_record.peer_id = "saved-beta".to_string();
-    sync_state
-        .upsert_for_test(beta_record.clone())
-        .await
-        .unwrap();
-    assert!(sync_state.replace_peer(
-        &beta_record,
-        ClientPeerStatus {
-            peer_id: "saved-beta".to_string(),
-            label: "Beta".to_string(),
-            agent_did: "did:key:beta".to_string(),
-            addr: "peer-beta".to_string(),
-            dial_succeeded: true,
-            last_error: None,
-            pairing: Vec::new(),
-            routes: Vec::new(),
-        }
-    ));
-    saved.insert("saved-beta".to_string());
-    request_client_recovery_for_ready_peers(&node, &p2p, &sync_state, &saved, &mut requested_for)
-        .await;
-    assert_eq!(
-        recording.sync_branchable_calls().len(),
-        recovery_collection_count * 2
-    );
-    assert_eq!(
-        requested_for.keys().cloned().collect::<BTreeSet<_>>(),
-        saved
-    );
-
-    requested_for.remove("saved-alpha");
-    request_client_recovery_for_ready_peers(&node, &p2p, &sync_state, &saved, &mut requested_for)
-        .await;
-    assert_eq!(
-        recording.sync_branchable_calls().len(),
-        recovery_collection_count * 3
-    );
-
-    requested_for.remove("saved-alpha");
-    recording.set_connected_peers(Vec::new());
-    request_client_recovery_for_ready_peers(&node, &p2p, &sync_state, &saved, &mut requested_for)
-        .await;
-    assert!(sync_state
-        .snapshot()
-        .peers
-        .iter()
-        .find(|status| status.peer_id == "saved-alpha")
-        .and_then(|status| status.last_error.as_deref())
-        .is_some_and(|error| error.contains("no connected peers")));
-    assert!(!requested_for.contains_key("saved-alpha"));
 
     core.shutdown().await.expect("shutdown");
 }

--- a/crates/gents-desktop-core/src/client/schema.rs
+++ b/crates/gents-desktop-core/src/client/schema.rs
@@ -1,9 +1,6 @@
 use anyhow::{Context, Result};
 use defra_node::EmbeddedNode;
-use gents::agent::p2p_reconcile::templates::CLIENT_INDEX_COLLECTIONS;
-use gents_protocol::schemas::{
-    AGENT_BEHAVIOR_READINESS_NAME, ALL_COLLECTION_NAMES, RUNTIME_COLLECTION_NAMES,
-};
+use gents_protocol::schemas::{ALL_COLLECTION_NAMES, RUNTIME_COLLECTION_NAMES};
 
 pub async fn ensure_runtime_schemas(node: &EmbeddedNode) -> Result<()> {
     gents_migration::ensure_migrations(node)
@@ -60,23 +57,10 @@ pub fn subscribed_collection_names() -> Vec<&'static str> {
         .collect()
 }
 
-/// The small control-plane/index set eagerly recovered by paired clients.
-///
-/// Readiness travels on the signed, agent-scoped `client` route rather than
-/// the requester-scoped `client-index` grant. Pulling its branch head here is
-/// a liveness operation only; it cannot expand the route's authority.
-pub fn client_recovery_collection_names() -> [&'static str; 4] {
-    [
-        CLIENT_INDEX_COLLECTIONS[0],
-        CLIENT_INDEX_COLLECTIONS[1],
-        CLIENT_INDEX_COLLECTIONS[2],
-        AGENT_BEHAVIOR_READINESS_NAME,
-    ]
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{subscribed_collection_names, CLIENT_INDEX_COLLECTIONS};
+    use super::subscribed_collection_names;
+    use gents::agent::p2p_reconcile::templates::CLIENT_INDEX_COLLECTIONS;
 
     /// The subscription set is derived from a list that grows whenever a
     /// collection is added, so the exclusion has to be asserted rather than
@@ -98,16 +82,6 @@ mod tests {
 
     #[test]
     fn index_collections_are_the_client_index_and_are_branchable() {
-        let index = super::client_recovery_collection_names();
-        assert_eq!(
-            index,
-            [
-                "AgentConversation",
-                "AgentSession",
-                "MailboxItem",
-                "AgentBehaviorReadiness"
-            ]
-        );
         for name in CLIENT_INDEX_COLLECTIONS {
             assert!(
                 gents_protocol::schemas::BRANCHABLE_COLLECTION_NAMES.contains(&name),
@@ -118,11 +92,10 @@ mod tests {
     }
 
     #[test]
-    fn behavior_readiness_is_subscribed_and_targeted_for_client_recovery() {
+    fn behavior_readiness_remains_subscribed() {
         let names = subscribed_collection_names();
         assert!(names.contains(&"AgentBehaviorReadiness"));
         assert!(gents_protocol::schemas::ALL_COLLECTION_NAMES.contains(&"AgentBehaviorReadiness"));
-        assert!(super::client_recovery_collection_names().contains(&"AgentBehaviorReadiness"));
         assert!(!gents_protocol::schemas::BRANCHABLE_COLLECTION_NAMES
             .contains(&"AgentBehaviorReadiness"));
     }

--- a/crates/gents-protocol/src/behavior_readiness.rs
+++ b/crates/gents-protocol/src/behavior_readiness.rs
@@ -3,8 +3,8 @@
 //! Runtime configuration is never treated as proof that a behavior can accept
 //! work. The source projector admits only installed dispatchers not vetoed by
 //! explicit unavailability or a generation-owned startup demotion. The client
-//! projector then fails closed on missing, malformed, non-ready, or stale
-//! observations.
+//! projector then fails closed on missing, malformed, non-ready, or generation-
+//! skewed observations. This is last-known application state, not connectivity.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -12,7 +12,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 pub const BEHAVIOR_READINESS_FORMAT_VERSION: u32 = 1;
-pub const BEHAVIOR_READINESS_MAX_AGE_SECONDS: i64 = 45;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BehaviorReadinessProcessState {
@@ -319,10 +318,12 @@ pub fn decode_behavior_readiness_snapshot(
 /// Strict operational summary from the sole durable readiness authority.
 /// Missing, malformed, non-ready, or generation-skewed observations fail
 /// closed and never manufacture behavior counts from configuration rows.
+/// The clock argument is retained for source compatibility; document age does
+/// not establish runtime liveness. Transport health has its own database owner.
 pub fn project_behavior_readiness_summary(
     row: Option<&AgentBehaviorReadinessRow>,
     expected_agent_did: &str,
-    observed_at: DateTime<Utc>,
+    _observed_at: DateTime<Utc>,
 ) -> ProjectedBehaviorReadinessSummary {
     let Some(row) = row else {
         return ProjectedBehaviorReadinessSummary::Unknown(
@@ -333,11 +334,6 @@ pub fn project_behavior_readiness_summary(
         Ok(snapshot) => snapshot,
         Err(reason) => return ProjectedBehaviorReadinessSummary::Unknown(reason),
     };
-    if !readiness_row_is_fresh(row, observed_at) {
-        return ProjectedBehaviorReadinessSummary::Unknown(
-            BehaviorReadinessUnknownReason::ReadinessStale,
-        );
-    }
     if !snapshot.process_state.accepts_work() {
         return ProjectedBehaviorReadinessSummary::Unknown(
             BehaviorReadinessUnknownReason::ProcessNotReady,
@@ -372,15 +368,14 @@ pub fn project_behavior_readiness_summary(
 
 /// Project the runtime-authored row into the only legal client readiness
 /// states. Configured identifiers are validated exactly, never normalized.
-/// A lagged replica reports `ReadinessStale` without wiping last-known
-/// dispatcher states: consumption clients cannot treat a 45s lease miss as
-/// "the agent is gone."
+/// Readiness changes only when the runtime publishes a semantic change.
+/// The clock argument is retained for source compatibility, not a liveness lease.
 pub fn project_behavior_readiness<'a>(
     row: Option<&AgentBehaviorReadinessRow>,
     expected_agent_did: &str,
     configured_behavior_ids: impl IntoIterator<Item = &'a str>,
     configured_default_behavior_id: Option<&str>,
-    observed_at: DateTime<Utc>,
+    _observed_at: DateTime<Utc>,
 ) -> BehaviorReadinessProjection {
     let mut behavior_ids = BTreeSet::new();
     let mut configured_ids_malformed = false;
@@ -415,7 +410,6 @@ pub fn project_behavior_readiness<'a>(
         Ok(snapshot) => snapshot,
         Err(reason) => return unknown_projection(behavior_ids, reason),
     };
-    let observation_stale = !readiness_row_is_fresh(row, observed_at);
 
     let entries = snapshot
         .behaviors
@@ -464,21 +458,9 @@ pub fn project_behavior_readiness<'a>(
         router_generation: Some(snapshot.router_generation),
         default_behavior_id: Some(snapshot.default_behavior_id),
         updated_at: Some(row.updated_at.clone()),
-        unknown_reason: global_unknown
-            .or(observation_stale.then_some(BehaviorReadinessUnknownReason::ReadinessStale)),
+        unknown_reason: global_unknown,
         behaviors,
     }
-}
-
-fn readiness_row_is_fresh(row: &AgentBehaviorReadinessRow, observed_at: DateTime<Utc>) -> bool {
-    DateTime::parse_from_rfc3339(&row.updated_at)
-        .ok()
-        .map(|updated_at| updated_at.with_timezone(&Utc))
-        .is_some_and(|updated_at| {
-            updated_at <= observed_at
-                && observed_at.signed_duration_since(updated_at).num_seconds()
-                    <= BEHAVIOR_READINESS_MAX_AGE_SECONDS
-        })
 }
 
 #[cfg(test)]

--- a/crates/gents-protocol/src/behavior_readiness.rs
+++ b/crates/gents-protocol/src/behavior_readiness.rs
@@ -216,6 +216,7 @@ pub enum BehaviorReadinessUnknownReason {
     ReadinessMissing,
     ReadinessMalformed,
     ReadinessVersionUnsupported,
+    /// Legacy wire value retained for older clients; current projections do not emit it.
     ReadinessStale,
     ProcessNotReady,
     RouterGenerationStale,

--- a/crates/gents-protocol/src/behavior_readiness/tests.rs
+++ b/crates/gents-protocol/src/behavior_readiness/tests.rs
@@ -67,27 +67,28 @@ fn source_projection_is_sorted_and_unavailability_wins() {
 }
 
 #[test]
-fn ready_snapshot_expires_without_a_runtime_heartbeat() {
+fn ready_snapshot_does_not_expire_without_semantic_changes() {
     let snapshot = readiness_snapshot(vec![BehaviorReadinessEntry {
         behavior_id: "a".to_string(),
         state: BehaviorReadinessState::Ready,
         reason: None,
     }]);
     let row = readiness_row("did:test:agent", serde_json::to_string(&snapshot).unwrap());
-    let stale_at = DateTime::parse_from_rfc3339("2026-08-28T00:00:46Z")
+    let stale_at = DateTime::parse_from_rfc3339("2027-08-28T00:00:46Z")
         .unwrap()
         .with_timezone(&Utc);
     let projection =
         project_behavior_readiness(Some(&row), "did:test:agent", ["a"], Some("a"), stale_at);
-    assert_eq!(
-        projection.unknown_reason,
-        Some(BehaviorReadinessUnknownReason::ReadinessStale)
-    );
+    assert_eq!(projection.unknown_reason, None);
     assert_eq!(
         projection.behaviors.get("a"),
         Some(&ProjectedBehaviorReadiness::Ready),
         "a lagged replica must keep last-known dispatcher readiness"
     );
+    assert!(matches!(
+        project_behavior_readiness_summary(Some(&row), "did:test:agent", stale_at),
+        ProjectedBehaviorReadinessSummary::Observed(_)
+    ));
 }
 
 #[test]

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Runtime.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Runtime.lean
@@ -1,9 +1,21 @@
 import Proofs.Conformance.Contracts.Json.Helpers
 import Proofs.Conformance.ContractCases
+import Proofs.RuntimeReconcile.StartupReadiness
 
 namespace Conformance.Contracts
 
 open Conformance.ContractCases
+
+def readinessPublicationTrace (previous : Option Nat) : List Nat → List Bool
+  | [] => []
+  | next :: rest =>
+      RuntimeReconcile.StartupReadiness.shouldPublish previous next ::
+        readinessPublicationTrace (some next) rest
+
+def readinessPublicationCasesJson : String :=
+  jsonArray ([ [0, 0, 0, 1, 1, 2], [0, 1, 0, 0, 2] ].map fun states =>
+    "{\"states\":" ++ jsonArray (states.map toString) ++
+    ",\"publishes\":" ++ jsonArray ((readinessPublicationTrace none states).map boolString) ++ "}")
 
 def runtimeReconcileCaseJson (witness : RuntimeReconcileCase) : String :=
   "{"

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -135,6 +135,8 @@ def snapshotJson : String :=
       ++ Conformance.ClientShellContracts.requestLifecycleOperatorUiCasesJson ++ ","
     ++ "\"startup_readiness_cases\":"
       ++ startupReadinessCasesJson ++ ","
+    ++ "\"readiness_publication_cases\":"
+      ++ readinessPublicationCasesJson ++ ","
     ++ "\"runtime_reconcile_cases\":"
       ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
     ++ "\"client_behavior_readiness_cases\":"

--- a/crates/gents/proofs/Proofs/RuntimeReconcile/StartupReadiness.lean
+++ b/crates/gents/proofs/Proofs/RuntimeReconcile/StartupReadiness.lean
@@ -256,26 +256,20 @@ theorem demotion_persists_when_unchanged (standing : BehaviorStanding) :
 theorem change_restores_the_budget (standing : BehaviorStanding) :
     acrossGeneration true standing = seeded := rfl
 
-/- A durable Ready row is only an observation lease. A client must see a
-runtime heartbeat no further than `maxAge` behind its current clock. -/
-def observationFresh (publishedAt observedAt maxAge : Nat) : Bool :=
-  decide (publishedAt ≤ observedAt ∧ observedAt - publishedAt ≤ maxAge)
+/- Readiness is durable semantic state, not a transport lease. A newly
+started publisher has no committed snapshot and must publish Recovering;
+subsequent publication requires a semantic change, not elapsed time. -/
+def shouldPublish {α : Type} [DecidableEq α] (previous : Option α) (next : α) : Bool :=
+  decide (previous ≠ some next)
 
-theorem future_readiness_fails_closed (publishedAt observedAt maxAge : Nat)
-    (hFuture : observedAt < publishedAt) :
-    observationFresh publishedAt observedAt maxAge = false := by
-  simp [observationFresh, Nat.not_le.mpr hFuture]
+theorem initial_state_publishes {α : Type} [DecidableEq α] (next : α) :
+    shouldPublish none next = true := by simp [shouldPublish]
 
-theorem expired_readiness_fails_closed (publishedAt observedAt maxAge : Nat)
-    (hPublished : publishedAt ≤ observedAt)
-    (hExpired : maxAge < observedAt - publishedAt) :
-    observationFresh publishedAt observedAt maxAge = false := by
-  simp [observationFresh, hPublished, Nat.not_le.mpr hExpired]
+theorem unchanged_state_does_not_publish {α : Type} [DecidableEq α] (state : α) :
+    shouldPublish (some state) state = false := by simp [shouldPublish]
 
-theorem current_readiness_is_fresh (publishedAt observedAt maxAge : Nat)
-    (hPublished : publishedAt ≤ observedAt)
-    (hCurrent : observedAt - publishedAt ≤ maxAge) :
-    observationFresh publishedAt observedAt maxAge = true := by
-  simp [observationFresh, hPublished, hCurrent]
+theorem changed_state_publishes {α : Type} [DecidableEq α] (previous next : α)
+    (hChanged : previous ≠ next) :
+    shouldPublish (some previous) next = true := by simp [shouldPublish, hChanged]
 
 end RuntimeReconcile.StartupReadiness

--- a/crates/gents/proofs/README.md
+++ b/crates/gents/proofs/README.md
@@ -210,6 +210,7 @@ Provider-input assembly for Claude: the body's `system[]` order and tools omissi
 | `Proofs/SessionHydration/` | Exact applied peer/requester/agent route admission plus selected-network verified membership; exact requester/agent/session document selection; terminality; idempotent crash re-drive; pairing non-interference; and resettable session-scoped receiver progress (#1142). Fence: `tests/conformance/session_hydration.rs`. The reconciler consumes the selected set through DefraDB's bounded peer-targeted document pusher. |
 | `Proofs/CompletionRetry.lean` | Barrel for per-completion retry state, transitions, executable semantics, and budget/deadline/effects properties |
 | `Proofs/RuntimeReconcile.lean` | Barrel for runtime reconcile state, relational transitions, and executable semantics |
+| `Proofs/RuntimeReconcile/StartupReadiness.lean` | Startup/readiness projection and semantic publication predicate. Generated `readiness_publication_cases` drive publisher process-state transitions and require no writes during idle time; document age is not a connectivity lease. |
 | `Proofs/ApplyReconcile.lean` | Barrel for desired-state apply, prefix safety, runtime bridge, and convergence |
 | `Proofs/SelfConfig.lean` | Barrel for agent self-configuration patch semantics: field partitions, merge, write step, and guardrails (#654) |
 | `Proofs/Triggers.lean` | Barrel for trigger types, dispatch, reachability, serial, latest-only, and lineage proofs |

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -356,8 +356,8 @@ const CONVERSATION_RULES: &[CollectionRule] = &[
     },
 ];
 
-/// Requester-scoped session-index grant. Complete historical index hydration
-/// is handled separately by the desktop's node-global branchable pull.
+/// Requester-scoped session-index grant. The database replicator owns initial
+/// replay and reconnect recovery; desktop paging reads its local replica.
 pub const CLIENT_INDEX_COLLECTIONS: [&str; 3] =
     ["AgentConversation", "AgentSession", "MailboxItem"];
 

--- a/crates/gents/src/behavior_readiness_publisher.rs
+++ b/crates/gents/src/behavior_readiness_publisher.rs
@@ -80,7 +80,6 @@ pub(crate) struct BehaviorReadinessPublisherOwner {
 }
 
 const MAX_PERSIST_ATTEMPTS: usize = 5;
-const READINESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 const MIN_PERSIST_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(250);
 const PRODUCTION_PERSIST_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -486,32 +485,16 @@ async fn run_publisher(
     retry_delay: Duration,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let mut heartbeat = tokio::time::interval(READINESS_HEARTBEAT_INTERVAL);
-    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    heartbeat.tick().await;
     loop {
         let command = tokio::select! {
             biased;
             _ = cancel.cancelled() => return Ok(()),
             command = commands.recv() => match command {
-                Some(command) => Some(command),
+                Some(command) => command,
                 None => return Err(anyhow!(
                     "behavior readiness publisher command channel closed"
                 )),
             },
-            _ = heartbeat.tick() => None,
-        };
-        let Some(command) = command else {
-            if state.source.is_some() {
-                let mut candidate = state.clone();
-                let next_observation =
-                    persist_candidate(&writer, &mut candidate, retry_delay, &cancel, true).await?;
-                state = candidate;
-                if *observation.borrow() != next_observation {
-                    observation.send_replace(next_observation);
-                }
-            }
-            continue;
         };
         let close = matches!(&command, Command::Close { .. });
         match command {
@@ -762,8 +745,7 @@ async fn commit_candidate(
     retry_delay: Duration,
     cancel: &CancellationToken,
 ) -> Result<()> {
-    let next_observation =
-        persist_candidate(writer, &mut candidate, retry_delay, cancel, false).await?;
+    let next_observation = persist_candidate(writer, &mut candidate, retry_delay, cancel).await?;
     *state = candidate;
     if *observation.borrow() != next_observation {
         observation.send_replace(next_observation);
@@ -776,7 +758,6 @@ async fn persist_candidate(
     state: &mut PublisherState,
     retry_delay: Duration,
     cancel: &CancellationToken,
-    force: bool,
 ) -> Result<BehaviorAdmissionObservation> {
     let source = state
         .source
@@ -802,7 +783,7 @@ async fn persist_candidate(
         sources,
     )
     .map_err(anyhow::Error::msg)?;
-    if force || state.persisted.as_ref() != Some(&snapshot) {
+    if state.persisted.as_ref() != Some(&snapshot) {
         state.updated_at = Utc::now().to_rfc3339();
         for attempt in 1..=MAX_PERSIST_ATTEMPTS {
             let write = tokio::select! {

--- a/crates/gents/src/behavior_readiness_publisher/tests.rs
+++ b/crates/gents/src/behavior_readiness_publisher/tests.rs
@@ -55,30 +55,58 @@ impl BehaviorReadinessWriter for ControlledWriter {
 }
 
 #[tokio::test(start_paused = true)]
-async fn unchanged_readiness_is_republished_as_a_heartbeat() {
-    let (attempts_tx, mut attempts_rx) = mpsc::unbounded_channel();
-    let writer = Arc::new(ControlledWriter {
-        plans: std::sync::Mutex::new(VecDeque::from([WritePlan::Success, WritePlan::Success])),
-        attempts: attempts_tx,
-        release: Semaphore::new(0),
-        persisted: tokio::sync::Mutex::new(Vec::new()),
-    });
-    let (owner, publisher) = BehaviorReadinessPublisherHandle::start_with_writer(
-        writer,
-        "did:test:heartbeat-readiness-writer",
-        Duration::from_millis(1),
-    );
-    publisher.initialize("general").await.unwrap();
-    assert_eq!(
-        attempts_rx.recv().await,
-        Some(BehaviorReadinessProcessState::Recovering)
-    );
-    tokio::time::advance(READINESS_HEARTBEAT_INTERVAL).await;
-    assert_eq!(
-        attempts_rx.recv().await,
-        Some(BehaviorReadinessProcessState::Recovering)
-    );
-    owner.close().await.unwrap();
+async fn generated_readiness_publication_traces_write_only_semantic_changes() {
+    let cases = crate::lean_vocab_test::lean_readiness_publication_cases();
+    assert_eq!(cases.len(), 2);
+    for case in cases {
+        let (attempts_tx, mut attempts_rx) = mpsc::unbounded_channel();
+        let writer = Arc::new(ControlledWriter {
+            plans: std::sync::Mutex::new(VecDeque::from(vec![
+                WritePlan::Success;
+                case.states.len()
+            ])),
+            attempts: attempts_tx,
+            release: Semaphore::new(0),
+            persisted: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let (owner, publisher) = BehaviorReadinessPublisherHandle::start_with_writer(
+            writer,
+            "did:test:semantic-readiness-writer",
+            Duration::from_millis(1),
+        );
+        assert_eq!(case.states.len(), case.publishes.len());
+        for (index, (&state, &publishes)) in case.states.iter().zip(&case.publishes).enumerate() {
+            let (process, expected) = match state {
+                0 => (
+                    ProcessLifecycleState::Recovering,
+                    BehaviorReadinessProcessState::Recovering,
+                ),
+                1 => (
+                    ProcessLifecycleState::Ready,
+                    BehaviorReadinessProcessState::Ready,
+                ),
+                2 => (
+                    ProcessLifecycleState::Shutdown,
+                    BehaviorReadinessProcessState::Shutdown,
+                ),
+                other => panic!("unmodeled readiness state {other}"),
+            };
+            if index == 0 {
+                assert_eq!(state, 0);
+                publisher.initialize("general").await.unwrap();
+            } else {
+                publisher.set_process_state(process).await.unwrap();
+            }
+            assert_eq!(attempts_rx.try_recv().ok(), publishes.then_some(expected));
+            tokio::time::advance(Duration::from_secs(3600)).await;
+            tokio::task::yield_now().await;
+            assert!(
+                attempts_rx.try_recv().is_err(),
+                "idle time must not publish readiness"
+            );
+        }
+        owner.close().await.unwrap();
+    }
 }
 
 #[tokio::test]

--- a/crates/gents/src/config_client/retry.rs
+++ b/crates/gents/src/config_client/retry.rs
@@ -79,20 +79,10 @@ pub(super) fn is_transaction_conflict_text(text: &str) -> bool {
 }
 
 pub(super) fn graphql_value_is_transaction_conflict(value: &serde_json::Value) -> bool {
-    // Match DefraDB's `QueryResponse::is_transaction_conflict`: a conflict is
-    // replayable only when the response has no data field at all. `data: null`
-    // is still a present response payload and must fail closed.
-    if value.get("data").is_some() {
-        return false;
-    }
-    let Some(errors) = value.get("errors").and_then(serde_json::Value::as_array) else {
-        return false;
-    };
-    errors.len() == 1
-        && errors[0]
-            .pointer("/extensions/code")
-            .and_then(serde_json::Value::as_str)
-            == Some("TXN_CONFLICT")
+    // Share the embedded DB's classification, including its JSON null/absent
+    // representation of no result. Malformed replies remain non-replayable.
+    <query::QueryResponse as serde::Deserialize>::deserialize(value)
+        .is_ok_and(|response| response.is_transaction_conflict())
 }
 
 #[cfg(test)]
@@ -120,7 +110,7 @@ mod tests {
         assert!(!graphql_value_is_transaction_conflict(&serde_json::json!({
             "errors": [{"message": "transaction conflict; please retry"}]
         })));
-        assert!(!graphql_value_is_transaction_conflict(&serde_json::json!({
+        assert!(graphql_value_is_transaction_conflict(&serde_json::json!({
             "data": null,
             "errors": [{"message": "opaque", "extensions": {"code": "TXN_CONFLICT"}}]
         })));
@@ -134,7 +124,7 @@ mod tests {
     fn conflict_shape_matches_pinned_defradb_serialization() {
         let response = query::QueryResponse::transaction_conflict("opaque");
         let value = serde_json::to_value(response).expect("serialize DefraDB response");
-        assert!(value.get("data").is_none());
+        assert_eq!(value.get("data"), Some(&serde_json::Value::Null));
         assert!(graphql_value_is_transaction_conflict(&value));
 
         let success = serde_json::to_value(query::QueryResponse::success(serde_json::json!({
@@ -142,5 +132,20 @@ mod tests {
         })))
         .expect("serialize successful DefraDB response");
         assert!(success.get("errors").is_none());
+    }
+
+    #[test]
+    fn malformed_or_mixed_replies_are_not_replayable() {
+        for value in [
+            serde_json::Value::Null,
+            serde_json::json!({"errors": "TXN_CONFLICT"}),
+            serde_json::json!({"errors": [{"extensions": {"code": "TXN_CONFLICT"}}]}),
+            serde_json::json!({"data": null, "errors": [
+                {"message": "conflict", "extensions": {"code": "TXN_CONFLICT"}},
+                {"message": "another error"}
+            ]}),
+        ] {
+            assert!(!graphql_value_is_transaction_conflict(&value), "{value}");
+        }
     }
 }

--- a/crates/gents/src/lean_vocab_test/support.rs
+++ b/crates/gents/src/lean_vocab_test/support.rs
@@ -97,6 +97,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) client_behavior_readiness_cases: Vec<LeanClientBehaviorReadinessCase>,
     #[serde(default)]
     pub(crate) startup_readiness_cases: Vec<LeanStartupReadinessCase>,
+    pub(crate) readiness_publication_cases: Vec<LeanReadinessPublicationCase>,
     pub(crate) apply_reconcile_cases: Vec<LeanApplyReconcileCase>,
     #[serde(default)]
     pub(crate) tool_policy_cases: Vec<LeanToolPolicyCase>,
@@ -921,6 +922,10 @@ pub(crate) fn lean_request_execution_lease_trace_cases(
 
 pub(crate) fn lean_startup_readiness_cases() -> &'static [LeanStartupReadinessCase] {
     &lean_contract_snapshot().startup_readiness_cases
+}
+
+pub(crate) fn lean_readiness_publication_cases() -> &'static [LeanReadinessPublicationCase] {
+    &lean_contract_snapshot().readiness_publication_cases
 }
 
 pub(crate) fn lean_runtime_reconcile_cases() -> &'static [LeanRuntimeReconcileCase] {

--- a/crates/gents/src/lean_vocab_test/triggers_runtime_apply.rs
+++ b/crates/gents/src/lean_vocab_test/triggers_runtime_apply.rs
@@ -186,6 +186,13 @@ pub(crate) struct LeanApplyReconcileCase {
     pub(crate) delete_safety_holds: bool,
 }
 
+/// Semantic readiness publication traces, independent of elapsed idle time.
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanReadinessPublicationCase {
+    pub(crate) states: Vec<u64>,
+    pub(crate) publishes: Vec<bool>,
+}
+
 /// Startup-readiness vectors for the bounded build-failure barrier (#559).
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct LeanStartupReadinessCase {

--- a/crates/gents/tests/conformance/client_runtime.rs
+++ b/crates/gents/tests/conformance/client_runtime.rs
@@ -291,6 +291,31 @@ fn generated_behavior_readiness_cases_drive_the_production_projector() {
             .behaviors
             .get("20")
             .unwrap_or_else(|| panic!("{} missing selected behavior", case.name));
+        // The generated model projects semantic runtime state, not an
+        // observation lease. Idle age and clock skew cannot change its answer.
+        for timestamp in ["1970-01-01T00:00:00Z", "2999-01-01T00:00:00Z"] {
+            let mut aged_row = row.clone();
+            aged_row.updated_at = timestamp.to_string();
+            let aged = project_behavior_readiness(
+                case.observation_present.then_some(&aged_row),
+                "did:test:lean-readiness",
+                ["20"],
+                Some("20"),
+                chrono::DateTime::parse_from_rfc3339("2026-08-28T00:00:10Z")
+                    .unwrap()
+                    .with_timezone(&chrono::Utc),
+            );
+            assert_eq!(
+                aged.behaviors, projection.behaviors,
+                "{}: {timestamp}",
+                case.name
+            );
+            assert_eq!(
+                aged.unknown_reason, projection.unknown_reason,
+                "{}: {timestamp}",
+                case.name
+            );
+        }
         let (state, reason) = match projected {
             ProjectedBehaviorReadiness::Ready => ("ready", None),
             ProjectedBehaviorReadiness::Unavailable(reason) => {

--- a/packages/gents-desktop-chat/src/chat-shell.test.ts
+++ b/packages/gents-desktop-chat/src/chat-shell.test.ts
@@ -448,7 +448,7 @@ describe("projectChatShell", () => {
     expect(projection.sendStatus).toEqual({
       kind: "disabled",
       reason: "routeNotReady",
-      hint: "The agent is connected, but its signed conversation route is not ready yet.",
+      hint: "The pairing request was sent and is waiting for the agent to accept it.",
     });
   });
 

--- a/packages/gents-desktop-client/src/operationalState.test.ts
+++ b/packages/gents-desktop-client/src/operationalState.test.ts
@@ -156,7 +156,7 @@ describe("deployment operational state", () => {
     });
   });
 
-  it("still fails closed when the local host stops publishing readiness", () => {
+  it("still accepts a legacy local readiness-stale verdict", () => {
     const state = projectDeploymentOperationalState(
       deployment({
         source: "local-standard",
@@ -171,6 +171,16 @@ describe("deployment operational state", () => {
       reason: "readiness_stale",
       shortLabel: "Runtime unavailable",
     });
+  });
+
+  it("blocks a disconnected local host despite retained Ready state", () => {
+    const state = projectDeploymentOperationalState(
+      deployment({ source: "local-standard", dialSucceeded: false }),
+    );
+    expect(state.behavior.kind).toBe("ready");
+    expect(state.admissionBlocker).toBe(state.transport);
+    expect(state.summary).toBe(state.transport);
+    expect(state.summary.shortLabel).toBe("Not connected");
   });
 
   it("does not let unrelated database work block current signed readiness", () => {


### PR DESCRIPTION
## Summary

Restore mobile conversation recovery using the existing database and pairing owners, with a canonical end-to-end acceptance test.

- Stop writing unchanged readiness every 15 seconds and stop interpreting its age as a connectivity lease. Preserve semantic changes, startup/shutdown writes, and legacy decoding/source compatibility.
- Delete app-issued collection-wide reconnect replay and its duplicate retry/error bookkeeping. Keep enrollment, route authorization, and explicit session-selection intent.
- Move to current-main DefraDB `287a934d3fe55800ef665b0cba74bf6d64cd0de7` with the replication fixes and new multiplexed Iroh protocol; no machine-local path overrides or identity reset.
- Delegate HTTP transaction-conflict classification to DefraDB's QueryResponse. The new revision serializes no result as `data: null`; the duplicated old rule suppressed legitimate retries. Partial, malformed, and mixed-error replies remain non-replayable.
- Fix the existing Claude-login mutation and stale test fixtures to use the single write owner.

## Release stack

Depends on the database fixes reviewed upstream in https://github.com/sourcenetwork/defradb.rs/pull/1726. Use current DefraDB and its new Iroh protocol downstream. The compatibility-backport plan is retired, not a release dependency. The phone and runtimes must be validated and upgraded together; mixed-version interoperability is not assumed.

Merge/release order: get the DB PR reviewed and green → validate Gents against that current-main revision → accept this Gents change → build matching server/iPhone candidates → verify Amy and Mandrake on the device → prepare v0.16.2. This PR does not tag or deploy a release.

## Canonical contract

Real CLI init/server, signed `/status` enrollment/operator approval, Iroh/QUIC, and iOS `ClientCore` plus its local database. Only inference is fake.

- Fresh and 2,500-revision runtime fixtures pair and produce a completed assistant transcript.
- The fake provider cannot send the offline reply until the app has shut down; reopening the same home recovers that distinct reply without reenrollment or app-wide recovery calls.
- The next provider prompt must contain both distinct previous replies.
- The aged gate requires the final seeded readiness timestamp or a later update, not mere row presence.
- After hydration completes, bounded local pages preserve ordering/completeness and full pairing/hydration state, including served progress.

Multi-session exclusion, reinstall with prior requester history, real iOS suspension/rendering, and production device latency remain separate acceptance gaps. The current integration budgets are regression bounds, not UX SLOs.

## Validation

Forward-pin validation (`CARGO_INCREMENTAL=0`):

- `cargo test -p gents`: pass.
- `cargo check --workspace --all-targets --locked`: pass.
- CLI library: 1,006 pass after correcting old fixture mutation calls and the obsolete Prometheus freshness expectation.
- Desktop core: 194 pass.
- Canonical enrollment/conversation E2E: all three tests pass, including both fresh/2,500-revision contracts and the existing enrollment smoke test (90.70 s total). Local enrollment: fresh 4.27 s, aged 14.10 s; offline reply recovery 5.76/3.59 s. Follow-up replies reached the client DB in 3.21/3.09 s including deterministic 2 s inference. These are local observations, not physical-phone measurements or percentile SLOs.
- Prior validation of unchanged proof/UI changes: `lake build` and 30 shared desktop-client tests pass. Generated readiness publication traces check semantic changes and idle periods without writes; the UI test covers a disconnected local host retaining Ready state. Old-pin E2E results are not new-protocol evidence.

All Rust worktree builds use `CARGO_INCREMENTAL=0`. npm dependencies retain the existing lock; install reported three audit advisories, and no automatic dependency fixes were applied.

## Review / why draft

Direct Claude reviews led to stronger offline, transcript-continuity, aged-convergence, and pagination assertions, plus the Prometheus test correction. Database reviews found two concrete defects now fixed with regressions: rooted timeouts vetoing independent grants and local deferred ingest bypassing retry pacing.
Direct Claude review of the forward-pin/API/conflict-classifier delta found no verified blocker; it does not establish physical-device acceptance.

The Gents `code_review` pack is running its four-lens scan → verification → triage workflow on pinned evidence in an isolated local-only server. Terminal reports and final-delta adjudication are still pending. Grok invocations returned setup-only text, so they are **not** counted as completed reviews.

Review must explicitly distinguish last-known semantic readiness from transport health. In particular, publisher-task supervision/healthz and historical index recovery coverage still require final adjudication; this PR does not claim they are proven by a Ready document or by the mobile transport test.

Keep draft until review and CI gates are resolved. No claim of completed iPhone acceptance or release readiness yet.
