### PR TITLE
fix: ship the merged native chat delivery dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2139,7 +2139,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -2266,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -2411,13 +2411,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2432,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "anyhow",
@@ -2497,7 +2497,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2522,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "async-stream",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "anyhow",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "async-trait",
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "serde",
 ]
@@ -2822,7 +2822,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3178,7 +3178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -3753,8 +3753,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4828,7 +4828,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4947,7 +4947,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -5662,7 +5662,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "async-channel",
@@ -5783,7 +5783,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6546,7 +6546,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6676,7 +6676,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7034,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "anyhow",
@@ -7844,7 +7844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "acp",
  "async-graphql",
@@ -7975,7 +7975,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8281,9 +8281,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regolith"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78ac133f988e47a96a6d9df82e22247b382cd92f785425377ca5b33a47d68b1"
+checksum = "c23240afcf67549a4a00ecdcb5752048eafeef83d47dc73ad4b676cc548b2c85"
 dependencies = [
  "js-sys",
  "kovan",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "p2p",
  "query",
@@ -8619,7 +8619,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8678,7 +8678,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8699,7 +8699,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8765,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "cid",
  "defra-core",
@@ -8933,7 +8933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -10181,7 +10181,7 @@ dependencies = [
 [[package]]
 name = "telemetry"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "tracing",
 ]
@@ -10196,7 +10196,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11769,7 +11769,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12468,8 +12468,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -12640,7 +12640,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=17093dac87c7d991272e7fc4da2efd1708b2bdd1#17093dac87c7d991272e7fc4da2efd1708b2bdd1"
+source = "git+https://github.com/sourcenetwork/defradb.rs.git?rev=f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e#f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,9 @@ clap = { version = "4", features = ["derive", "env"] }
 # Current DefraDB includes the multiplexed Iroh protocol: upgrade clients and
 # runtimes together. Keep its iterative parent-DAG replay for deep iOS history
 # and let the database own durable replication and recovery.
-acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
-crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
-defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+acp = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
+crypto = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
+defra-core = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-chatgpt-login = { path = "crates/gents-chatgpt-login" }
 gents-claude-login = { path = "crates/gents-claude-login" }
@@ -74,12 +74,12 @@ gents-desktop-bridge = { path = "crates/gents-desktop-bridge" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
 # Keep DefraDB defaults off: Gents selects Iroh P2P and Lens execution without
 # SourceHub ACP or the legacy libp2p transport (defradb.rs#1431-#1435).
-defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1", default-features = false }
-defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1", default-features = false }
+defra-node = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e", default-features = false }
+defra-p2p-adapter = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e", default-features = false }
 dirs = "5"
-events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+events = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
 hostname = "0.4"
-identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+identity = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -87,9 +87,9 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
-query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
-storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "17093dac87c7d991272e7fc4da2efd1708b2bdd1" }
+p2p = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
+query = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
+storage = { git = "https://github.com/sourcenetwork/defradb.rs.git", rev = "f3bf7b1ae5ea5a4ae4fbeafa43e4f0dc1fb13d1e" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/gents-desktop-core/src/client/observe.rs
+++ b/crates/gents-desktop-core/src/client/observe.rs
@@ -27,6 +27,11 @@ const RESYNC_RETRY_DELAY: Duration = Duration::from_millis(250);
 const FETCH_RETRY_LIMIT: u32 = 3;
 const SESSION_HYDRATION_REQUEST: &str = "SessionHydrationRequest";
 
+enum ObserverWake {
+    Changes(events::DocumentChangeBatch),
+    Retry,
+}
+
 pub struct ObserverHandle {
     stop_tx: watch::Sender<bool>,
     task: tokio::task::JoinHandle<()>,
@@ -64,7 +69,7 @@ pub fn spawn_observer_with_selection(
         let mut resync_pending = false;
 
         loop {
-            let next = tokio::select! {
+            let wake = tokio::select! {
                 changed = stop_rx.changed() => match changed {
                     Ok(()) if *stop_rx.borrow() => {
                         tracing::debug!("desktop observation requested shutdown");
@@ -73,50 +78,54 @@ pub fn spawn_observer_with_selection(
                     Ok(()) => continue,
                     Err(_) => break,
                 },
-                msg = subscription.recv() => msg,
+                msg = subscription.recv() => match msg {
+                    Some(msg) => ObserverWake::Changes(msg),
+                    None => {
+                        tracing::debug!("desktop observation subscription closed");
+                        break;
+                    }
+                },
                 _ = tokio::time::sleep(if resync_pending { RESYNC_RETRY_DELAY } else { FETCH_RETRY_DELAY }), if resync_pending || !dirty.is_empty() => {
-                    Some(events::DocumentChangeBatch::default())
+                    ObserverWake::Retry
                 }
             };
-            let Some(msg) = next else {
-                tracing::debug!("desktop observation subscription closed");
-                break;
-            };
-            metrics_for_task
-                .events_received
-                .fetch_add(msg.updates, Ordering::Relaxed);
-            metrics_for_task
-                .document_change_batches
-                .fetch_add(1, Ordering::Relaxed);
-            if !msg.resync_required {
-                metrics_for_task.coalesced_updates.fetch_add(
-                    msg.updates.saturating_sub(msg.changes.len() as u64),
-                    Ordering::Relaxed,
-                );
-            }
-
-            for update in &msg.changes {
-                accumulate_dirty(
-                    &mut dirty,
-                    resolver.as_ref(),
-                    node.as_ref(),
-                    &update.collection_id,
-                    &update.doc_id,
-                    !update.has_local_write,
-                    metrics_for_task.as_ref(),
-                )
-                .await;
-            }
-
-            if msg.resync_required {
-                tracing::warn!(
-                    updates = msg.updates,
-                    "desktop observation distinct-document capacity exceeded; performing scoped reload"
-                );
+            if let ObserverWake::Changes(msg) = wake {
                 metrics_for_task
-                    .drop_recoveries
+                    .events_received
+                    .fetch_add(msg.updates, Ordering::Relaxed);
+                metrics_for_task
+                    .document_change_batches
                     .fetch_add(1, Ordering::Relaxed);
-                resync_pending = true;
+                if !msg.resync_required {
+                    metrics_for_task.coalesced_updates.fetch_add(
+                        msg.updates.saturating_sub(msg.changes.len() as u64),
+                        Ordering::Relaxed,
+                    );
+                }
+
+                for update in &msg.changes {
+                    accumulate_dirty(
+                        &mut dirty,
+                        resolver.as_ref(),
+                        node.as_ref(),
+                        &update.collection_id,
+                        &update.doc_id,
+                        !update.has_local_write,
+                        metrics_for_task.as_ref(),
+                    )
+                    .await;
+                }
+
+                if msg.resync_required {
+                    tracing::warn!(
+                        updates = msg.updates,
+                        "desktop observation distinct-document capacity exceeded; performing scoped reload"
+                    );
+                    metrics_for_task
+                        .drop_recoveries
+                        .fetch_add(1, Ordering::Relaxed);
+                    resync_pending = true;
+                }
             }
             if resync_pending {
                 dirty.clear();

--- a/crates/gents/src/streaming.rs
+++ b/crates/gents/src/streaming.rs
@@ -66,10 +66,7 @@ pub struct DefraStreamWriter {
 }
 
 struct StreamBuffer {
-    content: String,
-    reasoning: String,
-    token_count: usize,
-    reasoning_progress_seq: usize,
+    current: StreamBufferSnapshot,
     last_flush_at: Instant,
     persisted: StreamBufferSnapshot,
     lease: ExecutionWriteFence,
@@ -87,11 +84,7 @@ impl DefraStreamWriter {
     pub(crate) async fn next_flush_deadline(&self, doc_id: &str) -> Option<tokio::time::Instant> {
         let buffers = self.buffers.lock().await;
         let buffer = buffers.get(doc_id)?;
-        if buffer.content == buffer.persisted.content
-            && buffer.reasoning == buffer.persisted.reasoning
-            && buffer.token_count == buffer.persisted.token_count
-            && buffer.reasoning_progress_seq == buffer.persisted.reasoning_progress_seq
-        {
+        if buffer.current == buffer.persisted {
             return None;
         }
         buffer
@@ -220,17 +213,13 @@ impl DefraStreamWriter {
         let buf = buffers
             .get_mut(doc_id)
             .ok_or_else(|| anyhow::anyhow!("no buffer for doc_id={}", doc_id))?;
-        let first_visible_content = (buf.persisted.content.is_empty() && !buf.content.is_empty())
-            || (buf.persisted.reasoning.is_empty() && !buf.reasoning.is_empty());
+        let first_visible_content = (buf.persisted.content.is_empty()
+            && !buf.current.content.is_empty())
+            || (buf.persisted.reasoning.is_empty() && !buf.current.reasoning.is_empty());
         if !force && !first_visible_content && buf.last_flush_at.elapsed() < self.batch_interval {
             return Ok(None);
         }
-        let snapshot = StreamBufferSnapshot {
-            content: buf.content.clone(),
-            reasoning: buf.reasoning.clone(),
-            token_count: buf.token_count,
-            reasoning_progress_seq: buf.reasoning_progress_seq,
-        };
+        let snapshot = buf.current.clone();
         Ok((snapshot != buf.persisted).then_some(snapshot))
     }
 
@@ -244,8 +233,8 @@ impl DefraStreamWriter {
         let buf = buffers
             .get_mut(doc_id)
             .ok_or_else(|| anyhow::anyhow!("no buffer for doc_id={}", doc_id))?;
-        if buf.content.is_empty()
-            && buf.reasoning.is_empty()
+        if buf.current.content.is_empty()
+            && buf.current.reasoning.is_empty()
             && buf.persisted.content.is_empty()
             && buf.persisted.reasoning.is_empty()
         {
@@ -269,8 +258,8 @@ impl DefraStreamWriter {
                     }}
                 ) {{ _docID }}
             }}"#,
-            token_count = buf.token_count,
-            reasoning_progress_seq = buf.reasoning_progress_seq,
+            token_count = buf.current.token_count,
+            reasoning_progress_seq = buf.current.reasoning_progress_seq,
         );
 
         let resp = lease
@@ -294,14 +283,9 @@ impl DefraStreamWriter {
             );
         }
 
-        buf.content.clear();
-        buf.reasoning.clear();
-        buf.persisted = StreamBufferSnapshot {
-            content: String::new(),
-            reasoning: String::new(),
-            token_count: buf.token_count,
-            reasoning_progress_seq: buf.reasoning_progress_seq,
-        };
+        buf.current.content.clear();
+        buf.current.reasoning.clear();
+        buf.persisted = buf.current.clone();
         buf.last_flush_at = Instant::now();
         Ok(())
     }
@@ -466,10 +450,7 @@ impl DefraStreamWriter {
         self.buffers.lock().await.insert(
             doc_id.clone(),
             StreamBuffer {
-                content: String::new(),
-                reasoning: String::new(),
-                token_count: 0,
-                reasoning_progress_seq: 0,
+                current: StreamBufferSnapshot::default(),
                 last_flush_at: Instant::now(),
                 persisted: StreamBufferSnapshot::default(),
                 lease,
@@ -496,8 +477,8 @@ impl DefraStreamWriter {
             let buf = buffers
                 .get_mut(doc_id)
                 .ok_or_else(|| anyhow::anyhow!("no buffer for doc_id={}", doc_id))?;
-            buf.content.push_str(tokens);
-            buf.token_count += tokens.split_whitespace().count();
+            buf.current.content.push_str(tokens);
+            buf.current.token_count += tokens.split_whitespace().count();
         }
 
         let snapshot = self.pending_snapshot(doc_id, false).await?;
@@ -518,8 +499,9 @@ impl DefraStreamWriter {
             let buf = buffers
                 .get_mut(doc_id)
                 .ok_or_else(|| anyhow::anyhow!("no buffer for doc_id={}", doc_id))?;
-            append_live_reasoning_preview(&mut buf.reasoning, reasoning);
-            buf.reasoning_progress_seq = buf.reasoning_progress_seq.saturating_add(1);
+            append_live_reasoning_preview(&mut buf.current.reasoning, reasoning);
+            buf.current.reasoning_progress_seq =
+                buf.current.reasoning_progress_seq.saturating_add(1);
         }
 
         let snapshot = self.pending_snapshot(doc_id, false).await?;


### PR DESCRIPTION
## Stack

Sixth and final layer above #1444. This pins Gents to the merged DefraDB native delivery stack at `f3bf7b1a`, which includes the bounded/coalesced document observer, iterative parent-DAG replay, reconnect convergence fix, and Regolith 0.1.4 scan fix.

The lower Gents layers remain responsible only for session intent, streaming cadence, local projection, and startup ordering. DefraDB owns durable delivery, catch-up, retries, and backpressure.

## Validation

On the full portable stack rebased onto current `main`:

- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p gents --locked`: pass (2,280 core tests plus all conformance/integration groups; five existing ignored tests).
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo check --workspace --all-targets --locked`: pass (one existing CLI dead-code warning).
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p gents-desktop-core --locked`: 227 passed.
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo test -p gents-cli --test cli_enrollment --locked -- --nocapture`: 6 passed, including the 2,500-revision aged-runtime case, streaming-before-provider-completion, offline recovery, reopen continuity, and fresh-client enrollment without an AgentPrincipal copy.

The canonical run showed 0 ms observer lag after the document reached the client database and no observer drop recovery or scope reloads.

## Upgrade

This is a coordinated phone/desktop/runtime dependency update. Upgrade both ends together; preserve stores, identities, and enrollment state. No schema or manifest changes.