### PR TITLE
fix: project native document changes and admit live session selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2139,7 +2139,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2432,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "anyhow",
@@ -2497,7 +2497,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2522,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "async-stream",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "anyhow",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "async-trait",
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "serde",
 ]
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4947,7 +4947,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -5662,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "async-channel",
@@ -5783,7 +5783,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7034,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "anyhow",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "acp",
  "async-graphql",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "p2p",
  "query",
@@ -8765,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "cid",
  "defra-core",
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10181,7 +10181,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "tracing",
 ]
@@ -12640,7 +12640,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=287a934d3fe55800ef665b0cba74bf6d64cd0de7#287a934d3fe55800ef665b0cba74bf6d64cd0de7"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,9 @@ clap = { version = "4", features = ["derive", "env"] }
 # Current DefraDB includes the multiplexed Iroh protocol: upgrade clients and
 # runtimes together. Keep its iterative parent-DAG replay for deep iOS history
 # and let the database own durable replication and recovery.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-claude-login = { path = "crates/gents-claude-login" }
@@ -74,12 +74,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -87,9 +87,9 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
-storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "287a934d3fe55800ef665b0cba74bf6d64cd0de7" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/gents-cli/tests/cli_enrollment/contract.rs
+++ b/crates/gents-cli/tests/cli_enrollment/contract.rs
@@ -15,10 +15,13 @@ const ENROLL_BUDGET: Duration = Duration::from_secs(30);
 const TURN_BUDGET: Duration = Duration::from_secs(20);
 const RECONNECT_BUDGET: Duration = Duration::from_secs(20);
 const MODEL_DELAY: Duration = Duration::from_secs(2);
+const RETURN_TO_OBSERVER_BUDGET: Duration = Duration::from_secs(2);
 const REPLY: &str = "PAIRING_CONTRACT_ASSISTANT_REPLY";
 const OFFLINE_REPLY: &str = "PAIRING_CONTRACT_OFFLINE_REPLY";
 const FOLLOWUP_REPLY: &str = "PAIRING_CONTRACT_CONTINUED_REPLY";
 const OFFLINE_PROMPT: &str = "Reply while the app is closed";
+#[path = "contract/streaming.rs"]
+mod streaming;
 const FOLLOWUP_PROMPT: &str = "Continue our existing conversation";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -32,6 +35,28 @@ async fn fresh_app_pairs_with_aged_runtime_with_bounded_latency() -> Result<()> 
 }
 
 async fn run_contract(readiness_revisions: usize) -> Result<()> {
+    run_contract_with_streaming(readiness_revisions, false).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_content_reaches_client_before_provider_completion() -> Result<()> {
+    run_contract_with_streaming(0, true).await
+}
+
+async fn run_contract_with_streaming(readiness_revisions: usize, streaming: bool) -> Result<()> {
+    run_contract_with_streaming_cadence(readiness_revisions, streaming, false).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn buffered_stream_chunk_reaches_client_during_provider_pause() -> Result<()> {
+    run_contract_with_streaming_cadence(0, true, true).await
+}
+
+async fn run_contract_with_streaming_cadence(
+    readiness_revisions: usize,
+    streaming: bool,
+    paced: bool,
+) -> Result<()> {
     let _guard = enrollment_e2e_lock().lock().await;
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
@@ -42,6 +67,10 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         .try_init();
     let offline_gate = Arc::new(tokio::sync::Semaphore::new(0));
     let model_gate = Arc::clone(&offline_gate);
+    let stream_gate = streaming.then(|| Arc::new(tokio::sync::Semaphore::new(0)));
+    let followup_stream_gate = streaming.then(|| Arc::new(tokio::sync::Semaphore::new(0)));
+    let model_stream_gate = stream_gate.clone();
+    let model_followup_stream_gate = followup_stream_gate.clone();
     let model = FakeLlm::start(
         "pairing-contract",
         None,
@@ -65,7 +94,39 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
                 } else {
                     REPLY
                 };
-                ChatAction::DelayThenSse(MODEL_DELAY, completion_text_sse(reply))
+                let selected_stream_gate =
+                    if request_contains_role_text(&latest, "user", FOLLOWUP_PROMPT) {
+                        &model_followup_stream_gate
+                    } else {
+                        &model_stream_gate
+                    };
+                if let Some(gate) = selected_stream_gate.as_ref().filter(|_| {
+                    request_contains_role_text(&latest, "user", "First conversation turn")
+                        || request_contains_role_text(&latest, "user", FOLLOWUP_PROMPT)
+                }) {
+                    let body = completion_text_sse(reply);
+                    let (first, rest) = body.split_once("\n\n").expect("SSE content frame");
+                    let chunks = if paced {
+                        let (prefix, suffix) = reply.split_at(reply.len() / 2);
+                        [prefix, suffix]
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, text)| {
+                                let body = completion_text_sse(text);
+                                let frame = body.split_once("\n\n").expect("SSE content frame").0;
+                                (
+                                    Duration::from_millis(if index == 0 { 0 } else { 20 }),
+                                    format!("{frame}\n\n"),
+                                )
+                            })
+                            .collect()
+                    } else {
+                        vec![(Duration::ZERO, format!("{first}\n\n"))]
+                    };
+                    ChatAction::GatedSse(chunks, gate.clone(), rest.to_owned())
+                } else {
+                    ChatAction::DelayThenSse(MODEL_DELAY, completion_text_sse(reply))
+                }
             }
         }),
     )?;
@@ -129,9 +190,10 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
             bail!("enroll/approve/readiness exceeded 30s or failed: {enrollment:?}; {diagnostics}");
         }
         tracing::info!(elapsed_ms = enrollment_started.elapsed().as_millis(), "app enrollment ready");
+        assert_observer_did_not_overflow(&core).await?;
 
         let session = Uuid::new_v4().to_string();
-        visible_turn(&core, &graphql, &agent_did, &behavior, &session, "First conversation turn").await?;
+        visible_turn(&core, &graphql, &agent_did, &behavior, &session, "First conversation turn", stream_gate.as_deref()).await?;
 
         // A request reaches the runtime, then the app closes before inference
         // finishes. Reopen exactly the same home: no re-enrollment, identity
@@ -164,8 +226,9 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         let reopened = core.peer_records().await;
         anyhow::ensure!(records.len() == reopened.len() && records.iter().zip(&reopened).all(|(old, new)| old.peer_id == new.peer_id && old.enrollment_request_id == new.enrollment_request_id), "reopen changed enrollment identity");
         tracing::info!(elapsed_ms = reconnect_started.elapsed().as_millis(), "app recovered offline reply");
-        visible_turn(&core, &graphql, &agent_did, &behavior, &session, FOLLOWUP_PROMPT).await?;
+        visible_turn(&core, &graphql, &agent_did, &behavior, &session, FOLLOWUP_PROMPT, followup_stream_gate.as_deref()).await?;
         assert_local_pagination(&core, &session, &agent_did).await?;
+        assert_observer_did_not_overflow(&core).await?;
         anyhow::ensure!(query_collection_dids(core.node(), "AgentPrincipal").await?.is_empty(), "reopen replicated runtime principal");
         core.shutdown().await?;
         anyhow::ensure!(model.captured_chat_requests().iter().any(|request| {
@@ -175,6 +238,10 @@ async fn run_contract(readiness_revisions: usize) -> Result<()> {
         }), "continued conversation lost its prior assistant transcript");
         Ok(())
     }).await;
+    if debug_filter.is_some() {
+        let (stdout, stderr) = server.captured_output()?;
+        tracing::debug!(target: "cli_enrollment::server", %stdout, %stderr, "paired runtime trace");
+    }
     if result.is_err() {
         let retained = temp.keep();
         tracing::error!(path = %retained.display(), "retained failed pairing fixture for investigation");
@@ -189,11 +256,13 @@ async fn visible_turn(
     behavior: &str,
     session: &str,
     prompt: &str,
+    stream_gate: Option<&tokio::sync::Semaphore>,
 ) -> Result<()> {
     let started = Instant::now();
     let result = timeout(TURN_BUDGET, async {
         core.submit_request(session, agent, prompt, Some(behavior))
             .await?;
+        let local_submit_completed = started.elapsed();
         let (request, _, _) =
             wait_for_runtime_agent_request(graphql, core.node(), agent, prompt).await?;
         let request_arrived = started.elapsed();
@@ -208,11 +277,27 @@ async fn visible_turn(
             },
             async {
                 let expected = if prompt == FOLLOWUP_PROMPT { FOLLOWUP_REPLY } else { REPLY };
+                if let Some(gate) = stream_gate {
+                    let visibility = streaming::wait_for_visible_content(core, &request, expected).await;
+                    gate.add_permits(1);
+                    visibility?;
+                }
                 wait_for_replicated_reply(core, session, agent, &request, expected).await?;
                 Ok::<_, anyhow::Error>(started.elapsed())
             },
         )?;
+        let return_budget = if stream_gate.is_some() {
+            Duration::from_millis(500)
+        } else {
+            RETURN_TO_OBSERVER_BUDGET
+        };
+        anyhow::ensure!(
+            client_visible.saturating_sub(runtime_completed) <= return_budget,
+            "completed reply took too long to reach the client projection: runtime={runtime_completed:?}, client={client_visible:?}",
+        );
         tracing::info!(
+            local_submit_ms = local_submit_completed.as_millis(),
+            submit_to_runtime_observed_ms = request_arrived.saturating_sub(local_submit_completed).as_millis(),
             request_delivery_ms = request_arrived.as_millis(),
             selection_admission_ms = selection_admitted.as_millis(),
             runtime_completion_ms = runtime_completed.as_millis(),
@@ -238,6 +323,17 @@ async fn visible_turn(
         prompt,
         "completed assistant reply visible in app store"
     );
+    assert_observer_did_not_overflow(core).await?;
+    Ok(())
+}
+
+async fn assert_observer_did_not_overflow(core: &ClientCore) -> Result<()> {
+    let metrics = core.observer_metrics().await.context("observer running")?;
+    anyhow::ensure!(
+        metrics.drop_recoveries == 0,
+        "history overflowed the state observer: {metrics:?}"
+    );
+    tracing::info!(?metrics, "bounded client observation");
     Ok(())
 }
 
@@ -256,7 +352,8 @@ async fn select_session(core: &ClientCore, session: &str, agent: &str) -> Result
 }
 
 /// No hydration, repair, UI refresh, or remote reads here: success is a
-/// completed conversation present in the phone-side database itself.
+/// completed conversation in the phone-side database AND the observed response
+/// projection consumed by the app. A healthy DB with a stuck observer must fail.
 async fn wait_for_replicated_reply(
     core: &ClientCore,
     session: &str,
@@ -278,6 +375,9 @@ async fn wait_for_replicated_reply(
         AgentMessage(filter: {{{filter}}}) {{role content}}
     }}"#
     );
+    let visibility_started = Instant::now();
+    let mut database_ready_at = None;
+    let mut stages_seen = [false; 3];
     loop {
         let result = core.node().execute(&query).await;
         anyhow::ensure!(
@@ -309,8 +409,54 @@ async fn wait_for_replicated_reply(
             })
             .collect::<Vec<_>>()
             .join("\n");
+        for (index, (stage, ready)) in [
+            (
+                "request_completed",
+                requests
+                    .iter()
+                    .any(|row| row["lifecycle_state"] == "completed"),
+            ),
+            (
+                "response_complete",
+                responses.iter().any(|row| row["status"] == "complete"),
+            ),
+            ("transcript_materialized", body.contains(expected_reply)),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            if ready && !stages_seen[index] {
+                stages_seen[index] = true;
+                tracing::info!(
+                    request,
+                    stage,
+                    elapsed_ms = visibility_started.elapsed().as_millis(),
+                    "client replica delivery stage"
+                );
+            }
+        }
         if completed && body.contains(expected_reply) {
-            return Ok(());
+            let database_ready = *database_ready_at.get_or_insert_with(Instant::now);
+            let observer_ready = core
+                .store()
+                .snapshot()
+                .latest_response_for_request(request)
+                .is_some_and(|response| response.status.as_deref() == Some("complete"));
+            if observer_ready {
+                tracing::info!(
+                    request,
+                    database_visible_ms = database_ready
+                        .duration_since(visibility_started)
+                        .as_millis(),
+                    observer_after_database_ms = database_ready.elapsed().as_millis(),
+                    "local database and observer visibility",
+                );
+                return Ok(());
+            }
+            anyhow::ensure!(
+                database_ready.elapsed() < Duration::from_millis(500),
+                "local DB has the completed reply but the observer has not projected it in 500ms"
+            );
         }
         anyhow::ensure!(
             !responses.iter().any(|row| row["status"] == "error"),
@@ -336,8 +482,8 @@ async fn pairing_diagnostics(core: &ClientCore, graphql: &str) -> String {
         Err(_) => None,
     };
     format!(
-        "database_now={database_now:?}; runtime_database={runtime_database:?}; database={:?}; peers={:?}; client={client:?}; runtime={runtime:?}",
-        sync.database_sync, sync.peers
+        "observer={:?}; database_now={database_now:?}; runtime_database={runtime_database:?}; database={:?}; peers={:?}; client={client:?}; runtime={runtime:?}",
+        core.observer_metrics().await, sync.database_sync, sync.peers
     )
 }
 

--- a/crates/gents-cli/tests/cli_enrollment/contract.rs
+++ b/crates/gents-cli/tests/cli_enrollment/contract.rs
@@ -291,10 +291,6 @@ async fn visible_turn(
         } else {
             RETURN_TO_OBSERVER_BUDGET
         };
-        anyhow::ensure!(
-            client_visible.saturating_sub(runtime_completed) <= return_budget,
-            "completed reply took too long to reach the client projection: runtime={runtime_completed:?}, client={client_visible:?}",
-        );
         tracing::info!(
             local_submit_ms = local_submit_completed.as_millis(),
             submit_to_runtime_observed_ms = request_arrived.saturating_sub(local_submit_completed).as_millis(),
@@ -310,6 +306,10 @@ async fn visible_turn(
             AgentResponse(filter: {{request_id: {{_eq: "{}"}}}}) {{created_at completed_at materialized_at}}
         }}"#, escape_graphql_string(&request), escape_graphql_string(&request))).await?;
         tracing::info!(timestamps = ?lifecycle, "runtime lifecycle timing evidence");
+        anyhow::ensure!(
+            client_visible.saturating_sub(runtime_completed) <= return_budget,
+            "completed reply took too long to reach the client projection: runtime={runtime_completed:?}, client={client_visible:?}",
+        );
         Ok::<_, anyhow::Error>(())
     })
     .await;
@@ -370,9 +370,9 @@ async fn wait_for_replicated_reply(
     );
     let query = format!(
         r#"{{
-        AgentRequest(filter: {{{filter}}}) {{lifecycle_state}}
-        AgentResponse(filter: {{{filter}}}) {{status content}}
-        AgentMessage(filter: {{{filter}}}) {{role content}}
+        AgentRequest(filter: {{{filter}}}) {{_docID lifecycle_state}}
+        AgentResponse(filter: {{{filter}}}) {{_docID status content}}
+        AgentMessage(filter: {{{filter}}}) {{_docID role content}}
     }}"#
     );
     let visibility_started = Instant::now();
@@ -427,6 +427,7 @@ async fn wait_for_replicated_reply(
         {
             if ready && !stages_seen[index] {
                 stages_seen[index] = true;
+                tracing::debug!(request, stage, documents = ?[&requests, &responses, &messages][index].iter().filter_map(|row| row["_docID"].as_str()).collect::<Vec<_>>(), "replica stage document identities");
                 tracing::info!(
                     request,
                     stage,

--- a/crates/gents-cli/tests/cli_enrollment/contract.rs
+++ b/crates/gents-cli/tests/cli_enrollment/contract.rs
@@ -468,7 +468,7 @@ async fn wait_for_replicated_reply(
 }
 
 async fn pairing_diagnostics(core: &ClientCore, graphql: &str) -> String {
-    let query = "{ PeerPairingDesired { peer_id template source } PeerPairingApplied { peer_id } AgentBehaviorReadiness { agent_did updated_at } AgentResponse { request_id status content } }";
+    let query = "{ PeerPairingDesired { peer_id template source } PeerPairingApplied { peer_id } AgentBehaviorReadiness { agent_did updated_at } AgentRequest { _docID request_id agent_did requester_did lifecycle_state } AgentResponse { _docID request_id agent_did requester_did status content } }";
     let client = core.node().execute(query).await;
     let runtime = graphql_query(graphql, query).await;
     let sync = core.sync_state();
@@ -482,8 +482,17 @@ async fn pairing_diagnostics(core: &ClientCore, graphql: &str) -> String {
         Ok(response) => response.json::<serde_json::Value>().await.ok(),
         Err(_) => None,
     };
+    let runtime_replicators = reqwest::Client::new()
+        .get(graphql.replace("/graphql", "/p2p/replicators"))
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await;
+    let runtime_replicators = match runtime_replicators {
+        Ok(response) => response.json::<serde_json::Value>().await.ok(),
+        Err(_) => None,
+    };
     format!(
-        "observer={:?}; database_now={database_now:?}; runtime_database={runtime_database:?}; database={:?}; peers={:?}; client={client:?}; runtime={runtime:?}",
+        "observer={:?}; database_now={database_now:?}; runtime_database={runtime_database:?}; runtime_replicators={runtime_replicators:?}; database={:?}; peers={:?}; client={client:?}; runtime={runtime:?}",
         core.observer_metrics().await, sync.database_sync, sync.peers
     )
 }

--- a/crates/gents-cli/tests/cli_enrollment/contract/streaming.rs
+++ b/crates/gents-cli/tests/cli_enrollment/contract/streaming.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[tokio::test]
+async fn offline_barrier_stays_open_for_later_provider_attempts() -> Result<()> {
+    let gate = Arc::new(tokio::sync::Semaphore::new(0));
+    let model_gate = gate.clone();
+    let model = FakeLlm::start(
+        "barrier-contract",
+        None,
+        Arc::new(move |_| {
+            ChatAction::WaitThenSse(model_gate.clone(), completion_text_sse("visible"))
+        }),
+    )?;
+    gate.add_permits(1);
+    let client = reqwest::Client::new();
+    for _ in 0..2 {
+        let body = timeout(Duration::from_secs(2), async {
+            client
+                .post(format!("{}/chat/completions", model.endpoint()))
+                .json(&serde_json::json!({"messages": []}))
+                .send()
+                .await?
+                .error_for_status()?
+                .text()
+                .await
+        })
+        .await
+        .context("an opened offline barrier blocked a later attempt")??;
+        anyhow::ensure!(body.contains("visible"), "missing fixture content");
+    }
+    Ok(())
+}
+
+pub(super) async fn wait_for_visible_content(
+    core: &ClientCore,
+    request: &str,
+    expected: &str,
+) -> Result<()> {
+    let started = Instant::now();
+    timeout(Duration::from_millis(500), async {
+        loop {
+            let visible = core
+                .store()
+                .snapshot()
+                .latest_response_for_request(request)
+                .is_some_and(|response| {
+                    response.status.as_deref() == Some("streaming")
+                        && response
+                            .content
+                            .as_deref()
+                            .is_some_and(|text| text.contains(expected))
+                });
+            if visible {
+                tracing::info!(
+                    request,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "streaming content observed while provider completion remains gated"
+                );
+                return;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .context("streaming content did not reach client projection before provider completion")?;
+    Ok(())
+}

--- a/crates/gents-cli/tests/support/mocks/fake_llm.rs
+++ b/crates/gents-cli/tests/support/mocks/fake_llm.rs
@@ -8,8 +8,8 @@
 //! Behavior is supplied per construction via a chat `Responder` closure, so the
 //! thin `MockChatEndpoint` / `MockModelEndpoint` / `MockOpenAIEndpoint` /
 //! spawn-mock wrappers keep their exact public APIs while sharing this one
-//! robust server. SSE bodies are written whole (matching the previous mocks),
-//! so no incremental streaming is needed.
+//! robust server. Whole-response and gated incremental SSE variants let tests
+//! distinguish visible streaming from delivery that waits for completion.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -28,6 +28,7 @@ pub enum ChatAction {
     Sse(String),
     DelayThenSse(Duration, String),
     WaitThenSse(Arc<tokio::sync::Semaphore>, String),
+    GatedSse(Vec<(Duration, String)>, Arc<tokio::sync::Semaphore>, String),
     Hang,
 }
 
@@ -207,6 +208,42 @@ async fn handle_chat(
 
     match (state.responder)(&request_json) {
         ChatAction::Sse(body) => sse_response(body),
+        ChatAction::GatedSse(first, gate, rest) => {
+            let stopped = state.stopped.clone();
+            let chunks = futures_util::stream::unfold(
+                (first.into_iter(), Some(rest), gate, stopped),
+                |(mut first, mut rest, gate, stopped)| async move {
+                    let chunk = if let Some((delay, first)) = first.next() {
+                        tokio::time::sleep(delay).await;
+                        first
+                    } else {
+                        let rest = rest.take()?;
+                        loop {
+                            if stopped.load(Ordering::Relaxed) {
+                                return None;
+                            }
+                            if let Ok(permit) =
+                                tokio::time::timeout(Duration::from_millis(50), gate.acquire())
+                                    .await
+                            {
+                                drop(permit.ok()?);
+                                break;
+                            }
+                        }
+                        rest
+                    };
+                    Some((
+                        Ok::<_, std::convert::Infallible>(chunk),
+                        (first, rest, gate, stopped),
+                    ))
+                },
+            );
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                axum::body::Body::from_stream(chunks),
+            )
+                .into_response()
+        }
         ChatAction::DelayThenSse(delay, body) => {
             let _ = tokio::time::timeout(delay, state.stop.notified()).await;
             sse_response(body)
@@ -222,7 +259,9 @@ async fn handle_chat(
                 tokio::time::timeout(Duration::from_millis(50), gate.acquire()).await
             {
                 if let Ok(permit) = permit {
-                    permit.forget();
+                    // This is a barrier (for example, the app has closed), not
+                    // a quota. Retries after it opens must not block again.
+                    drop(permit);
                     return sse_response(body);
                 }
                 return json_response(

--- a/crates/gents-desktop-core/Cargo.toml
+++ b/crates/gents-desktop-core/Cargo.toml
@@ -39,5 +39,6 @@ ts-rs = { version = "10.1", default-features = false, features = [
 uuid.workspace = true
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 gents-lean-contract.workspace = true
 wiremock = "0.6"

--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -65,7 +65,7 @@ impl ClientCore {
         ensure_desktop_schema_migrations(Arc::clone(&node)).await?;
         subscribe_all_collections(node.as_ref()).await?;
 
-        let observer_subscription = node.subscribe(&[defra_node::EventName::Update]);
+        let observer_subscription = node.subscribe_document_changes();
 
         let (selected_agent_did, _) = watch::channel::<Option<String>>(None);
 

--- a/crates/gents-desktop-core/src/client/core/writes.rs
+++ b/crates/gents-desktop-core/src/client/core/writes.rs
@@ -1769,8 +1769,10 @@ fn hydration_start_evidence_is_ready(
     progress: &gents::agent::p2p_reconcile::session_hydration::ClientHydrationProgress,
     evidence: &LocalHydrationStartEvidence,
 ) -> bool {
-    (evidence.owned_session_present || progress.merged_count > 0)
-        && !evidence.nonterminal_request_present
+    // SessionHydration.canStartInitial: once the owned header exists, waiting
+    // for request completion would prevent this session from receiving its stream.
+    evidence.owned_session_present
+        || (progress.merged_count > 0 && !evidence.nonterminal_request_present)
 }
 
 async fn load_local_hydration_start_evidence(
@@ -2189,7 +2191,7 @@ mod delete_source_tests {
                 nonterminal_request_present: false,
             },
         ));
-        assert!(!hydration_start_evidence_is_ready(
+        assert!(hydration_start_evidence_is_ready(
             &ClientHydrationProgress {
                 merged_count: 1,
                 ..idle
@@ -2217,6 +2219,37 @@ mod delete_source_tests {
             format!("{error:#}").contains("notARequestState"),
             "{error:#}"
         );
+    }
+
+    #[test]
+    fn initial_hydration_matches_receiver_start_truth_table() {
+        use gents::agent::p2p_reconcile::session_hydration::ClientHydrationProgress;
+        // SessionHydration.canStartInitial, including a live request with an
+        // owned header and a pending compose request without one.
+        for (owned, documents, active, expected) in [
+            (false, false, false, false),
+            (false, false, true, false),
+            (false, true, false, true),
+            (false, true, true, false),
+            (true, false, false, true),
+            (true, false, true, true),
+            (true, true, false, true),
+            (true, true, true, true),
+        ] {
+            let progress = ClientHydrationProgress {
+                merged_count: usize::from(documents),
+                ..Default::default()
+            };
+            let evidence = LocalHydrationStartEvidence {
+                owned_session_present: owned,
+                nonterminal_request_present: active,
+            };
+            assert_eq!(
+                hydration_start_evidence_is_ready(&progress, &evidence),
+                expected,
+                "owned={owned}, documents={documents}, active={active}"
+            );
+        }
     }
 
     #[test]

--- a/crates/gents-desktop-core/src/client/observe.rs
+++ b/crates/gents-desktop-core/src/client/observe.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use defra_node::EmbeddedNode;
-use events::Subscription;
+use events::DocumentChangeSubscription;
 use tokio::sync::watch;
 
 use super::collection_resolver::CollectionResolver;
@@ -22,7 +22,8 @@ pub use projection_store::{
     StoreUpdateNotice,
 };
 
-const OBSERVER_DEBOUNCE: Duration = Duration::from_millis(150);
+const FETCH_RETRY_DELAY: Duration = Duration::from_millis(10);
+const RESYNC_RETRY_DELAY: Duration = Duration::from_millis(250);
 const FETCH_RETRY_LIMIT: u32 = 3;
 const SESSION_HYDRATION_REQUEST: &str = "SessionHydrationRequest";
 
@@ -48,7 +49,7 @@ pub fn spawn_observer_with_selection(
     store: Arc<ObservedStore>,
     configured_peers: ClientSyncStateOwner,
     requester_did: String,
-    subscription: Subscription,
+    subscription: DocumentChangeSubscription,
     selected_agent_did_rx: watch::Receiver<Option<String>>,
 ) -> ObserverHandle {
     let (stop_tx, mut stop_rx) = watch::channel(false);
@@ -60,6 +61,7 @@ pub fn spawn_observer_with_selection(
         let mut subscription = subscription;
         let mut dirty: HashMap<&'static str, HashSet<String>> = HashMap::new();
         let mut redundant_fetches_pending: HashMap<(String, String), u32> = HashMap::new();
+        let mut resync_pending = false;
 
         loop {
             let next = tokio::select! {
@@ -72,6 +74,9 @@ pub fn spawn_observer_with_selection(
                     Err(_) => break,
                 },
                 msg = subscription.recv() => msg,
+                _ = tokio::time::sleep(if resync_pending { RESYNC_RETRY_DELAY } else { FETCH_RETRY_DELAY }), if resync_pending || !dirty.is_empty() => {
+                    Some(events::DocumentChangeBatch::default())
+                }
             };
             let Some(msg) = next else {
                 tracing::debug!("desktop observation subscription closed");
@@ -79,50 +84,41 @@ pub fn spawn_observer_with_selection(
             };
             metrics_for_task
                 .events_received
+                .fetch_add(msg.updates, Ordering::Relaxed);
+            metrics_for_task
+                .document_change_batches
                 .fetch_add(1, Ordering::Relaxed);
+            if !msg.resync_required {
+                metrics_for_task.coalesced_updates.fetch_add(
+                    msg.updates.saturating_sub(msg.changes.len() as u64),
+                    Ordering::Relaxed,
+                );
+            }
 
-            if let Some(update) = msg.as_update() {
+            for update in &msg.changes {
                 accumulate_dirty(
                     &mut dirty,
                     resolver.as_ref(),
                     node.as_ref(),
                     &update.collection_id,
                     &update.doc_id,
-                    update.is_relay,
+                    !update.has_local_write,
                     metrics_for_task.as_ref(),
                 )
                 .await;
             }
 
-            tokio::time::sleep(OBSERVER_DEBOUNCE).await;
-
-            while let Ok(msg) = subscription.try_recv() {
-                metrics_for_task
-                    .events_received
-                    .fetch_add(1, Ordering::Relaxed);
-                if let Some(update) = msg.as_update() {
-                    accumulate_dirty(
-                        &mut dirty,
-                        resolver.as_ref(),
-                        node.as_ref(),
-                        &update.collection_id,
-                        &update.doc_id,
-                        update.is_relay,
-                        metrics_for_task.as_ref(),
-                    )
-                    .await;
-                }
-            }
-
-            let dropped = subscription.check_and_reset_dropped();
-            if dropped > 0 {
+            if msg.resync_required {
                 tracing::warn!(
-                    dropped,
-                    "desktop observation subscription dropped messages; performing scoped reload"
+                    updates = msg.updates,
+                    "desktop observation distinct-document capacity exceeded; performing scoped reload"
                 );
                 metrics_for_task
                     .drop_recoveries
                     .fetch_add(1, Ordering::Relaxed);
+                resync_pending = true;
+            }
+            if resync_pending {
                 dirty.clear();
                 redundant_fetches_pending.clear();
 
@@ -145,6 +141,7 @@ pub fn spawn_observer_with_selection(
                 };
                 match result {
                     Ok(snapshot) => {
+                        resync_pending = false;
                         match scope.as_deref() {
                             Some(did) => store.replace_agent_snapshot(did, snapshot),
                             None => store.replace_snapshot(snapshot),
@@ -247,6 +244,7 @@ pub fn spawn_observer_with_selection(
                                     }
                                 },
                                 Err(error) => {
+                                    resync_pending = true;
                                     tracing::warn!(
                                         collection = collection_name,
                                         error = %error,
@@ -301,9 +299,10 @@ pub fn spawn_observer_with_selection(
                                     collection = collection_name,
                                     doc_id = %id,
                                     limit = FETCH_RETRY_LIMIT,
-                                    "fetch_doc_patch failed too many times; dropping"
+                                    "fetch_doc_patch retry limit reached; scheduling scoped resync"
                                 );
                                 redundant_fetches_pending.remove(&key);
+                                resync_pending = true;
                             } else {
                                 dirty.entry(collection_name).or_default().insert(id.clone());
                             }

--- a/crates/gents-desktop-core/src/client/observe/projection_store.rs
+++ b/crates/gents-desktop-core/src/client/observe/projection_store.rs
@@ -8,6 +8,8 @@ use crate::client::store::{ClientStore, SharedClientStore};
 #[derive(Debug, Default)]
 pub struct ObserverMetrics {
     pub events_received: AtomicU64,
+    pub document_change_batches: AtomicU64,
+    pub coalesced_updates: AtomicU64,
     pub docs_fetched: AtomicU64,
     pub debounce_flushes: AtomicU64,
     pub scope_reloads: AtomicU64,
@@ -22,6 +24,8 @@ pub struct ObserverMetrics {
 #[derive(Debug, Clone)]
 pub struct ObserverMetricsSnapshot {
     pub events_received: u64,
+    pub document_change_batches: u64,
+    pub coalesced_updates: u64,
     pub docs_fetched: u64,
     pub debounce_flushes: u64,
     pub scope_reloads: u64,
@@ -37,6 +41,8 @@ impl ObserverMetrics {
     pub fn snapshot(&self) -> ObserverMetricsSnapshot {
         ObserverMetricsSnapshot {
             events_received: self.events_received.load(Ordering::Relaxed),
+            document_change_batches: self.document_change_batches.load(Ordering::Relaxed),
+            coalesced_updates: self.coalesced_updates.load(Ordering::Relaxed),
             docs_fetched: self.docs_fetched.load(Ordering::Relaxed),
             debounce_flushes: self.debounce_flushes.load(Ordering::Relaxed),
             scope_reloads: self.scope_reloads.load(Ordering::Relaxed),

--- a/crates/gents-desktop-core/src/client/observe/tests.rs
+++ b/crates/gents-desktop-core/src/client/observe/tests.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+#[path = "tests/backpressure.rs"]
+mod backpressure;
+#[path = "tests/overflow.rs"]
+mod overflow;
+
 fn response_patch(content: &str, progress_seq: i64) -> ClientStore {
     ClientStore::from_rows(crate::client::store::ClientStoreRows {
         responses: vec![serde_json::from_value(serde_json::json!({
@@ -160,7 +165,7 @@ async fn build_observer_fixture() -> (
         peer_dir,
         Vec::new(),
     );
-    let subscription = node.subscribe(&[EventName::Update]);
+    let subscription = node.subscribe_document_changes();
     let (_tx, rx) = watch::channel::<Option<String>>(None);
     let handle = spawn_observer_with_selection(
         node.clone(),
@@ -208,7 +213,7 @@ async fn seed_message(node: &EmbeddedNode, session_id: &str, seq: i64, content: 
 }
 
 #[tokio::test]
-async fn coalesces_burst_into_one_fetch_per_doc() {
+async fn streaming_commits_converge_without_a_forced_batch_window() {
     let (_tempdir, node, store, handle) = build_observer_fixture().await;
 
     let create = r#"mutation {
@@ -244,10 +249,13 @@ async fn coalesces_burst_into_one_fetch_per_doc() {
 
     let fetches = metrics_after.docs_fetched - metrics_before.docs_fetched;
     let flushes = metrics_after.debounce_flushes - metrics_before.debounce_flushes;
-    assert!(fetches <= 5, "expected <=5 fetches, got {fetches}");
     assert!(
-        flushes >= 1 && flushes <= 5,
-        "expected 1..=5 flushes, got {flushes}"
+        fetches <= 51,
+        "more fetches than committed documents: {fetches}"
+    );
+    assert!(
+        flushes >= 1 && flushes <= 51,
+        "expected 1..=51 flushes, got {flushes}"
     );
 
     let snap = store.snapshot();

--- a/crates/gents-desktop-core/src/client/observe/tests/backpressure.rs
+++ b/crates/gents-desktop-core/src/client/observe/tests/backpressure.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+#[tokio::test(start_paused = true)]
+async fn idle_observer_publishes_without_advancing_a_batch_timer() {
+    let (_tempdir, node, store, handle) = build_observer_fixture().await;
+    let mut changes = store.subscribe();
+    let started = tokio::time::Instant::now();
+    seed_principal(node.as_ref(), "did:immediate").await;
+    tokio::time::timeout(Duration::from_millis(100), changes.changed())
+        .await
+        .expect("idle observer must not wait 150ms")
+        .unwrap();
+    assert!(started.elapsed() < Duration::from_millis(100));
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn committed_history_burst_does_not_force_a_snapshot_reload() {
+    let (_tempdir, node, store, handle) = build_observer_fixture().await;
+    let mut raw = node.subscribe(&[EventName::Update]);
+    let mut changes = store.subscribe();
+    seed_principal(node.as_ref(), "did:history").await;
+    let update = raw.recv().await.expect("committed update");
+    node.event_bus().unsubscribe(raw.id());
+    tokio::time::timeout(Duration::from_secs(5), changes.changed())
+        .await
+        .expect("initial projection deadline")
+        .expect("projection alive");
+    let before = handle.metrics_snapshot();
+
+    // Match the merge boundary: all revision events are published synchronously
+    // after commit, before a single-threaded mobile executor can drain them.
+    for _ in 0..12_000 {
+        node.event_bus().publish(update.clone());
+    }
+    tokio::time::timeout(Duration::from_secs(5), changes.changed())
+        .await
+        .expect("history projection deadline")
+        .expect("projection alive");
+    let after = handle.metrics_snapshot();
+    assert_eq!(after.drop_recoveries, before.drop_recoveries);
+    assert_eq!(after.scope_reloads, before.scope_reloads);
+    assert!(after.docs_fetched - before.docs_fetched <= 1);
+    assert_eq!(
+        after.document_change_batches - before.document_change_batches,
+        1
+    );
+    assert_eq!(after.coalesced_updates - before.coalesced_updates, 11_999);
+    assert!(store
+        .snapshot()
+        .agent_principals
+        .iter()
+        .any(|p| p.agent_did == "did:history"));
+    handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn change_after_drain_is_not_hidden_by_the_previous_snapshot() {
+    let (_tempdir, node, store, handle) = build_observer_fixture().await;
+    let mut changes = store.subscribe();
+    seed_principal(node.as_ref(), "did:first").await;
+    tokio::time::timeout(Duration::from_secs(5), changes.changed())
+        .await
+        .unwrap()
+        .unwrap();
+    seed_principal(node.as_ref(), "did:next").await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if store
+                .snapshot()
+                .agent_principals
+                .iter()
+                .any(|p| p.agent_did == "did:next")
+            {
+                break;
+            }
+            changes.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("subsequent change must be visible without another write");
+    assert_eq!(handle.metrics_snapshot().drop_recoveries, 0);
+    handle.shutdown().await;
+}

--- a/crates/gents-desktop-core/src/client/observe/tests/overflow.rs
+++ b/crates/gents-desktop-core/src/client/observe/tests/overflow.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[tokio::test]
+async fn distinct_document_overflow_reloads_once_and_keeps_observing() {
+    let (_tempdir, node, store, handle) = build_observer_fixture().await;
+    let mut raw = node.subscribe(&[EventName::Update]);
+    let mut changes = store.subscribe();
+    seed_principal(node.as_ref(), "did:survives-overflow").await;
+    let update = raw.recv().await.unwrap().as_update().unwrap().clone();
+    node.event_bus().unsubscribe(raw.id());
+    tokio::time::timeout(Duration::from_secs(5), changes.changed())
+        .await
+        .unwrap()
+        .unwrap();
+    let before = handle.metrics_snapshot();
+    for id in 0..12_000 {
+        let mut changed = update.clone();
+        changed.doc_id = format!("distinct-{id}");
+        node.event_bus().publish(events::Message::update(changed));
+    }
+    tokio::time::timeout(Duration::from_secs(5), changes.changed())
+        .await
+        .unwrap()
+        .unwrap();
+    let after = handle.metrics_snapshot();
+    assert_eq!(after.drop_recoveries - before.drop_recoveries, 1);
+    assert_eq!(after.scope_reloads - before.scope_reloads, 1);
+    assert!(store
+        .snapshot()
+        .agent_principals
+        .iter()
+        .any(|p| p.agent_did == "did:survives-overflow"));
+
+    seed_principal(node.as_ref(), "did:after-overflow").await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !store
+            .snapshot()
+            .agent_principals
+            .iter()
+            .any(|p| p.agent_did == "did:after-overflow")
+        {
+            changes.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("normal observation resumes after resync");
+    handle.shutdown().await;
+}

--- a/crates/gents/proofs/Proofs/SessionHydration/Receiver.lean
+++ b/crates/gents/proofs/Proofs/SessionHydration/Receiver.lean
@@ -67,6 +67,19 @@ def progressFor (prev : ClientProgress) (session agent : String) : ClientProgres
 def beginRequest (session agent : String) : ClientProgress :=
   { session, agent, phase := .requested }
 
+/-- An owned session header permits hydration during a live turn. Without that
+header, a pending local request alone does not prove the session exists. -/
+def canStartInitial (ownedSession hasDocuments nonterminalRequest : Bool) : Bool :=
+  ownedSession || (hasDocuments && !nonterminalRequest)
+
+theorem owned_session_can_start_during_turn (hasDocuments nonterminalRequest : Bool) :
+    canStartInitial true hasDocuments nonterminalRequest = true := by
+  simp [canStartInitial]
+
+theorem pending_request_without_session_waits (hasDocuments : Bool) :
+    canStartInitial false hasDocuments true = false := by
+  simp [canStartInitial]
+
 /-- An explicit retry is legal only for the same failed target. -/
 def canRetry (prev : ClientProgress) (session agent : String) : Bool :=
   decide (prev.session = session ∧ prev.agent = agent ∧ prev.phase = .failed)

--- a/crates/gents/src/agent/runtime/tests/control_watcher.rs
+++ b/crates/gents/src/agent/runtime/tests/control_watcher.rs
@@ -299,12 +299,10 @@ async fn control_watcher_recovers_after_resolve_error() {
 
     wait_for_runtime_reconcile_phase(node.as_ref(), agent.agent_did(), "debouncing").await;
     tokio::time::advance(CONTROL_RECONCILE_DEBOUNCE + Duration::from_millis(1)).await;
-    let recovered_status =
-        wait_for_runtime_reconcile_phase(node.as_ref(), agent.agent_did(), "resolving").await;
-
+    // The settle retry may already return the phase to idle after proposing
+    // this fingerprint. Recovery is the queued proposal, not a transient phase.
     let snapshot = proposal_rx.recv().await.expect("recovered snapshot");
     assert_eq!(snapshot.default_behavior_id, agent.default_behavior_id());
-    assert_eq!(recovered_status.reconcile_phase, "resolving");
 
     let _ = shutdown_tx.send(true);
     watcher_task.await.unwrap().unwrap();


### PR DESCRIPTION
## Stack and status

Third layer above #1439. Ready for review. The native DB dependencies that this observer relies on are merged upstream and pinned by the stack tip, #1450; there are no local path dependencies.

## Changes

- Subscribe to native bounded/coalesced document changes before the initial snapshot. Project available changes immediately, removing the 150 ms client debounce. Retain explicit overflow resync and bounded failure recovery.
- Permit live session selection when the owned session header already exists; preserve the pending-compose guard without that evidence. Lean model and model-driven Rust truth table updated together.
- Add real enrollment/client-store tests for first text and buffered text during a provider pause, retaining 500 ms streaming gates, local pagination checks, offline/reopen conversation continuity, and the 2,500-revision readiness fixture.
- Retain per-document stage and lifecycle diagnostics on failure, including live runtime replicator state and document scope.
- Fix #1440: the control-watcher recovery test observes the queued proposal instead of polling a transient phase. No production lifecycle behavior or timeout change.

## Validation

The full six-layer candidate rebased onto current `main` passes the complete Gents runtime suite, all-target workspace check, 227 desktop-core tests, and all six canonical enrollment cases. The aged-runtime case now passes with the merged reconnect and Regolith fixes at #1450; no gates were weakened.

No deployment, identity changes, re-enrollment workaround, or additional client delivery owner.