### PR TITLE
release: prepare v0.16.2 mobile recovery

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.16.1"
+        default: "0.16.2"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.16.1"
+        default: "0.16.2"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.16.2 - 2026-09-08
+
+### Fixed
+
+- Let DefraDB own durable reconnect recovery and immediate replication wakeups;
+  remove redundant application-wide replay and unchanged readiness heartbeats.
+- Batch deep-history merge writes and remove the extra pre-send delay.
+- Preserve HTTP transaction-conflict retries using DefraDB's own classifier.
+- Verify fresh and aged enrollment, completed conversations, offline reply
+  recovery, transcript continuity, and local pagination with canonical tests.
+
+### Upgrade
+
+- Upgrade phone/desktop clients and runtimes together. The updated DefraDB
+  dependency uses multiplexed Iroh; mixed old/new protocol peers are not
+  supported. Preserve existing stores, identities, and enrollment state.
+
 ## 0.16.1 - 2026-09-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "acp",
  "alloy-dyn-abi",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "gents-chatgpt-login"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "base64 0.22.1",
  "gents-protocol",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "gents-claude-login"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.2",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "acp",
  "anyhow",
@@ -3938,7 +3938,7 @@ dependencies = [
 
 [[package]]
 name = "gents-codex-protocol"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "globset",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4145,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.16.1"
+version = "0.16.2"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/gents-ai/gents"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.16.1",
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-fleet": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1",
+    "@source-inc/gents-desktop-chat": "0.16.2",
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-fleet": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -52,14 +52,14 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-chat": "0.16.1",
-    "@source-inc/gents-desktop-fleet": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1"
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-chat": "0.16.2",
+    "@source-inc/gents-desktop-fleet": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-operations": "0.16.1",
+    "@source-inc/gents-desktop-operations": "0.16.2",
     "@antithesishq/bombadil": "^0.6.0",
     "@playwright/test": "^1.61.0",
     "@tauri-apps/cli": "2.10.1",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.16.1</string>
+	<string>0.16.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.16.1</string>
+	<string>0.16.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.16.1
-        CFBundleVersion: "0.16.1"
+        CFBundleShortVersionString: 0.16.2
+        CFBundleVersion: "0.16.2"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/review-demo/package.json
+++ b/apps/review-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/review-demo-ui",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "scripts": {
     "dev": "vite --strictPort --host 127.0.0.1",
@@ -10,8 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -309,7 +309,7 @@
     "desktop://managed-server-updated",
     "desktop://managed-server-tray-stop"
   ],
-  "packageVersion": "0.16.1",
+  "packageVersion": "0.16.2",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -19,13 +19,13 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.16.1",
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-fleet": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-chat": "0.16.2",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-fleet": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,16 +43,16 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.16.1",
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-fleet": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-chat": "0.16.2",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-fleet": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -64,7 +64,7 @@
       "devDependencies": {
         "@antithesishq/bombadil": "^0.6.0",
         "@playwright/test": "^1.61.0",
-        "@source-inc/gents-desktop-operations": "0.16.1",
+        "@source-inc/gents-desktop-operations": "0.16.2",
         "@tauri-apps/cli": "2.10.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -82,10 +82,10 @@
     },
     "apps/review-demo": {
       "name": "@source-inc/review-demo-ui",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -5097,12 +5097,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5112,9 +5112,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5124,7 +5124,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5136,12 +5136,12 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5150,21 +5150,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5173,24 +5173,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.1",
-        "@source-inc/gents-desktop-tokens": "0.16.1",
-        "@source-inc/gents-desktop-ui": "0.16.1",
+        "@source-inc/gents-desktop-client": "0.16.2",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
+        "@source-inc/gents-desktop-ui": "0.16.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.16.1",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5202,7 +5202,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.16.1",
+        "@source-inc/gents-desktop-tokens": "0.16.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1"
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1",
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -12,7 +12,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.16.1";
+export const PACKAGE_VERSION = "0.16.2";
 // The client and bridge share one exact breaking contract. Sync status comes
 // from database-owned gauges; goal permissions are explicit fields.
 export const BRIDGE_CONTRACT_VERSION = "6.3";

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "description": "Reusable authenticated enrollment, connection health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -36,14 +36,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1"
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1",
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "description": "Focused holds, health, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1"
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.16.1",
-    "@source-inc/gents-desktop-tokens": "0.16.1",
-    "@source-inc/gents-desktop-ui": "0.16.1",
+    "@source-inc/gents-desktop-client": "0.16.2",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
+    "@source-inc/gents-desktop-ui": "0.16.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.16.1",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.16.1",
+    "@source-inc/gents-desktop-tokens": "0.16.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary

Prepare the lockstep v0.16.2 release on top of merged #1423. Version metadata and changelog only; keep the exact merged DefraDB production pin. Hashbrown's unrelated 0.16.1 dependency is unchanged.

The release requires matching phone/server upgrades for multiplexed Iroh. No store reset, identity change, or new network membership is part of this release.

## Validation

- Package boundary/lockstep version check passes.
- Locked workspace/all-target check passes.
- Full `cargo test -p gents --locked` passes, including runtime units, conformance, integration, and doc tests.
- iOS archive/export succeeds and codesign verifies bundle `com.source-inc.gents`, version 0.16.2, existing Apple team.
- Prior production-delta validation in #1423 includes all CI checks, 1,006 CLI library tests, 194 desktop-core tests, and all three enrollment tests (fresh/aged/offline conversation contracts).

The phone build has not yet been installed, and the targeted Amy/Mandrake rollout waits for verified release artifacts. No device acceptance claim yet.
