### PR TITLE
test(p2p): assert durable collection names

### DIFF
--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -1033,7 +1033,6 @@ mod tests {
         let node = Arc::clone(&test.node);
         let admin = EmbeddedRemoteP2pAdmin::new(Arc::clone(&node));
         let collection_name = "P2pReconcileThing".to_string();
-        let expected_collection_id = collection_id(&node, "P2pReconcileThing");
 
         admin
             .add_p2p_collections(std::slice::from_ref(&collection_name))
@@ -1044,7 +1043,7 @@ mod tests {
             .list_p2p_collections()
             .await
             .expect("list collections");
-        assert!(collections.contains(&expected_collection_id));
+        assert_eq!(collections, vec![collection_name]);
 
         node.shutdown().await;
     }


### PR DESCRIPTION
## Summary

- update the embedded P2P round-trip regression to assert durable collection names
- align the Gents contract with DefraDB Rust/Go list semantics landed in sourcenetwork/defradb.rs#1748
- unblock the v0.17.0 full release suite without reverting production behavior

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo test -p gents agent::p2p_reconcile::embedded_impl::tests::embedded_collections_round_trip --lib`
- `git diff --check`