### PR TITLE
fix: avoid redundant client startup work

### DIFF
--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -38,10 +38,21 @@ impl ClientCore {
         paths: DesktopPaths,
         options: ClientCoreOptions,
     ) -> Result<Self> {
+        let started = Instant::now();
+        let mut previous = started;
+        let mut checkpoint = |stage: &'static str| {
+            let now = Instant::now();
+            tracing::debug!(target: "gents_desktop_core::startup", stage,
+                stage_ms = now.duration_since(previous).as_millis(),
+                elapsed_ms = now.duration_since(started).as_millis(),
+                "client startup stage completed");
+            previous = now;
+        };
         paths.ensure_root_dirs().await?;
         gents::storage_backend::reject_legacy_store(paths.node_data_dir())?;
 
         let principal = PrincipalIdentity::load_or_create(&paths).await?;
+        checkpoint("paths_and_identity");
         let node = Arc::new(
             NodeBuilder::default()
                 .data_path(paths.node_data_dir())
@@ -53,6 +64,8 @@ impl ClientCore {
                 .context("starting embedded desktop node")?,
         );
 
+        checkpoint("embedded_node");
+
         let loaded_peer_directory = PeerDirectory::open_writer(paths.peer_directory_path()).await?;
         let sync_state = super::sync_state::ClientSyncStateOwner::new(
             P2PHealth::default(),
@@ -61,9 +74,11 @@ impl ClientCore {
         );
         sync_state.clear_ephemeral_pairing_readiness().await?;
         let records = sync_state.records();
+        checkpoint("peer_directory");
         ensure_runtime_schemas(node.as_ref()).await?;
-        ensure_desktop_schema_migrations(Arc::clone(&node)).await?;
+        checkpoint("runtime_schemas");
         subscribe_all_collections(node.as_ref()).await?;
+        checkpoint("collection_subscriptions");
 
         let observer_subscription = node.subscribe_document_changes();
 
@@ -73,6 +88,7 @@ impl ClientCore {
             load_full_snapshot_with_peer_records(node.as_ref(), &records, principal.did()).await?
         };
         let (store, _store_updates) = ObservedStore::new(initial_snapshot);
+        checkpoint("initial_snapshot");
 
         let p2p = node
             .p2p_arc()
@@ -94,6 +110,7 @@ impl ClientCore {
         };
         let (initial_health, initial_database_sync, initial_database_sync_error) =
             super::supervisor::probe_p2p_health(&p2p, &P2PHealth::default(), None, None).await;
+        checkpoint("bootstrap_and_health");
         for status in peer_statuses {
             if let Some(expected) = records
                 .iter()
@@ -169,13 +186,6 @@ fn desktop_p2p_config(paths: &DesktopPaths, options: &ClientCoreOptions) -> P2PC
         // Gossip rebroadcast adds a coalescing wait inside the merge loop.
         rebroadcast_on_merge: false,
     }
-}
-
-async fn ensure_desktop_schema_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
-    gents::migration::ensure_all_runtime_migrations(node)
-        .await
-        .context("ensure desktop runtime schema migrations")?;
-    Ok(())
 }
 
 pub(super) async fn bootstrap_saved_peers(

--- a/crates/gents-desktop-core/src/client/core/tests.rs
+++ b/crates/gents-desktop-core/src/client/core/tests.rs
@@ -18,6 +18,8 @@ use crate::client::{PeerDirectory, PeerRecord};
 
 #[derive(Default)]
 struct RecordingP2P {
+    collection_batches: StdRwLock<Vec<Vec<String>>>,
+    collection_error: StdRwLock<Option<String>>,
     notify_calls: AtomicUsize,
     local_peer_id_error: StdRwLock<Option<String>>,
     listen_addresses: StdRwLock<Vec<String>>,
@@ -33,6 +35,31 @@ struct RecordingP2P {
     replicators_error: StdRwLock<Option<String>>,
     sync_status: StdRwLock<serde_json::Value>,
     sync_status_error: StdRwLock<Option<String>>,
+}
+
+#[tokio::test]
+async fn startup_subscriptions_use_one_batch_with_the_exact_allowed_scope() {
+    let p2p = RecordingP2P::default();
+    crate::client::schema::subscribe_runtime_collections(&p2p)
+        .await
+        .unwrap();
+    let batches = p2p.collection_batches.read().unwrap();
+    assert_eq!(batches.len(), 1);
+    assert_eq!(
+        batches[0],
+        crate::client::schema::subscribed_collection_names()
+    );
+}
+
+#[tokio::test]
+async fn startup_subscription_failure_is_not_swallowed() {
+    let p2p = RecordingP2P::default();
+    *p2p.collection_error.write().unwrap() = Some("subscription denied".to_string());
+    let error = crate::client::schema::subscribe_runtime_collections(&p2p)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("subscription denied"));
+    assert_eq!(p2p.collection_batches.read().unwrap().len(), 1);
 }
 
 #[allow(dead_code)]
@@ -297,7 +324,11 @@ impl P2POps for RecordingP2P {
         Ok(Vec::new())
     }
 
-    async fn add_collections(&self, _collections: Vec<String>) -> P2PResult<()> {
+    async fn add_collections(&self, collections: Vec<String>) -> P2PResult<()> {
+        self.collection_batches.write().unwrap().push(collections);
+        if let Some(error) = self.collection_error.read().unwrap().as_ref() {
+            return Err(defra_p2p_adapter::P2PError::Transport(error.clone()));
+        }
         Ok(())
     }
 

--- a/crates/gents-desktop-core/src/client/schema.rs
+++ b/crates/gents-desktop-core/src/client/schema.rs
@@ -17,20 +17,21 @@ pub async fn ensure_schemas(node: &EmbeddedNode) -> Result<()> {
 
 pub async fn subscribe_all_collections(node: &EmbeddedNode) -> Result<()> {
     let p2p = node.p2p().context("desktop node missing P2P support")?;
+    subscribe_runtime_collections(p2p).await
+}
 
-    for name in subscribed_collection_names() {
-        match p2p.add_collections(vec![name.to_owned()]).await {
-            Ok(()) => {}
-            Err(error) => {
-                if error.to_string().contains("already") {
-                    tracing::debug!(collection = name, "collection already subscribed");
-                } else {
-                    return Err(error.into());
-                }
-            }
-        }
-    }
-
+pub(crate) async fn subscribe_runtime_collections(
+    p2p: &dyn defra_p2p_adapter::P2POperations,
+) -> Result<()> {
+    // The DB handles existing subscriptions idempotently and persists the
+    // resulting list once per API call.
+    p2p.add_collections(
+        subscribed_collection_names()
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fifth layer above #1442. Remove two redundant startup costs without changing sync ownership or readiness:

- Run the complete schema migration/verification/materialization engine once, instead of calling it through two equivalent wrappers.
- Subscribe the existing permitted collection set with one native DB batch. The DB already treats existing subscriptions idempotently. This avoids repeated authorization checks and full subscription-list persistence.
- Emit debug-level startup phase timings with no document content.
- Assert a single exact-scope subscription batch and fail-closed error handling.

The privacy/local-only exclusions, schema lineage checks, observer ordering, pairing authority, and recovery/streaming test budgets are unchanged.

## Measurements

Local aged-history diagnostic samples reduced duplicate migration work by 245 ms, collection subscription setup from 564 ms to 237 ms, and total client startup from 1661 ms to 1044 ms. Concurrent builds mean these are diagnostic samples, not isolated benchmarks.

## Stack and validation

Ready for review. The merged native DB/Regolith dependencies are supplied by tip #1450. The full six-layer candidate on current `main` passes the complete runtime suite, all-target workspace check, 227 desktop-core tests, and all six canonical enrollment cases, including aged history and offline recovery. No local dependency paths, schema changes, or rollout.