### PR TITLE
fix(pack): validate document templates in install scope

### DIFF
--- a/crates/gents-cli/src/commands/pack/mod.rs
+++ b/crates/gents-cli/src/commands/pack/mod.rs
@@ -398,7 +398,13 @@ async fn install(args: PackInstallArgs) -> Result<()> {
             }
             let temp = tempfile::tempdir()?;
             materialize(&pack, temp.path())?;
-            let (_, report) = crate::desired_state::load_manifest_root(temp.path());
+            // Distribution packs are templates: their principal is supplied by
+            // the installation target. Validate through the same scoped loader
+            // used by apply instead of requiring a pack-authored concrete DID.
+            let (_, report) = crate::desired_state::load_manifest_root_for_owner(
+                temp.path(),
+                Some("did:key:zPackInstallValidationOwner"),
+            );
             anyhow::ensure!(
                 report.errors.is_empty(),
                 "invalid pack configuration: {:?}",


### PR DESCRIPTION
## Summary
- validate document-pack templates with an explicit preflight scope
- keep the concrete principal owned by the eventual install target
- preserve offline shape/reference validation before dependency installation

## Regression
- `CARGO_INCREMENTAL=0 cargo test -p gents-cli --test cli_graph document_pack_installs_without_seeding_and_is_idempotent -- --nocapture --test-threads=1`

Follow-up caught by the complete CLI suite while preparing v0.17.0.