### PR TITLE
feat(cli): add Claude subscription to init picker, inline login, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ For worked document-driven scenarios, use `gents pack list` and see the
 
 The binary also carries an immutable catalog of useful graphs. Cataloging is
 read-only. Interactive init can configure OpenAI API access, ChatGPT/Codex
-OAuth, Grok OAuth, a local model, or a custom endpoint. A bundled graph inherits
-that default backend when it is installed:
+OAuth, Grok OAuth, Claude subscription OAuth, a local model, or a custom
+endpoint. A bundled graph inherits that default backend when it is installed:
 
 ```bash
-gents init                 # choose ChatGPT / Codex and complete OAuth
+gents init                 # choose ChatGPT / Codex, Grok, or Claude and complete OAuth
 gents server               # keep this running in another terminal
 
 gents pack show code_review

--- a/crates/gents-cli/src/commands/init.rs
+++ b/crates/gents-cli/src/commands/init.rs
@@ -190,6 +190,8 @@ pub(crate) async fn init(mut args: InitArgs) -> Result<()> {
         maybe_inline_codex_login(&access, initialized_identity.identity.did(), &summary).await;
     let grok_login =
         maybe_inline_grok_login(&access, initialized_identity.identity.did(), &summary).await;
+    let claude_login =
+        maybe_inline_claude_login(&access, initialized_identity.identity.did(), &summary).await;
 
     let output = json!({
         "status": "initialized",
@@ -225,10 +227,14 @@ pub(crate) async fn init(mut args: InitArgs) -> Result<()> {
         "grok_login": grok_login
             .outcome()
             .map(crate::commands::grok_login::grok_login_result_json),
+        "claude_login": claude_login
+            .outcome()
+            .map(crate::commands::claude_login::claude_login_result_json),
         "next_steps": init_next_steps(
             &summary,
             codex_login.is_authenticated(),
             grok_login.is_authenticated(),
+            claude_login.is_authenticated(),
         ),
         "init": summary,
     });
@@ -311,6 +317,72 @@ async fn maybe_inline_grok_login(
         Err(error) => {
             eprintln!("Grok login failed: {error:#}");
             InlineGrokLoginState::Unauthenticated
+        }
+    }
+}
+
+enum InlineClaudeLoginState {
+    Unauthenticated,
+    ExistingCredential,
+    Completed(crate::commands::claude_login::ClaudeLoginOutcome),
+}
+
+impl InlineClaudeLoginState {
+    fn is_authenticated(&self) -> bool {
+        matches!(self, Self::ExistingCredential | Self::Completed(_))
+    }
+
+    fn outcome(&self) -> Option<&crate::commands::claude_login::ClaudeLoginOutcome> {
+        match self {
+            Self::Completed(outcome) => Some(outcome),
+            Self::Unauthenticated | Self::ExistingCredential => None,
+        }
+    }
+}
+
+async fn maybe_inline_claude_login(
+    access: &ConfigAccess,
+    agent_did: &str,
+    summary: &InitSummary,
+) -> InlineClaudeLoginState {
+    if summary.provider_kind != gents::BackendProviderKind::ClaudeCliSubscription {
+        return InlineClaudeLoginState::Unauthenticated;
+    }
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return InlineClaudeLoginState::Unauthenticated;
+    }
+    let provider =
+        gents::claude_oauth::normalize_provider(gents::claude_oauth::CLAUDE_OAUTH_PROVIDER);
+    // The credential lookup is provider-generic; the grok probe just owns the copy.
+    match crate::commands::grok_auth_probe::load_oauth_credential(access, agent_did, &provider)
+        .await
+    {
+        Ok(Some(_)) => return InlineClaudeLoginState::ExistingCredential,
+        Ok(None) => {}
+        Err(error) => {
+            eprintln!("Could not check for an existing Claude credential: {error:#}");
+        }
+    }
+    if !crate::interactive_backend::confirm("Log in to Claude now to finish setup?", true).await {
+        return InlineClaudeLoginState::Unauthenticated;
+    }
+    match crate::commands::claude_login::run_claude_login(
+        access,
+        agent_did,
+        &crate::commands::claude_login::ClaudeLoginOptions {
+            provider,
+            manual: false,
+            open_browser: true,
+            client_id: None,
+            token_url: None,
+        },
+    )
+    .await
+    {
+        Ok(outcome) => InlineClaudeLoginState::Completed(outcome),
+        Err(error) => {
+            eprintln!("Claude login failed: {error:#}");
+            InlineClaudeLoginState::Unauthenticated
         }
     }
 }
@@ -955,6 +1027,7 @@ fn init_next_steps(
     summary: &InitSummary,
     codex_logged_in: bool,
     grok_logged_in: bool,
+    claude_logged_in: bool,
 ) -> Vec<String> {
     let mut steps = Vec::new();
     if summary.provider_kind == gents::BackendProviderKind::ChatGptCodex && !codex_logged_in {
@@ -962,6 +1035,11 @@ fn init_next_steps(
     }
     if summary.provider_kind == gents::BackendProviderKind::XaiGrokOAuth && !grok_logged_in {
         steps.push("gents grok-login".to_string());
+    }
+    if summary.provider_kind == gents::BackendProviderKind::ClaudeCliSubscription
+        && !claude_logged_in
+    {
+        steps.push("gents claude-login".to_string());
     }
     if is_probably_ollama_endpoint(&summary.endpoint) {
         steps.push(format!("ollama pull {}", summary.model_name));
@@ -1063,12 +1141,47 @@ mod tests {
     }
 
     #[test]
+    fn claude_next_steps_lead_with_login() {
+        let steps = init_next_steps(
+            &init_summary(
+                BackendProviderKind::ClaudeCliSubscription,
+                "claude-cli://subscription",
+            ),
+            false,
+            false,
+            false,
+        );
+        assert_eq!(
+            steps.first().map(String::as_str),
+            Some("gents claude-login")
+        );
+    }
+
+    #[test]
+    fn claude_next_steps_drop_login_after_inline_login() {
+        let steps = init_next_steps(
+            &init_summary(
+                BackendProviderKind::ClaudeCliSubscription,
+                "claude-cli://subscription",
+            ),
+            false,
+            false,
+            true,
+        );
+        assert!(!steps.iter().any(|step| step == "gents claude-login"));
+        let state = InlineClaudeLoginState::ExistingCredential;
+        assert!(state.is_authenticated());
+        assert!(state.outcome().is_none());
+    }
+
+    #[test]
     fn chatgpt_codex_next_steps_lead_with_login() {
         let steps = init_next_steps(
             &init_summary(
                 BackendProviderKind::ChatGptCodex,
                 "https://chatgpt.com/backend-api/codex",
             ),
+            false,
             false,
             false,
         );
@@ -1083,6 +1196,7 @@ mod tests {
                 "https://chatgpt.com/backend-api/codex",
             ),
             true,
+            false,
             false,
         );
         assert!(!steps.iter().any(|step| step == "gents codex-login"));
@@ -1101,6 +1215,7 @@ mod tests {
             ),
             state.is_authenticated(),
             false,
+            false,
         );
         assert!(!steps.iter().any(|step| step == "gents codex-login"));
     }
@@ -1112,6 +1227,7 @@ mod tests {
                 BackendProviderKind::OpenAiCompatible,
                 "http://127.0.0.1:8080/v1",
             ),
+            false,
             false,
             false,
         );
@@ -1126,6 +1242,7 @@ mod tests {
                 BackendProviderKind::XaiGrokOAuth,
                 "https://cli-chat-proxy.grok.com/v1",
             ),
+            false,
             false,
             false,
         );

--- a/crates/gents-cli/src/interactive_backend.rs
+++ b/crates/gents-cli/src/interactive_backend.rs
@@ -72,6 +72,7 @@ async fn pick_backend() -> Result<BackendSelection> {
     eprintln!("  3) custom URL");
     eprintln!("  4) ChatGPT / Codex subscription   (uses your ChatGPT plan; OAuth setup included)");
     eprintln!("  5) Grok subscription (SuperGrok / X Premium+)   (OAuth setup included)");
+    eprintln!("  6) Claude subscription (Claude Pro / Max)   (OAuth setup included)");
     let choice = prompt_line("> ").await?;
     match choice.trim() {
         "1" | "" => {
@@ -146,6 +147,13 @@ async fn pick_backend() -> Result<BackendSelection> {
             model_name: None,
             api_key: None,
             label: "Grok subscription (SuperGrok / X Premium+)".to_string(),
+        }),
+        "6" => Ok(BackendSelection {
+            inference_url: None,
+            backend_preset: Some(BackendPresetArg::ClaudeCliSubscription),
+            model_name: None,
+            api_key: None,
+            label: "Claude subscription (Claude Pro / Max)".to_string(),
         }),
         other => bail!("unrecognized choice: {other}"),
     }
@@ -335,6 +343,27 @@ mod tests {
         assert_eq!(args.inference_endpoint, None);
         assert_eq!(args.agent_name, "keep-me");
         assert!(args.enable_memory);
+    }
+
+    #[test]
+    fn claude_subscription_selection_seeds_keyless_preset() {
+        let mut args = bare_init_args();
+        BackendSelection {
+            inference_url: None,
+            backend_preset: Some(BackendPresetArg::ClaudeCliSubscription),
+            model_name: None,
+            api_key: None,
+            label: "Claude subscription (Claude Pro / Max)".to_string(),
+        }
+        .apply_to(&mut args);
+
+        assert_eq!(
+            args.backend_preset,
+            Some(BackendPresetArg::ClaudeCliSubscription)
+        );
+        assert_eq!(args.api_key, None);
+        assert_eq!(args.model_name, None);
+        assert_eq!(args.inference_endpoint, None);
     }
 
     #[test]

--- a/crates/gents-cli/src/lib.rs
+++ b/crates/gents-cli/src/lib.rs
@@ -97,6 +97,7 @@ Examples:
   gents init --inference-url http://HOST:PORT/v1 --model-name MODEL
   gents init --backend-preset openrouter --model-name MODEL
   gents init --backend-preset openai --model-name MODEL
+  gents init --backend-preset claude-cli-subscription   # then: gents claude-login
   gents init --write
   gents init --yolo
   gents init --inference-url $INFERENCE_ENDPOINT --model-name MODEL --write


### PR DESCRIPTION
## Summary

Closes #1433.

`gents init --backend-preset claude-cli-subscription` and `gents claude-login` already exist, but a human picking a backend interactively could not reach them. This adds the Claude subscription seat to the CLI onboarding surfaces only.

- `gents init` interactive picker: new option `6) Claude subscription (Claude Pro / Max)`, seeding the `claude-cli-subscription` preset (keyless, default endpoint and model).
- Inline OAuth after init: `maybe_inline_claude_login` mirrors the Grok path. It probes for an existing credential with the provider-generic `grok_auth_probe::load_oauth_credential`, asks `Log in to Claude now to finish setup?`, and runs `run_claude_login` with the browser flow. Non-TTY runs skip it, as for Codex and Grok.
- Init JSON output gains `claude_login`; `next_steps` emits `gents claude-login` when the preset is Claude and no credential exists.
- `gents init --help` examples and the README backend list mention the Claude subscription.

Desktop app, bridge, and packs are out of scope and tracked separately.

## Tests

- `interactive_backend::claude_subscription_selection_seeds_keyless_preset`
- `commands::init::claude_next_steps_lead_with_login`
- `commands::init::claude_next_steps_drop_login_after_inline_login`

Gate run locally: `cargo fmt --all --check`, `cargo test -p gents-cli --lib interactive_backend`, `cargo test -p gents-cli --lib commands::init`, `cargo check --workspace --all-targets`. Manually verified in a terminal: the picker shows option 6, selecting it prompts for Claude login, and declining leaves `gents claude-login` as the first next step. The full `gents` suite was not run on this machine.

