### PR TITLE
test(p2p): consume durable collection names

### DIFF
--- a/crates/gents/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
+++ b/crates/gents/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
@@ -229,21 +229,7 @@ async fn fetch_subscribed_collection_names(node: &EmbeddedNode) -> Vec<String> {
     let Some(p2p) = node.p2p() else {
         return Vec::new();
     };
-    let Ok(ids) = p2p.get_collections().await else {
-        return Vec::new();
-    };
-    let Ok(names) = node.list_collections() else {
-        return Vec::new();
-    };
-    names
-        .into_iter()
-        .filter(|name| {
-            node.get_collection(name)
-                .ok()
-                .flatten()
-                .is_some_and(|definition| ids.contains(&definition.collection_id))
-        })
-        .collect()
+    p2p.get_collections().await.unwrap_or_default()
 }
 
 async fn wait_for_subscribed_collections(


### PR DESCRIPTION
## Summary

- consume DefraDB P2P collection names directly in the pairing/trigger E2E
- remove the obsolete second name-to-CID translation introduced for the old Rust-only response contract
- continue proving that reconcile installs the subscription, replicates the document, and fires the event trigger

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo test -p gents --test e2e_triggers app_collection_pairing_p2p_e2e::app_collection_pairing_fires_event_trigger_via_reconcile -- --nocapture`
- `git diff --check`