### PR TITLE
fix: keep gossip rebroadcast off the chat merge path

### DIFF
--- a/crates/gents-cli/src/commands/serve.rs
+++ b/crates/gents-cli/src/commands/serve.rs
@@ -1393,9 +1393,9 @@ fn resolve_server_p2p_config(
         rate_limit_rate,
         max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
         max_pending_dags,
-        // Gents deployments may be multi-hop. DefraDB verifies every block
-        // before a relay re-announces it as a transport-routable origin.
-        rebroadcast_on_merge: true,
+        // Verified merges already fan out to explicit downstream replicators.
+        // Do not serialize the merge loop behind optional gossip rebroadcast.
+        rebroadcast_on_merge: false,
     }))
 }
 
@@ -1750,6 +1750,10 @@ mod shim_host_tests {
             .expect("resolve p2p config")
             .expect("p2p enabled");
 
+        assert!(
+            !config.rebroadcast_on_merge,
+            "merge delivery must not wait for gossip"
+        );
         assert_eq!(config.max_pending_dags, p2p::sync::DEFAULT_MAX_PENDING_DAGS);
         assert_eq!(
             config.max_concurrent_push_tasks,

--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -165,10 +165,9 @@ fn desktop_p2p_config(paths: &DesktopPaths, options: &ClientCoreOptions) -> P2PC
         rate_limit_rate: options.rate_limit_rate,
         max_doc_sync_request_doc_ids: p2p::sync::DEFAULT_MAX_DOC_SYNC_REQUEST_DOC_IDS,
         max_pending_dags: options.max_pending_dags,
-        // Desktop peers commonly sit behind a runtime relay. Re-announce only
-        // after DefraDB has verified and merged the block so downstream peers
-        // can fetch it from a transport-routable origin.
-        rebroadcast_on_merge: true,
+        // DefraDB forwards merges to explicit downstream replicators itself.
+        // Gossip rebroadcast adds a coalescing wait inside the merge loop.
+        rebroadcast_on_merge: false,
     }
 }
 
@@ -385,6 +384,10 @@ mod tests {
 
         let config = desktop_p2p_config(&paths, &options);
 
+        assert!(
+            !config.rebroadcast_on_merge,
+            "merge delivery must not wait for gossip"
+        );
         assert_eq!(config.max_pending_dags, 77);
         assert_eq!(
             config.max_doc_sync_request_doc_ids,


### PR DESCRIPTION
## Change

Disable optional merge-time gossip rebroadcast on both the CLI server and desktop/mobile node. DefraDB already forwards verified merged heads to explicitly configured downstream replicators independently of gossip. Both configurations had opted back into an awaited gossip coalescing window inside the serialized merge loop.

This restores the native DB delivery owner rather than adding another client recovery mechanism. No wire, schema, identity, authorization, or dependency changes.

## Evidence and validation

The released DB pin already contains `merged_head_forwards_to_configured_replicator_without_gossip_rebroadcast`. Add configuration regressions for both Gents consumers.

In the accumulated local integration candidate, changing only these two flags reduced observed streaming waits from roughly a second to 105–129 ms across three isolated end-to-end runs; completion-return observations were at most 101 ms. Those runs also include the separately stacked observer/hydration fixes, and measure the client store, not screen paint. One compilation-overlap run exceeded a new 500 ms gate at 512 ms; no deadline was relaxed.

Local validation passed on this clean branch:

- `CARGO_INCREMENTAL=0 cargo test -p gents`: 2,912 passed across unit, conformance, integration, structural and doc-test groups; five existing ignored tests.
- `CARGO_INCREMENTAL=0 cargo check --workspace --all-targets`: passed, with an existing dead-code warning.
- Server P2P configuration regression: passed.
- Full desktop-core suite: 220 passed.
- Formatting and diff whitespace checks: passed.

This is the first layer of the chat-latency stack. Later layers address streaming flush deadlines, live session selection, and DB-backed observation.

## Scope

Explicit downstream replication and local-write gossip remain enabled. Only optional re-announcement after an incoming merge is disabled. No deployment or fleet changes.
