### PR TITLE
release: prepare v0.17.0

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.16.4"
+        default: "0.17.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.16.4"
+        default: "0.17.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ and is what compatibility decisions key on — see `contracts/desktop-bridge.jso
 
 ## Unreleased
 
+## 0.17.0 - 2026-09-11
+
+### Changed
+
+- Resolve runtime, CLI, desktop, and bundled-pack configuration through one
+  canonical document model. `AgentSession` is the durable session, behaviors
+  select context and inference profiles, tools own their nested settings, and
+  tasks, triggers, schedules, and event sources share one desired-state owner.
+- Remove the duplicate conversation, deployment, approval-hold, graph-config,
+  validator, migration, and desktop configuration machinery superseded by the
+  canonical owners. The full refactor removes more than 24,000 net lines.
+- Keep the application/database boundary explicit: Gents selects authorized
+  sessions and projects locally available documents; DefraDB owns delivery,
+  reconnect catch-up, retries, and backpressure.
+
+### Fixed
+
+- Bound embedded transaction phases and route storage timeouts through the
+  standard retry classifier without claiming ambiguous transactions committed.
+- Converge hydration after failed or ambiguous delivery and terminal writes,
+  with idempotent repeat delivery and durable periodic recovery instead of
+  readiness heartbeats.
+- Coalesce native document-change bursts, remove per-lease global scans, and
+  keep sticky observer resync without event-drop amplification.
+- Batch durable collection subscription changes and startup restoration while
+  preserving Go-compatible DefraDB semantics. Failed live topic installation
+  and removal now retry in-process from durable desired state.
+- Scope pairing reconciliation wakes and skip redundant migration baselines,
+  eliminating broad application replay and repeated startup work.
+
+### Performance and validation
+
+- Cover fresh and 2,500-revision enrollment, streaming, offline reopen, local
+  transcript pagination, and independent database-to-observer projection in
+  the canonical mobile integration suite.
+- Verify all writes persist under a deterministic 32-writer hot-document load
+  and that the next canonical write remains live.
+- Measure clean client startup at 51-116 ms, collection subscription setup at
+  3-16 ms, steady request delivery at 95-243 ms, and offline reply recovery at
+  0.78-1.05 seconds, with no event-drop recovery in deterministic runs.
+- Complete a fresh server, client, enrollment, real P2P, live inference, and
+  client-visible conversation in 10.86 seconds against
+  `GLM-5.3-Flash-NVFP4`.
+
+### Upgrade
+
+- Upgrade phone/desktop clients and agent runtimes together. Preserve stores,
+  DIDs, identities, and enrollment state; do not wipe or re-pair installations.
+  Mixed pre-0.17 canonical configuration models are not supported.
+
 ## 0.16.4 - 2026-09-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3375,7 +3375,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fixture-domain-plugin"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "acp",
  "alloy-dyn-abi",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "gents-chatgpt-login"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "gents-protocol",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "gents-claude-login"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "rand 0.9.2",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "gents-codex-protocol"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3950,7 +3950,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-bridge"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fixture-host"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "dirs 5.0.1",
  "fixture-domain-plugin",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "gents-protocol",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "gents-migration"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "defra-node",
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.16.4"
+version = "0.17.0"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/gents-ai/gents"

--- a/apps/fixture-host/package.json
+++ b/apps/fixture-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/fixture-host-ui",
   "private": true,
-  "version": "0.16.4",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1421",
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-chat": "0.16.4",
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-fleet": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4",
+    "@source-inc/gents-desktop-chat": "0.17.0",
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-fleet": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0",
     "@tauri-apps/api": "^2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/fixture-host/src-tauri/tauri.conf.json
+++ b/apps/fixture-host/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents Fixture Host",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "identifier": "com.source-inc.gents-fixture-host",
   "build": {
     "beforeDevCommand": "npm run dev --workspace=@source-inc/fixture-host-ui",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/gents-desktop-app",
   "private": true,
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
@@ -52,14 +52,14 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-chat": "0.16.4",
-    "@source-inc/gents-desktop-fleet": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4"
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-chat": "0.17.0",
+    "@source-inc/gents-desktop-fleet": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-operations": "0.16.4",
+    "@source-inc/gents-desktop-operations": "0.17.0",
     "@antithesishq/bombadil": "^0.6.0",
     "@playwright/test": "^1.61.0",
     "@tauri-apps/cli": "2.10.1",

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.16.4</string>
+	<string>0.17.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.16.4</string>
+	<string>0.17.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.16.4
-        CFBundleVersion: "0.16.4"
+        CFBundleShortVersionString: 0.17.0
+        CFBundleVersion: "0.17.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/review-demo/package.json
+++ b/apps/review-demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@source-inc/review-demo-ui",
   "private": true,
-  "version": "0.16.4",
+  "version": "0.17.0",
   "type": "module",
   "scripts": {
     "dev": "vite --strictPort --host 127.0.0.1",
@@ -10,8 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/contracts/desktop-bridge.json
+++ b/contracts/desktop-bridge.json
@@ -317,7 +317,7 @@
     "desktop://managed-server-updated",
     "desktop://managed-server-tray-stop"
   ],
-  "packageVersion": "0.16.4",
+  "packageVersion": "0.17.0",
   "permissionSets": [
     {
       "kind": "bundle",

--- a/crates/gents-cli/tests/suites/cli_config_apply_transactional_rollback.rs
+++ b/crates/gents-cli/tests/suites/cli_config_apply_transactional_rollback.rs
@@ -1,17 +1,29 @@
 use crate::support::*;
 
 use std::fs;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
+use axum::body::Bytes;
+use axum::extract::{OriginalUri, State};
+use axum::http::{HeaderMap, Method, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum::Router;
 use serde_json::Value;
+use tokio::sync::Semaphore;
 use uuid::Uuid;
 
-const KILL_DELAY: Duration = Duration::from_millis(400);
+const TRANSACTION_STAGE_DEADLINE: Duration = Duration::from_secs(10);
 const TX_RECLAIM_DEADLINE: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(250);
-const PER_COLLECTION_SLEEP_MS: &str = "200";
+
+#[derive(Clone)]
+struct StallingProxyState {
+    target_origin: String,
+    client: reqwest::Client,
+    mutation_staged: std::sync::Arc<Semaphore>,
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
@@ -84,18 +96,33 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
         .to_str()
         .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
 
+    // Hold the first successfully staged transactional mutation at the HTTP
+    // boundary. This makes the SIGKILL point deterministic without a timing
+    // sleep or a production-only test hook in config apply.
+    let (proxy_graphql, mutation_staged, proxy) =
+        start_stalling_transaction_proxy(&graphql).await?;
     let mut cli = std::process::Command::new(crate::support::cli_bin())
         .env("HOME", &home_dir)
         .env("RUST_LOG", "error")
-        .env("GENTS_CONFIG_APPLY_SLEEP_MS", PER_COLLECTION_SLEEP_MS)
         .current_dir(&home_dir)
-        .args(["config", "apply", "--root", root_str, "--graphql", &graphql])
+        .args([
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--graphql",
+            &proxy_graphql,
+        ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .context("spawning gents config apply with apply-sleep env")?;
+        .context("spawning gents config apply through transaction proxy")?;
 
-    thread::sleep(KILL_DELAY);
+    let staged_permit = tokio::time::timeout(TRANSACTION_STAGE_DEADLINE, mutation_staged.acquire())
+        .await
+        .context("config apply did not stage a transactional mutation")?
+        .context("transaction proxy closed before staging a mutation")?;
+    staged_permit.forget();
     if let Some(status) = cli
         .try_wait()
         .context("checking config apply before SIGKILL")?
@@ -111,6 +138,7 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
     }
     cli.kill().context("SIGKILL CLI")?;
     cli.wait().context("reap CLI")?;
+    proxy.abort();
 
     let deadline = Instant::now() + TX_RECLAIM_DEADLINE;
     loop {
@@ -138,6 +166,93 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
+}
+
+async fn start_stalling_transaction_proxy(
+    graphql: &str,
+) -> Result<(
+    String,
+    std::sync::Arc<Semaphore>,
+    tokio::task::JoinHandle<()>,
+)> {
+    let mut origin = url::Url::parse(graphql).context("parsing GraphQL endpoint")?;
+    origin.set_path("");
+    origin.set_query(None);
+    origin.set_fragment(None);
+    let mutation_staged = std::sync::Arc::new(Semaphore::new(0));
+    let state = StallingProxyState {
+        target_origin: origin.as_str().trim_end_matches('/').to_owned(),
+        client: reqwest::Client::new(),
+        mutation_staged: mutation_staged.clone(),
+    };
+    let app = Router::new()
+        .fallback(any(forward_and_stall_transactional_mutation))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("binding transaction proxy")?;
+    let address = listener.local_addr().context("transaction proxy address")?;
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let path = url::Url::parse(graphql)
+        .context("parsing GraphQL endpoint path")?
+        .path()
+        .to_owned();
+    Ok((format!("http://{address}{path}"), mutation_staged, server))
+}
+
+async fn forward_and_stall_transactional_mutation(
+    State(state): State<StallingProxyState>,
+    OriginalUri(uri): OriginalUri,
+    method: Method,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let is_transactional_mutation = headers.contains_key("x-defradb-tx")
+        && serde_json::from_slice::<Value>(&body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("query")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+            .is_some_and(|query| query.trim_start().starts_with("mutation"));
+    let target = format!("{}{}", state.target_origin, uri);
+    let upstream = match state
+        .client
+        .request(method, target)
+        .headers(headers)
+        .body(body)
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("transaction proxy: {error}"),
+            )
+                .into_response();
+        }
+    };
+    let status = upstream.status();
+    let bytes = match upstream.bytes().await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("transaction proxy: {error}"),
+            )
+                .into_response();
+        }
+    };
+    if is_transactional_mutation && status.is_success() {
+        state.mutation_staged.add_permits(1);
+        std::future::pending::<()>().await;
+    }
+    (status, bytes).into_response()
 }
 
 async fn count_collection_rows(graphql: &str, collection: &str) -> Result<usize> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-workspace",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-workspace",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "workspaces": [
         "packages/*",
         "apps/gents-desktop",
@@ -19,13 +19,13 @@
     },
     "apps/fixture-host": {
       "name": "@source-inc/fixture-host-ui",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "dependencies": {
-        "@source-inc/gents-desktop-chat": "0.16.4",
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-fleet": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-chat": "0.17.0",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-fleet": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "@tauri-apps/api": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -43,16 +43,16 @@
     },
     "apps/gents-desktop": {
       "name": "@source-inc/gents-desktop-app",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",
         "@fontsource-variable/inter": "^5.2.8",
-        "@source-inc/gents-desktop-chat": "0.16.4",
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-fleet": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-chat": "0.17.0",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-fleet": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.1.0",
@@ -64,7 +64,7 @@
       "devDependencies": {
         "@antithesishq/bombadil": "^0.6.0",
         "@playwright/test": "^1.61.0",
-        "@source-inc/gents-desktop-operations": "0.16.4",
+        "@source-inc/gents-desktop-operations": "0.17.0",
         "@tauri-apps/cli": "2.10.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -82,10 +82,10 @@
     },
     "apps/review-demo": {
       "name": "@source-inc/review-demo-ui",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "dependencies": {
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -5097,12 +5097,12 @@
     },
     "packages/gents-desktop-chat": {
       "name": "@source-inc/gents-desktop-chat",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "@types/node": "^24.0.14",
         "@types/react": "^19.1.8",
         "react-markdown": "^10.1.0",
@@ -5112,9 +5112,9 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.0.0",
@@ -5124,7 +5124,7 @@
     },
     "packages/gents-desktop-client": {
       "name": "@source-inc/gents-desktop-client",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2"
@@ -5136,12 +5136,12 @@
     },
     "packages/gents-desktop-fleet": {
       "name": "@source-inc/gents-desktop-fleet",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5150,21 +5150,21 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-operations": {
       "name": "@source-inc/gents-desktop-operations",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "react": "^19.1.0",
@@ -5173,24 +5173,24 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-client": "0.16.4",
-        "@source-inc/gents-desktop-tokens": "0.16.4",
-        "@source-inc/gents-desktop-ui": "0.16.4",
+        "@source-inc/gents-desktop-client": "0.17.0",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
+        "@source-inc/gents-desktop-ui": "0.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
     },
     "packages/gents-desktop-tokens": {
       "name": "@source-inc/gents-desktop-tokens",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0"
     },
     "packages/gents-desktop-ui": {
       "name": "@source-inc/gents-desktop-ui",
-      "version": "0.16.4",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.16.4",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
@@ -5202,7 +5202,7 @@
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@source-inc/gents-desktop-tokens": "0.16.4",
+        "@source-inc/gents-desktop-tokens": "0.17.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-workspace",
   "private": true,
-  "version": "0.16.4",
+  "version": "0.17.0",
   "description": "npm workspaces for Gents desktop reusable packages",
   "workspaces": [
     "packages/*",

--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-chat",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "Headless chat projection and workflow helpers for Gents desktop",
   "type": "module",
@@ -32,14 +32,14 @@
     "remark-gfm": "^4.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4"
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4",
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0",
     "@types/node": "^24.0.14",
     "@types/react": "^19.1.8",
     "react-markdown": "^10.1.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-client",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "Transport, shared store, and view-model contract for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-client/src/client.ts
+++ b/packages/gents-desktop-client/src/client.ts
@@ -12,7 +12,7 @@ import type {
 
 export type DesktopBridgeContract = GeneratedBridgeContract;
 
-export const PACKAGE_VERSION = "0.16.4";
+export const PACKAGE_VERSION = "0.17.0";
 // The client and bridge share one exact breaking contract. Sync status comes
 // from database-owned gauges; goal permissions are explicit fields.
 export const BRIDGE_CONTRACT_VERSION = "7.1";

--- a/packages/gents-desktop-fleet/package.json
+++ b/packages/gents-desktop-fleet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-fleet",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "Reusable authenticated enrollment, connection health, and fleet surfaces for Gents desktop",
   "type": "module",
@@ -36,14 +36,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4"
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4",
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-operations/package.json
+++ b/packages/gents-desktop-operations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-operations",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "Focused health, trace, and workspace surfaces for Gents desktop",
   "type": "module",
@@ -29,14 +29,14 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4"
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-client": "0.16.4",
-    "@source-inc/gents-desktop-tokens": "0.16.4",
-    "@source-inc/gents-desktop-ui": "0.16.4",
+    "@source-inc/gents-desktop-client": "0.17.0",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
+    "@source-inc/gents-desktop-ui": "0.17.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "react": "^19.1.0",

--- a/packages/gents-desktop-tokens/package.json
+++ b/packages/gents-desktop-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-tokens",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "Semantic design tokens for Gents desktop packages",
   "type": "module",

--- a/packages/gents-desktop-ui/package.json
+++ b/packages/gents-desktop-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@source-inc/gents-desktop-ui",
-  "version": "0.16.4",
+  "version": "0.17.0",
   "license": "Apache-2.0",
   "description": "Shared accessible UI primitives for Gents desktop surfaces",
   "type": "module",
@@ -25,12 +25,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.16.4",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@source-inc/gents-desktop-tokens": "0.16.4",
+    "@source-inc/gents-desktop-tokens": "0.17.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",

--- a/packs/pipeline/pack_config.json
+++ b/packs/pipeline/pack_config.json
@@ -1,7 +1,5 @@
 {
-  "agent_principal": {
-    "agent_did": "did:example:pipeline-pack"
-  },
+  "agent_principal": {},
   "agent_behaviors": [
     {
       "behavior_id": "exp-stage1",


### PR DESCRIPTION
## Summary

- release the canonical single-owner runtime/configuration refactor
- ship the mobile data-plane latency, reconnect-convergence, hydration, event-coalescing, and transaction-liveness work
- pin DefraDB Rust at the merged Go-compatible durable-subscription stack
- bump the Rust, desktop, npm, bridge-contract, Tauri, and release-workflow train to 0.17.0
- document measured startup, request-delivery, offline-recovery, and live-inference E2E results

## Compatibility

Upgrade the phone/desktop clients and agent runtimes together. Preserve stores, DIDs, identities, and enrollment state; do not wipe or re-pair. Mixed pre-0.17 and 0.17 canonical configuration models are unsupported.

## Validation

- `CARGO_INCREMENTAL=0 cargo test -p gents`
- `CARGO_INCREMENTAL=0 cargo check --workspace --all-targets`
- `cargo metadata --locked --no-deps`
- `npm ci --ignore-scripts`
- `npm run check:package-boundaries`
- `npm run build:packages`
- canonical mobile integration suite: 5/5
- live P2P + inference conversation E2E against GLM-5.3-Flash-NVFP4
- `git diff --check`