### PR TITLE
fix(grok-shim): write the pager's session record so /resume can reattach

### DIFF
--- a/crates/gents-cli/src/commands/grok_shim.rs
+++ b/crates/gents-cli/src/commands/grok_shim.rs
@@ -37,6 +37,7 @@ mod goals;
 pub(crate) mod projection;
 pub(crate) mod protocol;
 pub(crate) mod server;
+mod session_record;
 mod sessions;
 mod task_control;
 pub(crate) mod turn;
@@ -202,6 +203,7 @@ impl AcpDelegateFactoryInputs {
                     name: inputs.bound.model_name.clone(),
                     total_context_tokens: inputs.bound.total_context_tokens,
                 },
+                grok_home: crate::commands::grok_shim::session_record::default_grok_home(),
             },
             turns,
             projections,

--- a/crates/gents-cli/src/commands/grok_shim/acp.rs
+++ b/crates/gents-cli/src/commands/grok_shim/acp.rs
@@ -221,6 +221,9 @@ pub(crate) struct AcpServiceConfig {
     pub(crate) behavior_id: Arc<str>,
     /// Bound model the runtime serves for this behavior.
     pub(crate) current_model: BoundModel,
+    /// Grok home the pager reads its `/resume` records from (`$GROK_HOME`,
+    /// else `~/.grok`). `None` disables the record write.
+    pub(crate) grok_home: Option<std::path::PathBuf>,
 }
 
 impl AcpServiceConfig {
@@ -912,6 +915,7 @@ impl AcpService {
 
         let session_id = preferred.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         ensure_session_document(&self.config, &session_id).await?;
+        self.write_pager_session_record(request, &session_id);
 
         {
             let mut sessions = self.sessions.lock().await;
@@ -960,6 +964,38 @@ impl AcpService {
 
     /// Replay existing observations, then attach after the RPC response.
     /// Loading does not reactivate or otherwise mutate AgentSession rows.
+    /// Stock grok lists every session the leader returns but only sends
+    /// `session/load` for one that also has a local record under its grok
+    /// home; the shim writes that record so `/resume` can reattach. A write
+    /// failure is logged, never surfaced: the durable session is the
+    /// `AgentSession` document, not grok's file.
+    fn write_pager_session_record(&self, request: &AcpRequest, session_id: &str) {
+        let Some(grok_home) = self.config.grok_home.as_deref() else {
+            return;
+        };
+        let cwd = request
+            .params
+            .get("cwd")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .unwrap_or_default();
+        match super::session_record::write_record(grok_home, cwd, session_id) {
+            Ok(Some(path)) => tracing::debug!(
+                %session_id,
+                path = %path.display(),
+                "grok shim wrote the pager's session record"
+            ),
+            Ok(None) => {}
+            Err(error) => tracing::warn!(
+                %error,
+                %session_id,
+                grok_home = %grok_home.display(),
+                "grok shim could not write the pager's session record; grok will list this \
+                 session but not resume it"
+            ),
+        }
+    }
+
     async fn handle_session_load(
         &self,
         request: &AcpRequest,
@@ -1766,6 +1802,7 @@ mod tests {
                 agent_name: Arc::from("grok-shim-test"),
                 behavior_id: Arc::from("did:test:grok-shim:default"),
                 current_model: bound_model(),
+                grok_home: None,
             },
         )
     }
@@ -2447,6 +2484,7 @@ mod tests {
             agent_name: Arc::from("grok-shim-test"),
             behavior_id: Arc::from(behavior_id.as_str()),
             current_model: bound_model(),
+            grok_home: None,
         };
         gents::schema::ensure_runtime_schemas(config.node.as_ref())
             .await
@@ -3268,6 +3306,38 @@ mod tests {
             !staging_root.exists(),
             "the whole staging directory must be cleaned up, not abandoned"
         );
+    }
+
+    #[tokio::test]
+    async fn session_new_writes_the_grok_record_the_resume_picker_needs() {
+        // Stock grok only sends session/load for a listed session that also has
+        // a local summary.json under <grok home>/sessions/<encoded cwd>/<id>/.
+        let (_staging, mut service) = test_service().await;
+        let home = tempfile::tempdir().expect("grok home");
+        service.config.grok_home = Some(home.path().to_path_buf());
+        let dispatch = service
+            .handle_acp_payload(&request_payload(
+                "session/new",
+                json!({
+                    "cwd": "/Users/edjroz/Repos/gents",
+                    "mcpServers": [],
+                    "_meta": { "sessionId": "grok-resume-record" },
+                }),
+            ))
+            .await;
+        let response = parse_response(dispatch.response.as_deref().expect("response"));
+        assert_eq!(response["result"]["sessionId"], "grok-resume-record");
+
+        let path = home
+            .path()
+            .join("sessions/%2FUsers%2Fedjroz%2FRepos%2Fgents/grok-resume-record/summary.json");
+        let record: Value = serde_json::from_slice(
+            &std::fs::read(&path).expect("session/new writes the pager's session record"),
+        )
+        .expect("record is json");
+        assert_eq!(record["info"]["id"], "grok-resume-record");
+        assert_eq!(record["info"]["cwd"], "/Users/edjroz/Repos/gents");
+        assert_eq!(record["chat_format_version"], 1);
     }
 
     #[tokio::test]

--- a/crates/gents-cli/src/commands/grok_shim/session_record.rs
+++ b/crates/gents-cli/src/commands/grok_shim/session_record.rs
@@ -1,0 +1,141 @@
+//! Grok-side session record for the pager's `/resume` picker.
+//!
+//! Stock Grok lists whatever the leader returns from `x.ai/session/list`, but
+//! it only sends `session/load` for a session that also has a local record at
+//! `<grok home>/sessions/<percent-encoded cwd>/<session id>/summary.json`.
+//! Grok's own leader writes that record; when Gents is the leader nothing
+//! does, so shim sessions are listed but silently unresumable. The shim writes
+//! the minimal record Grok needs at `session/new`. The record is Grok's file
+//! and Gents never reads it back; the durable session is the `AgentSession`
+//! document.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::{SecondsFormat, Utc};
+use serde_json::json;
+
+/// `$GROK_HOME` (documented by grok as the config directory override), else
+/// `$HOME/.grok`.
+pub(super) fn default_grok_home() -> Option<PathBuf> {
+    if let Some(home) = std::env::var_os("GROK_HOME") {
+        return Some(PathBuf::from(home));
+    }
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".grok"))
+}
+
+/// Grok names the per-cwd session directory with the percent-encoded path:
+/// everything but unreserved characters (`A-Z a-z 0-9 - _ . ~`) is `%XX`.
+pub(super) fn encode_cwd(cwd: &str) -> String {
+    let mut out = String::with_capacity(cwd.len() * 3);
+    for byte in cwd.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+/// Session ids come from the pager, so only a plain id may become a path
+/// segment inside the operator's grok home.
+fn is_plain_segment(session_id: &str) -> bool {
+    !session_id.is_empty()
+        && session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
+/// Write the minimal record unless one already exists (Grok owns it after
+/// that). Returns the path written, or `None` when nothing was written.
+pub(super) fn write_record(
+    grok_home: &Path,
+    cwd: &str,
+    session_id: &str,
+) -> Result<Option<PathBuf>> {
+    if !Path::new(cwd).is_absolute() || !is_plain_segment(session_id) {
+        return Ok(None);
+    }
+    let path = grok_home
+        .join("sessions")
+        .join(encode_cwd(cwd))
+        .join(session_id)
+        .join("summary.json");
+    if path.exists() {
+        return Ok(None);
+    }
+    let stamp = Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true);
+    crate::request_helpers::write_json_output_file(
+        &path,
+        &json!({
+            "info": {"id": session_id, "cwd": cwd},
+            "created_at": stamp,
+            "updated_at": stamp,
+            "last_active_at": stamp,
+            "chat_format_version": 1,
+        }),
+    )?;
+    Ok(Some(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_the_cwd_the_way_grok_names_session_directories() {
+        // Observed on disk: ~/.grok/sessions/%2FUsers%2Fedjroz%2FRepos%2Fgents
+        // and %2FRepos%2FSource%2Fdefradb.rs, %2F...%2Fdefradb-rustffi.
+        assert_eq!(
+            encode_cwd("/Users/edjroz/Repos/gents"),
+            "%2FUsers%2Fedjroz%2FRepos%2Fgents"
+        );
+        assert_eq!(encode_cwd("/Repos/defradb.rs"), "%2FRepos%2Fdefradb.rs");
+        assert_eq!(encode_cwd("/a b/x-y_z~"), "%2Fa%20b%2Fx-y_z~");
+    }
+
+    #[test]
+    fn writes_the_minimal_record_once_and_leaves_an_existing_one_alone() {
+        let home = tempfile::tempdir().expect("grok home");
+        let written = write_record(home.path(), "/Users/edjroz/Repos/gents", "3e5d627d")
+            .expect("write")
+            .expect("first write creates the record");
+        assert_eq!(
+            written,
+            home.path()
+                .join("sessions/%2FUsers%2Fedjroz%2FRepos%2Fgents/3e5d627d/summary.json")
+        );
+        let record: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&written).expect("read")).expect("json");
+        assert_eq!(record["info"]["id"], "3e5d627d");
+        assert_eq!(record["info"]["cwd"], "/Users/edjroz/Repos/gents");
+        let created = record["created_at"].as_str().expect("created_at");
+        assert!(created.ends_with('Z'), "rfc3339 utc: {created}");
+        assert_eq!(record["updated_at"], record["created_at"]);
+        assert_eq!(record["last_active_at"], record["created_at"]);
+        assert_eq!(record["chat_format_version"], 1);
+
+        let again = write_record(home.path(), "/Users/edjroz/Repos/gents", "3e5d627d")
+            .expect("second write");
+        assert_eq!(again, None, "an existing record belongs to grok");
+        let unchanged: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&written).expect("read")).expect("json");
+        assert_eq!(unchanged, record);
+    }
+
+    #[test]
+    fn refuses_relative_cwds_and_unsafe_session_ids() {
+        let home = tempfile::tempdir().expect("grok home");
+        assert_eq!(
+            write_record(home.path(), "relative", "s1").expect("ok"),
+            None
+        );
+        assert_eq!(
+            write_record(home.path(), "/tmp", "../escape").expect("ok"),
+            None
+        );
+        assert_eq!(write_record(home.path(), "/tmp", "").expect("ok"), None);
+        assert!(!home.path().join("sessions").exists());
+    }
+}


### PR DESCRIPTION
Closes #1428.

Stock grok's `/resume` picker lists every session the leader returns from `x.ai/session/list`, but only sends `session/load` for a session that also has a local record at `<grok home>/sessions/<percent-encoded cwd>/<id>/summary.json`. Grok's own leader writes that record; with gents as the leader nothing did, so shim sessions were listed and silently unresumable.

The shim now writes the minimal record at `session/new` for the pager's `cwd`, under `$GROK_HOME` (grok's documented override) or `~/.grok`: `info.{id,cwd}`, three timestamps, `chat_format_version: 1`. It never fails the request on a write error, never overwrites an existing record, and skips cwds or session ids that cannot be plain path segments. Gents never reads the file back; the durable session stays the `AgentSession` document.

**Evidence.** Traced on grok 1.0.13 with `--debug` against an isolated home: no record, Enter sends nothing; record present, `session/load` arrives, the shim replays, grok logs `Session loaded`. A 225-byte `summary.json` alone is sufficient. Verified end to end on this branch with a fresh pager and no hand-staged files.

**Tests.** `session_record` unit tests (cwd encoding matched against grok's on-disk directory names, record content and idempotence, refusal of relative cwds and unsafe ids) and `session_new_writes_the_grok_record_the_resume_picker_needs`. `cargo test -p gents-cli --lib grok_shim` 336/336 before the review trim; `cargo check --workspace --all-targets` clean.

**Local CI gate.** Mirror of the `rust-and-cli` pull_request steps run on this branch on macOS (fmt, native-e2e capabilities, package coverage, runtime/cli/desktop/tauri/support compiles, WASM, support tests, the 7 PR smoke tests, desktop and tauri tests): 19 of 21 pass. The two reds are iroh peer-dial timeouts on this machine: conformance `generated_r5_cross_deployment_cases_drive_production_dispatch` (reproduced identically on clean main here; passes on the Linux runners) and desktop `client_core::two_client_cores_connect_over_iroh` (the dial CI's own step comment guards with `--no-fail-fast`). CI on main is currently red at 7c9d9406 in the push-only full-suite steps, unrelated to this branch.

**Out of scope.** `updated_at` is not refreshed after turns (the leader's list orders the picker); list entries carry no `cwd`, so the picker groups them under "unknown"; `grok --resume <id>` from the command line goes to grok's local store then xAI.