### PR TITLE
fix: load the foreground chat before the fleet overview

### DIFF
--- a/apps/gents-desktop/src/hooks/desktopProjectionController.ts
+++ b/apps/gents-desktop/src/hooks/desktopProjectionController.ts
@@ -68,14 +68,6 @@ export function createDesktopProjectionController({
     while (!disposed && pending !== 0) {
       const work = pending;
       pending = 0;
-      if (work & SNAPSHOT) {
-        try {
-          await refreshSnapshot();
-        } catch (error) {
-          onError(error);
-        }
-      }
-
       try {
         const sessionId = currentSessionId();
         if (work & SESSION) {
@@ -98,6 +90,15 @@ export function createDesktopProjectionController({
         }
       } catch (error) {
         onError(error);
+      }
+      // Foreground/full refresh must show the selected chat without waiting
+      // for the unrelated fleet/index projection.
+      if (work & SNAPSHOT) {
+        try {
+          await refreshSnapshot();
+        } catch (error) {
+          onError(error);
+        }
       }
     }
   };

--- a/apps/gents-desktop/tests/desktop-projection-controller.test.ts
+++ b/apps/gents-desktop/tests/desktop-projection-controller.test.ts
@@ -66,7 +66,23 @@ describe("createDesktopProjectionController", () => {
     const full = projection.request("full");
     await Promise.all([delta, full]);
 
-    expect(calls).toEqual(["snapshot", "session"]);
+    expect(calls).toEqual(["session", "snapshot"]);
+  });
+
+  it("projects the selected chat before a slow fleet refresh on foreground", async () => {
+    const fleet = deferred();
+    const refreshSession = vi.fn(async () => null);
+    const refreshSnapshot = vi.fn(async () => fleet.promise);
+    const projection = controller({ refreshSession, refreshSnapshot });
+
+    const refresh = projection.request("full");
+    try {
+      await vi.waitFor(() => expect(refreshSnapshot).toHaveBeenCalledTimes(1));
+      expect(refreshSession).toHaveBeenCalledExactlyOnceWith("session-1");
+    } finally {
+      fleet.resolve();
+      await refresh;
+    }
   });
 
   it("still refreshes the bounded session when the fleet snapshot fails", async () => {


### PR DESCRIPTION
## Stack

Fourth layer above #1441. Ready for review; the merged native DB dependencies are pinned by stack tip #1450.

## Change

The existing projection controller loads the selected chat before the fleet/index snapshot during a foreground/full refresh. A slow overview no longer prevents the selected session from appearing. Keep the same projection owner, coalescing, bounded session reads, and terminal index refresh behavior; no replication or authorization changes.

## Validation

- Regression with a deliberately blocked fleet snapshot: red (two failed, eight passed), green with the fix.
- Projection/controller suites: 13 passed.
- Full UI suite: 379 passed, 13 existing skipped.
- Production desktop build and touched-file formatting: pass.
- Full six-layer stack on current `main`: complete runtime suite, all-target workspace check, 227 desktop-core tests, and six canonical enrollment cases pass.

This measures controller ordering, not physical iPhone screen-paint latency. No rollout.