### PR TITLE
fix: flush buffered chat text when the provider pauses

### DIFF
--- a/crates/gents/src/agent/daemon/inference.rs
+++ b/crates/gents/src/agent/daemon/inference.rs
@@ -456,6 +456,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                         let mut stream_error = None;
 
                         loop {
+                            let flush_deadline = processor.next_flush_deadline().await;
                             let item = match tokio::select! {
                                 biased;
                                 _ = shutdown.changed() => {
@@ -523,6 +524,15 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                                         return Err(error);
                                     }
                                     lease_poll.reset();
+                                    continue;
+                                }
+                                _ = async {
+                                    match flush_deadline {
+                                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                                        None => std::future::pending::<()>().await,
+                                    }
+                                } => {
+                                    processor.flush_pending().await?;
                                     continue;
                                 }
                                 result = await_with_request_deadline(

--- a/crates/gents/src/agent/stream_processor.rs
+++ b/crates/gents/src/agent/stream_processor.rs
@@ -54,6 +54,15 @@ impl<'a> StreamProcessor<'a> {
         self.lifecycle.validate_owned_execution().await
     }
 
+    pub(crate) async fn next_flush_deadline(&self) -> Option<tokio::time::Instant> {
+        self.stream_writer.next_flush_deadline(self.doc_id).await
+    }
+
+    pub(crate) async fn flush_pending(&self) -> Result<()> {
+        self.stream_writer.flush_pending(self.doc_id).await?;
+        Ok(())
+    }
+
     pub(crate) async fn process_item<R>(
         &mut self,
         item: Result<LoopStreamItem<R>, rig::agent::StreamingError>,

--- a/crates/gents/src/config.rs
+++ b/crates/gents/src/config.rs
@@ -13,7 +13,7 @@ use crate::tool_surface::BehaviorToolConfig;
 pub const DEFAULT_CONTEXT_WINDOW: usize = 131_072;
 pub const DEFAULT_MAX_OUTPUT_TOKENS: usize = 32_768;
 pub const DEFAULT_MAX_TURNS: usize = 250;
-pub const DEFAULT_STREAM_BATCH_MS: u64 = 1_000;
+pub const DEFAULT_STREAM_BATCH_MS: u64 = 100;
 pub const DEFAULT_COMPACTION_THRESHOLD: f64 = 0.75;
 /// Output budget for the internal compaction summary completion — independent
 /// of the user turn's `max_output_tokens` (#1017).

--- a/crates/gents/src/streaming.rs
+++ b/crates/gents/src/streaming.rs
@@ -84,6 +84,22 @@ struct StreamBufferSnapshot {
 }
 
 impl DefraStreamWriter {
+    pub(crate) async fn next_flush_deadline(&self, doc_id: &str) -> Option<tokio::time::Instant> {
+        let buffers = self.buffers.lock().await;
+        let buffer = buffers.get(doc_id)?;
+        if buffer.content == buffer.persisted.content
+            && buffer.reasoning == buffer.persisted.reasoning
+            && buffer.token_count == buffer.persisted.token_count
+            && buffer.reasoning_progress_seq == buffer.persisted.reasoning_progress_seq
+        {
+            return None;
+        }
+        buffer
+            .last_flush_at
+            .checked_add(self.batch_interval)
+            .map(tokio::time::Instant::from_std)
+    }
+
     pub fn new(node: Arc<EmbeddedNode>, agent_did: &str, batch_interval: Duration) -> Self {
         let response_write_gate = response_write_gate(&node);
         Self {
@@ -204,7 +220,9 @@ impl DefraStreamWriter {
         let buf = buffers
             .get_mut(doc_id)
             .ok_or_else(|| anyhow::anyhow!("no buffer for doc_id={}", doc_id))?;
-        if !force && buf.last_flush_at.elapsed() < self.batch_interval {
+        let first_visible_content = (buf.persisted.content.is_empty() && !buf.content.is_empty())
+            || (buf.persisted.reasoning.is_empty() && !buf.reasoning.is_empty());
+        if !force && !first_visible_content && buf.last_flush_at.elapsed() < self.batch_interval {
             return Ok(None);
         }
         let snapshot = StreamBufferSnapshot {

--- a/crates/gents/src/streaming/tests.rs
+++ b/crates/gents/src/streaming/tests.rs
@@ -79,6 +79,52 @@ async fn response_stores_exact_request_document_edge() {
     let _ = fs::remove_dir_all(&data_path);
 }
 
+#[tokio::test]
+async fn first_visible_content_does_not_wait_for_the_batch_interval() {
+    let (node, data_path) = build_test_node("first-visible").await;
+    let writer = DefraStreamWriter::new(node.clone(), "did:test:test", Duration::from_secs(60));
+    let mut lifecycle =
+        create_claimed_request(&node, "first-visible-request", "first-visible-session").await;
+    let doc_id = lifecycle.begin_owned_execution(&writer).await.unwrap();
+
+    assert!(writer.write_reasoning(&doc_id, "Thinking").await.unwrap());
+    assert!(writer.write_tokens(&doc_id, "Hello").await.unwrap());
+    assert_eq!(load_response(&node, &doc_id).await["content"], "Hello");
+    assert!(!writer.write_tokens(&doc_id, " again").await.unwrap());
+    assert_eq!(load_response(&node, &doc_id).await["content"], "Hello");
+    writer.flush_pending(&doc_id).await.unwrap();
+    assert_eq!(
+        load_response(&node, &doc_id).await["content"],
+        "Hello again"
+    );
+
+    node.shutdown().await;
+    fs::remove_dir_all(data_path).unwrap();
+}
+
+#[tokio::test]
+async fn pending_stream_deadline_is_fixed_until_flush_and_idle_has_no_timer() {
+    let (node, data_path) = build_test_node("flush-deadline").await;
+    let writer = DefraStreamWriter::new(node.clone(), "did:test:test", Duration::from_secs(60));
+    let mut lifecycle =
+        create_claimed_request(&node, "flush-deadline-request", "flush-deadline-session").await;
+    let doc_id = lifecycle.begin_owned_execution(&writer).await.unwrap();
+    assert!(writer.next_flush_deadline(&doc_id).await.is_none());
+    assert!(writer.write_tokens(&doc_id, "Hello").await.unwrap());
+    assert!(writer.next_flush_deadline(&doc_id).await.is_none());
+    assert!(!writer.write_tokens(&doc_id, " again").await.unwrap());
+    let deadline = writer
+        .next_flush_deadline(&doc_id)
+        .await
+        .expect("buffered content deadline");
+    assert!(!writer.write_tokens(&doc_id, " text").await.unwrap());
+    assert_eq!(writer.next_flush_deadline(&doc_id).await, Some(deadline));
+    writer.flush_pending(&doc_id).await.unwrap();
+    assert!(writer.next_flush_deadline(&doc_id).await.is_none());
+    node.shutdown().await;
+    fs::remove_dir_all(data_path).unwrap();
+}
+
 async fn create_claimed_request(
     node: &Arc<EmbeddedNode>,
     request_id: &str,


### PR DESCRIPTION
## Change

Stacked on `fix/chat-delivery-no-rebroadcast`.

Persist the first text and first reasoning immediately. For later chunks, give the existing owned completion loop a deadline for its dirty response buffer. When the provider pauses, that loop flushes the due batch; no detached timer, background writer, or second execution owner is created. An idle buffer has no timer, and arriving tokens do not postpone an existing deadline.

Reduce the default batch interval from 1000 ms to 100 ms. Explicit profile settings remain respected. Writes retain the existing execution fence, response write gate, status checks, and terminal owners.

## Validation

New writer regressions cover immediate first content, pending deadlines, non-extension by later tokens, and no timer after a flush. Full `cargo test -p gents`: 2,914 passed, zero failures, five existing ignored tests. `cargo check --locked --workspace --all-targets` passes (existing CLI dead-code warning). Diff whitespace checks pass.

The next stack layer adds the real pairing/client-store regression: emit a text prefix, emit its suffix 20 ms later, and withhold provider completion until the client observes the whole text. The latest accumulated-candidate run passed: full text visible in 373/475 ms, observed completion return 21/219 ms, zero observer drops/reloads. This candidate also contains the native DB observer and a local Regolith scan fix; it is not validation of this layer alone. An earlier run failed the unchanged 500 ms completion-return gate under concurrent compilation. No claim of saturation reliability or screen-paint latency.

No DB, transport, schema, identity, or deployment changes.
